### PR TITLE
Jsonnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,23 @@ $ go build -o kubeapps main.go
 
 ## Usage
 
-Put manifests in a particular folder (default to `~/.kubeapps`)
+**Deploy with kubeapps.jsonnet**
+
+```
+$ d=$PWD/kubeapps-manifest
+$ git clone --recurse-submodules https://github.com/kubeapps/manifest $d
+$ export KUBECFG_JPATH=$d/lib:$d/vendor/kubecfg/lib:$d/vendor/ksonnet-lib
+$ kubeapps up --file $d/kubeapps.jsonnet
+$ kubeapps down --file $d/kubeapps.jsonnet
+```
+
+**Deploy with yaml manifests**
+
+Put yaml manifests in a particular folder (default to `~/.kubeapps`)
 ```
 # Bring up cluster
 $ kubeapps up
-# Or providing manifests folder
+# Or providing yaml manifests folder
 $ kubeapps up --path /path/to/manifests
 
 # Bring down cluster

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -29,19 +29,26 @@ var downCmd = &cobra.Command{
 			return err
 		}
 
-		kaManifestDir, err := cmd.Flags().GetString("path")
+		kaFile, err := cmd.Flags().GetString("file")
 		if err != nil {
 			return err
 		}
-		if kaManifestDir == "" {
-			home, err := getHome()
+
+		if kaFile == "" {
+			kaFile, err = cmd.Flags().GetString("path")
 			if err != nil {
 				return err
 			}
-			kaManifestDir = filepath.Join(home, KUBEAPPS_DIR)
+			if kaFile == "" {
+				home, err := getHome()
+				if err != nil {
+					return err
+				}
+				kaFile = filepath.Join(home, KUBEAPPS_DIR)
+			}
 		}
 
-		objs, err := parseObjects(kaManifestDir)
+		objs, err := parseObjects(kaFile)
 		if err != nil {
 			return err
 		}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -24,16 +24,24 @@ var upCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		kaManifestDir, err := cmd.Flags().GetString("path")
+
+		kaFile, err := cmd.Flags().GetString("file")
 		if err != nil {
 			return err
 		}
-		if kaManifestDir == "" {
-			home, err := getHome()
+
+		if kaFile == "" {
+			kaFile, err = cmd.Flags().GetString("path")
 			if err != nil {
 				return err
 			}
-			kaManifestDir = filepath.Join(home, KUBEAPPS_DIR)
+			if kaFile == "" {
+				home, err := getHome()
+				if err != nil {
+					return err
+				}
+				kaFile = filepath.Join(home, KUBEAPPS_DIR)
+			}
 		}
 
 		c.Create = true
@@ -56,7 +64,7 @@ var upCmd = &cobra.Command{
 		}
 		wd := metadata.AbsPath(cwd)
 
-		objs, err := parseObjects(kaManifestDir)
+		objs, err := parseObjects(kaFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This supports deploy kubeapps components via the `kubeapps.jsonnet` file.

```
$ d=$PWD/kubeapps-manifest
$ git clone --recurse-submodules https://github.com/kubeapps/manifest $d
$ export KUBECFG_JPATH=$d/lib:$d/vendor/kubecfg/lib:$d/vendor/ksonnet-lib
$ kubeapps up --file $d/kubeapps.jsonnet
$ kubeapps down --file $d/kubeapps.jsonnet
```