### PR TITLE
add validation to k8s version, improve error messages

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/ksonnet/kubecfg/pkg/kubecfg"
 	"github.com/ksonnet/kubecfg/utils"
@@ -50,8 +49,7 @@ var downCmd = &cobra.Command{
 			return fmt.Errorf("can't verify Kubernetes version: %v", err)
 		}
 		if version.Major <= 1 && version.Minor < 7 {
-			fmt.Println("warning: Kubernetes with RBAC enabled (v1.7+) is required to run Kubeapps")
-			os.Exit(0)
+			return fmt.Errorf("kubernetes with RBAC enabled (v1.7+) is required to run Kubeapps")
 		}
 
 		manifest, err := fsGetFile("/kubeapps-objs.yaml")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,8 @@ var RootCmd = &cobra.Command{
 	Long: `kubeapps installs the Kubeapps components into your cluster.
   
 Find more information at https://github.com/kubeapps/kubeapps.`,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStderr()
 		logrus.SetOutput(out)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -69,8 +69,7 @@ List of components that kubeapps up installs:
 			return fmt.Errorf("can't verify Kubernetes version: %v", err)
 		}
 		if version.Major <= 1 && version.Minor < 7 {
-			fmt.Println("warning: Kubernetes with RBAC enabled (v1.7+) is required to run Kubeapps")
-			os.Exit(0)
+			return fmt.Errorf("kubernetes with RBAC enabled (v1.7+) is required to run Kubeapps")
 		}
 
 		cwd, err := os.Getwd()


### PR DESCRIPTION
This PR adds validation to k8s version before installing/uninstalling kubeapps and returns a warning message to let user aware of using k8s 1.7+ with RBAC enabled. This also contains several error messages which turns the tool to become more friendly.