### PR TITLE
remove monocular api resource limits and tweak mem request

### DIFF
--- a/static/kubeapps-objs.yaml
+++ b/static/kubeapps-objs.yaml
@@ -103,12 +103,9 @@ spec:
           initialDelaySeconds: 0
           timeoutSeconds: 5
         resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 512Mi
         stdin: false
         tty: false
         volumeMounts:


### PR DESCRIPTION
This will stop OOMKilled stopping Monocular from syncing and I also bumped the memory request to 512Mi just to be on the safe side.

https://github.com/kubeapps/manifest/pull/31 makes this change in the manifest