### PR TITLE
reduce chart refresh interval to 15 mins

### DIFF
--- a/static/kubeapps-objs.yaml
+++ b/static/kubeapps-objs.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 data:
   monocular.yaml: |
     {
-        "cacheRefreshInterval": 3600,
+        "cacheRefreshInterval": 900,
         "cors": {
             "allowed_headers": [
                 "content-type",


### PR DESCRIPTION
Currently, adding a new repository in the Dashboard it can take up to an
hour to see charts from the new repo to appear. This reduces that time
greatly by configuring Monocular to sync every 15 mins.