### PR TITLE
add cross compiling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
       export GOARCH="amd64"
       go env
     fi
-  - make VERSION="$VERSION" binary
+  - make VERSION="$VERSION" binary-travis
   - file kubeapps
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_deploy:
           EXE_NAME=kubeapps-$GOOS-$GOARCH.exe
     fi
   - cp kubeapps $EXE_NAME
-  - strip $EXE_NAME && ./$EXE_NAME version
+  - strip $EXE_NAME
   - >
     size $EXE_NAME || :
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,14 @@ go_import_path: github.com/kubeapps/kubeapps
 env:
   global:
     VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID}
+    GO_XFLAGS=""
 
 matrix:
   include:
     - env: TARGET=x86_64-w64-mingw32
     - env: TARGET=""
+    - env: TARGET=x86_64-apple-darwin15-clang
+
 addons:
   apt:
     packages:
@@ -33,9 +36,24 @@ script:
       export CXX="$TARGET-g++"
       export GOOS="windows"
       export GOARCH="amd64"
+      GO_XFLAGS="-ldflags='-extldflags \"-static\"'"
       go env
     fi
-  - make VERSION="$VERSION" binary-travis
+  - |
+    if [ "$TARGET" == "x86_64-apple-darwin15-clang" ]; then
+      git clone https://github.com/tpoechtrager/osxcross
+      sudo $PWD/osxcross/tools/get_dependencies.sh
+      wget -O $PWD/osxcross/tarballs/MacOSX10.11.sdk.tar.xz \
+        https://storage.googleapis.com/osx-cross-compiler/MacOSX10.11.sdk.tar.xz
+      UNATTENDED=1 OSX_VERSION_MIN=10.9 $PWD/osxcross/build.sh
+      export PATH=$PATH:$PWD/osxcross/target/bin/
+      export CC="$TARGET"
+      export CXX="$TARGET++"
+      export GOOS="darwin"
+      export GOARCH="amd64"
+      go env
+    fi
+  - make VERSION="$VERSION" GO_XFLAGS="$GO_XFLAGS" binary-travis
   - file kubeapps
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,13 @@ addons:
     packages:
       # cross compiling for windows
       - mingw-w64
+  artifacts:
+    debug: true
+    paths:
+      - kubeapps-*
+    s3_region: "ap-southeast-1"
+    target_paths: $TRAVIS_BUILD_NUMBER
+    bucket: "kubeapps"
 
 before_install:
   - set -e
@@ -53,29 +60,32 @@ script:
       export GOARCH="amd64"
       go env
     fi
+  - |
+    if [ "$TARGET" == "" ]; then
+      export GOOS="linux"
+      export GOARCH="amd64"
+      go env
+    fi
   - make VERSION="$VERSION" GO_XFLAGS="$GO_XFLAGS" binary-travis
   - file kubeapps
 
-before_deploy:
+after_success:
   - EXE_NAME=kubeapps-$GOOS-$GOARCH
   - |
     if [ "$TARGET" == "x86_64-w64-mingw32" ]; then
           EXE_NAME=kubeapps-$GOOS-$GOARCH.exe
     fi
   - cp kubeapps $EXE_NAME
-  - strip $EXE_NAME
-  - >
-    size $EXE_NAME || :
 
 deploy:
-  provider: releases
-  api_key:
-    secure: "G0BmT6tXyXkXlgo9pa4/SNWYZHfwKqxWJ9hVz0LybYnon0IbEjpo5mppsltezEHEQvgdX6H+tujcmOIDAHK2hh3KdeYzZ7GjM1oGRau4x2sN42o6bw7wQ7lC9+ZgPvH9vWiBxf3bZ0TYVjmZ2OcvzBSycg2T5XFKEQKGyJc1cGABFm6At8WXimbaXhWLsrQ0MP9yd5uwvp9PBG+SxJmInDdUIw7sFtEYDL4YDIG6JVgJOV1+3f8oTNiM1wwTPJuaHoybbyeE8xdT9pN6DOk0HZXP+/f6rjx63lMoKCqsqMi6Bz6rDpmI5YfSRh7M2RVebaKnHxYhVKQ20+y0+0UznFmArVSSH4SbFCwz9fYn3NBPLMaSdR91HS4BZe1AeOdXZlfowGOdQuZf3oY/aLtB6cu2jwiUh58CtoTFbg53iZcYwiW69Ap6G40SD2JZNlHPScB5eFJkj1f+3CFHAmB89nLgpZw+S12/HZGQa/OmdB4wd73mqe2XQa7ez60UOjhURwU2LzI02/0NaSswcpu9ygCAYgz1Cy6jAJnmxdvIdcACzYDpgNKNj+yC8GSvAqxEDX+wi6WdUVhy+jwaCzhRgbBZScP8kcFFOKjmdLdeeujRpw3qUzqEh4HW8oNvlg6yXHpoNwjgQJlDIbCHsevPIs/duBCMPy+3st+KaLLwZig="
-  file_glob: true
-  file: $EXE_NAME
-  skip_cleanup: true
-  overwrite: true
-  on:
-    tags: true
-    branch: master
-    repo: kubeapps/kubeapps
+  - provider: releases
+    api_key:
+      secure: "G0BmT6tXyXkXlgo9pa4/SNWYZHfwKqxWJ9hVz0LybYnon0IbEjpo5mppsltezEHEQvgdX6H+tujcmOIDAHK2hh3KdeYzZ7GjM1oGRau4x2sN42o6bw7wQ7lC9+ZgPvH9vWiBxf3bZ0TYVjmZ2OcvzBSycg2T5XFKEQKGyJc1cGABFm6At8WXimbaXhWLsrQ0MP9yd5uwvp9PBG+SxJmInDdUIw7sFtEYDL4YDIG6JVgJOV1+3f8oTNiM1wwTPJuaHoybbyeE8xdT9pN6DOk0HZXP+/f6rjx63lMoKCqsqMi6Bz6rDpmI5YfSRh7M2RVebaKnHxYhVKQ20+y0+0UznFmArVSSH4SbFCwz9fYn3NBPLMaSdR91HS4BZe1AeOdXZlfowGOdQuZf3oY/aLtB6cu2jwiUh58CtoTFbg53iZcYwiW69Ap6G40SD2JZNlHPScB5eFJkj1f+3CFHAmB89nLgpZw+S12/HZGQa/OmdB4wd73mqe2XQa7ez60UOjhURwU2LzI02/0NaSswcpu9ygCAYgz1Cy6jAJnmxdvIdcACzYDpgNKNj+yC8GSvAqxEDX+wi6WdUVhy+jwaCzhRgbBZScP8kcFFOKjmdLdeeujRpw3qUzqEh4HW8oNvlg6yXHpoNwjgQJlDIbCHsevPIs/duBCMPy+3st+KaLLwZig="
+    file_glob: true
+    file: $EXE_NAME
+    skip_cleanup: true
+    overwrite: true
+    on:
+      tags: true
+      branch: master
+      repo: kubeapps/kubeapps

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,44 @@ language: go
 
 os:
   - linux
-  - osx
 
 go:
   - 1.8.3
 
 go_import_path: github.com/kubeapps/kubeapps
 
+env:
+  global:
+    VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID}
+
+matrix:
+  include:
+    - env: TARGET=x86_64-w64-mingw32
+    - env: TARGET=""
+addons:
+  apt:
+    packages:
+      # cross compiling for windows
+      - mingw-w64
+
 before_install:
   - set -e
 
 script:
   - make test
-  - make VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID} binary
+  - |
+    if [ -n "$TARGET" ]; then
+      export CC="$TARGET-gcc"
+      export CXX="$TARGET-g++"
+      export GOOS="windows"
+      export GOARCH="amd64"
+      go env
+    fi
+  - make VERSION="$VERSION" binary
+  - file kubeapps
 
 before_deploy:
-  - echo OS_NAME=$TRAVIS_OS_NAME GO_VERSION=$TRAVIS_GO_VERSION
-  - EXE_NAME=kubeapps-$(go env GOOS)-$(go env GOARCH)
+  - EXE_NAME=kubeapps-$GOOS-$GOARCH
   - cp kubeapps $EXE_NAME
   - strip $EXE_NAME && ./$EXE_NAME version
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 script:
   - make test
   - |
-    if [ -n "$TARGET" ]; then
+    if [ "$TARGET" == "x86_64-w64-mingw32" ]; then
       export CC="$TARGET-gcc"
       export CXX="$TARGET-g++"
       export GOOS="windows"
@@ -40,6 +40,10 @@ script:
 
 before_deploy:
   - EXE_NAME=kubeapps-$GOOS-$GOARCH
+  - |
+    if [ "$TARGET" == "x86_64-w64-mingw32" ]; then
+          EXE_NAME=kubeapps-$GOOS-$GOARCH.exe
+    fi
   - cp kubeapps $EXE_NAME
   - strip $EXE_NAME && ./$EXE_NAME version
   - >

--- a/Makefile
+++ b/Makefile
@@ -7,26 +7,28 @@ GO = /usr/bin/env GOPATH=$(GOPATH_TMP) $(GOBIN)
 GOFMT = gofmt
 VERSION = dev-$(shell date +%FT%T%z)
 
-GO_OS = GOOS="${GOOS}"
-GO_ARCH = GOARCH="${GOARCH}"
 BINARY = kubeapps
 GO_PACKAGES = $(IMPORT_PATH)/cmd $(IMPORT_PATH)/pkg/...
 GO_FILES := $(shell find $(shell $(GOBIN) list -f '{{.Dir}}' $(GO_PACKAGES)) -name \*.go)
-GO_FLAGS = -ldflags='-extldflags "-static" -w -X github.com/kubeapps/kubeapps/cmd.VERSION=${VERSION}'
-GO_LDFLAGS =
+GO_FLAGS = -ldflags='-w -X github.com/kubeapps/kubeapps/cmd.VERSION=${VERSION}'
 EMBEDDED_STATIC = generated/statik/statik.go
-CC_ = CC="${CC}"
-CXX_ = CXX="${CXX}"
 
 default: binary
 
 binary: build-prep $(EMBEDDED_STATIC)
-	CGO_ENABLED=1 $(CC_) $(CXX_) $(GO_OS) $(GO_ARCH) $(GO) build -i -o $(BINARY) $(GO_FLAGS) $(IMPORT_PATH)
+	CGO_ENABLED=1 $(GO) build -i -o $(BINARY) $(GO_FLAGS) $(IMPORT_PATH)
+
+binary-travis: build-prep  $(EMBEDDED_STATIC)-travis
+	CGO_ENABLED=1 $(GO) build -i -o $(BINARY) $(GO_FLAGS) $(IMPORT_PATH)
 
 test: build-prep $(EMBEDDED_STATIC)
 	$(GO) test $(GO_FLAGS) $(GO_PACKAGES)
 
 $(EMBEDDED_STATIC): build-prep $(wilcard static/*)
+	$(GO) build -o statik ./vendor/github.com/rakyll/statik/statik.go
+	$(GO) generate
+
+$(EMBEDDED_STATIC)-travis: build-prep $(wilcard static/*)
 	GOOS=linux $(GO) build -o statik ./vendor/github.com/rakyll/statik/statik.go
 	GOOS=linux $(GO) generate
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GO_ARCH = GOARCH="${GOARCH}"
 BINARY = kubeapps
 GO_PACKAGES = $(IMPORT_PATH)/cmd $(IMPORT_PATH)/pkg/...
 GO_FILES := $(shell find $(shell $(GOBIN) list -f '{{.Dir}}' $(GO_PACKAGES)) -name \*.go)
-GO_FLAGS = -ldflags="-w -X github.com/kubeapps/kubeapps/cmd.VERSION=${VERSION}"
+GO_FLAGS = -ldflags='-extldflags "-static" -w -X github.com/kubeapps/kubeapps/cmd.VERSION=${VERSION}'
 GO_LDFLAGS =
 EMBEDDED_STATIC = generated/statik/statik.go
 CC_ = CC="${CC}"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ BINARY = kubeapps
 GO_PACKAGES = $(IMPORT_PATH)/cmd $(IMPORT_PATH)/pkg/...
 GO_FILES := $(shell find $(shell $(GOBIN) list -f '{{.Dir}}' $(GO_PACKAGES)) -name \*.go)
 GO_FLAGS = -ldflags='-w -X github.com/kubeapps/kubeapps/cmd.VERSION=${VERSION}'
+GO_XFLAGS =
 EMBEDDED_STATIC = generated/statik/statik.go
 
 default: binary
@@ -19,7 +20,7 @@ binary: build-prep $(EMBEDDED_STATIC)
 	CGO_ENABLED=1 $(GO) build -i -o $(BINARY) $(GO_FLAGS) $(IMPORT_PATH)
 
 binary-travis: build-prep  $(EMBEDDED_STATIC)-travis
-	CGO_ENABLED=1 $(GO) build -i -o $(BINARY) $(GO_FLAGS) $(IMPORT_PATH)
+	CGO_ENABLED=1 $(GO) build -i -o $(BINARY) $(GO_FLAGS) $(GO_XFLAGS) $(IMPORT_PATH)
 
 test: build-prep $(EMBEDDED_STATIC)
 	$(GO) test $(GO_FLAGS) $(GO_PACKAGES)


### PR DESCRIPTION
This PR adds a build job for windows binary relying on the https://mingw-w64.org/ package for windows compiling on linux. The travis structure is changed to easily add more build for other platform (osx), motivated by [travis matrix](https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix)

- [x] add osx build