### PR TITLE
update kubecfg to latest

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -158,7 +158,7 @@ List of components that kubeapps up installs:
 		}
 
 		if c.DryRun {
-			return dump(cmd.OutOrStdout(), out, objs)
+			return dump(cmd.OutOrStdout(), out, c.Discovery, objs)
 		}
 
 		err = c.Run(objs)
@@ -187,9 +187,13 @@ func init() {
 	upCmd.Flags().StringP("out", "o", "yaml", "Specify manifest format: yaml | json. Note: used only with --dry-run")
 }
 
-func dump(w io.Writer, out string, objs []*unstructured.Unstructured) error {
+func dump(w io.Writer, out string, disco discovery.DiscoveryInterface, objs []*unstructured.Unstructured) error {
 	bObjs := [][]byte{}
-	sort.Sort(utils.DependencyOrder(objs))
+	toSort, err := utils.DependencyOrder(disco, objs)
+	if err != nil {
+		return fmt.Errorf("can't dump kubeapps manifest: %v", err)
+	}
+	sort.Sort(toSort)
 
 	switch out {
 	case "json":

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -209,7 +209,14 @@ func TestDump(t *testing.T) {
 	objs = append(objs, obj)
 	var buf bytes.Buffer
 
-	err := dump(&buf, "yaml", objs)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	client := discovery.NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+
+	err := dump(&buf, "yaml", client, objs)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -209,14 +209,9 @@ func TestDump(t *testing.T) {
 	objs = append(objs, obj)
 	var buf bytes.Buffer
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-	client := discovery.NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+	client := fake.NewSimpleClientset()
 
-	err := dump(&buf, "yaml", client, objs)
+	err := dump(&buf, "yaml", client.Discovery(), objs)
 	if err != nil {
 		t.Error(err)
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4a7d4ee8f03ce08b87dc0de942e9867f8ed157f6fc16d246ee154f6258d0e835
-updated: 2017-12-19T15:02:52.567185532+07:00
+hash: 97f50ee558073718f05eaf441a838268b5088fcb208f5a7eb07b2aa36f6fc818
+updated: 2018-01-03T14:04:44.628970231Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -35,7 +35,7 @@ imports:
 - name: github.com/emicklei/go-restful-swagger12
   version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-ini/ini
   version: 32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a
 - name: github.com/go-openapi/analysis
@@ -77,7 +77,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
 - name: github.com/ksonnet/kubecfg
-  version: 1d656906cf6b19e94a02619f2f7a086ca06ea48e
+  version: 0870136f9a627a7e4609839183a7155ff5ecba5d
   subpackages:
   - metadata
   - pkg/kubecfg
@@ -176,7 +176,7 @@ imports:
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: c95af922eae69f190717a0b7148960af8c55a072
 - name: k8s.io/apimachinery
   version: 917740426ad66ff818da4809990480bcc0786a77
   subpackages:
@@ -231,29 +231,51 @@ imports:
   version: d92e8497f71b7b4e0494e5bd204b48d34bd6f254
   subpackages:
   - discovery
+  - discovery/fake
   - dynamic
   - kubernetes
+  - kubernetes/fake
   - kubernetes/scheme
   - kubernetes/typed/admissionregistration/v1alpha1
+  - kubernetes/typed/admissionregistration/v1alpha1/fake
   - kubernetes/typed/apps/v1beta1
+  - kubernetes/typed/apps/v1beta1/fake
   - kubernetes/typed/authentication/v1
+  - kubernetes/typed/authentication/v1/fake
   - kubernetes/typed/authentication/v1beta1
+  - kubernetes/typed/authentication/v1beta1/fake
   - kubernetes/typed/authorization/v1
+  - kubernetes/typed/authorization/v1/fake
   - kubernetes/typed/authorization/v1beta1
+  - kubernetes/typed/authorization/v1beta1/fake
   - kubernetes/typed/autoscaling/v1
+  - kubernetes/typed/autoscaling/v1/fake
   - kubernetes/typed/autoscaling/v2alpha1
+  - kubernetes/typed/autoscaling/v2alpha1/fake
   - kubernetes/typed/batch/v1
+  - kubernetes/typed/batch/v1/fake
   - kubernetes/typed/batch/v2alpha1
+  - kubernetes/typed/batch/v2alpha1/fake
   - kubernetes/typed/certificates/v1beta1
+  - kubernetes/typed/certificates/v1beta1/fake
   - kubernetes/typed/core/v1
+  - kubernetes/typed/core/v1/fake
   - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/extensions/v1beta1/fake
   - kubernetes/typed/networking/v1
+  - kubernetes/typed/networking/v1/fake
   - kubernetes/typed/policy/v1beta1
+  - kubernetes/typed/policy/v1beta1/fake
   - kubernetes/typed/rbac/v1alpha1
+  - kubernetes/typed/rbac/v1alpha1/fake
   - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/rbac/v1beta1/fake
   - kubernetes/typed/settings/v1alpha1
+  - kubernetes/typed/settings/v1alpha1/fake
   - kubernetes/typed/storage/v1
+  - kubernetes/typed/storage/v1/fake
   - kubernetes/typed/storage/v1beta1
+  - kubernetes/typed/storage/v1beta1/fake
   - pkg/api
   - pkg/api/v1
   - pkg/api/v1/ref
@@ -298,6 +320,7 @@ imports:
   - plugin/pkg/client/auth/oidc
   - rest
   - rest/watch
+  - testing
   - third_party/forked/golang/template
   - tools/auth
   - tools/clientcmd

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,7 @@ import:
 - package: k8s.io/apimachinery
   version: 917740426ad66ff818da4809990480bcc0786a77
 - package: github.com/ksonnet/kubecfg
-  version: 1d656906cf6b19e94a02619f2f7a086ca06ea48e
+  version: 0870136f9a627a7e4609839183a7155ff5ecba5d
   subpackages:
   - utils
   - metadata

--- a/vendor/github.com/ghodss/yaml/README.md
+++ b/vendor/github.com/ghodss/yaml/README.md
@@ -4,13 +4,13 @@
 
 ## Introduction
 
-A wrapper around [go-yaml](https://github.com/go-yaml/yaml) designed to enable a better way of handling YAML when marshaling to and from structs. 
+A wrapper around [go-yaml](https://github.com/go-yaml/yaml) designed to enable a better way of handling YAML when marshaling to and from structs.
 
 In short, this library first converts YAML to JSON using go-yaml and then uses `json.Marshal` and `json.Unmarshal` to convert to or from the struct. This means that it effectively reuses the JSON struct tags as well as the custom JSON methods `MarshalJSON` and `UnmarshalJSON` unlike go-yaml. For a detailed overview of the rationale behind this method, [see this blog post](http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/).
 
 ## Compatibility
 
-This package uses [go-yaml v2](https://github.com/go-yaml/yaml) and therefore supports [everything go-yaml supports](https://github.com/go-yaml/yaml#compatibility).
+This package uses [go-yaml](https://github.com/go-yaml/yaml) and therefore supports [everything go-yaml supports](https://github.com/go-yaml/yaml#compatibility).
 
 ## Caveats
 
@@ -44,6 +44,8 @@ import "github.com/ghodss/yaml"
 Usage is very similar to the JSON library:
 
 ```go
+package main
+
 import (
 	"fmt"
 
@@ -51,8 +53,8 @@ import (
 )
 
 type Person struct {
-	Name string `json:"name"`  // Affects YAML field names too.
-	Age int `json:"name"`
+	Name string `json:"name"` // Affects YAML field names too.
+	Age  int    `json:"age"`
 }
 
 func main() {
@@ -65,13 +67,13 @@ func main() {
 	}
 	fmt.Println(string(y))
 	/* Output:
-	name: John
 	age: 30
+	name: John
 	*/
 
 	// Unmarshal the YAML back into a Person struct.
 	var p2 Person
-	err := yaml.Unmarshal(y, &p2)
+	err = yaml.Unmarshal(y, &p2)
 	if err != nil {
 		fmt.Printf("err: %v\n", err)
 		return
@@ -86,11 +88,14 @@ func main() {
 `yaml.YAMLToJSON` and `yaml.JSONToYAML` methods are also available:
 
 ```go
+package main
+
 import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
 )
+
 func main() {
 	j := []byte(`{"name": "John", "age": 30}`)
 	y, err := yaml.JSONToYAML(j)

--- a/vendor/github.com/ghodss/yaml/fields.go
+++ b/vendor/github.com/ghodss/yaml/fields.go
@@ -45,7 +45,11 @@ func indirect(v reflect.Value, decodingNull bool) (json.Unmarshaler, encoding.Te
 			break
 		}
 		if v.IsNil() {
-			v.Set(reflect.New(v.Type().Elem()))
+			if v.CanSet() {
+				v.Set(reflect.New(v.Type().Elem()))
+			} else {
+				v = reflect.New(v.Type().Elem())
+			}
 		}
 		if v.Type().NumMethod() > 0 {
 			if u, ok := v.Interface().(json.Unmarshaler); ok {

--- a/vendor/github.com/ghodss/yaml/yaml.go
+++ b/vendor/github.com/ghodss/yaml/yaml.go
@@ -15,12 +15,12 @@ import (
 func Marshal(o interface{}) ([]byte, error) {
 	j, err := json.Marshal(o)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling into JSON: ", err)
+		return nil, fmt.Errorf("error marshaling into JSON: %v", err)
 	}
 
 	y, err := JSONToYAML(j)
 	if err != nil {
-		return nil, fmt.Errorf("error converting JSON to YAML: ", err)
+		return nil, fmt.Errorf("error converting JSON to YAML: %v", err)
 	}
 
 	return y, nil
@@ -48,7 +48,7 @@ func JSONToYAML(j []byte) ([]byte, error) {
 	var jsonObj interface{}
 	// We are using yaml.Unmarshal here (instead of json.Unmarshal) because the
 	// Go JSON library doesn't try to pick the right number type (int, float,
-	// etc.) when unmarshling to interface{}, it just picks float64
+	// etc.) when unmarshalling to interface{}, it just picks float64
 	// universally. go-yaml does go through the effort of picking the right
 	// number type, so we can preserve number type throughout this process.
 	err := yaml.Unmarshal(j, &jsonObj)

--- a/vendor/github.com/ghodss/yaml/yaml_test.go
+++ b/vendor/github.com/ghodss/yaml/yaml_test.go
@@ -88,6 +88,22 @@ func TestUnmarshal(t *testing.T) {
 	s4 := UnmarshalStringMap{}
 	e4 := UnmarshalStringMap{map[string]string{"b": "1"}}
 	unmarshal(t, y, &s4, &e4)
+
+	y = []byte(`
+a:
+  name: TestA
+b:
+  name: TestB
+`)
+	type NamedThing struct {
+		Name string `json:"name"`
+	}
+	s5 := map[string]*NamedThing{}
+	e5 := map[string]*NamedThing{
+		"a": &NamedThing{Name: "TestA"},
+		"b": &NamedThing{Name: "TestB"},
+	}
+	unmarshal(t, y, &s5, &e5)
 }
 
 func unmarshal(t *testing.T, y []byte, s, e interface{}) {

--- a/vendor/github.com/ksonnet/kubecfg/pkg/kubecfg/delete.go
+++ b/vendor/github.com/ksonnet/kubecfg/pkg/kubecfg/delete.go
@@ -44,7 +44,12 @@ func (c DeleteCmd) Run(apiObjects []*unstructured.Unstructured) error {
 		return err
 	}
 
-	sort.Sort(sort.Reverse(utils.DependencyOrder(apiObjects)))
+	log.Infof("Fetching schemas for %d resources", len(apiObjects))
+	depOrder, err := utils.DependencyOrder(c.Discovery, apiObjects)
+	if err != nil {
+		return err
+	}
+	sort.Sort(sort.Reverse(depOrder))
 
 	deleteOpts := metav1.DeleteOptions{}
 	if version.Compare(1, 6) < 0 {

--- a/vendor/github.com/ksonnet/kubecfg/pkg/kubecfg/diff_test.go
+++ b/vendor/github.com/ksonnet/kubecfg/pkg/kubecfg/diff_test.go
@@ -76,6 +76,11 @@ func TestRemoveMapFields(t *testing.T) {
 }
 
 func TestRemoveFields(t *testing.T) {
+	emptyVal := map[string]interface{}{
+		"args":    map[string]interface{}{},
+		"volumes": []string{},
+		"stdin":   false,
+	}
 	for _, tc := range []struct {
 		config, live, expected interface{}
 	}{
@@ -98,6 +103,13 @@ func TestRemoveFields(t *testing.T) {
 			config:   "a",
 			live:     "b",
 			expected: "b",
+		},
+		// Check we handle empty configs by copying them as if were live
+		// (API won't return them)
+		{
+			config:   emptyVal,
+			live:     map[string]interface{}{},
+			expected: emptyVal,
 		},
 
 		// Check we can handle combinations.

--- a/vendor/github.com/ksonnet/kubecfg/pkg/kubecfg/update.go
+++ b/vendor/github.com/ksonnet/kubecfg/pkg/kubecfg/update.go
@@ -56,7 +56,12 @@ func (c UpdateCmd) Run(apiObjects []*unstructured.Unstructured) error {
 		dryRunText = " (dry-run)"
 	}
 
-	sort.Sort(utils.DependencyOrder(apiObjects))
+	log.Infof("Fetching schemas for %d resources", len(apiObjects))
+	depOrder, err := utils.DependencyOrder(c.Discovery, apiObjects)
+	if err != nil {
+		return err
+	}
+	sort.Sort(depOrder)
 
 	seenUids := sets.NewString()
 

--- a/vendor/github.com/ksonnet/kubecfg/utils/client.go
+++ b/vendor/github.com/ksonnet/kubecfg/utils/client.go
@@ -172,15 +172,15 @@ func ClientForResource(pool dynamic.ClientPool, disco discovery.DiscoveryInterfa
 	return rc, nil
 }
 
-func serverResourceForGroupVersionKind(disco discovery.DiscoveryInterface, gvk schema.GroupVersionKind) (*metav1.APIResource, error) {
+func serverResourceForGroupVersionKind(disco discovery.ServerResourcesInterface, gvk schema.GroupVersionKind) (*metav1.APIResource, error) {
 	resources, err := disco.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to fetch resource description for %s: %v", gvk.GroupVersion(), err)
 	}
 
 	for _, r := range resources.APIResources {
 		if r.Kind == gvk.Kind {
-			log.Debugf("Chose API '%s' for %s", r.Name, gvk)
+			log.Debugf("Using resource '%s' for %s", r.Name, gvk)
 			return &r, nil
 		}
 	}

--- a/vendor/github.com/ksonnet/kubecfg/utils/sort.go
+++ b/vendor/github.com/ksonnet/kubecfg/utils/sort.go
@@ -16,55 +16,182 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/emicklei/go-restful-swagger12"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/discovery"
 )
 
 var (
-	gkNamespace    = schema.GroupKind{Group: "", Kind: "Namespace"}
-	gkTpr          = schema.GroupKind{Group: "extensions", Kind: "ThirdPartyResource"}
-	gkStorageClass = schema.GroupKind{Group: "storage.k8s.io", Kind: "StorageClass"}
-
-	gkPod         = schema.GroupKind{Group: "", Kind: "Pod"}
-	gkJob         = schema.GroupKind{Group: "batch", Kind: "Job"}
-	gkDeployment  = schema.GroupKind{Group: "extensions", Kind: "Deployment"}
-	gkDaemonSet   = schema.GroupKind{Group: "extensions", Kind: "DaemonSet"}
-	gkStatefulSet = schema.GroupKind{Group: "apps", Kind: "StatefulSet"}
+	gkTpr = schema.GroupKind{Group: "extensions", Kind: "ThirdPartyResource"}
+	gkCrd = schema.GroupKind{Group: "apiextensions", Kind: "CustomResourceDefinition"}
 )
 
-// These kinds all start pods.
-// TODO: expand this list.
-func isPodOrSimilar(gk schema.GroupKind) bool {
-	return gk == gkPod ||
-		gk == gkJob ||
-		gk == gkDeployment ||
-		gk == gkDaemonSet ||
-		gk == gkStatefulSet
+// Heh: Swagger. Walk. :P
+func swaggerWalk(api *swagger.ApiDeclaration, typeName string, seen sets.String, visitor func(string) error) error {
+	if !versionRegexp.MatchString(typeName) {
+		return nil
+	}
+
+	// Prevent possible schema loops
+	if seen.Has(typeName) {
+		return nil
+	}
+	seen.Insert(typeName)
+
+	if err := visitor(typeName); err != nil {
+		return err
+	}
+
+	// is an API object of some sort
+	models := api.Models
+	model, ok := models.At(typeName)
+	if !ok {
+		return fmt.Errorf("type %q not found in schema", typeName)
+	}
+
+	properties := model.Properties
+	for _, namedproperty := range properties.List {
+		details := namedproperty.Property
+		var fieldType string
+		if details.Type != nil {
+			fieldType = *details.Type
+		} else if details.Ref != nil {
+			fieldType = *details.Ref
+		} else {
+			return fmt.Errorf("type of field %q in %q undefined in schema", namedproperty.Name, typeName)
+		}
+
+		if fieldType == "array" {
+			if details.Items.Ref != nil {
+				fieldType = *details.Items.Ref
+			} else if details.Items.Type != nil {
+				fieldType = *details.Items.Type
+			} else {
+				return fmt.Errorf("array type of %q undefined in schema", fieldType)
+			}
+		}
+
+		if err := swaggerWalk(api, fieldType, seen, visitor); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var podSpecCache = map[string]bool{}
+
+func containsPodSpec(disco discovery.SwaggerSchemaInterface, gvk schema.GroupVersionKind) bool {
+	if result, ok := podSpecCache[gvk.String()]; ok {
+		return result
+	}
+
+	swagger, err := disco.SwaggerSchema(gvk.GroupVersion())
+	if err != nil {
+		// Indeterminate result.
+		log.Debugf("Unable to fetch schema for %s (%v), assuming not a PodSpec", gvk, err)
+		return false
+	}
+
+	foundErr := errors.New("Found") // not really an error ...
+	visitor := func(typeName string) error {
+		if typeName == "v1.PodSpec" {
+			return foundErr
+		}
+		return nil
+	}
+
+	var result bool
+
+	typeName := fmt.Sprintf("%s.%s", gvk.Version, gvk.Kind)
+	err = swaggerWalk(swagger, typeName, sets.NewString(), visitor)
+	switch err {
+	case nil:
+		result = false
+	case foundErr:
+		result = true
+	default:
+		// Indeterminate result, but repeatable so may as well cache it
+		log.Debugf("Error walking swagger schema for %q: %v", typeName, err)
+		result = false
+	}
+
+	podSpecCache[gvk.String()] = result
+	return result
 }
 
 // Arbitrary numbers used to do a simple topological sort of resources.
-// TODO: expand this list.
-func depTier(o schema.ObjectKind) int {
-	gk := o.GroupVersionKind().GroupKind()
-	if gk == gkNamespace || gk == gkTpr || gk == gkStorageClass {
-		return 10
-	} else if isPodOrSimilar(gk) {
-		return 100
-	} else {
-		return 50
+func depTier(disco ServerResourcesSwaggerSchema, o schema.ObjectKind) (int, error) {
+	gvk := o.GroupVersionKind()
+	if gk := gvk.GroupKind(); gk == gkTpr || gk == gkCrd {
+		// Special case: these create other types
+		return 10, nil
 	}
+
+	rsrc, err := serverResourceForGroupVersionKind(disco, gvk)
+	if err != nil {
+		log.Debugf("unable to fetch resource for %s (%v), continuing", gvk, err)
+		return 50, nil
+	}
+
+	if !rsrc.Namespaced {
+		// Place global before namespaced
+		return 20, nil
+	} else if containsPodSpec(disco, gvk) {
+		// (Potentially) starts a pod, so place last
+		return 100, nil
+	} else {
+		// Everything else
+		return 50, nil
+	}
+}
+
+// A subset of discovery.DiscoveryInterface
+type ServerResourcesSwaggerSchema interface {
+	discovery.ServerResourcesInterface
+	discovery.SwaggerSchemaInterface
 }
 
 // DependencyOrder is a `sort.Interface` that *best-effort* sorts the
 // objects so that known dependencies appear earlier in the list.  The
 // idea is to prevent *some* of the "crash-restart" loops when
 // creating inter-dependent resources.
-type DependencyOrder []*unstructured.Unstructured
+func DependencyOrder(disco ServerResourcesSwaggerSchema, list []*unstructured.Unstructured) (sort.Interface, error) {
+	sortKeys := make([]int, len(list))
+	for i, item := range list {
+		var err error
+		sortKeys[i], err = depTier(disco, item.GetObjectKind())
+		if err != nil {
+			return nil, err
+		}
+	}
+	log.Debugf("sortKeys is %v", sortKeys)
+	return &mappedSort{sortKeys: sortKeys, items: list}, nil
+}
 
-func (l DependencyOrder) Len() int      { return len(l) }
-func (l DependencyOrder) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
-func (l DependencyOrder) Less(i, j int) bool {
-	return depTier(l[i].GetObjectKind()) < depTier(l[j].GetObjectKind())
+type mappedSort struct {
+	sortKeys []int
+	items    []*unstructured.Unstructured
+}
+
+func (l *mappedSort) Len() int { return len(l.items) }
+func (l *mappedSort) Swap(i, j int) {
+	l.sortKeys[i], l.sortKeys[j] = l.sortKeys[j], l.sortKeys[i]
+	l.items[i], l.items[j] = l.items[j], l.items[i]
+}
+func (l *mappedSort) Less(i, j int) bool {
+	if l.sortKeys[i] != l.sortKeys[j] {
+		return l.sortKeys[i] < l.sortKeys[j]
+	}
+	// Fall back to alpha sort, to give persistent order
+	return AlphabeticalOrder(l.items).Less(i, j)
 }
 
 // AlphabeticalOrder is a `sort.Interface` that sorts the

--- a/vendor/github.com/ksonnet/kubecfg/utils/sort_test.go
+++ b/vendor/github.com/ksonnet/kubecfg/utils/sort_test.go
@@ -16,16 +16,105 @@
 package utils
 
 import (
+	"fmt"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
 
+	"github.com/emicklei/go-restful-swagger12"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	ktesting "k8s.io/client-go/testing"
 )
 
-var _ sort.Interface = DependencyOrder{}
+type FakeDiscovery struct {
+	Fake     *ktesting.Fake
+	delegate discovery.SwaggerSchemaInterface
+}
+
+func NewFakeDiscovery(delegate discovery.SwaggerSchemaInterface) *FakeDiscovery {
+	fakePtr := &ktesting.Fake{}
+	return &FakeDiscovery{
+		Fake:     fakePtr,
+		delegate: delegate,
+	}
+}
+
+var _ discovery.ServerResourcesInterface = &FakeDiscovery{}
+
+func (c *FakeDiscovery) ServerResourcesForGroupVersion(gv string) (*metav1.APIResourceList, error) {
+	parsedGv, err := schema.ParseGroupVersion(gv)
+	if err != nil {
+		return nil, err
+	}
+	action := ktesting.ActionImpl{}
+	action.Verb = "get"
+	action.Resource = parsedGv.WithResource("apiresources")
+	c.Fake.Invokes(action, nil)
+
+	var rsrcs []metav1.APIResource
+	switch gv {
+	case "v1":
+		rsrcs = []metav1.APIResource{
+			{
+				Name:       "configmaps",
+				Kind:       "ConfigMap",
+				Namespaced: true,
+			},
+			{
+				Name:       "namespaces",
+				Kind:       "Namespace",
+				Namespaced: false,
+			},
+			{
+				Name:       "replicationcontrollers",
+				Kind:       "ReplicationController",
+				Namespaced: true,
+			},
+		}
+	default:
+		return nil, fmt.Errorf("gv %v not found in test implementation", gv)
+	}
+	rsrc := metav1.APIResourceList{
+		GroupVersion: gv,
+		APIResources: rsrcs,
+	}
+	return &rsrc, nil
+}
+
+func (c *FakeDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
+	panic("unimplemented")
+}
+
+func (c *FakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	panic("unimplemented")
+}
+
+func (c *FakeDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	panic("unimplemented")
+}
+
+var _ discovery.SwaggerSchemaInterface = &FakeDiscovery{}
+
+func (c *FakeDiscovery) SwaggerSchema(gv schema.GroupVersion) (*swagger.ApiDeclaration, error) {
+	log.Debugf("SwaggerSchema(%v) called", gv)
+	action := ktesting.ActionImpl{}
+	action.Verb = "get"
+	action.Resource = gv.WithResource("schema")
+	c.Fake.Invokes(action, nil)
+
+	return c.delegate.SwaggerSchema(gv)
+}
 
 func TestDepSort(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+
+	disco := NewFakeDiscovery(schemaFromFile{dir: filepath.FromSlash("../testdata")})
+
 	newObj := func(apiVersion, kind string) *unstructured.Unstructured {
 		return &unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -36,19 +125,31 @@ func TestDepSort(t *testing.T) {
 	}
 
 	objs := []*unstructured.Unstructured{
-		newObj("extensions/v1beta1", "Deployment"),
+		newObj("v1", "ReplicationController"),
 		newObj("v1", "ConfigMap"),
 		newObj("v1", "Namespace"),
-		newObj("v1", "Service"),
+		newObj("bogus/v1", "UnknownKind"),
+		newObj("apiextensions/v1beta1", "CustomResourceDefinition"),
 	}
 
-	sort.Sort(DependencyOrder(objs))
-
-	if objs[0].GetKind() != "Namespace" {
-		t.Error("Namespace should be sorted first")
+	sorter, err := DependencyOrder(disco, objs)
+	if err != nil {
+		t.Fatalf("DependencyOrder error: %v", err)
 	}
-	if objs[3].GetKind() != "Deployment" {
-		t.Error("Deployment should be sorted after other objects")
+	sort.Sort(sorter)
+
+	for i, o := range objs {
+		t.Logf("obj[%d] after sort is %v", i, o.GroupVersionKind())
+	}
+
+	if objs[0].GetKind() != "CustomResourceDefinition" {
+		t.Error("CRD should be sorted first")
+	}
+	if objs[1].GetKind() != "Namespace" {
+		t.Error("Namespace should be sorted second")
+	}
+	if objs[4].GetKind() != "ReplicationController" {
+		t.Error("RC should be sorted after other objects")
 	}
 }
 

--- a/vendor/gopkg.in/yaml.v2/.travis.yml
+++ b/vendor/gopkg.in/yaml.v2/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+    - 1.4
+    - 1.5
+    - 1.6
+    - tip
+
+go_import_path: gopkg.in/yaml.v2

--- a/vendor/gopkg.in/yaml.v2/LICENSE
+++ b/vendor/gopkg.in/yaml.v2/LICENSE
@@ -1,188 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2011-2014 - Canonical Inc.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-This software is licensed under the LGPLv3, included below.
+   1. Definitions.
 
-As a special exception to the GNU Lesser General Public License version 3
-("LGPL3"), the copyright holders of this Library give you permission to
-convey to a third party a Combined Work that links statically or dynamically
-to this Library without providing any Minimal Corresponding Source or
-Minimal Application Code as set out in 4d or providing the installation
-information set out in section 4e, provided that you comply with the other
-provisions of LGPL3 and provided that you meet, for the Application the
-terms and conditions of the license(s) which apply to the Application.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-Except as stated in this special exception, the provisions of LGPL3 will
-continue to comply in full to this Library. If you modify this Library, you
-may apply this exception to your version of this Library, but you are not
-obliged to do so. If you do not wish to do so, delete this exception
-statement from your version. This exception does not (and cannot) modify any
-license terms which apply to the Application, with which you must still
-comply.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-  0. Additional Definitions.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-  1. Exception to Section 3 of the GNU GPL.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-  2. Conveying Modified Versions.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-  3. Object Code Incorporating Material from Library Header Files.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
+   END OF TERMS AND CONDITIONS
 
-  4. Combined Works.
+   APPENDIX: How to apply the Apache License to your work.
 
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
+   Copyright {yyyy} {name of copyright owner}
 
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/gopkg.in/yaml.v2/README.md
+++ b/vendor/gopkg.in/yaml.v2/README.md
@@ -42,11 +42,13 @@ The package API for yaml v2 will remain stable as described in [gopkg.in](https:
 License
 -------
 
-The yaml package is licensed under the LGPL with an exception that allows it to be linked statically. Please see the LICENSE file for details.
+The yaml package is licensed under the Apache License 2.0. Please see the LICENSE file for details.
 
 
 Example
 -------
+
+Some more examples can be found in the "examples" folder.
 
 ```Go
 package main

--- a/vendor/gopkg.in/yaml.v2/decode.go
+++ b/vendor/gopkg.in/yaml.v2/decode.go
@@ -120,7 +120,6 @@ func (p *parser) parse() *node {
 	default:
 		panic("attempted to parse unknown event: " + strconv.Itoa(int(p.event.typ)))
 	}
-	panic("unreachable")
 }
 
 func (p *parser) node(kind int) *node {
@@ -191,6 +190,7 @@ type decoder struct {
 	aliases map[string]bool
 	mapType reflect.Type
 	terrors []string
+	strict  bool
 }
 
 var (
@@ -200,8 +200,8 @@ var (
 	ifaceType      = defaultMapType.Elem()
 )
 
-func newDecoder() *decoder {
-	d := &decoder{mapType: defaultMapType}
+func newDecoder(strict bool) *decoder {
+	d := &decoder{mapType: defaultMapType, strict: strict}
 	d.aliases = make(map[string]bool)
 	return d
 }
@@ -251,7 +251,7 @@ func (d *decoder) callUnmarshaler(n *node, u Unmarshaler) (good bool) {
 //
 // If n holds a null value, prepare returns before doing anything.
 func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
-	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "") {
+	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "~" || n.value == "" && n.implicit) {
 		return out, false, false
 	}
 	again := true
@@ -640,6 +640,8 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 			value := reflect.New(elemType).Elem()
 			d.unmarshal(n.children[i+1], value)
 			inlineMap.SetMapIndex(name, value)
+		} else if d.strict {
+			d.terrors = append(d.terrors, fmt.Sprintf("line %d: field %s not found in struct %s", ni.line+1, name.String(), out.Type()))
 		}
 	}
 	return true

--- a/vendor/gopkg.in/yaml.v2/decode_test.go
+++ b/vendor/gopkg.in/yaml.v2/decode_test.go
@@ -405,6 +405,12 @@ var unmarshalTests = []struct {
 		map[string]interface{}{"v": 1},
 	},
 
+	// Non-specific tag (Issue #75)
+	{
+		"v: ! test",
+		map[string]interface{}{"v": "test"},
+	},
+
 	// Anchors and aliases.
 	{
 		"a: &x 1\nb: &y 2\nc: *x\nd: *y\n",
@@ -434,9 +440,24 @@ var unmarshalTests = []struct {
 		map[string]*string{"foo": new(string)},
 	}, {
 		"foo: null",
+		map[string]*string{"foo": nil},
+	}, {
+		"foo: null",
 		map[string]string{"foo": ""},
 	}, {
 		"foo: null",
+		map[string]interface{}{"foo": nil},
+	},
+
+	// Support for ~
+	{
+		"foo: ~",
+		map[string]*string{"foo": nil},
+	}, {
+		"foo: ~",
+		map[string]string{"foo": ""},
+	}, {
+		"foo: ~",
 		map[string]interface{}{"foo": nil},
 	},
 
@@ -551,13 +572,44 @@ var unmarshalTests = []struct {
 	},
 	{
 		"a: 2015-02-24T18:19:39Z\n",
-		map[string]time.Time{"a": time.Unix(1424801979, 0)},
+		map[string]time.Time{"a": time.Unix(1424801979, 0).In(time.UTC)},
 	},
 
 	// Encode empty lists as zero-length slices.
 	{
 		"a: []",
 		&struct{ A []int }{[]int{}},
+	},
+
+	// UTF-16-LE
+	{
+		"\xff\xfe\xf1\x00o\x00\xf1\x00o\x00:\x00 \x00v\x00e\x00r\x00y\x00 \x00y\x00e\x00s\x00\n\x00",
+		M{"ñoño": "very yes"},
+	},
+	// UTF-16-LE with surrogate.
+	{
+		"\xff\xfe\xf1\x00o\x00\xf1\x00o\x00:\x00 \x00v\x00e\x00r\x00y\x00 \x00y\x00e\x00s\x00 \x00=\xd8\xd4\xdf\n\x00",
+		M{"ñoño": "very yes 🟔"},
+	},
+
+	// UTF-16-BE
+	{
+		"\xfe\xff\x00\xf1\x00o\x00\xf1\x00o\x00:\x00 \x00v\x00e\x00r\x00y\x00 \x00y\x00e\x00s\x00\n",
+		M{"ñoño": "very yes"},
+	},
+	// UTF-16-BE with surrogate.
+	{
+		"\xfe\xff\x00\xf1\x00o\x00\xf1\x00o\x00:\x00 \x00v\x00e\x00r\x00y\x00 \x00y\x00e\x00s\x00 \xd8=\xdf\xd4\x00\n",
+		M{"ñoño": "very yes 🟔"},
+	},
+
+	// YAML Float regex shouldn't match this
+	{
+		"a: 123456e1\n",
+		M{"a": "123456e1"},
+	}, {
+		"a: 123456E1\n",
+		M{"a": "123456E1"},
 	},
 }
 
@@ -573,7 +625,8 @@ type inlineC struct {
 }
 
 func (s *S) TestUnmarshal(c *C) {
-	for _, item := range unmarshalTests {
+	for i, item := range unmarshalTests {
+		c.Logf("test %d: %q", i, item.data)
 		t := reflect.ValueOf(item.value).Type()
 		var value interface{}
 		switch t.Kind() {
@@ -617,6 +670,7 @@ var unmarshalErrorTests = []struct {
 	{"a: !!binary ==", "yaml: !!binary value contains invalid base64 data"},
 	{"{[.]}", `yaml: invalid map key: \[\]interface \{\}\{"\."\}`},
 	{"{{.}}", `yaml: invalid map key: map\[interface\ \{\}\]interface \{\}\{".":interface \{\}\(nil\)\}`},
+	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
 }
 
 func (s *S) TestUnmarshalErrors(c *C) {
@@ -638,6 +692,7 @@ var unmarshalerTests = []struct {
 	{`_: BAR!`, "!!str", "BAR!"},
 	{`_: "BAR!"`, "!!str", "BAR!"},
 	{"_: !!foo 'BAR!'", "!!foo", "BAR!"},
+	{`_: ""`, "!!str", ""},
 }
 
 var unmarshalerResult = map[int]error{}
@@ -934,6 +989,17 @@ func (s *S) TestUnmarshalSliceOnPreset(c *C) {
 	v := struct{ A []int }{[]int{1}}
 	yaml.Unmarshal([]byte("a: [2]"), &v)
 	c.Assert(v.A, DeepEquals, []int{2})
+}
+
+func (s *S) TestUnmarshalStrict(c *C) {
+	v := struct{ A, B int }{}
+
+	err := yaml.UnmarshalStrict([]byte("a: 1\nb: 2"), &v)
+	c.Check(err, IsNil)
+	err = yaml.Unmarshal([]byte("a: 1\nb: 2\nc: 3"), &v)
+	c.Check(err, IsNil)
+	err = yaml.UnmarshalStrict([]byte("a: 1\nb: 2\nc: 3"), &v)
+	c.Check(err, ErrorMatches, "yaml: unmarshal errors:\n  line 3: field c not found in struct struct { A int; B int }")
 }
 
 //var data []byte

--- a/vendor/gopkg.in/yaml.v2/emitterc.go
+++ b/vendor/gopkg.in/yaml.v2/emitterc.go
@@ -666,7 +666,6 @@ func yaml_emitter_emit_node(emitter *yaml_emitter_t, event *yaml_event_t,
 		return yaml_emitter_set_emitter_error(emitter,
 			"expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS")
 	}
-	return false
 }
 
 // Expect ALIAS.
@@ -995,7 +994,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		break_space    = false
 		space_break    = false
 
-		preceeded_by_whitespace = false
+		preceded_by_whitespace = false
 		followed_by_whitespace  = false
 		previous_space          = false
 		previous_break          = false
@@ -1017,7 +1016,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		flow_indicators = true
 	}
 
-	preceeded_by_whitespace = true
+	preceded_by_whitespace = true
 	for i, w := 0, 0; i < len(value); i += w {
 		w = width(value[i])
 		followed_by_whitespace = i+w >= len(value) || is_blank(value, i+w)
@@ -1048,7 +1047,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 					block_indicators = true
 				}
 			case '#':
-				if preceeded_by_whitespace {
+				if preceded_by_whitespace {
 					flow_indicators = true
 					block_indicators = true
 				}
@@ -1089,7 +1088,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		}
 
 		// [Go]: Why 'z'? Couldn't be the end of the string as that's the loop condition.
-		preceeded_by_whitespace = is_blankz(value, i)
+		preceded_by_whitespace = is_blankz(value, i)
 	}
 
 	emitter.scalar_data.multiline = line_breaks

--- a/vendor/gopkg.in/yaml.v2/example_embedded_test.go
+++ b/vendor/gopkg.in/yaml.v2/example_embedded_test.go
@@ -1,0 +1,41 @@
+package yaml_test
+
+import (
+	"fmt"
+	"log"
+
+        "gopkg.in/yaml.v2"
+)
+
+// An example showing how to unmarshal embedded
+// structs from YAML.
+
+type StructA struct {
+	A string `yaml:"a"`
+}
+
+type StructB struct {
+	// Embedded structs are not treated as embedded in YAML by default. To do that,
+	// add the ",inline" annotation below
+	StructA   `yaml:",inline"`
+	B string `yaml:"b"`
+}
+
+var data = `
+a: a string from struct A
+b: a string from struct B
+`
+
+func ExampleUnmarshal_embedded() {
+	var b StructB
+
+	err := yaml.Unmarshal([]byte(data), &b)
+	if err != nil {
+		log.Fatal("cannot unmarshal data: %v", err)
+	}
+        fmt.Println(b.A)
+        fmt.Println(b.B)
+        // Output:
+        // a string from struct A
+        // a string from struct B
+}

--- a/vendor/gopkg.in/yaml.v2/parserc.go
+++ b/vendor/gopkg.in/yaml.v2/parserc.go
@@ -166,7 +166,6 @@ func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool 
 	default:
 		panic("invalid parser state")
 	}
-	return false
 }
 
 // Parse the production:

--- a/vendor/gopkg.in/yaml.v2/readerc.go
+++ b/vendor/gopkg.in/yaml.v2/readerc.go
@@ -247,7 +247,7 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 				if parser.encoding == yaml_UTF16LE_ENCODING {
 					low, high = 0, 1
 				} else {
-					high, low = 1, 0
+					low, high = 1, 0
 				}
 
 				// The UTF-16 encoding is not as simple as one might
@@ -357,23 +357,26 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 			if value <= 0x7F {
 				// 0000 0000-0000 007F . 0xxxxxxx
 				parser.buffer[buffer_len+0] = byte(value)
+				buffer_len += 1
 			} else if value <= 0x7FF {
 				// 0000 0080-0000 07FF . 110xxxxx 10xxxxxx
 				parser.buffer[buffer_len+0] = byte(0xC0 + (value >> 6))
 				parser.buffer[buffer_len+1] = byte(0x80 + (value & 0x3F))
+				buffer_len += 2
 			} else if value <= 0xFFFF {
 				// 0000 0800-0000 FFFF . 1110xxxx 10xxxxxx 10xxxxxx
 				parser.buffer[buffer_len+0] = byte(0xE0 + (value >> 12))
 				parser.buffer[buffer_len+1] = byte(0x80 + ((value >> 6) & 0x3F))
 				parser.buffer[buffer_len+2] = byte(0x80 + (value & 0x3F))
+				buffer_len += 3
 			} else {
 				// 0001 0000-0010 FFFF . 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
 				parser.buffer[buffer_len+0] = byte(0xF0 + (value >> 18))
 				parser.buffer[buffer_len+1] = byte(0x80 + ((value >> 12) & 0x3F))
 				parser.buffer[buffer_len+2] = byte(0x80 + ((value >> 6) & 0x3F))
 				parser.buffer[buffer_len+3] = byte(0x80 + (value & 0x3F))
+				buffer_len += 4
 			}
-			buffer_len += width
 
 			parser.unread++
 		}

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -3,6 +3,7 @@ package yaml
 import (
 	"encoding/base64"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -80,6 +81,8 @@ func resolvableTag(tag string) bool {
 	return false
 }
 
+var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
+
 func resolve(tag string, in string) (rtag string, out interface{}) {
 	if !resolvableTag(tag) {
 		return tag, in
@@ -135,9 +138,11 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 			if err == nil {
 				return yaml_INT_TAG, uintv
 			}
-			floatv, err := strconv.ParseFloat(plain, 64)
-			if err == nil {
-				return yaml_FLOAT_TAG, floatv
+			if yamlStyleFloat.MatchString(plain) {
+				floatv, err := strconv.ParseFloat(plain, 64)
+				if err == nil {
+					return yaml_FLOAT_TAG, floatv
+				}
 			}
 			if strings.HasPrefix(plain, "0b") {
 				intv, err := strconv.ParseInt(plain[2:], 2, 64)

--- a/vendor/gopkg.in/yaml.v2/scannerc.go
+++ b/vendor/gopkg.in/yaml.v2/scannerc.go
@@ -9,7 +9,7 @@ import (
 // ************
 //
 // The following notes assume that you are familiar with the YAML specification
-// (http://yaml.org/spec/cvs/current.html).  We mostly follow it, although in
+// (http://yaml.org/spec/1.2/spec.html).  We mostly follow it, although in
 // some cases we are less restrictive that it requires.
 //
 // The process of transforming a YAML stream into a sequence of events is
@@ -611,7 +611,7 @@ func yaml_parser_set_scanner_tag_error(parser *yaml_parser_t, directive bool, co
 	if directive {
 		context = "while parsing a %TAG directive"
 	}
-	return yaml_parser_set_scanner_error(parser, context, context_mark, "did not find URI escaped octet")
+	return yaml_parser_set_scanner_error(parser, context, context_mark, problem)
 }
 
 func trace(args ...interface{}) func() {
@@ -1546,7 +1546,7 @@ func yaml_parser_scan_directive(parser *yaml_parser_t, token *yaml_token_t) bool
 		// Unknown directive.
 	} else {
 		yaml_parser_set_scanner_error(parser, "while scanning a directive",
-			start_mark, "found uknown directive name")
+			start_mark, "found unknown directive name")
 		return false
 	}
 
@@ -1944,7 +1944,7 @@ func yaml_parser_scan_tag_handle(parser *yaml_parser_t, directive bool, start_ma
 	} else {
 		// It's either the '!' tag or not really a tag handle.  If it's a %TAG
 		// directive, it's an error.  If it's a tag token, it must be a part of URI.
-		if directive && !(s[0] == '!' && s[1] == 0) {
+		if directive && string(s) != "!" {
 			yaml_parser_set_scanner_tag_error(parser, directive,
 				start_mark, "did not find expected '!'")
 			return false
@@ -1959,6 +1959,7 @@ func yaml_parser_scan_tag_handle(parser *yaml_parser_t, directive bool, start_ma
 func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte, start_mark yaml_mark_t, uri *[]byte) bool {
 	//size_t length = head ? strlen((char *)head) : 0
 	var s []byte
+	hasTag := len(head) > 0
 
 	// Copy the head if needed.
 	//
@@ -2000,10 +2001,10 @@ func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte
 		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 			return false
 		}
+		hasTag = true
 	}
 
-	// Check if the tag is non-empty.
-	if len(s) == 0 {
+	if !hasTag {
 		yaml_parser_set_scanner_tag_error(parser, directive,
 			start_mark, "did not find expected tag URI")
 		return false

--- a/vendor/gopkg.in/yaml.v2/yaml.go
+++ b/vendor/gopkg.in/yaml.v2/yaml.go
@@ -77,8 +77,19 @@ type Marshaler interface {
 // supported tag options.
 //
 func Unmarshal(in []byte, out interface{}) (err error) {
+	return unmarshal(in, out, false)
+}
+
+// UnmarshalStrict is like Unmarshal except that any fields that are found
+// in the data that do not have corresponding struct members will result in
+// an error.
+func UnmarshalStrict(in []byte, out interface{}) (err error) {
+	return unmarshal(in, out, true)
+}
+
+func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 	defer handleErr(&err)
-	d := newDecoder()
+	d := newDecoder(strict)
 	p := newParser(in)
 	defer p.destroy()
 	node := p.parse()
@@ -129,7 +140,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 // For example:
 //
 //     type T struct {
-//         F int "a,omitempty"
+//         F int `yaml:"a,omitempty"`
 //         B int
 //     }
 //     yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
@@ -222,7 +233,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 	inlineMap := -1
 	for i := 0; i != n; i++ {
 		field := st.Field(i)
-		if field.PkgPath != "" {
+		if field.PkgPath != "" && !field.Anonymous {
 			continue // Private field
 		}
 

--- a/vendor/gopkg.in/yaml.v2/yamlh.go
+++ b/vendor/gopkg.in/yaml.v2/yamlh.go
@@ -508,7 +508,7 @@ type yaml_parser_t struct {
 
 	problem string // Error description.
 
-	// The byte about which the problem occured.
+	// The byte about which the problem occurred.
 	problem_offset int
 	problem_value  int
 	problem_mark   yaml_mark_t


### PR DESCRIPTION
Kubecfg contains an improvement to the sort utility which, in
particular, ensures CustomResourceDefinitions are created before CRD
resources themselves. This is required for the upcoming AppRepository
stuff (improving the chart repo syncing).

I've updated Kubecfg to the latest commit as not much else has changed
since the sort improvement and latest.

This also contains glide updates to the YAML packages, let me know if
you'd like me to undo those.