### PR TITLE
disable use of cgo only for the ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 env:
   global:
   - VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID}
+  - CGO_ENABLED=0
 
 install:
 - |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ IMPORT_PATH:= github.com/kubeapps/kubeapps
 GO = /usr/bin/env go
 GOFMT = /usr/bin/env gofmt
 VERSION ?= dev-$(shell date +%FT%H-%M-%S-%Z)
-CGO_ENABLED ?= 1
 
 BINARY ?= kubeapps
 GO_PACKAGES = ./...
@@ -13,7 +12,7 @@ EMBEDDED_STATIC = generated/statik/statik.go
 default: kubeapps
 
 kubeapps: $(EMBEDDED_STATIC)
-	CGO_ENABLED=$(CGO_ENABLED) $(GO) build -i -o $(BINARY) $(GO_FLAGS) $(IMPORT_PATH)
+	$(GO) build -i -o $(BINARY) $(GO_FLAGS) $(IMPORT_PATH)
 
 test: $(EMBEDDED_STATIC)
 	$(GO) test $(GO_PACKAGES)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ IMPORT_PATH:= github.com/kubeapps/kubeapps
 GO = /usr/bin/env go
 GOFMT = /usr/bin/env gofmt
 VERSION ?= dev-$(shell date +%FT%H-%M-%S-%Z)
+CGO_ENABLED ?= 1
 
 BINARY ?= kubeapps
 GO_PACKAGES = ./...
@@ -12,7 +13,7 @@ EMBEDDED_STATIC = generated/statik/statik.go
 default: kubeapps
 
 kubeapps: $(EMBEDDED_STATIC)
-	CGO_ENABLED=0 $(GO) build -i -o $(BINARY) $(GO_FLAGS) $(IMPORT_PATH)
+	CGO_ENABLED=$(CGO_ENABLED) $(GO) build -i -o $(BINARY) $(GO_FLAGS) $(IMPORT_PATH)
 
 test: $(EMBEDDED_STATIC)
 	$(GO) test $(GO_PACKAGES)


### PR DESCRIPTION
If you set `CGO_ENABLED=0`, the go tool has to rebuild all the standard lib packages at `$GOROOT`. 
`GOROOT` may be a system path on the developer host and thus would require dev's to execute `make` as a
privileged user.

This PR re-enables the use of cgo by default, while disabling it in CI builds