### PR TITLE
Fix installation script for OS X in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The simplest way to try Kubeapps is to deploy it with the Kubeapps Installer on 
 
 ```
 curl -s https://api.github.com/repos/kubeapps/kubeapps/releases/latest | grep -i $(uname -s) | grep browser_download_url | cut -d '"' -f 4 | wget -i -
-sudo mv kubeapps-linux-amd64 /usr/local/bin/kubeapps
+sudo mv kubeapps-$(uname -s| tr '[:upper:]' '[:lower:]')-amd64 /usr/local/bin/kubeapps
 sudo chmod +x /usr/local/bin/kubeapps
 kubeapps up
 kubeapps dashboard

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ For example, to install the latest binary release on Linux or OS X, use this com
 
 ```
 curl -s https://api.github.com/repos/kubeapps/kubeapps/releases/latest | grep -i $(uname -s) | grep browser_download_url | cut -d '"' -f 4 | wget -i -
-sudo mv kubeapps-linux-amd64 /usr/local/bin/kubeapps
+sudo mv kubeapps-$(uname -s| tr '[:upper:]' '[:lower:]')-amd64 /usr/local/bin/kubeapps
 sudo chmod +x /usr/local/bin/kubeapps
 ```
 


### PR DESCRIPTION
Installation scripts does not work on OS X as `linux` is hardcoded in the filename for (OS aware) downloaded release `kubeapps-linux-amd64`

Both readme and install guide has been updated to select the respective os when moving the file.