### PR TITLE
fix sealed-secrets check on kubeapps up

### DIFF
--- a/cmd/kubeapps/up.go
+++ b/cmd/kubeapps/up.go
@@ -316,6 +316,9 @@ func ssecretsExists(c kubecfg.UpdateCmd) (bool, error) {
 		return false, err
 	}
 	ssc, err := rc.Get("sealed-secrets-controller", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
 	return ssc.GetLabels()["created-by"] != "kubeapps", nil
 }
 


### PR DESCRIPTION
kubeapps was not checking for the case where the sealed-secrets
deployment didn't exist, and was incorectly reporting that it did and
wasn't installed by kubeapps