### PR TITLE
add support for upgrading helm releases

### DIFF
--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -135,12 +135,17 @@ export function deployChart(
   releaseName: string,
   namespace: string,
   values?: string,
+  resourceVersion?: string,
 ) {
   return (dispatch: Dispatch<IStoreState>): Promise<{}> => {
     const chartAttrs = chartVersion.relationships.chart.data;
-    return fetch(url.api.helmreleases.create(namespace), {
+    const method = resourceVersion ? "PUT" : "POST";
+    const endpoint = resourceVersion
+      ? url.api.helmreleases.upgrade(namespace, releaseName)
+      : url.api.helmreleases.create(namespace);
+    return fetch(endpoint, {
       headers: { "Content-Type": "application/json" },
-      method: "POST",
+      method,
 
       body: JSON.stringify({
         apiVersion: "helm.bitnami.com/v1",
@@ -150,6 +155,7 @@ export function deployChart(
             "apprepositories.kubeapps.com/repo-name": chartAttrs.repo.name,
           },
           name: releaseName,
+          resourceVersion,
         },
         spec: {
           chartName: chartAttrs.name,

--- a/dashboard/src/components/AppEdit/AppEdit.tsx
+++ b/dashboard/src/components/AppEdit/AppEdit.tsx
@@ -12,6 +12,7 @@ interface IAppEditProps {
   namespace: string;
   releaseName: string;
   selected: IChartState["selected"];
+  version: string;
   deployChart: (
     version: IChartVersion,
     releaseName: string,
@@ -47,7 +48,7 @@ class AppEdit extends React.Component<IAppEditProps> {
           {...this.props}
           hr={app.hr}
           chartID={app.chart.id}
-          chartVersion={app.hr.spec.version}
+          chartVersion={this.props.version ? this.props.version : app.hr.spec.version}
         />
       </div>
     );

--- a/dashboard/src/components/AppEdit/AppEdit.tsx
+++ b/dashboard/src/components/AppEdit/AppEdit.tsx
@@ -12,7 +12,6 @@ interface IAppEditProps {
   namespace: string;
   releaseName: string;
   selected: IChartState["selected"];
-  version: string;
   deployChart: (
     version: IChartVersion,
     releaseName: string,
@@ -48,7 +47,7 @@ class AppEdit extends React.Component<IAppEditProps> {
           {...this.props}
           hr={app.hr}
           chartID={app.chart.id}
-          chartVersion={this.props.version ? this.props.version : app.hr.spec.version}
+          chartVersion={app.hr.spec.version}
         />
       </div>
     );

--- a/dashboard/src/components/AppEdit/AppEdit.tsx
+++ b/dashboard/src/components/AppEdit/AppEdit.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+
+import { RouterAction } from "react-router-redux";
+import { IServiceBinding } from "../../shared/ServiceBinding";
+import { IApp, IChartState, IChartVersion } from "../../shared/types";
+
+import DeploymentForm from "../../components/DeploymentForm";
+
+interface IAppEditProps {
+  app: IApp;
+  bindings: IServiceBinding[];
+  namespace: string;
+  releaseName: string;
+  selected: IChartState["selected"];
+  deployChart: (
+    version: IChartVersion,
+    releaseName: string,
+    namespace: string,
+    values?: string,
+    resourceVersion?: string,
+  ) => Promise<{}>;
+  fetchChartVersions: (id: string) => Promise<{}>;
+  getApp: (releaseName: string, namespace: string) => Promise<void>;
+  getBindings: () => Promise<IServiceBinding[]>;
+  getChartVersion: (id: string, chartVersion: string) => Promise<{}>;
+  getChartValues: (id: string, chartVersion: string) => Promise<any>;
+  push: (location: string) => RouterAction;
+  selectChartVersionAndGetFiles: (version: IChartVersion) => Promise<{}>;
+}
+
+class AppEdit extends React.Component<IAppEditProps> {
+  public componentDidMount() {
+    const { releaseName, getApp, namespace } = this.props;
+    getApp(releaseName, namespace);
+  }
+
+  public render() {
+    const { app } = this.props;
+
+    if (!app || !app.hr || !app.chart) {
+      return <div>Loading</div>;
+    }
+
+    return (
+      <div>
+        <DeploymentForm
+          {...this.props}
+          hr={app.hr}
+          chartID={app.chart.id}
+          chartVersion={app.hr.spec.version}
+        />
+      </div>
+    );
+  }
+}
+
+export default AppEdit;

--- a/dashboard/src/components/AppEdit/index.tsx
+++ b/dashboard/src/components/AppEdit/index.tsx
@@ -1,0 +1,3 @@
+import AppEdit from "./AppEdit";
+
+export default AppEdit;

--- a/dashboard/src/components/AppView/AppControls.tsx
+++ b/dashboard/src/components/AppView/AppControls.tsx
@@ -12,20 +12,24 @@ interface IAppControlsProps {
 interface IAppControlsState {
   modalIsOpen: boolean;
   redirectToAppList: boolean;
+  upgrade: boolean;
 }
 
 class AppControls extends React.Component<IAppControlsProps, IAppControlsState> {
   public state: IAppControlsState = {
     modalIsOpen: false,
     redirectToAppList: false,
+    upgrade: false,
   };
 
   public render() {
+    const { name, namespace } = this.props.app.data;
     return (
       <div className="AppControls">
-        <button className="button" disabled={true}>
+        <button className="button" onClick={this.handleUpgradeClick}>
           Upgrade
         </button>
+        {this.state.upgrade && <Redirect to={`/apps/edit/${namespace}/${name}`} />}
         <button className="button button-danger" onClick={this.openModel}>
           Delete
         </button>
@@ -38,6 +42,10 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
       </div>
     );
   }
+
+  public handleUpgradeClick = () => {
+    this.setState({ upgrade: true });
+  };
 
   public openModel = () => {
     this.setState({

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -256,10 +256,14 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
     this.setState({ releaseName: e.currentTarget.value });
   };
   public handleChartVersionChange = (e: React.FormEvent<HTMLSelectElement>) => {
-    const { chartID, getChartVersion, getChartValues } = this.props;
+    const { hr, chartID, getChartVersion, getChartValues } = this.props;
 
-    getChartVersion(chartID, e.currentTarget.value);
-    getChartValues(chartID, e.currentTarget.value);
+    if (hr) {
+      getChartVersion(chartID, e.currentTarget.value);
+      getChartValues(chartID, e.currentTarget.value);
+    } else {
+      this.props.push(`/apps/new/${this.props.chartID}/versions/${e.currentTarget.value}`);
+    }
   };
   public handleNamespaceChange = (e: React.FormEvent<HTMLInputElement>) => {
     this.setState({ namespace: e.currentTarget.value });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -68,10 +68,8 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
 
     if (hr) {
       this.setState({
-        appValues: hr.spec.values,
         namespace: hr.metadata.namespace,
         releaseName: hr.metadata.name,
-        valuesModified: true,
       });
     }
   }
@@ -165,7 +163,6 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
                   onChange={this.handleChartVersionChange}
                   value={this.props.chartVersion}
                   required={true}
-                  disabled={hr ? true : false}
                 >
                   {versions.map(v => (
                     <option key={v.id} value={v.attributes.version}>
@@ -259,7 +256,15 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
     this.setState({ releaseName: e.currentTarget.value });
   };
   public handleChartVersionChange = (e: React.FormEvent<HTMLSelectElement>) => {
-    this.props.push(`/apps/new/${this.props.chartID}/versions/${e.currentTarget.value}`);
+    const { hr } = this.props;
+    let pushUrl;
+    if (hr) {
+      const { releaseName, namespace } = this.state;
+      pushUrl = `/apps/edit/${namespace}/${namespace}-${releaseName}/${e.currentTarget.value}`;
+    } else {
+      pushUrl = `/apps/new/${this.props.chartID}/versions/${e.currentTarget.value}`;
+    }
+    this.props.push(pushUrl);
   };
   public handleNamespaceChange = (e: React.FormEvent<HTMLInputElement>) => {
     this.setState({ namespace: e.currentTarget.value });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -77,7 +77,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   public componentWillReceiveProps(nextProps: IDeploymentFormProps) {
     const { selectChartVersionAndGetFiles, chartVersion } = this.props;
     const { versions } = this.props.selected;
-    const { version, values } = nextProps.selected;
+    const { values } = nextProps.selected;
 
     if (nextProps.chartVersion !== chartVersion) {
       const cv = versions.find(v => v.attributes.version === nextProps.chartVersion);
@@ -86,7 +86,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
       } else {
         throw new Error("could not find chart");
       }
-    } else if (version && values && !this.state.valuesModified) {
+    } else if (values && !this.state.valuesModified) {
       this.setState({ appValues: values });
     }
   }

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -161,7 +161,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
                 <select
                   id="chartVersion"
                   onChange={this.handleChartVersionChange}
-                  value={this.props.chartVersion}
+                  value={version.attributes.version}
                   required={true}
                 >
                   {versions.map(v => (
@@ -256,15 +256,10 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
     this.setState({ releaseName: e.currentTarget.value });
   };
   public handleChartVersionChange = (e: React.FormEvent<HTMLSelectElement>) => {
-    const { hr } = this.props;
-    let pushUrl;
-    if (hr) {
-      const { releaseName, namespace } = this.state;
-      pushUrl = `/apps/edit/${namespace}/${namespace}-${releaseName}/${e.currentTarget.value}`;
-    } else {
-      pushUrl = `/apps/new/${this.props.chartID}/versions/${e.currentTarget.value}`;
-    }
-    this.props.push(pushUrl);
+    const { chartID, getChartVersion, getChartValues } = this.props;
+
+    getChartVersion(chartID, e.currentTarget.value);
+    getChartValues(chartID, e.currentTarget.value);
   };
   public handleNamespaceChange = (e: React.FormEvent<HTMLInputElement>) => {
     this.setState({ namespace: e.currentTarget.value });

--- a/dashboard/src/containers/AppEditContainer/AppEditContainer.tsx
+++ b/dashboard/src/containers/AppEditContainer/AppEditContainer.tsx
@@ -3,15 +3,14 @@ import { push } from "react-router-redux";
 import { Dispatch } from "redux";
 
 import actions from "../../actions";
-import DeploymentForm from "../../components/DeploymentForm";
+import AppEdit from "../../components/AppEdit";
 import { IChartVersion, IStoreState } from "../../shared/types";
 
 interface IRouteProps {
   match: {
     params: {
-      repo: string;
-      id: string;
-      version: string;
+      namespace: string;
+      releaseName: string;
     };
   };
 }
@@ -21,9 +20,10 @@ function mapStateToProps(
   { match: { params } }: IRouteProps,
 ) {
   return {
+    app: apps.selected,
     bindings: catalog.bindings,
-    chartID: `${params.repo}/${params.id}`,
-    chartVersion: params.version,
+    namespace: params.namespace,
+    releaseName: params.releaseName,
     selected: charts.selected,
   };
 }
@@ -41,6 +41,7 @@ function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
         actions.charts.deployChart(version, releaseName, namespace, values, resourceVersion),
       ),
     fetchChartVersions: (id: string) => dispatch(actions.charts.fetchChartVersions(id)),
+    getApp: (r: string, ns: string) => dispatch(actions.apps.getApp(r, ns)),
     getBindings: () => dispatch(actions.catalog.getBindings()),
     getChartValues: (id: string, version: string) =>
       dispatch(actions.charts.getChartValues(id, version)),
@@ -52,4 +53,4 @@ function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DeploymentForm);
+export default connect(mapStateToProps, mapDispatchToProps)(AppEdit);

--- a/dashboard/src/containers/AppEditContainer/AppEditContainer.tsx
+++ b/dashboard/src/containers/AppEditContainer/AppEditContainer.tsx
@@ -11,7 +11,6 @@ interface IRouteProps {
     params: {
       namespace: string;
       releaseName: string;
-      version?: string;
     };
   };
 }
@@ -26,7 +25,6 @@ function mapStateToProps(
     namespace: params.namespace,
     releaseName: params.releaseName,
     selected: charts.selected,
-    version: params.version,
   };
 }
 

--- a/dashboard/src/containers/AppEditContainer/AppEditContainer.tsx
+++ b/dashboard/src/containers/AppEditContainer/AppEditContainer.tsx
@@ -11,6 +11,7 @@ interface IRouteProps {
     params: {
       namespace: string;
       releaseName: string;
+      version?: string;
     };
   };
 }
@@ -25,6 +26,7 @@ function mapStateToProps(
     namespace: params.namespace,
     releaseName: params.releaseName,
     selected: charts.selected,
+    version: params.version,
   };
 }
 

--- a/dashboard/src/containers/AppEditContainer/index.tsx
+++ b/dashboard/src/containers/AppEditContainer/index.tsx
@@ -1,0 +1,3 @@
+import AppEdit from "./AppEditContainer";
+
+export default AppEdit;

--- a/dashboard/src/containers/Root.tsx
+++ b/dashboard/src/containers/Root.tsx
@@ -7,6 +7,7 @@ import { ClassViewContainer } from "./ClassView";
 
 import Layout from "../components/Layout";
 import configureStore from "../store";
+import AppEdit from "./AppEditContainer";
 import AppList from "./AppListContainer";
 import AppNew from "./AppNewContainer";
 import AppView from "./AppViewContainer";
@@ -30,6 +31,7 @@ class Root extends React.Component {
   } = {
     "/": AppList,
     "/apps/:namespace/:releaseName": AppView,
+    "/apps/edit/:namespace/:releaseName": AppEdit,
     "/apps/new/:repo/:id/versions/:version": AppNew,
     "/charts": ChartList,
     "/charts/:repo": ChartList,

--- a/dashboard/src/containers/Root.tsx
+++ b/dashboard/src/containers/Root.tsx
@@ -32,7 +32,6 @@ class Root extends React.Component {
     "/": AppList,
     "/apps/:namespace/:releaseName": AppView,
     "/apps/edit/:namespace/:releaseName": AppEdit,
-    "/apps/edit/:namespace/:releaseName/:version": AppEdit,
     "/apps/new/:repo/:id/versions/:version": AppNew,
     "/charts": ChartList,
     "/charts/:repo": ChartList,

--- a/dashboard/src/containers/Root.tsx
+++ b/dashboard/src/containers/Root.tsx
@@ -32,6 +32,7 @@ class Root extends React.Component {
     "/": AppList,
     "/apps/:namespace/:releaseName": AppView,
     "/apps/edit/:namespace/:releaseName": AppEdit,
+    "/apps/edit/:namespace/:releaseName/:version": AppEdit,
     "/apps/new/:repo/:id/versions/:version": AppNew,
     "/charts": ChartList,
     "/charts/:repo": ChartList,

--- a/dashboard/src/shared/HelmRelease.ts
+++ b/dashboard/src/shared/HelmRelease.ts
@@ -142,7 +142,7 @@ export class HelmRelease {
   private static parseRelease(hr: IHelmRelease, cm: IHelmReleaseConfigMap): IApp {
     const protoBytes = inflate(atob(cm.data.release));
     const rel = hapi.release.Release.decode(protoBytes);
-    const app: IApp = { data: rel, type: "helm" };
+    const app: IApp = { data: rel, type: "helm", hr };
     const repoName = hr.metadata.annotations["apprepositories.kubeapps.com/repo-name"];
     if (repoName) {
       app.repo = {

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -120,6 +120,7 @@ export interface IFunction extends IResource {
 
 export interface IApp {
   chart?: IChart;
+  hr?: IHelmRelease;
   type: string;
   data: hapi.release.Release;
   repo?: IRepo;
@@ -237,9 +238,13 @@ export interface IHelmRelease {
     };
     name: string;
     namespace: string;
+    resourceVersion: string;
   };
   spec: {
+    chartName: string;
     repoUrl: string;
+    values: string;
+    version: string;
   };
 }
 

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -42,6 +42,8 @@ export const api = {
       `/api/kube/api/v1/namespaces/kubeapps/configmaps?labelSelector=NAME in (${releaseNames.join(
         ",",
       )})`,
+    upgrade: (namespace = "default", releaseName: string) =>
+      `/api/kube/apis/helm.bitnami.com/v1/namespaces/${namespace}/helmreleases/${releaseName}`,
   },
   serviceinstances: {
     base: `/api/kube/apis/servicecatalog.k8s.io/v1beta1`,


### PR DESCRIPTION
Implements Helm Release feature

Status:
 - User can deploy changes to an existing release. 
 - The values.yaml file is populated from the existing release, so the user will be presented the values that were used previously
 - Currently I have disabled the version selection which means only changes to values.yaml are possible. I need to figure out how to propogate the chartVersion changes to the Deployment form since this is a property field of the component.
