### PR TITLE
chart-repo: fix bug indexing with missing files

### DIFF
--- a/cmd/chart-repo/chart_repo.go
+++ b/cmd/chart-repo/chart_repo.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var RootCmd = &cobra.Command{
+var rootCmd = &cobra.Command{
 	Use:   "chart-repo",
 	Short: "Kubeapps Chart Repository utility",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -31,7 +31,7 @@ var RootCmd = &cobra.Command{
 }
 
 func main() {
-	cmd := RootCmd
+	cmd := rootCmd
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}
@@ -41,7 +41,7 @@ func init() {
 	cmds := []*cobra.Command{syncCmd, deleteCmd}
 
 	for _, cmd := range cmds {
-		RootCmd.AddCommand(cmd)
+		rootCmd.AddCommand(cmd)
 		cmd.Flags().String("mongo-url", "localhost", "MongoDB URL (see https://godoc.org/labix.org/v2/mgo#Dial for format)")
 		cmd.Flags().String("mongo-database", "charts", "MongoDB database")
 		cmd.Flags().String("mongo-user", "", "MongoDB user")


### PR DESCRIPTION
Previously, when attempting to extract multiple files (README and
values) from the tarball, we were not resetting the file pointer when
reading through the tarball. This meant that only the first file we
searched for would actually be picked up.

This changes the logic to search for all files at the same time when
passing through the tarball, without needing to rewind the file pointer.

fixes #224