### PR TITLE
highlight current release, persist values configuration for current version

### DIFF
--- a/dashboard/src/components/AppEdit/AppEdit.tsx
+++ b/dashboard/src/components/AppEdit/AppEdit.tsx
@@ -25,7 +25,6 @@ interface IAppEditProps {
   getChartVersion: (id: string, chartVersion: string) => Promise<{}>;
   getChartValues: (id: string, chartVersion: string) => Promise<any>;
   push: (location: string) => RouterAction;
-  selectChartVersionAndGetFiles: (version: IChartVersion) => Promise<{}>;
 }
 
 class AppEdit extends React.Component<IAppEditProps> {

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -26,7 +26,6 @@ interface IDeploymentFormProps {
   getBindings: () => Promise<IServiceBinding[]>;
   getChartVersion: (id: string, chartVersion: string) => Promise<{}>;
   getChartValues: (id: string, chartVersion: string) => Promise<any>;
-  selectChartVersionAndGetFiles: (version: IChartVersion) => Promise<{}>;
 }
 
 interface IDeploymentFormState {

--- a/dashboard/src/containers/AppEditContainer/AppEditContainer.tsx
+++ b/dashboard/src/containers/AppEditContainer/AppEditContainer.tsx
@@ -48,8 +48,6 @@ function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
     getChartVersion: (id: string, version: string) =>
       dispatch(actions.charts.getChartVersion(id, version)),
     push: (location: string) => dispatch(push(location)),
-    selectChartVersionAndGetFiles: (version: IChartVersion) =>
-      dispatch(actions.charts.selectChartVersionAndGetFiles(version)),
   };
 }
 

--- a/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -47,8 +47,6 @@ function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
     getChartVersion: (id: string, version: string) =>
       dispatch(actions.charts.getChartVersion(id, version)),
     push: (location: string) => dispatch(push(location)),
-    selectChartVersionAndGetFiles: (version: IChartVersion) =>
-      dispatch(actions.charts.selectChartVersionAndGetFiles(version)),
   };
 }
 


### PR DESCRIPTION
This PR serializes the `getChartVersion` and ``getChartValues` call when the version is changed from the drop down ensuring the value of version is settled before applying the values from the `values.yaml` file.

Additionally, during upgrade of the use selects the currently deployed version from the dropdown, then the value.yaml from the current field is loaded rather than the one from the chart release