### PR TITLE
Fix error message, as RBAC enabled cluster is recommended, but not required

### DIFF
--- a/cmd/kubeapps/down.go
+++ b/cmd/kubeapps/down.go
@@ -52,7 +52,7 @@ var downCmd = &cobra.Command{
 			return fmt.Errorf("can't verify Kubernetes version: %v", err)
 		}
 		if version.Major <= 1 && version.Minor < 8 {
-			return fmt.Errorf("kubernetes with RBAC enabled (v1.8+) is required to run Kubeapps")
+			return fmt.Errorf("kubernetes v1.8+ is required to run Kubeapps")
 		}
 
 		//delete mongodb secret

--- a/cmd/kubeapps/up.go
+++ b/cmd/kubeapps/up.go
@@ -94,7 +94,7 @@ List of components that kubeapps up installs:
 			return fmt.Errorf("can't verify Kubernetes version: %v", err)
 		}
 		if version.Major <= 1 && version.Minor < 8 {
-			return fmt.Errorf("kubernetes with RBAC enabled (v1.8+) is required to run Kubeapps")
+			return fmt.Errorf("kubernetes v1.8+ is required to run Kubeapps")
 		}
 
 		if ssecrets, _ := ssecretsExists(c); ssecrets {


### PR DESCRIPTION
The error message for the wrong version mentioned that RBAC was required, but actually it is not. We had already fixed the docs, but this message needed also fixing