### PR TITLE
chart-repo: strip leading and trailing spaces for the repo URL

### DIFF
--- a/cmd/chart-repo/sync.go
+++ b/cmd/chart-repo/sync.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"os"
-	"strings"
 
 	"github.com/kubeapps/common/datastore"
 	"github.com/sirupsen/logrus"
@@ -61,7 +60,7 @@ var syncCmd = &cobra.Command{
 			logrus.Fatalf("Can't connect to mongoDB: %v", err)
 		}
 
-		if err = syncRepo(dbSession, args[0], strings.TrimSpace(args[1])); err != nil {
+		if err = syncRepo(dbSession, args[0], args[1]); err != nil {
 			logrus.Fatalf("Can't add chart repository to database: %v", err)
 		}
 

--- a/cmd/chart-repo/sync.go
+++ b/cmd/chart-repo/sync.go
@@ -18,14 +18,15 @@ package main
 
 import (
 	"os"
+	"strings"
 
-	"github.com/spf13/cobra"
-	"github.com/sirupsen/logrus"
 	"github.com/kubeapps/common/datastore"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var syncCmd = &cobra.Command{
-	Use: "sync [REPO NAME] [REPO URL]",
+	Use:   "sync [REPO NAME] [REPO URL]",
 	Short: "add a new chart repository, and resync its charts periodically",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 2 {
@@ -60,7 +61,7 @@ var syncCmd = &cobra.Command{
 			logrus.Fatalf("Can't connect to mongoDB: %v", err)
 		}
 
-		if err = syncRepo(dbSession, args[0], args[1]); err != nil {
+		if err = syncRepo(dbSession, args[0], strings.TrimSpace(args[1])); err != nil {
 			logrus.Fatalf("Can't add chart repository to database: %v", err)
 		}
 

--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -68,6 +69,7 @@ var netClient httpClient = &http.Client{
 // imported into the database as fast as possible. E.g. we want all icons for
 // charts before fetching readmes for each chart and version pair.
 func syncRepo(dbSession datastore.Session, repoName, repoURL string) error {
+	repoURL = strings.TrimSpace(repoURL)
 	url, err := url.ParseRequestURI(repoURL)
 	if err != nil {
 		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")

--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -84,7 +84,7 @@ func syncRepo(dbSession datastore.Session, repoName, repoURL string) error {
 		return err
 	}
 
-	charts := chartsFromIndex(index, repo{Name: repoName, URL: strings.TrimSpace(repoURL)})
+	charts := chartsFromIndex(index, repo{Name: repoName, URL: url.String()})
 	err = importCharts(dbSession, charts)
 	if err != nil {
 		return err

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -29,7 +29,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -155,7 +154,7 @@ func Test_fetchRepoIndex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			netClient = &goodHTTPClient{}
-			url, _ := url.ParseRequestURI(strings.TrimSpace(tt.repoURL))
+			url, _ := parseRepoUrl(tt.repoURL)
 			_, err := fetchRepoIndex(url)
 			assert.NoErr(t, err)
 		})
@@ -163,7 +162,7 @@ func Test_fetchRepoIndex(t *testing.T) {
 
 	t.Run("failed request", func(t *testing.T) {
 		netClient = &badHTTPClient{}
-		url, _ := url.ParseRequestURI("https://my.examplerepo.com")
+		url, _ := parseRepoUrl("https://my.examplerepo.com")
 		_, err := fetchRepoIndex(url)
 		assert.ExistsErr(t, err, "failed request")
 	})

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -149,11 +149,13 @@ func Test_fetchRepoIndex(t *testing.T) {
 		{"valid HTTPS URL", "https://my.examplerepo.com"},
 		{"valid trailing URL", "https://my.examplerepo.com/"},
 		{"valid subpath URL", "https://subpath.test/subpath/"},
+		{"valid URL with trailing spaces", "https://subpath.test/subpath/  "},
+		{"valid URL with leading spaces", "  https://subpath.test/subpath/"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			netClient = &goodHTTPClient{}
-			url, _ := url.ParseRequestURI(tt.repoURL)
+			url, _ := url.ParseRequestURI(strings.TrimSpace(tt.repoURL))
 			_, err := fetchRepoIndex(url)
 			assert.NoErr(t, err)
 		})


### PR DESCRIPTION
Repo sync fails of the specified repo URL is sumbitted with
leading/trailing spaces.