### PR TITLE
initial Auth implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /statik
 .GOPATH
 *.*~
+telepresence.log

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -35,9 +35,10 @@ export function deleteApp(releaseName: string, namespace: string) {
 }
 
 export function fetchApps() {
-  return async (dispatch: Dispatch<IStoreState>): Promise<void> => {
+  return async (dispatch: Dispatch<IStoreState>, getState: () => IStoreState): Promise<void> => {
+    const { namespace } = getState();
     dispatch(requestApps());
-    const apps = await HelmRelease.getAllWithDetails();
+    const apps = await HelmRelease.getAllWithDetails(namespace);
     dispatch(receiveApps(apps));
   };
 }

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -1,0 +1,16 @@
+import { Dispatch } from "redux";
+import { createAction, getReturnOfExpression } from "typesafe-actions";
+
+import { IStoreState } from "../shared/types";
+
+export const setAuthenticated = createAction("SET_AUTHENTICATED");
+
+const allActions = [setAuthenticated].map(getReturnOfExpression);
+export type AuthAction = typeof allActions[number];
+
+export function authenticate(token: string) {
+  return async (dispatch: Dispatch<IStoreState>) => {
+    localStorage.setItem("kubeapps_auth_token", token);
+    return dispatch(setAuthenticated());
+  };
+}

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -3,7 +3,10 @@ import { createAction, getReturnOfExpression } from "typesafe-actions";
 
 import { IStoreState } from "../shared/types";
 
-export const setAuthenticated = createAction("SET_AUTHENTICATED");
+export const setAuthenticated = createAction("SET_AUTHENTICATED", (authenticated: boolean) => ({
+  authenticated,
+  type: "SET_AUTHENTICATED",
+}));
 
 const allActions = [setAuthenticated].map(getReturnOfExpression);
 export type AuthAction = typeof allActions[number];
@@ -11,6 +14,13 @@ export type AuthAction = typeof allActions[number];
 export function authenticate(token: string) {
   return async (dispatch: Dispatch<IStoreState>) => {
     localStorage.setItem("kubeapps_auth_token", token);
-    return dispatch(setAuthenticated());
+    return dispatch(setAuthenticated(true));
+  };
+}
+
+export function logout() {
+  return async (dispatch: Dispatch<IStoreState>) => {
+    localStorage.removeItem("kubeapps_auth_token");
+    return dispatch(setAuthenticated(false));
   };
 }

--- a/dashboard/src/actions/catalog.ts
+++ b/dashboard/src/actions/catalog.ts
@@ -82,9 +82,10 @@ export function sync(broker: IServiceBroker) {
 export type ServiceCatalogAction = typeof actions[number];
 
 export function getBindings() {
-  return async (dispatch: Dispatch<IStoreState>) => {
+  return async (dispatch: Dispatch<IStoreState>, getState: () => IStoreState) => {
+    const { namespace } = getState();
     dispatch(requestBindings());
-    const bindings = await ServiceBinding.list();
+    const bindings = await ServiceBinding.list(namespace);
     dispatch(receiveBindings(bindings));
     return bindings;
   };
@@ -109,9 +110,10 @@ export function getClasses() {
 }
 
 export function getInstances() {
-  return async (dispatch: Dispatch<IStoreState>) => {
+  return async (dispatch: Dispatch<IStoreState>, getState: () => IStoreState) => {
+    const { namespace } = getState();
     dispatch(requestInstances());
-    const instances = await ServiceInstance.list();
+    const instances = await ServiceInstance.list(namespace);
     dispatch(receiveInstances(instances));
     return instances;
   };

--- a/dashboard/src/actions/functions.ts
+++ b/dashboard/src/actions/functions.ts
@@ -22,10 +22,11 @@ const allActions = [requestFunctions, receiveFunctions, selectFunction, setPodNa
 );
 export type FunctionsAction = typeof allActions[number];
 
-export function fetchFunctions(namespace: string) {
-  return async (dispatch: Dispatch<IStoreState>) => {
+export function fetchFunctions() {
+  return async (dispatch: Dispatch<IStoreState>, getState: () => IStoreState) => {
+    const { namespace } = getState();
     dispatch(requestFunctions());
-    const functionList = await Function.list();
+    const functionList = await Function.list(namespace);
     dispatch(receiveFunctions(functionList.items));
     return functionList;
   };

--- a/dashboard/src/actions/index.ts
+++ b/dashboard/src/actions/index.ts
@@ -1,4 +1,5 @@
 import * as apps from "./apps";
+import * as auth from "./auth";
 import * as catalog from "./catalog";
 import * as charts from "./charts";
 import * as functions from "./functions";
@@ -6,6 +7,7 @@ import * as repos from "./repos";
 
 export default {
   apps,
+  auth,
   catalog,
   charts,
   functions,

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -20,7 +20,7 @@ class AppListItem extends React.Component<IAppListItemProps> {
 
     return (
       <Card key={release.name} responsive={true} className="AppListItem">
-        <Link to={`/apps/${release.namespace}/${release.name}`}>
+        <Link to={`/apps/ns/${release.namespace}/${release.name}`}>
           <CardIcon icon={iconSrc} />
           <CardContent>
             <div className="ChartListItem__content">

--- a/dashboard/src/components/AppView/AppControls.tsx
+++ b/dashboard/src/components/AppView/AppControls.tsx
@@ -29,7 +29,7 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
         <button className="button" onClick={this.handleUpgradeClick}>
           Upgrade
         </button>
-        {this.state.upgrade && <Redirect to={`/apps/edit/${namespace}/${name}`} />}
+        {this.state.upgrade && <Redirect push={true} to={`/apps/ns/${namespace}/edit/${name}`} />}
         <button className="button button-danger" onClick={this.openModel}>
           Delete
         </button>
@@ -38,7 +38,7 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
           modalIsOpen={this.state.modalIsOpen}
           closeModal={this.closeModal}
         />
-        {this.state.redirectToAppList && <Redirect to="/" />}
+        {this.state.redirectToAppList && <Redirect to={`/apps/ns/${namespace}`} />}
       </div>
     );
   }

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -1,6 +1,7 @@
 import * as yaml from "js-yaml";
 import * as React from "react";
 
+import { Auth } from "../../shared/Auth";
 import { IApp, IResource } from "../../shared/types";
 import DeploymentStatus from "../DeploymentStatus";
 import AppControls from "./AppControls";
@@ -66,6 +67,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
         `${apiBase}/apis/apps/v1beta1/namespaces/${
           newApp.data.namespace
         }/deployments?watch=true&fieldSelector=metadata.name%3D${d.metadata.name}`,
+        Auth.wsProtocols(),
       );
       s.addEventListener("message", e => this.handleEvent(e));
       sockets.push(s);
@@ -75,6 +77,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
         `${apiBase}/api/v1/namespaces/${
           newApp.data.namespace
         }/services?watch=true&fieldSelector=metadata.name%3D${svc.metadata.name}`,
+        Auth.wsProtocols(),
       );
       s.addEventListener("message", e => this.handleEvent(e));
       sockets.push(s);

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -39,7 +39,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
     getApp(releaseName, namespace);
   }
 
-  public componentWillReceiveProps(nextProps: IAppViewProps) {
+  public async componentWillReceiveProps(nextProps: IAppViewProps) {
     const newApp = nextProps.app;
     if (!newApp) {
       return;

--- a/dashboard/src/components/ChartView/ChartDeployButton.tsx
+++ b/dashboard/src/components/ChartView/ChartDeployButton.tsx
@@ -4,6 +4,7 @@ import { IChartVersion } from "../../shared/types";
 
 interface IChartDeployButtonProps {
   version: IChartVersion;
+  namespace: string;
 }
 
 interface IChartDeployButtonState {
@@ -16,7 +17,7 @@ class ChartDeployButton extends React.Component<IChartDeployButtonProps, IChartD
   };
 
   public render() {
-    const { version } = this.props;
+    const { namespace, version } = this.props;
     const repoName = version.relationships.chart.data.repo.name;
     const chartName = version.relationships.chart.data.name;
     const versionStr = version.attributes.version;
@@ -27,7 +28,10 @@ class ChartDeployButton extends React.Component<IChartDeployButtonProps, IChartD
           Deploy using Helm
         </button>
         {this.state.clicked && (
-          <Redirect to={`/apps/new/${repoName}/${chartName}/versions/${versionStr}`} />
+          <Redirect
+            push={true}
+            to={`/apps/ns/${namespace}/new/${repoName}/${chartName}/versions/${versionStr}`}
+          />
         )}
       </div>
     );

--- a/dashboard/src/components/ChartView/ChartView.tsx
+++ b/dashboard/src/components/ChartView/ChartView.tsx
@@ -16,6 +16,7 @@ interface IChartViewProps {
   selectChartVersion: (version: IChartVersion) => any;
   resetChartVersion: () => any;
   getChartReadme: (version: string) => any;
+  namespace: string;
   version: string | undefined;
 }
 
@@ -43,7 +44,7 @@ class ChartView extends React.Component<IChartViewProps> {
   }
 
   public render() {
-    const { isFetching, getChartReadme } = this.props;
+    const { isFetching, getChartReadme, namespace } = this.props;
     const { version, readme, readmeError, versions } = this.props.selected;
     if (isFetching || !version) {
       return <div>Loading</div>;
@@ -73,7 +74,7 @@ class ChartView extends React.Component<IChartViewProps> {
                 <aside className="ChartViewSidebar bg-light margin-v-big padding-h-normal padding-b-normal">
                   <div className="ChartViewSidebar__section">
                     <h2>Usage</h2>
-                    <ChartDeployButton version={version} />
+                    <ChartDeployButton version={version} namespace={namespace} />
                   </div>
                   <div className="ChartViewSidebar__section">
                     <h2>Chart Versions</h2>

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -26,6 +26,7 @@ interface IDeploymentFormProps {
   getBindings: () => Promise<IServiceBinding[]>;
   getChartVersion: (id: string, chartVersion: string) => Promise<{}>;
   getChartValues: (id: string, chartVersion: string) => Promise<any>;
+  namespace: string;
 }
 
 interface IDeploymentFormState {
@@ -58,6 +59,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
       getBindings,
       getChartVersion,
       chartVersion,
+      namespace,
     } = this.props;
     fetchChartVersions(chartID);
     getBindings();
@@ -67,6 +69,10 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
       this.setState({
         namespace: hr.metadata.namespace,
         releaseName: hr.metadata.name,
+      });
+    } else {
+      this.setState({
+        namespace,
       });
     }
   }
@@ -184,7 +190,8 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
                   onChange={this.handleNamespaceChange}
                   value={this.state.namespace}
                   required={true}
-                  disabled={hr ? true : false}
+                  // this is now fixed due to state & URL
+                  disabled={true}
                 />
               </div>
               <div style={{ marginBottom: "1em" }}>
@@ -253,7 +260,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
     const { releaseName, namespace, appValues } = this.state;
     if (selected.version) {
       deployChart(selected.version, releaseName, namespace, appValues, resourceVersion)
-        .then(() => push(`/apps/${namespace}/${namespace}-${releaseName}`))
+        .then(() => push(`/apps/ns/${namespace}/${namespace}-${releaseName}`))
         .catch(err => this.setState({ isDeploying: false, error: err.toString() }));
     }
   };

--- a/dashboard/src/components/FunctionList/FunctionList.tsx
+++ b/dashboard/src/components/FunctionList/FunctionList.tsx
@@ -7,16 +7,15 @@ import FunctionListItem from "./FunctionListItem";
 
 interface IFunctionListProps {
   functions: IFunction[];
-  namespace: string;
-  fetchFunctions: (namespace: string) => Promise<any>;
+  fetchFunctions: () => Promise<any>;
   deployFunction: (n: string, ns: string, spec: IFunction["spec"]) => Promise<any>;
   navigateToFunction: (n: string, ns: string) => any;
 }
 
 class FunctionList extends React.Component<IFunctionListProps> {
   public componentDidMount() {
-    const { namespace, fetchFunctions } = this.props;
-    fetchFunctions(namespace);
+    const { fetchFunctions } = this.props;
+    fetchFunctions();
   }
 
   public render() {

--- a/dashboard/src/components/FunctionList/FunctionListItem.tsx
+++ b/dashboard/src/components/FunctionList/FunctionListItem.tsx
@@ -16,7 +16,7 @@ class FunctionListItem extends React.Component<IFunctionListItemProps> {
 
     return (
       <Card responsive={true} className="FunctionListItem">
-        <Link to={`/functions/${f.metadata.namespace}/${f.metadata.name}`}>
+        <Link to={`/functions/ns/${f.metadata.namespace}/${f.metadata.name}`}>
           <FunctionIcon runtime={f.spec.runtime} />
           <CardContent>
             <div className="ChartListItem__content">

--- a/dashboard/src/components/FunctionView/FunctionControls.tsx
+++ b/dashboard/src/components/FunctionView/FunctionControls.tsx
@@ -8,6 +8,7 @@ interface IFunctionControlsProps {
   enableSaveButton: boolean;
   deleteFunction: () => Promise<void>;
   updateFunction: () => void;
+  namespace: string;
 }
 
 interface IFunctionControlsState {
@@ -22,6 +23,7 @@ class FunctionControls extends React.Component<IFunctionControlsProps, IFunction
   };
 
   public render() {
+    const { namespace } = this.props;
     return (
       <div className="FunctionControls">
         <button
@@ -39,7 +41,7 @@ class FunctionControls extends React.Component<IFunctionControlsProps, IFunction
           modalIsOpen={this.state.modalIsOpen}
           closeModal={this.closeModal}
         />
-        {this.state.redirectToFunctionsList && <Redirect to="/functions" />}
+        {this.state.redirectToFunctionsList && <Redirect to={`/functions/ns/${namespace}`} />}
       </div>
     );
   }

--- a/dashboard/src/components/FunctionView/FunctionLogs.tsx
+++ b/dashboard/src/components/FunctionView/FunctionLogs.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { LazyStream, LineNumber } from "react-lazylog/lib/LazyLog.es5";
 
+import { Auth } from "../../shared/Auth";
 import { IFunction } from "../../shared/types";
 import "./FunctionLogs.css";
 
@@ -23,7 +24,11 @@ class FunctionLogs extends React.Component<IFunctionLogsProps> {
       <div className="FunctionLogs">
         <h6>Logs</h6>
         <hr />
-        {url ? <LazyStream follow={true} url={url} /> : <div>Loading</div>}
+        {url ? (
+          <LazyStream follow={true} url={url} fetchOptions={Auth.fetchOptions()} />
+        ) : (
+          <div>Loading</div>
+        )}
       </div>
     );
   }

--- a/dashboard/src/components/FunctionView/FunctionTester.tsx
+++ b/dashboard/src/components/FunctionView/FunctionTester.tsx
@@ -1,7 +1,9 @@
-import axios, { AxiosRequestConfig } from "axios";
+import { AxiosRequestConfig } from "axios";
 import * as qs from "qs";
 import * as React from "react";
 import AceEditor from "react-ace";
+
+import { axios } from "../../shared/Auth";
 
 import "brace/mode/json";
 import "brace/mode/plain_text";
@@ -139,12 +141,13 @@ class FunctionTester extends React.Component<IFunctionTesterProps, IFunctionTest
       method: method.toLowerCase(),
       // disable axios JSON parsing, always get a raw string back
       transformResponse: r => r,
+      url,
     };
     if (method === Method.GET) {
       // Params has to be an object, so for the Text format we parse it
       config.params = format === Format.Text ? qs.parse(reqBody) : reqBody;
     }
-    const res = await axios(url, config);
+    const res = await axios.request(config);
     this.setState({
       response: res.data,
     });

--- a/dashboard/src/components/FunctionView/FunctionView.tsx
+++ b/dashboard/src/components/FunctionView/FunctionView.tsx
@@ -110,6 +110,7 @@ class FunctionView extends React.Component<IFunctionViewProps, IFunctionViewStat
                       enableSaveButton={this.state.codeModified}
                       updateFunction={this.handleFunctionUpdate}
                       deleteFunction={deleteFunction}
+                      namespace={f.metadata.namespace}
                     />
                   </div>
                 </div>

--- a/dashboard/src/components/FunctionView/FunctionView.tsx
+++ b/dashboard/src/components/FunctionView/FunctionView.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { Auth } from "../../shared/Auth";
 import { IDeploymentStatus, IFunction, IResource } from "../../shared/types";
 import DeploymentStatus from "../DeploymentStatus";
 import FunctionControls from "./FunctionControls";
@@ -52,6 +53,7 @@ class FunctionView extends React.Component<IFunctionViewProps, IFunctionViewStat
       `${apiBase}/apis/apps/v1beta1/namespaces/${
         f.metadata.namespace
       }/deployments?watch=true&labelSelector=function=${f.metadata.name}`,
+      Auth.wsProtocols(),
     );
     socket.addEventListener("message", e => this.handleEvent(e));
     this.setState({

--- a/dashboard/src/components/Header/Header.css
+++ b/dashboard/src/components/Header/Header.css
@@ -1,3 +1,4 @@
 .header .header__nav-config {
   justify-content: flex-end;
+  flex: inherit;
 }

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -1,18 +1,17 @@
 import * as React from "react";
-import { connect } from "react-redux";
 import { NavLink } from "react-router-dom";
 import logo from "../../logo.svg";
-
-import { IRouterPathname } from "../../shared/types";
 
 import HeaderLink, { IHeaderLinkProps } from "./HeaderLink";
 
 // Icons
-import Cog from "../../icons/Cog";
+import { LogOut, Settings } from "react-feather";
 
 import "./Header.css";
 
 interface IHeaderProps {
+  authenticated: boolean;
+  logout: () => void;
   pathname: string;
 }
 
@@ -59,6 +58,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   }
 
   public render() {
+    const showNav = this.props.authenticated;
     const header = `header ${this.state.mobileOpen ? "header-open" : ""}`;
     const submenu = `header__nav__submenu ${
       this.state.configOpen ? "header__nav__submenu-open" : ""
@@ -73,47 +73,56 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                 <img src={logo} alt="Kubeapps logo" />
               </NavLink>
             </div>
-            <nav className="header__nav">
-              <button
-                className="header__nav__hamburguer"
-                aria-label="Menu"
-                aria-haspopup="true"
-                aria-expanded="false"
-                onClick={this.toggleMobile}
-              >
-                <div />
-                <div />
-                <div />
-              </button>
-              <ul className="header__nav__menu" role="menubar">
-                {this.links.map(link => (
-                  <li key={link.to}>
-                    <HeaderLink {...link} />
-                  </li>
-                ))}
-              </ul>
-            </nav>
-            <div className="header__nav header__nav-config">
-              <ul className="header__nav__menu" role="menubar">
-                <li
-                  onMouseEnter={this.openSubmenu}
-                  onMouseLeave={this.closeSubmenu}
-                  onClick={this.toggleSubmenu}
+            {showNav && (
+              <nav className="header__nav">
+                <button
+                  className="header__nav__hamburguer"
+                  aria-label="Menu"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  onClick={this.toggleMobile}
                 >
-                  <a>
-                    <Cog className="icon icon-small margin-r-tiny" /> Configuration
-                  </a>
-                  <ul role="menu" aria-label="Products" className={submenu}>
-                    <li role="none">
-                      <NavLink to="/config/repos">App Repositories</NavLink>
+                  <div />
+                  <div />
+                  <div />
+                </button>
+                <ul className="header__nav__menu" role="menubar">
+                  {this.links.map(link => (
+                    <li key={link.to}>
+                      <HeaderLink {...link} />
                     </li>
-                    <li role="none">
-                      <NavLink to="/config/brokers">Service Brokers</NavLink>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-            </div>
+                  ))}
+                </ul>
+              </nav>
+            )}
+            {showNav && (
+              <div className="header__nav header__nav-config">
+                <ul className="header__nav__menu" role="menubar">
+                  <li
+                    onMouseEnter={this.openSubmenu}
+                    onMouseLeave={this.closeSubmenu}
+                    onClick={this.toggleSubmenu}
+                  >
+                    <a>
+                      <Settings size={16} className="icon margin-r-tiny" /> Configuration
+                    </a>
+                    <ul role="menu" aria-label="Products" className={submenu}>
+                      <li role="none">
+                        <NavLink to="/config/repos">App Repositories</NavLink>
+                      </li>
+                      <li role="none">
+                        <NavLink to="/config/brokers">Service Brokers</NavLink>
+                      </li>
+                    </ul>
+                  </li>
+                  <li>
+                    <NavLink to="#" onClick={this.handleLogout}>
+                      <LogOut size={16} className="icon margin-r-tiny" /> Logout
+                    </NavLink>
+                  </li>
+                </ul>
+              </div>
+            )}
           </header>
         </div>
       </section>
@@ -143,10 +152,11 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   private toggleSubmenu = () => {
     this.setState({ configOpen: !this.state.configOpen });
   };
+
+  private handleLogout = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    this.props.logout();
+  };
 }
 
-const mapStateToProps = ({ router: { location: { pathname } } }: IRouterPathname): IHeaderProps => {
-  return { pathname };
-};
-
-export default connect(mapStateToProps)(Header);
+export default Header;

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -12,6 +12,7 @@ import "./Header.css";
 interface IHeaderProps {
   authenticated: boolean;
   logout: () => void;
+  namespace: string;
   pathname: string;
 }
 
@@ -26,7 +27,8 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
     {
       children: "Applications",
       exact: true,
-      to: "/",
+      namespaced: true,
+      to: "/apps",
     },
     {
       children: "Charts",
@@ -34,10 +36,12 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
     },
     {
       children: "Functions",
+      namespaced: true,
       to: "/functions",
     },
     {
       children: "Service Instances",
+      namespaced: true,
       to: "/services/instances",
     },
   ];
@@ -58,7 +62,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   }
 
   public render() {
-    const showNav = this.props.authenticated;
+    const { namespace, authenticated: showNav } = this.props;
     const header = `header ${this.state.mobileOpen ? "header-open" : ""}`;
     const submenu = `header__nav__submenu ${
       this.state.configOpen ? "header__nav__submenu-open" : ""
@@ -89,7 +93,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                 <ul className="header__nav__menu" role="menubar">
                   {this.links.map(link => (
                     <li key={link.to}>
-                      <HeaderLink {...link} />
+                      <HeaderLink {...link} currentNamespace={namespace} />
                     </li>
                   ))}
                 </ul>

--- a/dashboard/src/components/Header/HeaderLink.tsx
+++ b/dashboard/src/components/Header/HeaderLink.tsx
@@ -7,6 +7,8 @@ export interface IHeaderLinkProps {
   exact?: boolean;
   external?: boolean;
   children?: React.ReactChildren | React.ReactNode | string;
+  currentNamespace?: string;
+  namespaced?: boolean;
 }
 
 class HeaderLink extends React.Component<IHeaderLinkProps> {
@@ -16,9 +18,11 @@ class HeaderLink extends React.Component<IHeaderLinkProps> {
   };
 
   public renderInternalLink() {
+    const { currentNamespace, namespaced, to } = this.props;
+    const link = currentNamespace && namespaced ? `${to}/ns/${currentNamespace}` : to;
     return (
       <NavLink
-        to={this.props.to}
+        to={link}
         activeClassName="header__nav__menu__item-active"
         className="header__nav__menu__item"
         exact={this.props.exact}

--- a/dashboard/src/components/Layout/Layout.tsx
+++ b/dashboard/src/components/Layout/Layout.tsx
@@ -1,15 +1,19 @@
 import * as React from "react";
 
 import Footer from "../Footer";
-import Header from "../Header";
 
 import "./Layout.css";
 
-class Layout extends React.Component {
+interface ILayoutProps {
+  headerComponent: React.ComponentClass<any> | React.StatelessComponent<any>;
+}
+
+class Layout extends React.Component<ILayoutProps> {
   public render() {
+    const HeaderComponent = this.props.headerComponent;
     return (
       <section className="Layout">
-        <Header />
+        <HeaderComponent />
         <main>
           <div className="container">{this.props.children}</div>
         </main>

--- a/dashboard/src/components/LoginForm/LoginForm.css
+++ b/dashboard/src/components/LoginForm/LoginForm.css
@@ -1,0 +1,8 @@
+.LoginForm__container {
+  width: 500px;
+  margin: 5em auto;
+}
+
+.LoginForm > .bg-skew .bg-skew__content {
+  max-width: 75%;
+}

--- a/dashboard/src/components/LoginForm/LoginForm.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.tsx
@@ -1,0 +1,72 @@
+import { Location } from "history";
+import * as React from "react";
+import { Lock } from "react-feather";
+import { Redirect } from "react-router";
+
+import "./LoginForm.css";
+
+interface ILoginFormProps {
+  authenticated: boolean;
+  authenticate: (token: string) => any;
+  location: Location;
+}
+
+interface ILoginFormState {
+  token?: string;
+}
+
+class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
+  public render() {
+    if (this.props.authenticated) {
+      const { from } = this.props.location.state || { from: { pathname: "/" } };
+      return <Redirect to={from} />;
+    }
+    return (
+      <section className="LoginForm">
+        <div className="LoginForm__container padding-v-bigger bg-skew type-color-reverse">
+          <div className="bg-skew__pattern bg-skew__pattern-dark">
+            <div className="container">
+              <h2>
+                <Lock /> Login
+              </h2>
+              <p>
+                Your cluster operator should provide you with a Kubernetes API token.{" "}
+                <a href="#">Click here</a> for more info on how to create and use Bearer Tokens.
+              </p>
+              <div className="bg-skew__content">
+                <form onSubmit={this.handleSubmit}>
+                  <div>
+                    <label htmlFor="token">Kubernetes API Token</label>
+                    <input
+                      name="token"
+                      id="token"
+                      type="password"
+                      placeholder="Token"
+                      required={true}
+                      onChange={this.handleTokenChange}
+                    />
+                  </div>
+                  <p>
+                    <a className="button button-accent">Login</a>
+                  </p>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  private handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const { token } = this.state;
+    return token && this.props.authenticate(token);
+  };
+
+  private handleTokenChange = (e: React.FormEvent<HTMLInputElement>) => {
+    this.setState({ token: e.currentTarget.value });
+  };
+}
+
+export default LoginForm;

--- a/dashboard/src/components/LoginForm/LoginForm.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.tsx
@@ -47,7 +47,9 @@ class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
                     />
                   </div>
                   <p>
-                    <a className="button button-accent">Login</a>
+                    <button type="submit" className="button button-accent">
+                      Login
+                    </button>
                   </p>
                 </form>
               </div>

--- a/dashboard/src/components/LoginForm/index.ts
+++ b/dashboard/src/components/LoginForm/index.ts
@@ -1,0 +1,3 @@
+import LoginForm from "./LoginForm";
+
+export default LoginForm;

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { Redirect, Route, RouteComponentProps, RouteProps } from "react-router";
+
+type IRouteComponentPropsAndRouteProps = RouteProps & RouteComponentProps<any>;
+interface IPrivateRouteProps extends IRouteComponentPropsAndRouteProps {
+  authenticated: boolean;
+}
+
+class PrivateRoute extends React.Component<IPrivateRouteProps> {
+  public render() {
+    const { authenticated, component: Component, ...rest } = this.props;
+    return <Route {...rest} render={this.renderRouteIfAuthenticated} />;
+  }
+
+  private renderRouteIfAuthenticated = (props: RouteComponentProps<any>) => {
+    const { authenticated, component: Component } = this.props;
+    return authenticated && Component ? (
+      <Component {...props} />
+    ) : (
+      <Redirect to={{ pathname: "/login", state: { from: props.location } }} />
+    );
+  };
+}
+
+export default PrivateRoute;

--- a/dashboard/src/components/PrivateRoute/index.tsx
+++ b/dashboard/src/components/PrivateRoute/index.tsx
@@ -1,0 +1,3 @@
+import PrivateRoute from "./PrivateRoute";
+
+export default PrivateRoute;

--- a/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -17,13 +17,14 @@ interface IRouteProps {
 }
 
 function mapStateToProps(
-  { apps, catalog, charts }: IStoreState,
+  { apps, catalog, charts, namespace }: IStoreState,
   { match: { params } }: IRouteProps,
 ) {
   return {
     bindings: catalog.bindings,
     chartID: `${params.repo}/${params.id}`,
     chartVersion: params.version,
+    namespace,
     selected: charts.selected,
   };
 }

--- a/dashboard/src/containers/ChartViewContainer/ChartViewContainer.tsx
+++ b/dashboard/src/containers/ChartViewContainer/ChartViewContainer.tsx
@@ -15,10 +15,11 @@ interface IRouteProps {
   };
 }
 
-function mapStateToProps({ charts }: IStoreState, { match: { params } }: IRouteProps) {
+function mapStateToProps({ charts, namespace }: IStoreState, { match: { params } }: IRouteProps) {
   return {
     chartID: chartID(params),
     isFetching: charts.isFetching,
+    namespace,
     selected: charts.selected,
     version: params.version,
   };

--- a/dashboard/src/containers/FunctionListContainer/FunctionListContainer.tsx
+++ b/dashboard/src/containers/FunctionListContainer/FunctionListContainer.tsx
@@ -6,21 +6,9 @@ import actions from "../../actions";
 import FunctionList from "../../components/FunctionList";
 import { IFunction, IStoreState } from "../../shared/types";
 
-interface IRouteProps {
-  match: {
-    params: {
-      namespace: string;
-    };
-  };
-}
-
-function mapStateToProps(
-  { functions: { items } }: IStoreState,
-  { match: { params } }: IRouteProps,
-) {
+function mapStateToProps({ functions: { items } }: IStoreState) {
   return {
     functions: items,
-    namespace: params.namespace,
   };
 }
 
@@ -28,9 +16,9 @@ function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
     deployFunction: (name: string, namespace: string, spec: IFunction["spec"]) =>
       dispatch(actions.functions.createFunction(name, namespace, spec)),
-    fetchFunctions: (namespace: string) => dispatch(actions.functions.fetchFunctions(namespace)),
+    fetchFunctions: () => dispatch(actions.functions.fetchFunctions()),
     navigateToFunction: (name: string, namespace: string) =>
-      dispatch(push(`/functions/${namespace}/${name}`)),
+      dispatch(push(`/functions/ns/${namespace}/${name}`)),
   };
 }
 

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -1,0 +1,26 @@
+import { connect } from "react-redux";
+import { RouteComponentProps } from "react-router";
+import { Dispatch } from "redux";
+
+import actions from "../../actions";
+import Header from "../../components/Header";
+import { IStoreState } from "../../shared/types";
+
+interface IState extends IStoreState {
+  router: RouteComponentProps<{}>;
+}
+
+function mapStateToProps({ auth: { authenticated }, router: { location: { pathname } } }: IState) {
+  return {
+    authenticated,
+    pathname,
+  };
+}
+
+function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
+  return {
+    logout: (token: string) => dispatch(actions.auth.logout()),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -10,9 +10,14 @@ interface IState extends IStoreState {
   router: RouteComponentProps<{}>;
 }
 
-function mapStateToProps({ auth: { authenticated }, router: { location: { pathname } } }: IState) {
+function mapStateToProps({
+  auth: { authenticated },
+  namespace,
+  router: { location: { pathname } },
+}: IState) {
   return {
     authenticated,
+    namespace,
     pathname,
   };
 }

--- a/dashboard/src/containers/HeaderContainer/index.ts
+++ b/dashboard/src/containers/HeaderContainer/index.ts
@@ -1,0 +1,3 @@
+import HeaderContainer from "./HeaderContainer";
+
+export default HeaderContainer;

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
@@ -1,0 +1,35 @@
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+
+import actions from "../../actions";
+import LoginForm from "../../components/LoginForm";
+import { IStoreState } from "../../shared/types";
+
+interface IRouteProps {
+  match: {
+    params: {
+      name: string;
+      namespace: string;
+    };
+  };
+}
+
+function mapStateToProps(
+  { auth: { authenticated } }: IStoreState,
+  { match: { params } }: IRouteProps,
+) {
+  return {
+    authenticated,
+  };
+}
+
+function mapDispatchToProps(
+  dispatch: Dispatch<IStoreState>,
+  { match: { params: { name, namespace } } }: IRouteProps,
+) {
+  return {
+    authenticate: (token: string) => dispatch(actions.auth.authenticate(token)),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(LoginForm);

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
@@ -5,28 +5,13 @@ import actions from "../../actions";
 import LoginForm from "../../components/LoginForm";
 import { IStoreState } from "../../shared/types";
 
-interface IRouteProps {
-  match: {
-    params: {
-      name: string;
-      namespace: string;
-    };
-  };
-}
-
-function mapStateToProps(
-  { auth: { authenticated } }: IStoreState,
-  { match: { params } }: IRouteProps,
-) {
+function mapStateToProps({ auth: { authenticated } }: IStoreState) {
   return {
     authenticated,
   };
 }
 
-function mapDispatchToProps(
-  dispatch: Dispatch<IStoreState>,
-  { match: { params: { name, namespace } } }: IRouteProps,
-) {
+function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
     authenticate: (token: string) => dispatch(actions.auth.authenticate(token)),
   };

--- a/dashboard/src/containers/LoginFormContainer/index.ts
+++ b/dashboard/src/containers/LoginFormContainer/index.ts
@@ -1,0 +1,3 @@
+import LoginFormContainer from "./LoginFormContainer";
+
+export default LoginFormContainer;

--- a/dashboard/src/containers/PrivateRouteContainer/PrivateRouteContainer.ts
+++ b/dashboard/src/containers/PrivateRouteContainer/PrivateRouteContainer.ts
@@ -1,0 +1,13 @@
+import { connect } from "react-redux";
+import { withRouter } from "react-router";
+
+import PrivateRoute from "../../components/PrivateRoute";
+import { IStoreState } from "../../shared/types";
+
+function mapStateToProps({ auth: { authenticated } }: IStoreState) {
+  return {
+    authenticated,
+  };
+}
+
+export default withRouter(connect(mapStateToProps)(PrivateRoute));

--- a/dashboard/src/containers/PrivateRouteContainer/index.ts
+++ b/dashboard/src/containers/PrivateRouteContainer/index.ts
@@ -1,0 +1,3 @@
+import PrivateRouteContainer from "./PrivateRouteContainer";
+
+export default PrivateRouteContainer;

--- a/dashboard/src/containers/Root.tsx
+++ b/dashboard/src/containers/Root.tsx
@@ -1,7 +1,7 @@
 import createHistory from "history/createBrowserHistory";
 import * as React from "react";
 import { Provider } from "react-redux";
-import { Route, RouteComponentProps } from "react-router";
+import { Redirect, Route, RouteComponentProps } from "react-router";
 import { ConnectedRouter } from "react-router-redux";
 import { ClassViewContainer } from "./ClassView";
 
@@ -31,10 +31,11 @@ class Root extends React.Component {
   public static exactRoutes: {
     [route: string]: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
   } = {
-    "/": AppList,
-    "/apps/:namespace/:releaseName": AppView,
-    "/apps/edit/:namespace/:releaseName": AppEdit,
-    "/apps/new/:repo/:id/versions/:version": AppNew,
+    "/apps": AppList,
+    "/apps/ns/:namespace": AppList,
+    "/apps/ns/:namespace/:releaseName": AppView,
+    "/apps/ns/:namespace/edit/:releaseName": AppEdit,
+    "/apps/ns/:namespace/new/:repo/:id/versions/:version": AppNew,
     "/charts": ChartList,
     "/charts/:repo": ChartList,
     "/charts/:repo/:id": ChartView,
@@ -42,12 +43,13 @@ class Root extends React.Component {
     "/config/brokers": ServiceCatalogContainer,
     "/config/repos": RepoListContainer,
     "/functions": FunctionListContainer,
-    "/functions/:namespace": FunctionListContainer,
-    "/functions/:namespace/:name": FunctionViewContainer,
+    "/functions/ns/:namespace": FunctionListContainer,
+    "/functions/ns/:namespace/:name": FunctionViewContainer,
     "/services/brokers/:brokerName/classes/:className": ClassViewContainer,
-    "/services/brokers/:brokerName/instances/:namespace/:instanceName": InstanceView,
+    "/services/brokers/:brokerName/instances/ns/:namespace/:instanceName": InstanceView,
     "/services/classes": ClassListContainer,
     "/services/instances": InstanceListViewContainer,
+    "/services/instances/ns/:namespace": InstanceListViewContainer,
   };
 
   public render() {
@@ -55,6 +57,7 @@ class Root extends React.Component {
       <Provider store={store}>
         <ConnectedRouter history={history}>
           <Layout headerComponent={HeaderContainer}>
+            <Route exact={true} path="/" render={this.rootNamespacedRedirect} />
             <Route exact={true} path="/login" component={LoginFormContainer} />
             {Object.keys(Root.exactRoutes).map(route => (
               <PrivateRouteContainer
@@ -69,6 +72,11 @@ class Root extends React.Component {
       </Provider>
     );
   }
+
+  public rootNamespacedRedirect = (props: any) => {
+    const { namespace } = store.getState();
+    return <Redirect to={`/apps/ns/${namespace}`} />;
+  };
 }
 
 export default Root;

--- a/dashboard/src/containers/Root.tsx
+++ b/dashboard/src/containers/Root.tsx
@@ -16,6 +16,7 @@ import ChartView from "./ChartViewContainer";
 import ClassListContainer from "./ClassListContainer";
 import FunctionListContainer from "./FunctionListContainer";
 import FunctionViewContainer from "./FunctionViewContainer";
+import HeaderContainer from "./HeaderContainer";
 import InstanceListViewContainer from "./InstanceListViewContainer";
 import InstanceView from "./InstanceView";
 import LoginFormContainer from "./LoginFormContainer";
@@ -53,7 +54,7 @@ class Root extends React.Component {
     return (
       <Provider store={store}>
         <ConnectedRouter history={history}>
-          <Layout>
+          <Layout headerComponent={HeaderContainer}>
             <Route exact={true} path="/login" component={LoginFormContainer} />
             {Object.keys(Root.exactRoutes).map(route => (
               <PrivateRouteContainer

--- a/dashboard/src/containers/Root.tsx
+++ b/dashboard/src/containers/Root.tsx
@@ -18,7 +18,8 @@ import FunctionListContainer from "./FunctionListContainer";
 import FunctionViewContainer from "./FunctionViewContainer";
 import InstanceListViewContainer from "./InstanceListViewContainer";
 import InstanceView from "./InstanceView";
-
+import LoginFormContainer from "./LoginFormContainer";
+import PrivateRouteContainer from "./PrivateRouteContainer";
 import RepoListContainer from "./RepoListContainer";
 import ServiceCatalogContainer from "./ServiceCatalogContainer";
 
@@ -53,11 +54,15 @@ class Root extends React.Component {
       <Provider store={store}>
         <ConnectedRouter history={history}>
           <Layout>
-            <section className="routes">
-              {Object.keys(Root.exactRoutes).map(route => (
-                <Route key={route} exact={true} path={route} component={Root.exactRoutes[route]} />
-              ))}
-            </section>
+            <Route exact={true} path="/login" component={LoginFormContainer} />
+            {Object.keys(Root.exactRoutes).map(route => (
+              <PrivateRouteContainer
+                key={route}
+                exact={true}
+                path={route}
+                component={Root.exactRoutes[route]}
+              />
+            ))}
           </Layout>
         </ConnectedRouter>
       </Provider>

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -12,20 +12,7 @@ body {
 }
 
 svg.icon {
-  height: 1em;
   /* Fix positioning */
   position: relative;
-  top: 0.1em;
-  left: 0;
-  width: 1em;
-}
-
-svg.icon-small {
-  width: 0.75em;
-  height: 0.75em;
-}
-
-svg.icon-big {
-  width: 1.5em;
-  height: 1.5em;
+  bottom: -0.125em;
 }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=Hind");
+@import url("https://fonts.googleapis.com/css?family=Fira+Sans:300,400,700|Hind:300,400,700");
 @import url("https://d1d5nb8vlsbujg.cloudfront.net/bitnami-ui/3.0.0-alpha-20/bitnami.ui.min.css");
 @import url("https://d1d5nb8vlsbujg.cloudfront.net/bitnami-ui/3.0.0-alpha-20/bitnami.ui.components.min.css");
 

--- a/dashboard/src/reducers/auth.ts
+++ b/dashboard/src/reducers/auth.ts
@@ -1,0 +1,23 @@
+import { getType } from "typesafe-actions";
+
+import actions from "../actions";
+import { AuthAction } from "../actions/auth";
+
+export interface IAuthState {
+  authenticated: boolean;
+}
+
+const initialState: IAuthState = {
+  authenticated: !(localStorage.getItem("kubeapps_auth_token") === null),
+};
+
+const authReducer = (state: IAuthState = initialState, action: AuthAction): IAuthState => {
+  switch (action.type) {
+    case getType(actions.auth.setAuthenticated):
+      return { authenticated: true };
+    default:
+  }
+  return state;
+};
+
+export default authReducer;

--- a/dashboard/src/reducers/auth.ts
+++ b/dashboard/src/reducers/auth.ts
@@ -14,7 +14,7 @@ const initialState: IAuthState = {
 const authReducer = (state: IAuthState = initialState, action: AuthAction): IAuthState => {
   switch (action.type) {
     case getType(actions.auth.setAuthenticated):
-      return { authenticated: true };
+      return { authenticated: action.authenticated };
     default:
   }
   return state;

--- a/dashboard/src/reducers/index.ts
+++ b/dashboard/src/reducers/index.ts
@@ -3,6 +3,7 @@ import { combineReducers } from "redux";
 
 import { IStoreState } from "../shared/types";
 import appsReducer from "./apps";
+import authReducer from "./auth";
 import catalogReducer from "./catalog";
 import chartsReducer from "./charts";
 import functionsReducer from "./functions";
@@ -10,6 +11,7 @@ import reposReducer from "./repos";
 
 const rootReducer = combineReducers<IStoreState>({
   apps: appsReducer,
+  auth: authReducer,
   catalog: catalogReducer,
   charts: chartsReducer,
   functions: functionsReducer,

--- a/dashboard/src/reducers/index.ts
+++ b/dashboard/src/reducers/index.ts
@@ -7,6 +7,7 @@ import authReducer from "./auth";
 import catalogReducer from "./catalog";
 import chartsReducer from "./charts";
 import functionsReducer from "./functions";
+import namespaceReducer from "./namespace";
 import reposReducer from "./repos";
 
 const rootReducer = combineReducers<IStoreState>({
@@ -15,6 +16,7 @@ const rootReducer = combineReducers<IStoreState>({
   catalog: catalogReducer,
   charts: chartsReducer,
   functions: functionsReducer,
+  namespace: namespaceReducer,
   repos: reposReducer,
   router: routerReducer,
 });

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -1,0 +1,7 @@
+const initialState: string = localStorage.getItem("kubeapps_namespace") || "default";
+
+const namespaceReducer = (state: string = initialState): string => {
+  return state;
+};
+
+export default namespaceReducer;

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -1,5 +1,4 @@
-import axios from "axios";
-
+import { axios } from "./Auth";
 import { IAppRepository, IAppRepositoryList } from "./types";
 
 export class AppRepository {

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -1,0 +1,41 @@
+import Axios, { AxiosRequestConfig } from "axios";
+
+const AuthTokenKey = "kubeapps_auth_token";
+
+export class Auth {
+  public static getAuthToken() {
+    return localStorage.getItem(AuthTokenKey);
+  }
+
+  public static setAuthToken(token: string) {
+    return localStorage.setItem(AuthTokenKey, token);
+  }
+
+  public static wsProtocols() {
+    const token = this.getAuthToken();
+    if (!token) {
+      return [];
+    }
+    return ["base64url.bearer.authorization.k8s.io." + btoa(token).replace(/=*$/g, "")];
+  }
+
+  public static fetchOptions() {
+    return { headers: { Authorization: `Bearer ${this.getAuthToken()}` } };
+  }
+}
+
+// authenticatedAxiosInstance returns an axios instance with an interceptor
+// configured to set the current auth token
+function authenticatedAxiosInstance() {
+  const a = Axios.create();
+  a.interceptors.request.use((config: AxiosRequestConfig) => {
+    const authToken = Auth.getAuthToken();
+    if (authToken) {
+      config.headers.Authorization = `Bearer ${authToken}`;
+    }
+    return config;
+  });
+  return a;
+}
+
+export const axios = authenticatedAxiosInstance();

--- a/dashboard/src/shared/ClusterServiceClass.ts
+++ b/dashboard/src/shared/ClusterServiceClass.ts
@@ -39,7 +39,7 @@ export class ClusterServiceClass {
   }
 
   public static async list(namespace?: string): Promise<IClusterServiceClass[]> {
-    const instances = await ServiceCatalog.getItems<IClusterServiceClass>("/serviceinstances");
+    const instances = await ServiceCatalog.getItems<IClusterServiceClass>("serviceinstances");
     return instances;
   }
 

--- a/dashboard/src/shared/ClusterServiceClass.ts
+++ b/dashboard/src/shared/ClusterServiceClass.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { axios } from "./Auth";
 import { ServiceCatalog } from "./ServiceCatalog";
 
 export interface IClusterServiceClass {

--- a/dashboard/src/shared/Function.ts
+++ b/dashboard/src/shared/Function.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { axios } from "./Auth";
 
 import { IFunction, IFunctionList, IResource, IStatus } from "./types";
 

--- a/dashboard/src/shared/Function.ts
+++ b/dashboard/src/shared/Function.ts
@@ -3,8 +3,8 @@ import { axios } from "./Auth";
 import { IFunction, IFunctionList, IResource, IStatus } from "./types";
 
 export default class Function {
-  public static async list() {
-    const { data } = await axios.get<IFunctionList>(`${Function.APIEndpoint}/functions`);
+  public static async list(namespace?: string) {
+    const { data } = await axios.get<IFunctionList>(`${Function.getResourceLink(namespace)}`);
     return data;
   }
 
@@ -62,6 +62,9 @@ export default class Function {
 
   private static APIBase: string = "/api/kube";
   private static APIEndpoint: string = `${Function.APIBase}/apis/kubeless.io/v1beta1`;
+  private static getResourceLink(namespace?: string): string {
+    return `${Function.APIEndpoint}/${namespace ? `namespaces/${namespace}/` : ""}functions`;
+  }
   private static getSelfLink(name: string, namespace: string): string {
     return `${Function.APIEndpoint}/namespaces/${namespace}/functions/${name}`;
   }

--- a/dashboard/src/shared/HelmRelease.ts
+++ b/dashboard/src/shared/HelmRelease.ts
@@ -1,28 +1,66 @@
-import axios from "axios";
 import { inflate } from "pako";
 import { clearInterval, setInterval } from "timers";
 
-import { hapi } from "../shared/hapi/release";
-import { IApp, IChart, IHelmRelease, IHelmReleaseConfigMap } from "./types";
+import { axios } from "./Auth";
+import { hapi } from "./hapi/release";
+import { IApp, IChart, IChartVersion, IHelmRelease, IHelmReleaseConfigMap } from "./types";
 import * as url from "./url";
 
 export class HelmRelease {
-  public static async create(chart: IChart, releaseName: string, namespace: string) {
+  public static async create(
+    releaseName: string,
+    namespace: string,
+    chartVersion: IChartVersion,
+    values?: string,
+  ) {
+    const chartAttrs = chartVersion.relationships.chart.data;
     const endpoint = HelmRelease.getResourceLink(namespace);
     const { data } = await axios.post(endpoint, {
-      data: {
+      apiVersion: "helm.bitnami.com/v1",
+      kind: "HelmRelease",
+      metadata: {
+        annotations: {
+          "apprepositories.kubeapps.com/repo-name": chartAttrs.repo.name,
+        },
+        name: releaseName,
+      },
+      spec: {
+        chartName: chartAttrs.name,
+        repoUrl: chartAttrs.repo.url,
+        values,
+        version: chartVersion.attributes.version,
+      },
+    });
+    return data;
+  }
+
+  public static async upgrade(
+    releaseName: string,
+    namespace: string,
+    chartVersion: IChartVersion,
+    values?: string,
+  ) {
+    const chartAttrs = chartVersion.relationships.chart.data;
+    const endpoint = HelmRelease.getSelfLink(releaseName, namespace);
+    const { data } = await axios.patch(
+      endpoint,
+      {
         apiVersion: "helm.bitnami.com/v1",
         kind: "HelmRelease",
         metadata: {
-          releaseName,
+          name: releaseName,
         },
         spec: {
-          chartName: chart.attributes.name,
-          repoUrl: chart.attributes.repo.url,
-          version: chart.relationships.latestChartVersion.data.version,
+          chartName: chartAttrs.name,
+          repoUrl: chartAttrs.repo.url,
+          values,
+          version: chartVersion.attributes.version,
         },
       },
-    });
+      {
+        headers: { "Content-Type": "application/merge-patch+json" },
+      },
+    );
     return data;
   }
 

--- a/dashboard/src/shared/HelmRelease.ts
+++ b/dashboard/src/shared/HelmRelease.ts
@@ -71,9 +71,9 @@ export class HelmRelease {
     return data;
   }
 
-  public static async getAllWithDetails() {
+  public static async getAllWithDetails(namespace?: string) {
     const { data: { items: helmReleaseList } } = await axios.get<{ items: IHelmRelease[] }>(
-      this.getResourceLink(),
+      this.getResourceLink(namespace),
     );
     // Convert list of HelmReleases to release name -> HelmRelease pair
     const helmReleaseMap = helmReleaseList.reduce((acc, hr) => {

--- a/dashboard/src/shared/ServiceBinding.ts
+++ b/dashboard/src/shared/ServiceBinding.ts
@@ -54,11 +54,7 @@ export interface IServiceBinding {
 }
 
 export class ServiceBinding {
-  public static async create(
-    bindingName: string,
-    instanceRefName: string,
-    namespace: string = "default",
-  ) {
+  public static async create(bindingName: string, instanceRefName: string, namespace: string) {
     const url = ServiceBinding.getLink(namespace);
     try {
       const { data } = await axios.post<IServiceBinding>(url, {
@@ -77,19 +73,19 @@ export class ServiceBinding {
     }
   }
 
-  public static async delete(name: string, namespace: string = "default") {
+  public static async delete(name: string, namespace: string) {
     const url = this.getLink(namespace, name);
     return axios.delete(url);
   }
 
-  public static async get(namespace: string = "default", name: string) {
+  public static async get(namespace: string, name: string) {
     const url = this.getLink(namespace, name);
     const { data } = await axios.get<IServiceBinding>(url);
     return data;
   }
 
-  public static async list(namespace: string = "default") {
-    const bindings = await ServiceCatalog.getItems<IServiceBinding>("/servicebindings");
+  public static async list(namespace?: string) {
+    const bindings = await ServiceCatalog.getItems<IServiceBinding>("servicebindings", namespace);
 
     // initiate with undefined secrets
     for (const binding of bindings) {

--- a/dashboard/src/shared/ServiceBinding.ts
+++ b/dashboard/src/shared/ServiceBinding.ts
@@ -1,5 +1,4 @@
-import axios from "axios";
-
+import { axios } from "./Auth";
 import { ICondition, ServiceCatalog } from "./ServiceCatalog";
 import { IStatus } from "./types";
 

--- a/dashboard/src/shared/ServiceCatalog.ts
+++ b/dashboard/src/shared/ServiceCatalog.ts
@@ -1,6 +1,5 @@
-import axios from "axios";
-
 import * as urls from "../shared/url";
+import { axios } from "./Auth";
 import { IClusterServiceClass } from "./ClusterServiceClass";
 import { IServiceInstance } from "./ServiceInstance";
 import { IK8sList, IStatus } from "./types";

--- a/dashboard/src/shared/ServiceInstance.ts
+++ b/dashboard/src/shared/ServiceInstance.ts
@@ -68,7 +68,10 @@ export class ServiceInstance {
   }
 
   public static async list(namespace?: string): Promise<IServiceInstance[]> {
-    const instances = await ServiceCatalog.getItems<IServiceInstance>("/serviceinstances");
+    const instances = await ServiceCatalog.getItems<IServiceInstance>(
+      "serviceinstances",
+      namespace,
+    );
     return instances;
   }
 

--- a/dashboard/src/shared/ServiceInstance.ts
+++ b/dashboard/src/shared/ServiceInstance.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { axios } from "./Auth";
 import { ICondition, ServiceCatalog } from "./ServiceCatalog";
 import { IStatus } from "./types";
 

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -142,6 +142,7 @@ export interface IStoreState {
   repos: IAppRepositoryState;
   deployment: IDeployment;
   functions: IFunctionState;
+  namespace: string;
 }
 
 interface IK8sResource {

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -1,3 +1,4 @@
+import { IAuthState } from "../reducers/auth";
 import { IServiceCatalogState } from "../reducers/catalog";
 import { IFunctionState } from "../reducers/functions";
 import { IAppRepositoryState } from "../reducers/repos";
@@ -136,6 +137,7 @@ export interface IAppState {
 export interface IStoreState {
   catalog: IServiceCatalogState;
   apps: IAppState;
+  auth: IAuthState;
   charts: IChartState;
   repos: IAppRepositoryState;
   deployment: IDeployment;


### PR DESCRIPTION
- Redirected to /login if not logged in, which contains a form to login
  with a bearer token
- All Kubernetes API requests send the bearer token
- All Kubernetes API requests namespaced by default

caveats:
- currently namespace is hardcoded to `default` and there's no way to
  change it, this will be fixed in a follow-up PR (#237)

closes #240
closes #202
closes #238