### PR TITLE
feature: support for specifying optional authorization token for HTTP requests

### DIFF
--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -526,10 +526,12 @@ func apprepoSyncJobEnvVars(apprepo *apprepov1alpha1.AppRepository) []corev1.EnvV
 		},
 	})
 	if apprepo.Spec.Auth != nil {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:      "AUTHORIZATION_HEADER",
-			ValueFrom: apprepo.Spec.Auth,
-		})
+		if apprepo.Spec.Auth.Header != nil {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:      "AUTHORIZATION_HEADER",
+				ValueFrom: apprepo.Spec.Auth.Header,
+			})
+		}
 	}
 	return envVars
 }

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -525,13 +525,11 @@ func apprepoSyncJobEnvVars(apprepo *apprepov1alpha1.AppRepository) []corev1.EnvV
 			},
 		},
 	})
-	if apprepo.Spec.Auth != nil {
-		if apprepo.Spec.Auth.Header != nil {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:      "AUTHORIZATION_HEADER",
-				ValueFrom: apprepo.Spec.Auth.Header,
-			})
-		}
+	if apprepo.Spec.Auth.Header != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:      "AUTHORIZATION_HEADER",
+			ValueFrom: apprepo.Spec.Auth.Header,
+		})
 	}
 	return envVars
 }

--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,9 +36,10 @@ type AppRepository struct {
 
 // AppRepositorySpec is the spec for an AppRepository resource
 type AppRepositorySpec struct {
-	Type           string `json:"type"`
-	URL            string `json:"url"`
-	ResyncRequests uint   `json:"resyncRequests"`
+	Type           string               `json:"type"`
+	URL            string               `json:"url"`
+	Auth           *corev1.EnvVarSource `json:"auth,omitempty"`
+	ResyncRequests uint                 `json:"resyncRequests"`
 }
 
 // AppRepositoryStatus is the status for an AppRepository resource

--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
@@ -36,10 +36,15 @@ type AppRepository struct {
 
 // AppRepositorySpec is the spec for an AppRepository resource
 type AppRepositorySpec struct {
-	Type           string               `json:"type"`
-	URL            string               `json:"url"`
-	Auth           *corev1.EnvVarSource `json:"auth,omitempty"`
-	ResyncRequests uint                 `json:"resyncRequests"`
+	Type           string             `json:"type"`
+	URL            string             `json:"url"`
+	Auth           *AppRepositoryAuth `json:"auth,omitempty"`
+	ResyncRequests uint               `json:"resyncRequests"`
+}
+
+// AppRepositoryAuth is the auth for an AppRepository resource
+type AppRepositoryAuth struct {
+	Header *corev1.EnvVarSource `json:"header,omitempty"`
 }
 
 // AppRepositoryStatus is the status for an AppRepository resource

--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
@@ -36,10 +36,10 @@ type AppRepository struct {
 
 // AppRepositorySpec is the spec for an AppRepository resource
 type AppRepositorySpec struct {
-	Type           string             `json:"type"`
-	URL            string             `json:"url"`
-	Auth           *AppRepositoryAuth `json:"auth,omitempty"`
-	ResyncRequests uint               `json:"resyncRequests"`
+	Type           string            `json:"type"`
+	URL            string            `json:"url"`
+	Auth           AppRepositoryAuth `json:"auth,omitempty"`
+	ResyncRequests uint              `json:"resyncRequests"`
 }
 
 // AppRepositoryAuth is the auth for an AppRepository resource

--- a/cmd/chart-repo/sync.go
+++ b/cmd/chart-repo/sync.go
@@ -60,7 +60,8 @@ var syncCmd = &cobra.Command{
 			logrus.Fatalf("Can't connect to mongoDB: %v", err)
 		}
 
-		if err = syncRepo(dbSession, args[0], args[1]); err != nil {
+		accessToken := os.Getenv("ACCESS_TOKEN")
+		if err = syncRepo(dbSession, args[0], args[1], accessToken); err != nil {
 			logrus.Fatalf("Can't add chart repository to database: %v", err)
 		}
 

--- a/cmd/chart-repo/sync.go
+++ b/cmd/chart-repo/sync.go
@@ -60,7 +60,7 @@ var syncCmd = &cobra.Command{
 			logrus.Fatalf("Can't connect to mongoDB: %v", err)
 		}
 
-		accessToken := os.Getenv("ACCESS_TOKEN")
+		accessToken := os.Getenv("AUTHORIZATION_HEADER")
 		if err = syncRepo(dbSession, args[0], args[1], accessToken); err != nil {
 			logrus.Fatalf("Can't add chart repository to database: %v", err)
 		}

--- a/cmd/chart-repo/sync.go
+++ b/cmd/chart-repo/sync.go
@@ -60,8 +60,8 @@ var syncCmd = &cobra.Command{
 			logrus.Fatalf("Can't connect to mongoDB: %v", err)
 		}
 
-		accessToken := os.Getenv("AUTHORIZATION_HEADER")
-		if err = syncRepo(dbSession, args[0], args[1], accessToken); err != nil {
+		authorizationHeader := os.Getenv("AUTHORIZATION_HEADER")
+		if err = syncRepo(dbSession, args[0], args[1], authorizationHeader); err != nil {
 			logrus.Fatalf("Can't add chart repository to database: %v", err)
 		}
 

--- a/cmd/chart-repo/types.go
+++ b/cmd/chart-repo/types.go
@@ -21,8 +21,9 @@ import (
 )
 
 type repo struct {
-	Name string
-	URL  string
+	Name        string
+	URL         string
+	AccessToken string `bson:"-"`
 }
 
 type maintainer struct {

--- a/cmd/chart-repo/types.go
+++ b/cmd/chart-repo/types.go
@@ -21,9 +21,9 @@ import (
 )
 
 type repo struct {
-	Name        string
-	URL         string
-	AccessToken string `bson:"-"`
+	Name                string
+	URL                 string
+	AuthorizationHeader string `bson:"-"`
 }
 
 type maintainer struct {

--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -73,14 +73,14 @@ func parseRepoUrl(repoURL string) (*url.URL, error) {
 // These steps are processed in this way to ensure relevant chart data is
 // imported into the database as fast as possible. E.g. we want all icons for
 // charts before fetching readmes for each chart and version pair.
-func syncRepo(dbSession datastore.Session, repoName, repoURL string, accessToken string) error {
+func syncRepo(dbSession datastore.Session, repoName, repoURL string, authorizationHeader string) error {
 	url, err := parseRepoUrl(repoURL)
 	if err != nil {
 		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
 		return err
 	}
 
-	r := repo{Name: repoName, URL: url.String(), AccessToken: accessToken}
+	r := repo{Name: repoName, URL: url.String(), AuthorizationHeader: authorizationHeader}
 	index, err := fetchRepoIndex(r)
 	if err != nil {
 		return err
@@ -166,8 +166,8 @@ func fetchRepoIndex(r repo) (*helmrepo.IndexFile, error) {
 		return nil, err
 	}
 	req.Header.Set("User-Agent", userAgent)
-	if len(r.AccessToken) > 0 {
-		req.Header.Set("Authorization", r.AccessToken)
+	if len(r.AuthorizationHeader) > 0 {
+		req.Header.Set("Authorization", r.AuthorizationHeader)
 	}
 	res, err := netClient.Do(req)
 	if err != nil {
@@ -276,8 +276,8 @@ func fetchAndImportIcon(dbSession datastore.Session, c chart) error {
 		return err
 	}
 	req.Header.Set("User-Agent", userAgent)
-	if len(c.Repo.AccessToken) > 0 {
-		req.Header.Set("Authorization", c.Repo.AccessToken)
+	if len(c.Repo.AuthorizationHeader) > 0 {
+		req.Header.Set("Authorization", c.Repo.AuthorizationHeader)
 	}
 
 	res, err := netClient.Do(req)
@@ -322,8 +322,8 @@ func fetchAndImportFiles(dbSession datastore.Session, name string, r repo, cv ch
 		return err
 	}
 	req.Header.Set("User-Agent", userAgent)
-	if len(r.AccessToken) > 0 {
-		req.Header.Set("Authorization", r.AccessToken)
+	if len(r.AuthorizationHeader) > 0 {
+		req.Header.Set("Authorization", r.AuthorizationHeader)
 	}
 
 	res, err := netClient.Do(req)

--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -167,7 +167,7 @@ func fetchRepoIndex(r repo) (*helmrepo.IndexFile, error) {
 	}
 	req.Header.Set("User-Agent", userAgent)
 	if len(r.AccessToken) > 0 {
-		req.Header.Set("Authorization", "Bearer "+r.AccessToken)
+		req.Header.Set("Authorization", r.AccessToken)
 	}
 	res, err := netClient.Do(req)
 	if err != nil {
@@ -277,7 +277,7 @@ func fetchAndImportIcon(dbSession datastore.Session, c chart) error {
 	}
 	req.Header.Set("User-Agent", userAgent)
 	if len(c.Repo.AccessToken) > 0 {
-		req.Header.Set("Authorization", "Bearer "+c.Repo.AccessToken)
+		req.Header.Set("Authorization", c.Repo.AccessToken)
 	}
 
 	res, err := netClient.Do(req)
@@ -323,7 +323,7 @@ func fetchAndImportFiles(dbSession datastore.Session, name string, r repo, cv ch
 	}
 	req.Header.Set("User-Agent", userAgent)
 	if len(r.AccessToken) > 0 {
-		req.Header.Set("Authorization", "Bearer "+r.AccessToken)
+		req.Header.Set("Authorization", r.AccessToken)
 	}
 
 	res, err := netClient.Do(req)

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -133,7 +133,7 @@ func Test_syncURLInvalidity(t *testing.T) {
 	dbSession := mockstore.NewMockSession(&m)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := syncRepo(dbSession, "test", tt.repoURL)
+			err := syncRepo(dbSession, "test", tt.repoURL, "")
 			assert.ExistsErr(t, err, tt.name)
 		})
 	}
@@ -141,29 +141,27 @@ func Test_syncURLInvalidity(t *testing.T) {
 
 func Test_fetchRepoIndex(t *testing.T) {
 	tests := []struct {
-		name    string
-		repoURL string
+		name string
+		r    repo
 	}{
-		{"valid HTTP URL", "http://my.examplerepo.com"},
-		{"valid HTTPS URL", "https://my.examplerepo.com"},
-		{"valid trailing URL", "https://my.examplerepo.com/"},
-		{"valid subpath URL", "https://subpath.test/subpath/"},
-		{"valid URL with trailing spaces", "https://subpath.test/subpath/  "},
-		{"valid URL with leading spaces", "  https://subpath.test/subpath/"},
+		{"valid HTTP URL", repo{URL: "http://my.examplerepo.com"}},
+		{"valid HTTPS URL", repo{URL: "https://my.examplerepo.com"}},
+		{"valid trailing URL", repo{URL: "https://my.examplerepo.com/"}},
+		{"valid subpath URL", repo{URL: "https://subpath.test/subpath/"}},
+		{"valid URL with trailing spaces", repo{URL: "https://subpath.test/subpath/  "}},
+		{"valid URL with leading spaces", repo{URL: "  https://subpath.test/subpath/"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			netClient = &goodHTTPClient{}
-			url, _ := parseRepoUrl(tt.repoURL)
-			_, err := fetchRepoIndex(url)
+			_, err := fetchRepoIndex(tt.r)
 			assert.NoErr(t, err)
 		})
 	}
 
 	t.Run("failed request", func(t *testing.T) {
 		netClient = &badHTTPClient{}
-		url, _ := parseRepoUrl("https://my.examplerepo.com")
-		_, err := fetchRepoIndex(url)
+		_, err := fetchRepoIndex(repo{URL: "https://my.examplerepo.com"})
 		assert.ExistsErr(t, err, "failed request")
 	})
 }

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -79,7 +79,7 @@ type authenticatedHTTPClient struct{}
 func (h *authenticatedHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	w := httptest.NewRecorder()
 
-	// Ensure we're sending the right User-Agent
+	// Ensure we're sending the right Authorization header
 	if !strings.Contains(req.Header.Get("Authorization"), "Bearer ThisSecretAccessTokenAuthenticatesTheClient") {
 		w.WriteHeader(500)
 	}
@@ -121,10 +121,6 @@ var testChartValues = "image: test"
 
 func (h *goodTarballClient) Do(req *http.Request) (*http.Response, error) {
 	w := httptest.NewRecorder()
-	if !strings.Contains(req.Header.Get("Authorization"), "Bearer ThisSecretAccessTokenAuthenticatesTheClient") {
-		w.WriteHeader(500)
-		return w.Result(), nil
-	}
 	gzw := gzip.NewWriter(w)
 	files := []tarballFile{{h.c.Name + "/Chart.yaml", "should be a Chart.yaml here..."}}
 	if !h.skipValues {
@@ -135,6 +131,27 @@ func (h *goodTarballClient) Do(req *http.Request) (*http.Response, error) {
 	}
 	createTestTarball(gzw, files)
 	gzw.Flush()
+	return w.Result(), nil
+}
+
+type authenticatedTarballClient struct {
+	c chart
+}
+
+func (h *authenticatedTarballClient) Do(req *http.Request) (*http.Response, error) {
+	w := httptest.NewRecorder()
+
+	// Ensure we're sending the right Authorization header
+	if !strings.Contains(req.Header.Get("Authorization"), "Bearer ThisSecretAccessTokenAuthenticatesTheClient") {
+		w.WriteHeader(500)
+	} else {
+		gzw := gzip.NewWriter(w)
+		files := []tarballFile{{h.c.Name + "/Chart.yaml", "should be a Chart.yaml here..."}}
+		files = append(files, tarballFile{h.c.Name + "/values.yaml", testChartValues})
+		files = append(files, tarballFile{h.c.Name + "/README.md", testChartReadme})
+		createTestTarball(gzw, files)
+		gzw.Flush()
+	}
 	return w.Result(), nil
 }
 
@@ -314,7 +331,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 
 func Test_fetchAndImportFiles(t *testing.T) {
 	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
-	charts := chartsFromIndex(index, repo{Name: "test", URL: "http://testrepo.com", AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient"})
+	charts := chartsFromIndex(index, repo{Name: "test", URL: "http://testrepo.com", AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient1s"})
 	cv := charts[0].ChartVersions[0]
 
 	t.Run("http error", func(t *testing.T) {
@@ -330,6 +347,17 @@ func Test_fetchAndImportFiles(t *testing.T) {
 		m := mock.Mock{}
 		m.On("One", mock.Anything).Return(errors.New("return an error when checking if files already exists to force fetching"))
 		m.On("Insert", chartFiles{fmt.Sprintf("%s/%s-%s", charts[0].Repo.Name, charts[0].Name, cv.Version), "", "", charts[0].Repo})
+		dbSession := mockstore.NewMockSession(&m)
+		err := fetchAndImportFiles(dbSession, charts[0].Name, charts[0].Repo, cv)
+		assert.NoErr(t, err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("authenticated request", func(t *testing.T) {
+		netClient = &authenticatedTarballClient{c: charts[0]}
+		m := mock.Mock{}
+		m.On("One", mock.Anything).Return(errors.New("return an error when checking if files already exists to force fetching"))
+		m.On("Insert", chartFiles{fmt.Sprintf("%s/%s-%s", charts[0].Repo.Name, charts[0].Name, cv.Version), testChartReadme, testChartValues, charts[0].Repo})
 		dbSession := mockstore.NewMockSession(&m)
 		err := fetchAndImportFiles(dbSession, charts[0].Name, charts[0].Repo, cv)
 		assert.NoErr(t, err)

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -178,7 +178,7 @@ func Test_fetchRepoIndex(t *testing.T) {
 
 	t.Run("authenticated request", func(t *testing.T) {
 		netClient = &authenticatedHTTPClient{}
-		_, err := fetchRepoIndex(repo{URL: "https://my.examplerepo.com", AccessToken: "Bearer ThisSecretAccessTokenAuthenticatesTheClient"})
+		_, err := fetchRepoIndex(repo{URL: "https://my.examplerepo.com", AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient"})
 		assert.NoErr(t, err)
 	})
 
@@ -314,7 +314,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 
 func Test_fetchAndImportFiles(t *testing.T) {
 	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
-	charts := chartsFromIndex(index, repo{Name: "test", URL: "http://testrepo.com", AccessToken: "Bearer ThisSecretAccessTokenAuthenticatesTheClient"})
+	charts := chartsFromIndex(index, repo{Name: "test", URL: "http://testrepo.com", AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient"})
 	cv := charts[0].ChartVersions[0]
 
 	t.Run("http error", func(t *testing.T) {

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -88,9 +88,11 @@ export const installRepo = (name: string, url: string, authHeader: string) => {
     const secretName = `apprepo-${name}-secrets`;
     if (authHeader.length) {
       auth = {
-        secretKeyRef: {
-          key: "authorizationHeader",
-          name: secretName,
+        header: {
+          secretKeyRef: {
+            key: "authorizationHeader",
+            name: secretName,
+          },
         },
       };
     }

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -57,7 +57,7 @@ export const deleteRepo = (name: string) => {
     const repos = await AppRepository.list();
     dispatch(receiveRepos(repos.items));
     if (repo.spec.auth && repo.spec.auth.secretKeyRef.name) {
-      Secret.delete(repo.spec.auth.secretKeyRef.name);
+      Secret.delete(repo.spec.auth.secretKeyRef.name, "kubeapps");
     }
     return repos;
   };
@@ -91,7 +91,7 @@ export const installRepo = (name: string, url: string, authHeader: string) => {
     let auth;
     if (authHeader.length) {
       const secretName = `apprepo-${name}-secrets`;
-      await Secret.create(secretName, { authorizationHeader: btoa(authHeader) });
+      await Secret.create(secretName, { authorizationHeader: btoa(authHeader) }, "kubeapps");
       auth = {
         secretKeyRef: {
           key: "authorizationHeader",

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -5,17 +5,18 @@ import { Redirect } from "react-router";
 interface IAppRepoFormProps {
   name: string;
   url: string;
+  authHeader: string;
   message?: string;
   redirectTo?: string;
-  install: (name: string, url: string) => Promise<any>;
-  update: (values: { name?: string; url?: string }) => void;
+  install: (name: string, url: string, authHeader: string) => Promise<any>;
+  update: (values: { name?: string; url?: string; authHeader?: string }) => void;
   onAfterInstall?: () => Promise<any>;
 }
 
 export const AppRepoForm = (props: IAppRepoFormProps) => {
-  const { name, url, update, install, onAfterInstall } = props;
+  const { name, url, authHeader, update, install, onAfterInstall } = props;
   const handleInstallClick = async () => {
-    await install(name, url);
+    await install(name, url, authHeader);
     if (onAfterInstall) {
       await onAfterInstall();
     }
@@ -24,6 +25,8 @@ export const AppRepoForm = (props: IAppRepoFormProps) => {
     update({ name: e.target.value });
   const handleURLChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     update({ url: e.target.value });
+  const handleAuthHeaderChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    update({ authHeader: e.target.value });
   return (
     <form className="container padding-b-bigger" onSubmit={handleInstallClick}>
       <div className="row">
@@ -56,6 +59,17 @@ export const AppRepoForm = (props: IAppRepoFormProps) => {
             </label>
           </div>
           <div>
+            <label>
+              <span>Authorization Header (optional):</span>
+              <input
+                type="text"
+                placeholder="Bearer xrxNcWghpRLdcPHFgVRM73rr4N7qjvjm"
+                value={authHeader}
+                onChange={handleAuthHeaderChange}
+              />
+            </label>
+          </div>
+          <div>
             <button className="button button-primary" type="submit">
               Install Repo
             </button>
@@ -68,10 +82,11 @@ export const AppRepoForm = (props: IAppRepoFormProps) => {
 };
 
 interface IAppRepoAddButtonProps {
-  install: (name: string, url: string) => Promise<any>;
+  install: (name: string, url: string, authHeader: string) => Promise<any>;
   redirectTo?: string;
 }
 interface IAppRepoAddButtonState {
+  authHeader: string;
   error?: string;
   modalIsOpen: boolean;
   name: string;
@@ -83,6 +98,7 @@ export class AppRepoAddButton extends React.Component<
   IAppRepoAddButtonState
 > {
   public state = {
+    authHeader: "",
     error: undefined,
     modalIsOpen: false,
     name: "",
@@ -91,7 +107,7 @@ export class AppRepoAddButton extends React.Component<
 
   public render() {
     const { redirectTo, install } = this.props;
-    const { name, url } = this.state;
+    const { name, url, authHeader } = this.state;
     return (
       <div className="AppRepoAddButton">
         <button className="button button-primary" onClick={this.openModal}>
@@ -108,6 +124,7 @@ export class AppRepoAddButton extends React.Component<
           <AppRepoForm
             name={name}
             url={url}
+            authHeader={authHeader}
             update={this.updateValues}
             install={install}
             onAfterInstall={this.closeModal}
@@ -120,6 +137,6 @@ export class AppRepoAddButton extends React.Component<
 
   private closeModal = async () => this.setState({ modalIsOpen: false });
   private openModal = async () => this.setState({ modalIsOpen: true });
-  private updateValues = async (values: { name: string; url: string }) =>
+  private updateValues = async (values: { name: string; url: string; authHeader: string }) =>
     this.setState({ ...values });
 }

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -25,22 +25,45 @@ export const AppRepoForm = (props: IAppRepoFormProps) => {
   const handleURLChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     update({ url: e.target.value });
   return (
-    <div className="app-repo-form">
-      <h1>Add an App Repository</h1>
-      <label>
-        <span>Name:</span>
-        <input type="text" value={name} onChange={handleNameChange} />
-      </label>
-      <br />
-      <label>
-        <span>URL:</span>
-        <input type="text" value={url} onChange={handleURLChange} />
-      </label>
-      <button className="button button-primary" onClick={handleInstallClick}>
-        Install Repo
-      </button>
-      {props.redirectTo && <Redirect to={props.redirectTo} />}
-    </div>
+    <form className="container padding-b-bigger" onSubmit={handleInstallClick}>
+      <div className="row">
+        <div className="col-12">
+          <div>
+            <h2>Add an App Repository</h2>
+          </div>
+          <div>
+            <label>
+              <span>Name:</span>
+              <input
+                type="text"
+                placeholder="example"
+                value={name}
+                onChange={handleNameChange}
+                required={true}
+              />
+            </label>
+          </div>
+          <div>
+            <label>
+              <span>URL:</span>
+              <input
+                type="url"
+                placeholder="https://charts.example.com/stable"
+                value={url}
+                onChange={handleURLChange}
+                required={true}
+              />
+            </label>
+          </div>
+          <div>
+            <button className="button button-primary" type="submit">
+              Install Repo
+            </button>
+          </div>
+          {props.redirectTo && <Redirect to={props.redirectTo} />}
+        </div>
+      </div>
+    </form>
   );
 };
 

--- a/dashboard/src/components/Config/AppRepoList/index.tsx
+++ b/dashboard/src/components/Config/AppRepoList/index.tsx
@@ -9,7 +9,7 @@ export interface IAppRepoListProps {
   fetchRepos: () => Promise<any>;
   deleteRepo: (name: string) => Promise<any>;
   resyncRepo: (name: string) => Promise<any>;
-  install: (name: string, url: string) => Promise<any>;
+  install: (name: string, url: string, authHeader: string) => Promise<any>;
 }
 
 export class AppRepoList extends React.Component<IAppRepoListProps> {

--- a/dashboard/src/containers/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer.ts
@@ -19,8 +19,8 @@ function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
     fetchRepos: async () => {
       return dispatch(actions.repos.fetchRepos());
     },
-    install: async (name: string, url: string) => {
-      return dispatch(actions.repos.installRepo(name, url));
+    install: async (name: string, url: string, authHeader: string) => {
+      return dispatch(actions.repos.installRepo(name, url, authHeader));
     },
     resyncRepo: async (name: string) => {
       return dispatch(actions.repos.resyncRepo(name));

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -23,14 +23,14 @@ export class AppRepository {
     return data;
   }
 
-  public static async create(name: string, url: string) {
+  public static async create(name: string, url: string, auth: any) {
     const { data } = await axios.post<IAppRepository>(AppRepository.APIEndpoint, {
       apiVersion: "kubeapps.com/v1alpha1",
       kind: "AppRepository",
       metadata: {
         name,
       },
-      spec: { type: "helm", url },
+      spec: { auth, type: "helm", url },
     });
     return data;
   }

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -1,11 +1,11 @@
 import axios from "axios";
 
-import { ISecret, IStatus } from "./types";
+import { IOwnerReference, IResource, ISecret, IStatus } from "./types";
 
 export default class Secret {
   public static async create(
     name: string,
-    secrets: any,
+    secrets: { [s: string]: string },
     owner: any | undefined,
     namespace: string = "default",
   ) {
@@ -44,15 +44,15 @@ export default class Secret {
     return data;
   }
 
-  private static getOwnerReference(owner: any) {
+  private static getOwnerReference(owner: IResource) {
     return owner
-      ? {
+      ? ({
           apiVersion: owner.apiVersion,
           blockOwnerDeletion: true,
           kind: owner.kind,
           name: owner.metadata.name,
           uid: owner.metadata.uid,
-        }
+        } as IOwnerReference)
       : undefined;
   }
 

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -1,0 +1,42 @@
+import axios from "axios";
+
+import { ISecret, IStatus } from "./types";
+
+export default class Secret {
+  public static async create(name: string, secrets: any) {
+    const url = Secret.getLink();
+    try {
+      const { data } = await axios.post<ISecret>(url, {
+        apiVersion: "v1",
+        data: secrets,
+        kind: "Secret",
+        metadata: { name },
+        type: "Opaque",
+      });
+      return data;
+    } catch (e) {
+      throw new Error((e.response.data as IStatus).message);
+    }
+  }
+
+  public static async delete(name: string) {
+    const url = this.getLink(name);
+    return axios.delete(url);
+  }
+
+  public static async get(name: string) {
+    const url = this.getLink(name);
+    const { data } = await axios.get<ISecret>(url);
+    return data;
+  }
+
+  public static async list() {
+    const url = Secret.getLink();
+    const { data } = await axios.get<ISecret>(url);
+    return data;
+  }
+
+  private static getLink(name?: string): string {
+    return `/api/kube/api/v1/namespaces/kubeapps/secrets${name ? `/${name}` : ""}`;
+  }
+}

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -1,12 +1,12 @@
 import axios from "axios";
 
-import { IOwnerReference, IResource, ISecret, IStatus } from "./types";
+import { IOwnerReference, ISecret, IStatus } from "./types";
 
 export default class Secret {
   public static async create(
     name: string,
     secrets: { [s: string]: string },
-    owner: any | undefined,
+    owner: IOwnerReference | undefined,
     namespace: string = "default",
   ) {
     const url = Secret.getLink(namespace);
@@ -17,7 +17,7 @@ export default class Secret {
         kind: "Secret",
         metadata: {
           name,
-          ownerReferences: [Secret.getOwnerReference(owner)],
+          ownerReferences: [owner],
         },
         type: "Opaque",
       });
@@ -42,18 +42,6 @@ export default class Secret {
     const url = Secret.getLink(namespace);
     const { data } = await axios.get<ISecret>(url);
     return data;
-  }
-
-  private static getOwnerReference(owner: IResource) {
-    return owner
-      ? ({
-          apiVersion: owner.apiVersion,
-          blockOwnerDeletion: true,
-          kind: owner.kind,
-          name: owner.metadata.name,
-          uid: owner.metadata.uid,
-        } as IOwnerReference)
-      : undefined;
   }
 
   private static getLink(namespace: string, name?: string): string {

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -3,8 +3,8 @@ import axios from "axios";
 import { ISecret, IStatus } from "./types";
 
 export default class Secret {
-  public static async create(name: string, secrets: any) {
-    const url = Secret.getLink();
+  public static async create(name: string, secrets: any, namespace: string = "default") {
+    const url = Secret.getLink(namespace);
     try {
       const { data } = await axios.post<ISecret>(url, {
         apiVersion: "v1",
@@ -19,24 +19,24 @@ export default class Secret {
     }
   }
 
-  public static async delete(name: string) {
-    const url = this.getLink(name);
+  public static async delete(name: string, namespace: string = "default") {
+    const url = this.getLink(namespace, name);
     return axios.delete(url);
   }
 
-  public static async get(name: string) {
-    const url = this.getLink(name);
+  public static async get(name: string, namespace: string = "default") {
+    const url = this.getLink(namespace, name);
     const { data } = await axios.get<ISecret>(url);
     return data;
   }
 
-  public static async list() {
-    const url = Secret.getLink();
+  public static async list(namespace: string = "default") {
+    const url = Secret.getLink(namespace);
     const { data } = await axios.get<ISecret>(url);
     return data;
   }
 
-  private static getLink(name?: string): string {
-    return `/api/kube/api/v1/namespaces/kubeapps/secrets${name ? `/${name}` : ""}`;
+  private static getLink(namespace: string, name?: string): string {
+    return `/api/kube/api/v1/namespaces/${namespace}/secrets${name ? `/${name}` : ""}`;
   }
 }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -194,9 +194,11 @@ export interface IAppRepository
         type: string;
         url: string;
         auth: {
-          secretKeyRef: {
-            name: string;
-            key: string;
+          header: {
+            secretKeyRef: {
+              name: string;
+              key: string;
+            };
           };
         };
       },

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -101,11 +101,20 @@ export interface IResource {
     selfLink: string;
     resourceVersion: string;
     deletionTimestamp?: string;
+    uid: string;
   };
 }
 
+export interface IOwnerReference {
+  apiVersion: string;
+  blockOwnerDeletion: boolean;
+  kind: string;
+  name: string;
+  uid: string;
+}
+
 export interface ISecret extends IResource {
-  data: any;
+  data: { [s: string]: string };
 }
 
 export interface IDeploymentStatus {

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -190,7 +190,16 @@ export interface IAppRepository
         resourceVersion: string;
         selfLink: string;
       },
-      { type: string; url: string; auth: any },
+      {
+        type: string;
+        url: string;
+        auth: {
+          secretKeyRef: {
+            name: string;
+            key: string;
+          };
+        };
+      },
       undefined
     > {}
 

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -98,8 +98,14 @@ export interface IResource {
     namespace: string;
     annotations: string;
     creationTimestamp: string;
+    selfLink: string;
+    resourceVersion: string;
     deletionTimestamp?: string;
   };
+}
+
+export interface ISecret extends IResource {
+  data: any;
 }
 
 export interface IDeploymentStatus {
@@ -184,7 +190,7 @@ export interface IAppRepository
         resourceVersion: string;
         selfLink: string;
       },
-      { type: string; url: string },
+      { type: string; url: string; auth: any },
       undefined
     > {}
 

--- a/manifests/helm-crd.jsonnet
+++ b/manifests/helm-crd.jsonnet
@@ -24,6 +24,7 @@ local controllerOverlay = {
               host: "localhost:44134",
             },
             env_: {
+              POD_NAMESPACE: $.metadata.namespace,
               TMPDIR: "/helm",
             },
             volumeMounts_: {


### PR DESCRIPTION
Adds `auth` field to AppRepository spec to providing the authentication header for HTTP requests. `chart-repo sync` command use the specified header to make the requests

eg.

```
apiVersion: kubeapps.com/v1alpha1
kind: AppRepository
metadata:
  annotations: {}
  labels:
    created-by: kubeapps
    name: fuloi
  name: fuloi
  namespace: kubeapps
spec:
  type: helm
  url: http://artifactory.fuloi.com/artifactory/helm
  auth:
    header: 
      secretKeyRef:
        name: apprepo-fuloi-secrets
        key: authorizationHeader
```
