### PR TITLE
Updated apiBase to use WSS if connection is established with HTTPS

### DIFF
--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -26,6 +26,19 @@ interface IAppViewState {
 }
 
 class AppView extends React.Component<IAppViewProps, IAppViewState> {
+
+  private static apiBase(): string {
+    let apiBase: string;
+
+    // Use WebSockets Secure if using HTTPS and WebSockets if not
+    if(location.protocol === 'https:') {
+      apiBase = `wss://${window.location.host}/api/kube`;
+  } else {
+      apiBase = `ws://${window.location.host}/api/kube`;
+  }
+    return apiBase;
+  }
+
   public state: IAppViewState = {
     deployments: new Map<string, IResource>(),
     otherResources: new Map<string, IResource>(),
@@ -59,7 +72,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
 
     const deployments = manifest.filter(d => d.kind === "Deployment");
     const services = manifest.filter(d => d.kind === "Service");
-    const apiBase = `ws://${window.location.host}/api/kube`;
+    const apiBase = AppView.apiBase();
     const sockets: WebSocket[] = [];
     for (const d of deployments) {
       const s = new WebSocket(

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -2,6 +2,7 @@ import * as yaml from "js-yaml";
 import * as React from "react";
 
 import { IApp, IResource } from "../../shared/types";
+import WebSocketHelper from "../../shared/WebSocketHelper";
 import DeploymentStatus from "../DeploymentStatus";
 import AppControls from "./AppControls";
 import AppDetails from "./AppDetails";
@@ -26,19 +27,6 @@ interface IAppViewState {
 }
 
 class AppView extends React.Component<IAppViewProps, IAppViewState> {
-
-  private static apiBase(): string {
-    let apiBase: string;
-
-    // Use WebSockets Secure if using HTTPS and WebSockets if not
-    if(location.protocol === 'https:') {
-      apiBase = `wss://${window.location.host}/api/kube`;
-  } else {
-      apiBase = `ws://${window.location.host}/api/kube`;
-  }
-    return apiBase;
-  }
-
   public state: IAppViewState = {
     deployments: new Map<string, IResource>(),
     otherResources: new Map<string, IResource>(),
@@ -72,7 +60,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
 
     const deployments = manifest.filter(d => d.kind === "Deployment");
     const services = manifest.filter(d => d.kind === "Service");
-    const apiBase = AppView.apiBase();
+    const apiBase = WebSocketHelper.apiBase();
     const sockets: WebSocket[] = [];
     for (const d of deployments) {
       const s = new WebSocket(

--- a/dashboard/src/components/FunctionView/FunctionView.tsx
+++ b/dashboard/src/components/FunctionView/FunctionView.tsx
@@ -2,6 +2,7 @@ import * as crypto from "crypto";
 import * as React from "react";
 
 import { IDeploymentStatus, IFunction, IResource } from "../../shared/types";
+import WebSocketHelper from "../../shared/WebSocketHelper";
 import DeploymentStatus from "../DeploymentStatus";
 import FunctionControls from "./FunctionControls";
 import FunctionEditor from "./FunctionEditor";
@@ -29,19 +30,6 @@ interface IFunctionViewState {
 }
 
 class FunctionView extends React.Component<IFunctionViewProps, IFunctionViewState> {
-  
-  private static apiBase(): string {
-    let apiBase: string;
-
-    // Use WebSockets Secure if using HTTPS and WebSockets if not
-    if(location.protocol === 'https:') {
-      apiBase = `wss://${window.location.host}/api/kube`;
-  } else {
-      apiBase = `ws://${window.location.host}/api/kube`;
-  }
-    return apiBase;
-  }
-  
   public state: IFunctionViewState = {
     codeModified: false,
     deploymentHealthy: false,
@@ -61,7 +49,7 @@ class FunctionView extends React.Component<IFunctionViewProps, IFunctionViewStat
     }
 
     const f = nextProps.function;
-    const apiBase = FunctionView.apiBase();
+    const apiBase = WebSocketHelper.apiBase();
     const socket = new WebSocket(
       `${apiBase}/apis/apps/v1beta1/namespaces/${
         f.metadata.namespace

--- a/dashboard/src/components/FunctionView/FunctionView.tsx
+++ b/dashboard/src/components/FunctionView/FunctionView.tsx
@@ -29,6 +29,19 @@ interface IFunctionViewState {
 }
 
 class FunctionView extends React.Component<IFunctionViewProps, IFunctionViewState> {
+  
+  private static apiBase(): string {
+    let apiBase: string;
+
+    // Use WebSockets Secure if using HTTPS and WebSockets if not
+    if(location.protocol === 'https:') {
+      apiBase = `wss://${window.location.host}/api/kube`;
+  } else {
+      apiBase = `ws://${window.location.host}/api/kube`;
+  }
+    return apiBase;
+  }
+  
   public state: IFunctionViewState = {
     codeModified: false,
     deploymentHealthy: false,
@@ -48,7 +61,7 @@ class FunctionView extends React.Component<IFunctionViewProps, IFunctionViewStat
     }
 
     const f = nextProps.function;
-    const apiBase = `ws://${window.location.host}/api/kube`;
+    const apiBase = FunctionView.apiBase();
     const socket = new WebSocket(
       `${apiBase}/apis/apps/v1beta1/namespaces/${
         f.metadata.namespace

--- a/dashboard/src/shared/WebSocketHelper.ts
+++ b/dashboard/src/shared/WebSocketHelper.ts
@@ -1,0 +1,13 @@
+export default class WebSocketHelper {
+  public static apiBase() {
+    let apiBase: string;
+
+    // Use WebSockets Secure if using HTTPS and WebSockets if not
+    if (location.protocol === "https:") {
+      apiBase = `wss://${window.location.host}/api/kube`;
+    } else {
+      apiBase = `ws://${window.location.host}/api/kube`;
+    }
+    return apiBase;
+  }
+}


### PR DESCRIPTION
Added in a private function in 2 areas (AppView.tsx and FunctionView.tsx) to determine if browser is using HTTP or HTTPS, and use the corresponding ws or wss protocols in apiBase. Tested with both HTTP & HTTPS browsers and works in both situations.

NOTE: There may be a better location for a shared function, but couldn't determine the optimal shared functions area. (I'm not a developer by trade... I know just enough to get flamed on github, so be kind).