### PR TITLE
add rule to manage secrets in the kubeapps namespace

### DIFF
--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -527,8 +527,10 @@ func apprepoSyncJobEnvVars(apprepo *apprepov1alpha1.AppRepository) []corev1.EnvV
 	})
 	if apprepo.Spec.Auth.Header != nil {
 		envVars = append(envVars, corev1.EnvVar{
-			Name:      "AUTHORIZATION_HEADER",
-			ValueFrom: apprepo.Spec.Auth.Header,
+			Name: "AUTHORIZATION_HEADER",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &apprepo.Spec.Auth.Header.SecretKeyRef,
+			},
 		})
 	}
 	return envVars

--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
@@ -44,7 +44,12 @@ type AppRepositorySpec struct {
 
 // AppRepositoryAuth is the auth for an AppRepository resource
 type AppRepositoryAuth struct {
-	Header *corev1.EnvVarSource `json:"header,omitempty"`
+	Header *AppRepositoryAuthHeader `json:"header,omitempty"`
+}
+
+type AppRepositoryAuthHeader struct {
+	// Selects a key of a secret in the pod's namespace
+	SecretKeyRef corev1.SecretKeySelector `json:"secretKeyRef,omitempty"`
 }
 
 // AppRepositoryStatus is the status for an AppRepository resource

--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -43,7 +43,7 @@ import (
 const (
 	chartCollection       = "charts"
 	chartFilesCollection  = "files"
-	defaultTimeoutSeconds = 180
+	defaultTimeoutSeconds = 10
 )
 
 type importChartFilesJob struct {

--- a/manifests/kube-api.jsonnet
+++ b/manifests/kube-api.jsonnet
@@ -13,6 +13,12 @@ local kube = import "kube.libsonnet";
         resources: ["configmaps"],
         verbs: ["get", "list"],
       },
+      // Kubeapps creates Secrets with authorization token data for private chart repos
+      {
+        apiGroups: [""],
+        resources: ["secrets"],
+        verbs: ["get", "list", "create", "delete"],
+      },
       // Kubeapps creates and manages AppRepository CRD objects that define
       // which application (e.g. chart) repositories will be indexed.
       {

--- a/manifests/kube-api.jsonnet
+++ b/manifests/kube-api.jsonnet
@@ -17,7 +17,7 @@ local kube = import "kube.libsonnet";
       {
         apiGroups: [""],
         resources: ["secrets"],
-        verbs: ["get", "list", "create", "delete"],
+        verbs: ["create"],
       },
       // Kubeapps creates and manages AppRepository CRD objects that define
       // which application (e.g. chart) repositories will be indexed.


### PR DESCRIPTION
The dashboard creates a Secret resource if a chart repo requires authentication. This 
PR adds a rule to the `kubeapps-kube-api` role to be able to do that.

Additionally some minor fixes have been imported from bitnami-labs/helm-crd/pull/23