### PR TITLE
dashboard: adds no charts error message

### DIFF
--- a/dashboard/src/components/ChartList/ChartList.css
+++ b/dashboard/src/components/ChartList/ChartList.css
@@ -1,0 +1,4 @@
+.ChartList__error_nocharts {
+  padding-left: 1em;
+  font-style: italic;
+}

--- a/dashboard/src/components/ChartList/ChartList.tsx
+++ b/dashboard/src/components/ChartList/ChartList.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
+import { Link } from "react-router-dom";
 
 import { IChartState } from "../../shared/types";
 import { CardGrid } from "../Card";
 import ChartListItem from "./ChartListItem";
+
+import "./ChartList.css";
 
 interface IChartListProps {
   charts: IChartState;
@@ -17,7 +20,17 @@ class ChartList extends React.Component<IChartListProps> {
   }
 
   public render() {
-    const chartItems = this.props.charts.items.map(c => <ChartListItem key={c.id} chart={c} />);
+    let chartItems;
+    if (this.props.charts.items) {
+      chartItems = this.props.charts.items.map(c => <ChartListItem key={c.id} chart={c} />);
+    } else {
+      chartItems = (
+        <div className="ChartList__error_nocharts">
+          No charts available. Manage your Helm chart repositories in Kubeapps by visiting the{" "}
+          <Link to={`/config/repos`}>App repositories configuration</Link> page.
+        </div>
+      );
+    }
     return (
       <section className="ChartList">
         <header className="ChartList__header">


### PR DESCRIPTION
The charts tab errors out if there are no charts available in repos. To reproduce remove all chart repos from the app repository configuration page.

![no-charts](https://user-images.githubusercontent.com/410147/39347888-7f09ac34-4a12-11e8-9cdf-aa25ae1e947a.png)

This PR displays a helpful message when no charts are available

![after](https://user-images.githubusercontent.com/410147/39347974-d4d2bb88-4a12-11e8-98fc-081df4ae6dc7.png)
