### PR TITLE
dashboard: adds no charts error message

### DIFF
--- a/dashboard/src/components/ChartList/ChartList.tsx
+++ b/dashboard/src/components/ChartList/ChartList.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 
+import { Link } from "react-router-dom";
 import { IChartState } from "../../shared/types";
+import { NotFoundErrorAlert } from "../ErrorAlert";
+
 import { CardGrid } from "../Card";
 import ChartListItem from "./ChartListItem";
 
@@ -17,6 +20,20 @@ class ChartList extends React.Component<IChartListProps> {
   }
 
   public render() {
+    if (!this.props.charts.items) {
+      return (
+        <NotFoundErrorAlert
+          resource={"Charts"}
+          children={
+            <div>
+              Manage your Helm chart repositories in Kubeapps by visiting the{" "}
+              <Link to={`/config/repos`}>App repositories configuration</Link> page.
+            </div>
+          }
+        />
+      );
+    }
+
     const chartItems = this.props.charts.items.map(c => <ChartListItem key={c.id} chart={c} />);
     return (
       <section className="ChartList">

--- a/dashboard/src/components/ChartList/ChartList.tsx
+++ b/dashboard/src/components/ChartList/ChartList.tsx
@@ -20,7 +20,8 @@ class ChartList extends React.Component<IChartListProps> {
   }
 
   public render() {
-    if (!this.props.charts.items) {
+    const { isFetching, items } = this.props.charts;
+    if (!isFetching && !items) {
       return (
         <NotFoundErrorAlert
           resource={"Charts"}
@@ -33,15 +34,14 @@ class ChartList extends React.Component<IChartListProps> {
         />
       );
     }
-
-    const chartItems = this.props.charts.items.map(c => <ChartListItem key={c.id} chart={c} />);
+    const chartItems = items.map(c => <ChartListItem key={c.id} chart={c} />);
     return (
       <section className="ChartList">
         <header className="ChartList__header">
           <h1>Charts</h1>
           <hr />
         </header>
-        <CardGrid>{chartItems}</CardGrid>
+        {isFetching ? <div>Loading...</div> : <CardGrid>{chartItems}</CardGrid>}
       </section>
     );
   }


### PR DESCRIPTION
The charts tab errors out if there are no charts available in repos. To reproduce remove all chart repos from the app repository configuration page.

![no-charts](https://user-images.githubusercontent.com/410147/39347888-7f09ac34-4a12-11e8-9cdf-aa25ae1e947a.png)

This PR displays a helpful message when no charts are available

![after](https://user-images.githubusercontent.com/410147/39355608-45f2a086-4a2b-11e8-8ceb-e12e1086d7a4.png)

