### PR TITLE
Make the release name configurable

### DIFF
--- a/dashboard/src/components/AppEdit/AppEdit.tsx
+++ b/dashboard/src/components/AppEdit/AppEdit.tsx
@@ -10,10 +10,12 @@ interface IAppEditProps {
   app: IApp;
   bindings: IServiceBinding[];
   error: Error | undefined;
+  hrName: string;
   namespace: string;
   releaseName: string;
   selected: IChartState["selected"];
   deployChart: (
+    hrName: string,
     version: IChartVersion,
     releaseName: string,
     namespace: string,
@@ -21,7 +23,7 @@ interface IAppEditProps {
     resourceVersion?: string,
   ) => Promise<boolean>;
   fetchChartVersions: (id: string) => Promise<{}>;
-  getApp: (releaseName: string, namespace: string) => Promise<void>;
+  getApp: (hrName: string, releaseName: string, namespace: string) => Promise<void>;
   getBindings: () => Promise<IServiceBinding[]>;
   getChartVersion: (id: string, chartVersion: string) => Promise<{}>;
   getChartValues: (id: string, chartVersion: string) => Promise<any>;
@@ -30,14 +32,14 @@ interface IAppEditProps {
 
 class AppEdit extends React.Component<IAppEditProps> {
   public componentDidMount() {
-    const { releaseName, getApp, namespace } = this.props;
-    getApp(releaseName, namespace);
+    const { hrName, releaseName, getApp, namespace } = this.props;
+    getApp(hrName, releaseName, namespace);
   }
 
   public componentWillReceiveProps(nextProps: IAppEditProps) {
-    const { releaseName, getApp, namespace } = this.props;
+    const { hrName, releaseName, getApp, namespace } = this.props;
     if (nextProps.namespace !== namespace) {
-      getApp(releaseName, nextProps.namespace);
+      getApp(hrName, releaseName, nextProps.namespace);
     }
   }
 

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -15,12 +15,13 @@ import ServiceTable from "./ServiceTable";
 
 interface IAppViewProps {
   namespace: string;
+  hrName: string;
   releaseName: string;
   app: IApp;
   error: Error;
   deleteError: Error;
-  getApp: (releaseName: string, namespace: string) => Promise<void>;
-  deleteApp: (releaseName: string, namespace: string) => Promise<boolean>;
+  getApp: (hrName: string, releaseName: string, namespace: string) => Promise<void>;
+  deleteApp: (hrName: string, namespace: string) => Promise<boolean>;
 }
 
 interface IAppViewState {
@@ -72,14 +73,14 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
   };
 
   public async componentDidMount() {
-    const { releaseName, getApp, namespace } = this.props;
-    getApp(releaseName, namespace);
+    const { hrName, releaseName, getApp, namespace } = this.props;
+    getApp(hrName, releaseName, namespace);
   }
 
   public async componentWillReceiveProps(nextProps: IAppViewProps) {
-    const { releaseName, getApp, namespace } = this.props;
+    const { hrName, releaseName, getApp, namespace } = this.props;
     if (nextProps.namespace !== namespace) {
-      getApp(releaseName, nextProps.namespace);
+      getApp(hrName, releaseName, nextProps.namespace);
       return;
     }
     if (nextProps.error) {

--- a/dashboard/src/containers/AppEditContainer/AppEditContainer.tsx
+++ b/dashboard/src/containers/AppEditContainer/AppEditContainer.tsx
@@ -32,15 +32,19 @@ function mapStateToProps(
 function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
     deployChart: (
+      hrName: string,
       version: IChartVersion,
       releaseName: string,
       namespace: string,
       values?: string,
       resourceVersion?: string,
     ) =>
-      dispatch(actions.apps.deployChart(version, releaseName, namespace, values, resourceVersion)),
+      dispatch(
+        actions.apps.deployChart(hrName, version, releaseName, namespace, values, resourceVersion),
+      ),
     fetchChartVersions: (id: string) => dispatch(actions.charts.fetchChartVersions(id)),
-    getApp: (r: string, ns: string) => dispatch(actions.apps.getApp(r, ns)),
+    getApp: (hrName: string, releaseName: string, ns: string) =>
+      dispatch(actions.apps.getApp(hrName, releaseName, ns)),
     getBindings: (ns: string) => dispatch(actions.catalog.getBindings(ns)),
     getChartValues: (id: string, version: string) =>
       dispatch(actions.charts.getChartValues(id, version)),

--- a/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -33,13 +33,16 @@ function mapStateToProps(
 function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
     deployChart: (
+      hrName: string,
       version: IChartVersion,
       releaseName: string,
       namespace: string,
       values?: string,
       resourceVersion?: string,
     ) =>
-      dispatch(actions.apps.deployChart(version, releaseName, namespace, values, resourceVersion)),
+      dispatch(
+        actions.apps.deployChart(hrName, version, releaseName, namespace, values, resourceVersion),
+      ),
     fetchChartVersions: (id: string) => dispatch(actions.charts.fetchChartVersions(id)),
     getBindings: (ns: string) => dispatch(actions.catalog.getBindings(ns)),
     getChartValues: (id: string, version: string) =>

--- a/dashboard/src/containers/AppViewContainer/AppViewContainer.tsx
+++ b/dashboard/src/containers/AppViewContainer/AppViewContainer.tsx
@@ -26,8 +26,10 @@ function mapStateToProps({ apps }: IStoreState, { match: { params } }: IRoutePro
 
 function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
-    deleteApp: (r: string, ns: string) => dispatch(actions.apps.deleteApp(r, ns)),
-    getApp: (r: string, ns: string) => dispatch(actions.apps.getApp(r, ns)),
+    deleteApp: (releaseName: string, ns: string) =>
+      dispatch(actions.apps.deleteApp(releaseName, ns)),
+    getApp: (hrName: string, releaseName: string, ns: string) =>
+      dispatch(actions.apps.getApp(hrName, releaseName, ns)),
   };
 }
 

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -290,6 +290,7 @@ export interface IHelmRelease {
   };
   spec: {
     chartName: string;
+    releaseName: string;
     repoUrl: string;
     values: string;
     version: string;


### PR DESCRIPTION
This PR:
 - Requires changes in helm-crd: https://github.com/bitnami-labs/helm-crd/pull/29
 - Fixes #220 
 - Is needed for #320 

Added an additional field to specify the Tiller release name:

<img width="876" alt="screen shot 2018-05-24 at 17 03 00" src="https://user-images.githubusercontent.com/4025665/40494220-9e83f37c-5f74-11e8-8acb-b8b79da53fb9.png">

Note that in the code `hrName` refers to the name of the HelmRelease object while `releaseName` is the cluster-wide name used by Tiller.