### PR TITLE
manifests: Use non-persistent emptyDir volume for MongoDB

### DIFF
--- a/manifests/mongodb.jsonnet
+++ b/manifests/mongodb.jsonnet
@@ -16,10 +16,6 @@ local labels = {app: "mongodb"};
     target_pod: $.mongodb.spec.template,
   },
 
-  pvc: kube.PersistentVolumeClaim("mongodb-data") + $.namespace {
-    storage: "8Gi",
-  },
-
   mongodb: kube.Deployment("mongodb") + $.namespace {
     metadata+: {labels+: labels},
 
@@ -55,7 +51,7 @@ local labels = {app: "mongodb"};
             },
           },
           volumes_+: {
-            data: kube.PersistentVolumeClaimVolume($.pvc),
+            data: kube.EmptyDirVolume(),
           },
         },
       },


### PR DESCRIPTION
Kubeapps uses mongodb for cache storage, we do not really need to attach persistent storage for this cache as it can be easily be populated automatically or on demand. This commit swaps out the pvc volume with a emptyDir volume which should not only reduce the system requirements of running kubeapps but also help alleviate any mongodb file permission issues.

closes #336