### PR TITLE
use two-step form for provisioning service instances

### DIFF
--- a/dashboard/src/components/ProvisionButton/index.tsx
+++ b/dashboard/src/components/ProvisionButton/index.tsx
@@ -41,6 +41,17 @@ const RequiredRBACRoles: IRBACRole[] = [
   },
 ];
 
+const smallModalStyle = {
+  content: {
+    bottom: "auto",
+    left: "50%",
+    marginRight: "-50%",
+    right: "auto",
+    top: "50%",
+    transform: "translate(-50%, -50%)",
+  },
+};
+
 class ProvisionButton extends React.Component<IProvisionButtonProps, IProvisionButtonState> {
   public state: IProvisionButtonState = {
     displayNameForm: true,
@@ -78,6 +89,7 @@ class ProvisionButton extends React.Component<IProvisionButtonProps, IProvisionB
           isOpen={this.state.modalIsOpen}
           onRequestClose={this.closeModal}
           contentLabel="Modal"
+          style={this.state.displayNameForm ? smallModalStyle : {}}
         >
           {this.props.error && <div className="margin-b-big">{this.renderError()}</div>}
           {this.state.displayNameForm ? (

--- a/dashboard/src/components/ProvisionButton/index.tsx
+++ b/dashboard/src/components/ProvisionButton/index.tsx
@@ -122,7 +122,7 @@ class ProvisionButton extends React.Component<IProvisionButtonProps, IProvisionB
 
   public handleBackButton = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    this.setState({ ...this.state, displayNameForm: true });
+    this.setState({ displayNameForm: true });
   };
 
   public handleNameChange = ({ formData }: ISubmitEvent<{ Name: string }>) => {

--- a/dashboard/src/components/SchemaForm/CustomObjectField.tsx
+++ b/dashboard/src/components/SchemaForm/CustomObjectField.tsx
@@ -29,9 +29,10 @@ class CustomObjectField extends React.Component<FieldProps, ICustomObjectFieldSt
     if (schema.properties) {
       return <ObjectField {...this.props} />;
     }
+    const label = schema.title || name;
     return (
       <div>
-        <label htmlFor={name}>{name} (JSON)</label>
+        <label htmlFor={label}>{label} (JSON)</label>
         <AceEditor
           className="margin-b-big"
           mode="json"

--- a/dashboard/src/components/SchemaForm/FieldTemplate.tsx
+++ b/dashboard/src/components/SchemaForm/FieldTemplate.tsx
@@ -9,7 +9,7 @@ const FieldTemplate: React.SFC<FieldTemplateProps> = props => {
       {displayLabel && (
         <label htmlFor={id}>
           {label}
-          {required && " *"}
+          {required && " (required)"}
         </label>
       )}
       {children}

--- a/dashboard/src/components/SchemaForm/FieldTemplate.tsx
+++ b/dashboard/src/components/SchemaForm/FieldTemplate.tsx
@@ -3,10 +3,15 @@ import { FieldTemplateProps } from "react-jsonschema-form";
 
 // adapted from https://jsfiddle.net/hdp1kgn6/1/
 const FieldTemplate: React.SFC<FieldTemplateProps> = props => {
-  const { id, classNames, label, children, displayLabel } = props;
+  const { id, classNames, label, children, displayLabel, required } = props;
   return (
     <div className={classNames}>
-      {displayLabel && <label htmlFor={id}>{label}</label>}
+      {displayLabel && (
+        <label htmlFor={id}>
+          {label}
+          {required && " *"}
+        </label>
+      )}
       {children}
     </div>
   );


### PR DESCRIPTION
A two step form allows us to cleanly separate input that Kubeapps needs
from the generalised input from the Service Broker's schema. The first
form simply asks for the name of the Service Instance, and the second
form renders the parameters using the broker-provided instanceCreateParameterSchema.

fixes #362 

![kubeapps svc cat paremeters 2-step](https://user-images.githubusercontent.com/1544861/41752296-8f8dd096-757b-11e8-8484-d5e49ad52b2b.gif)
