### PR TITLE
[tiller-proxy] Improve forbidden response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,3 +86,5 @@ jobs:
     env: IMAGE=kubeapps/apprepository-controller
   - <<: *imageBuild
     env: IMAGE=kubeapps/dashboard
+  - <<: *imageBuild
+    env: IMAGE=kubeapps/tiller-proxy

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ kubeapps/%:
 kubeapps/dashboard:
 	docker build -t kubeapps/dashboard:$(VERSION) -f dashboard/Dockerfile dashboard/
 
-tiller-proxy:
+kubeapps/tiller-proxy:
 	CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -o ./cmd/tiller-proxy/proxy-static ./cmd/tiller-proxy
-	docker build -t kubeapps/tiller-proxy -f cmd/tiller-proxy/Dockerfile cmd/tiller-proxy
+	docker build -t kubeapps/tiller-proxy:$(VERSION) -f cmd/tiller-proxy/Dockerfile cmd/tiller-proxy
 
 test: $(EMBEDDED_STATIC)
 	$(GO) test $(GO_PACKAGES)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ kubeapps/dashboard:
 	docker build -t kubeapps/dashboard:$(VERSION) -f dashboard/Dockerfile dashboard/
 
 tiller-proxy:
-	docker build -t kubeapps/tiller-proxy -f ./cmd/tiller-proxy/Dockerfile .
+	CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -o ./cmd/tiller-proxy/proxy-static ./cmd/tiller-proxy
+	docker build -t kubeapps/tiller-proxy -f cmd/tiller-proxy/Dockerfile cmd/tiller-proxy
 
 test: $(EMBEDDED_STATIC)
 	$(GO) test $(GO_PACKAGES)

--- a/cmd/tiller-proxy/Dockerfile
+++ b/cmd/tiller-proxy/Dockerfile
@@ -1,9 +1,4 @@
-FROM quay.io/deis/go-dev:v1.8.2 as builder
-COPY . /go/src/github.com/kubeapps/kubeapps
-WORKDIR /go/src/github.com/kubeapps/kubeapps
-RUN CGO_ENABLED=0 go build -a -installsuffix cgo ./cmd/tiller-proxy
-
-FROM scratch
-COPY --from=builder /go/src/github.com/kubeapps/kubeapps/tiller-proxy /proxy
-EXPOSE 8080
+FROM alpine:3.6
+RUN apk --no-cache add ca-certificates
+COPY ./proxy-static /proxy
 CMD ["/proxy"]

--- a/cmd/tiller-proxy/Dockerfile.dev
+++ b/cmd/tiller-proxy/Dockerfile.dev
@@ -1,4 +1,0 @@
-FROM alpine:3.6
-RUN apk --no-cache add ca-certificates
-COPY ./proxy-static /proxy
-CMD ["/proxy"]

--- a/cmd/tiller-proxy/handler.go
+++ b/cmd/tiller-proxy/handler.go
@@ -163,7 +163,7 @@ func createRelease(w http.ResponseWriter, req *http.Request, params Params) {
 			return
 		}
 		userAuth := req.Context().Value(userKey).(auth.UserAuth)
-		forbiddenActions, err := userAuth.CanI(params["namespace"], "create", manifest)
+		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "create", manifest)
 		if err != nil {
 			response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
 			return
@@ -197,7 +197,7 @@ func upgradeRelease(w http.ResponseWriter, req *http.Request, params Params) {
 			return
 		}
 		userAuth := req.Context().Value(userKey).(auth.UserAuth)
-		forbiddenActions, err := userAuth.CanI(params["namespace"], "upgrade", manifest)
+		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "upgrade", manifest)
 		if err != nil {
 			response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
 			return
@@ -248,7 +248,7 @@ func getRelease(w http.ResponseWriter, req *http.Request, params Params) {
 			return
 		}
 		userAuth := req.Context().Value(userKey).(auth.UserAuth)
-		forbiddenActions, err := userAuth.CanI(params["namespace"], "get", manifest)
+		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "get", manifest)
 		if err != nil {
 			response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
 			return
@@ -274,7 +274,7 @@ func deleteRelease(w http.ResponseWriter, req *http.Request, params Params) {
 			return
 		}
 		userAuth := req.Context().Value(userKey).(auth.UserAuth)
-		forbiddenActions, err := userAuth.CanI(params["namespace"], "delete", manifest)
+		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "delete", manifest)
 		if err != nil {
 			response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
 			return

--- a/cmd/tiller-proxy/handler.go
+++ b/cmd/tiller-proxy/handler.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -138,6 +139,16 @@ func logStatus(name string) {
 	}
 }
 
+func returnForbiddenActions(forbiddenActions []auth.Action, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	body, err := json.Marshal(forbiddenActions)
+	if err != nil {
+		response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
+		return
+	}
+	response.NewErrorResponse(http.StatusForbidden, string(body)).Write(w)
+}
+
 func createRelease(w http.ResponseWriter, req *http.Request, params Params) {
 	log.Printf("Creating Helm Release")
 	chartDetails, ch, err := getChart(req)
@@ -152,9 +163,13 @@ func createRelease(w http.ResponseWriter, req *http.Request, params Params) {
 			return
 		}
 		userAuth := req.Context().Value(userKey).(auth.UserAuth)
-		err = userAuth.CanI(params["namespace"], "create", manifest)
+		forbiddenActions, err := userAuth.CanI(params["namespace"], "create", manifest)
 		if err != nil {
 			response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
+			return
+		}
+		if len(forbiddenActions) > 0 {
+			returnForbiddenActions(forbiddenActions, w)
 			return
 		}
 	}
@@ -182,9 +197,13 @@ func upgradeRelease(w http.ResponseWriter, req *http.Request, params Params) {
 			return
 		}
 		userAuth := req.Context().Value(userKey).(auth.UserAuth)
-		err = userAuth.CanI(params["namespace"], "create", manifest)
+		forbiddenActions, err := userAuth.CanI(params["namespace"], "upgrade", manifest)
 		if err != nil {
 			response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
+			return
+		}
+		if len(forbiddenActions) > 0 {
+			returnForbiddenActions(forbiddenActions, w)
 			return
 		}
 	}
@@ -229,7 +248,15 @@ func getRelease(w http.ResponseWriter, req *http.Request, params Params) {
 			return
 		}
 		userAuth := req.Context().Value(userKey).(auth.UserAuth)
-		err = userAuth.CanI(params["namespace"], "get", manifest)
+		forbiddenActions, err := userAuth.CanI(params["namespace"], "get", manifest)
+		if err != nil {
+			response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
+			return
+		}
+		if len(forbiddenActions) > 0 {
+			returnForbiddenActions(forbiddenActions, w)
+			return
+		}
 	}
 	response.NewDataResponse(*rel).Write(w)
 }
@@ -247,9 +274,13 @@ func deleteRelease(w http.ResponseWriter, req *http.Request, params Params) {
 			return
 		}
 		userAuth := req.Context().Value(userKey).(auth.UserAuth)
-		err = userAuth.CanI(params["namespace"], "delete", manifest)
+		forbiddenActions, err := userAuth.CanI(params["namespace"], "delete", manifest)
 		if err != nil {
 			response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
+			return
+		}
+		if len(forbiddenActions) > 0 {
+			returnForbiddenActions(forbiddenActions, w)
 			return
 		}
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -77,6 +77,7 @@ type AppOverview struct {
 	ReleaseName string `json:"releaseName"`
 	Version     string `json:"version"`
 	Namespace   string `json:"namespace"`
+	Icon        string `json:"icon,omitempty"`
 }
 
 func (p *Proxy) get(name, namespace string) (*release.Release, error) {
@@ -139,7 +140,12 @@ func (p *Proxy) ListReleases(namespace string) ([]AppOverview, error) {
 	if list != nil {
 		for _, r := range list.Releases {
 			if namespace == "" || namespace == r.Namespace {
-				appList = append(appList, AppOverview{r.Name, r.Chart.Metadata.Version, r.Namespace})
+				appList = append(appList, AppOverview{
+					ReleaseName: r.Name,
+					Version:     r.Chart.Metadata.Version,
+					Namespace:   r.Namespace,
+					Icon:        r.Chart.Metadata.Icon,
+				})
 			}
 		}
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -85,10 +85,12 @@ func (p *Proxy) get(name, namespace string) (*release.Release, error) {
 		return nil, fmt.Errorf("Unable to list helm releases: %v", err)
 	}
 	var rel *release.Release
-	for _, r := range list.Releases {
-		if (namespace == "" || namespace == r.Namespace) && r.Name == name {
-			rel = r
-			break
+	if list != nil && list.Releases != nil {
+		for _, r := range list.Releases {
+			if (namespace == "" || namespace == r.Namespace) && r.Name == name {
+				rel = r
+				break
+			}
 		}
 	}
 	if rel == nil {
@@ -169,6 +171,7 @@ func (p *Proxy) CreateRelease(name, namespace, values string, ch *chart.Chart) (
 	if err != nil {
 		return nil, fmt.Errorf("Unable create release: %v", err)
 	}
+	log.Printf("%s successfully installed in %s", name, namespace)
 	return res.GetRelease(), nil
 }
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -38,6 +38,7 @@ func newFakeProxy(existingTillerReleases []AppOverview) *Proxy {
 			Chart: &chart.Chart{
 				Metadata: &chart.Metadata{
 					Version: r.Version,
+					Icon:    r.Icon,
 				},
 			},
 		})
@@ -47,8 +48,8 @@ func newFakeProxy(existingTillerReleases []AppOverview) *Proxy {
 }
 
 func TestListAllReleases(t *testing.T) {
-	app1 := AppOverview{"foo", "1.0.0", "my_ns"}
-	app2 := AppOverview{"bar", "1.0.0", "other_ns"}
+	app1 := AppOverview{"foo", "1.0.0", "my_ns", "icon.png"}
+	app2 := AppOverview{"bar", "1.0.0", "other_ns", "icon2.png"}
 	proxy := newFakeProxy([]AppOverview{app1, app2})
 
 	// Should return all the releases if no namespace is given
@@ -65,8 +66,8 @@ func TestListAllReleases(t *testing.T) {
 }
 
 func TestListNamespacedRelease(t *testing.T) {
-	app1 := AppOverview{"foo", "1.0.0", "my_ns"}
-	app2 := AppOverview{"bar", "1.0.0", "other_ns"}
+	app1 := AppOverview{"foo", "1.0.0", "my_ns", "icon.png"}
+	app2 := AppOverview{"bar", "1.0.0", "other_ns", "icon2.png"}
 	proxy := newFakeProxy([]AppOverview{app1, app2})
 
 	// Should return all the releases if no namespace is given
@@ -136,7 +137,7 @@ func TestCreateConflictingHelmRelease(t *testing.T) {
 		Metadata: &chart.Metadata{Name: chartName, Version: version},
 	}
 	ns2 := "other_ns"
-	app := AppOverview{rs, version, ns2}
+	app := AppOverview{rs, version, ns2, "icon.png"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	_, err := proxy.CreateRelease(rs, ns, "", ch)
@@ -156,7 +157,7 @@ func TestHelmReleaseUpdated(t *testing.T) {
 	ch := &chart.Chart{
 		Metadata: &chart.Metadata{Name: chartName, Version: version},
 	}
-	app := AppOverview{rs, version, ns}
+	app := AppOverview{rs, version, ns, "icon.png"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	result, err := proxy.UpdateRelease(rs, ns, "", ch)
@@ -190,7 +191,7 @@ func TestUpdateMissingHelmRelease(t *testing.T) {
 	}
 	// Simulate the same app but in a different namespace
 	ns2 := "other_ns"
-	app := AppOverview{rs, version, ns2}
+	app := AppOverview{rs, version, ns2, "icon.png"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	_, err := proxy.UpdateRelease(rs, ns, "", ch)
@@ -203,8 +204,8 @@ func TestUpdateMissingHelmRelease(t *testing.T) {
 }
 
 func TestGetHelmRelease(t *testing.T) {
-	app1 := AppOverview{"foo", "1.0.0", "my_ns"}
-	app2 := AppOverview{"bar", "1.0.0", "other_ns"}
+	app1 := AppOverview{"foo", "1.0.0", "my_ns", "icon.png"}
+	app2 := AppOverview{"bar", "1.0.0", "other_ns", "icon2.png"}
 	type testStruct struct {
 		existingApps    []AppOverview
 		shouldFail      bool
@@ -236,7 +237,7 @@ func TestGetHelmRelease(t *testing.T) {
 }
 
 func TestHelmReleaseDeleted(t *testing.T) {
-	app := AppOverview{"foo", "1.0.0", "my_ns"}
+	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	err := proxy.DeleteRelease(app.ReleaseName, app.Namespace)
@@ -253,7 +254,7 @@ func TestHelmReleaseDeleted(t *testing.T) {
 }
 
 func TestDeleteMissingHelmRelease(t *testing.T) {
-	app := AppOverview{"foo", "1.0.0", "my_ns"}
+	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	err := proxy.DeleteRelease(app.ReleaseName, "other_ns")


### PR DESCRIPTION
Improve response in case the request is forbidden returning a JSON with all the items that the user is not allowed to perform (instead of a string with the first item found).

This PR also improves the unit tests for the auth package.