### PR TITLE
Fix app repository role

### DIFF
--- a/manifests/apprepository.jsonnet
+++ b/manifests/apprepository.jsonnet
@@ -43,7 +43,7 @@ local labels = {
       {
         apiGroups: [""],
         resources: ["events"],
-        verbs: ["create"],
+        verbs: ["create", "patch"],
       },
       {
         apiGroups: ["batch"],


### PR DESCRIPTION
The button `Refresh` of the app repositories view didn't work because of this error:

```
'events "artifactory.153c4d4c29911fd9" is forbidden: User "system:serviceaccount:kubeapps:apprepository-controller" cannot patch events in the namespace "kubeapps": Unknown user "system:serviceaccount:kubeapps:apprepository-controller"'
```

Adding the required permission.