### PR TITLE
Add support for TLS connection with tiller

### DIFF
--- a/cmd/tiller-proxy/handler.go
+++ b/cmd/tiller-proxy/handler.go
@@ -89,6 +89,13 @@ func (h WithParams) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h(w, req, vars)
 }
 
+// WithoutParams can be used to wrap handlers that doesn't take params
+type WithoutParams func(http.ResponseWriter, *http.Request)
+
+func (h WithoutParams) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	h(w, req)
+}
+
 func isNotFound(err error) bool {
 	return strings.Contains(err.Error(), "not found")
 }

--- a/manifests/tiller-proxy.jsonnet
+++ b/manifests/tiller-proxy.jsonnet
@@ -7,7 +7,7 @@ local kube = import "kube.libsonnet";
 {
   namespace:: {metadata+: {namespace: "kube-system"}},
   local proxyContainer = kube.Container("proxy") {
-    image: "kubeapps/tiller-proxy:v0.0.3",
+    image: "kubeapps/tiller-proxy:v0.0.4",
     securityContext: {
       readOnlyRootFilesystem: true,
     },


### PR DESCRIPTION
Ref #354 

Secure Tiller adding a TLS certificate when installed with TLS flags:

```
./kubeapps up \
  --tiller-tls \
  --tiller-tls-cert /path/to/cert.pem \
  --tiller-tls-key /path/to/key.pem \
  --tls-ca-cert /path/to/ca.pem
```

This prevents unauthorized connections to the Tiller pod using the `helm` CLI:

```
▶ helm list --tiller-namespace kubeapps
Error: transport is closing
▶ helm list --tiller-namespace kubeapps \
  --tls \
  --tls-ca-cert /path/to/ca.pem \
  --tls-cert /path/to/cert.pem \
  --tls-key /path/to/key.pem  
NAME    REVISION        UPDATED                         STATUS          CHART           NAMESPACE
wp      2               Tue Jul  3 15:34:02 2018        DEPLOYED        wordpress-2.0.1 default
```