### PR TITLE
manifests: specify catch-all server_name for kubeapps vhost, closes #361

### DIFF
--- a/manifests/nginx-vhost.conf
+++ b/manifests/nginx-vhost.conf
@@ -10,6 +10,7 @@ proxy_set_header Connection $connection_upgrade;
 
 server {
   listen %(ui_port)s;
+  server_name _;
 
   location /api/kube {
     rewrite /api/kube/(.*) /$1 break;


### PR DESCRIPTION
Description: The catch-all `server_name` directive remove's the warning message listed in #361

fixes #361 