### PR TITLE
Removed Sealed Secrets references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Kubeapps is a set of tools written by [Bitnami](https://bitnami.com) to super-ch
 
 * Your own application [dashboard](https://kubeapps.com/), allowing you to deploy Kubernetes-ready applications into your cluster with a single click.
 * [Kubeless](http://kubeless.io/), a Kubernetes-native Serverless Framework, compatible with [serverless.com](https://serverless.com).
-* [SealedSecrets](https://github.com/bitnami/sealed-secrets), a way to encrypt a Secret into a SealedSecret, which is safe to store...even for a public repository.
 
 ## Quickstart
 

--- a/cmd/kubeapps/up.go
+++ b/cmd/kubeapps/up.go
@@ -78,7 +78,6 @@ var upCmd = &cobra.Command{
 List of components that kubeapps up installs:
 
 - Kubeless (https://github.com/kubeless/kubeless)
-- Sealed-Secrets (https://github.com/bitnami/sealed-secrets)
 - Helm/Tiller (https://github.com/kubernetes/helm)
 - Kubeapps Dashboard (https://github.com/kubeapps/dashboard)`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -4,7 +4,6 @@ Kubeapps is a set of tools written by [Bitnami](https://bitnami.com) to super-ch
 
 * Your own applications [dashboard](https://kubeapps.com/), allowing you to deploy Kubernetes-ready applications into your cluster with a single click.
 * [Kubeless](http://kubeless.io/) - a Kubernetes-native Serverless Framework, compatible with [serverless.com](https://serverless.com).
-* [SealedSecrets](https://github.com/bitnami/sealed-secrets) - a SealedSecret can be decrypted only by the controller running in the cluster and nobody else (not even the original author).
 
 This guide will walk you through the process of deploying Kubeapps for your cluster and installing an example application.
 


### PR DESCRIPTION
We had some left overs about sealed secrets in the documentation. Removing those.