### PR TITLE
Add a role to grant read access

### DIFF
--- a/docs/user/access-control.md
+++ b/docs/user/access-control.md
@@ -40,13 +40,14 @@ Kubeapps.
 
 #### Read access to Applications within a namespace
 
-In order to list and view Applications in a namespace, apply the `view` ClusterRole
-in the desired namespace. The `view` ClusterRole should be available in most
-Kubernetes distributions, you can find more information about that role [here](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles).
+In order to list and view Applications in a namespace, apply the `kubeapps-applications-read`
+ClusterRole in the desired namespace. Note that the `kubeapps-applications-read` role provides
+read access to **all** the resources of a namespace so apply it carefully. In case you want
+to limit the access create a custom cluster role or use one of the [default ones](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles).
 
 ```
 kubectl create -n default rolebinding example-view \
-  --clusterrole=view \
+  --clusterrole=kubeapps-applications-read \
   --serviceaccount default:example
 ```
 

--- a/manifests/user-roles.jsonnet
+++ b/manifests/user-roles.jsonnet
@@ -4,6 +4,21 @@ local kubecfg = import "kubecfg.libsonnet";
 {
   namespace:: {metadata+: {namespace: "kubeapps"}},
 
+applications: {
+    // kubeapps-applications-read
+    // Gives read-only access to all the elements within a Namespace.
+    // Usage:
+    //   Apply kubeapps-applications-read clusterrole to user/serviceaccount in the desired namespace
+    read: kube.ClusterRole("kubeapps-applications-read") {
+      rules: [
+        {
+          apiGroups: ["*"],
+          resources: ["*"],
+          verbs: ["list", "get", "watch"],
+        },
+      ],
+    },
+  },
   functions: {
     // kubeapps-functions-read
     // Gives read-only access to Functions within a Namespace in Kubeapps.


### PR DESCRIPTION
Ref #393

The generic `view` role doesn't have access to read secrets which is useful when viewing apps in kubeapps. Add a specific role to access all the possible resources in a namespace.