### PR TITLE
Custom namespace support for local development

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -39,7 +39,8 @@
     "typesafe-actions": "^1.1.2"
   },
   "scripts": {
-    "start": "BROWSER=none react-scripts-ts start",
+    "start":
+      "BROWSER=none REACT_APP_KUBEAPPS_NS=${TELEPRESENCE_CONTAINER_NAMESPACE} react-scripts-ts start",
     "build": "react-scripts-ts build",
     "test": "react-scripts-ts test --env=jsdom",
     "eject": "react-scripts-ts eject",
@@ -66,6 +67,7 @@
     "@types/react-router-dom": "^4.2.3",
     "@types/react-router-redux": "^5.0.11",
     "@types/react-test-renderer": "^16.0.0",
+    "axios-mock-adapter": "^1.15.0",
     "husky": "0.14.3",
     "lint-staged": "^6.1.0",
     "prettier": "^1.10.2",

--- a/dashboard/src/shared/Config.test.ts
+++ b/dashboard/src/shared/Config.test.ts
@@ -1,13 +1,13 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import Config from "./Config";
+import Config, { IConfig } from "./Config";
 
 describe("Config", () => {
-  let defaultJSON: any;
-  let initialEnv: string;
+  let defaultJSON: IConfig;
+  let initialEnv: any;
 
-  beforeAll(() => {
-    initialEnv = process.env.REACT_APP_KUBEAPPS_NS || "";
+  beforeEach(() => {
+    initialEnv = { ...process.env };
     const mock = new MockAdapter(axios);
 
     defaultJSON = require("../../public/config.json");
@@ -16,15 +16,21 @@ describe("Config", () => {
   });
 
   afterEach(() => {
-    process.env.REACT_APP_KUBEAPPS_NS = initialEnv;
+    process.env = initialEnv;
   });
 
-  it("returns default namespace if no override proced", async () => {
+  it("returns default namespace if no override provided", async () => {
     expect(await Config.getConfig()).toEqual(defaultJSON);
   });
 
   it("returns the overriden namespace if env variable provided", async () => {
     process.env.REACT_APP_KUBEAPPS_NS = "magic-playground";
     expect(await Config.getConfig()).toEqual({ ...defaultJSON, namespace: "magic-playground" });
+  });
+
+  it("does not returns the overriden namespace if NODE_ENV=production", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.REACT_APP_KUBEAPPS_NS = "magic-playground";
+    expect(await Config.getConfig()).toEqual(defaultJSON);
   });
 });

--- a/dashboard/src/shared/Config.test.ts
+++ b/dashboard/src/shared/Config.test.ts
@@ -1,0 +1,30 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import Config from "./Config";
+
+describe("Config", () => {
+  let defaultJSON: any;
+  let initialEnv: string;
+
+  beforeAll(() => {
+    initialEnv = process.env.REACT_APP_KUBEAPPS_NS || "";
+    const mock = new MockAdapter(axios);
+
+    defaultJSON = require("../../public/config.json");
+
+    mock.onGet("/config.json").reply(200, defaultJSON);
+  });
+
+  afterEach(() => {
+    process.env.REACT_APP_KUBEAPPS_NS = initialEnv;
+  });
+
+  it("returns default namespace if no override proced", async () => {
+    expect(await Config.getConfig()).toEqual(defaultJSON);
+  });
+
+  it("returns the overriden namespace if env variable provided", async () => {
+    process.env.REACT_APP_KUBEAPPS_NS = "magic-playground";
+    expect(await Config.getConfig()).toEqual({ ...defaultJSON, namespace: "magic-playground" });
+  });
+});

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -11,8 +11,9 @@ export default class Config {
     const { data } = await axios.get<IConfig>(url);
 
     // Development environment config overrides
-    // TODO(miguel) Rename env variable to TELEPRESENCE_CONTAINER_NAMESPACE
-    // and remove package.json yarn run mapping once create-react-app is ejected
+    // TODO(miguel) Rename env variable to KUBEAPPS_NAMESPACE once/if we eject create-react-app
+    // Currently we are using REACT_APP_* because it's the only way to inject env variables in a sealed setup.
+    // Please note that this env variable gets mapped in the run command in the package.json file
     if (process.env.NODE_ENV !== "production" && process.env.REACT_APP_KUBEAPPS_NS) {
       data.namespace = process.env.REACT_APP_KUBEAPPS_NS;
     }

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -13,7 +13,7 @@ export default class Config {
     // Development environment config overrides
     // TODO(miguel) Rename env variable to TELEPRESENCE_CONTAINER_NAMESPACE
     // and remove package.json yarn run mapping once create-react-app is ejected
-    if (process.env.REACT_APP_KUBEAPPS_NS) {
+    if (process.env.NODE_ENV !== "production" && process.env.REACT_APP_KUBEAPPS_NS) {
       data.namespace = process.env.REACT_APP_KUBEAPPS_NS;
     }
 

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -9,6 +9,14 @@ export default class Config {
   public static async getConfig() {
     const url = Config.APIEndpoint;
     const { data } = await axios.get<IConfig>(url);
+
+    // Development environment config overrides
+    // TODO(miguel) Rename env variable to TELEPRESENCE_CONTAINER_NAMESPACE
+    // and remove package.json yarn run mapping once create-react-app is ejected
+    if (process.env.REACT_APP_KUBEAPPS_NS) {
+      data.namespace = process.env.REACT_APP_KUBEAPPS_NS;
+    }
+
     return data;
   }
 

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -476,6 +476,12 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios-mock-adapter@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.15.0.tgz#fbc06825d8302c95c3334d21023bba996255d45d"
+  dependencies:
+    deep-equal "^1.0.1"
+
 axios@^0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.1.tgz#2d8e3e5d0bdbd7327f91bc814f5c57660f81824d"


### PR DESCRIPTION
The latest release added support for deploying kubeapps in a custom namespace, this means that supports needs to be added to the local development as well. 

This patch takes a telepresence generated env variable representing the namespace the app is running locally and configures the app accordingly. 