### PR TITLE
Add chart tests

### DIFF
--- a/chart/kubeapps/templates/tests/test-chartsvc.yaml
+++ b/chart/kubeapps/templates/tests/test-chartsvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-chartsvc-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: {{ .Release.Name }}-chartsvc-test
+    image: appropriate/curl
+    env:
+      - name: CHARTSVC_HOST
+        value: {{ template "kubeapps.chartsvc.fullname" . }}.{{ .Release.Namespace }}
+      - name: CHARTSVC_PORT
+        value: "{{ .Values.chartsvc.service.port }}"
+    command: ["sh", "-c", "curl $CHARTSVC_HOST:$CHARTSVC_PORT/v1/charts | grep wordpress"]
+  restartPolicy: Never

--- a/chart/kubeapps/templates/tests/test-dashboard.yaml
+++ b/chart/kubeapps/templates/tests/test-dashboard.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-dashboard-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: {{ .Release.Name }}-dashboard-test
+    image: appropriate/curl
+    env:
+      - name: DASHBOARD_HOST
+        value: {{ template "kubeapps.fullname" . }}.{{ .Release.Namespace }}
+    command: ["sh", "-c", "curl $DASHBOARD_HOST | grep 'You need to enable JavaScript to run this app.'"]
+  restartPolicy: Never

--- a/chart/kubeapps/templates/tests/test-tiller-proxy.yaml
+++ b/chart/kubeapps/templates/tests/test-tiller-proxy.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-tiller-proxy-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: {{ .Release.Name }}-tiller-proxy-test
+    image: appropriate/curl
+    env:
+      - name: TILLER_PROXY_HOST
+        value: {{ template "kubeapps.tiller-proxy.fullname" . }}.{{ .Release.Namespace }}
+      - name: TILLER_PROXY_PORT
+        value: "{{ .Values.tillerProxy.service.port }}"
+      - name: KUBEAPPS_RELEASE
+        value: {{ .Release.Name }}
+    command: ["sh", "-c", "curl -ik -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" $TILLER_PROXY_HOST:$TILLER_PROXY_PORT/v1/releases | grep $KUBEAPPS_RELEASE"]
+  restartPolicy: Never


### PR DESCRIPTION
These simple tests ensures that:

 - The the Nginx proxy and the `dashboard` app are running and return a react error message (due to the lack of javascript).
 - The `apprepository-controller`, `chart-repo` and `chart-svc` work together checking that the chart `wordpress` is present.
 - Tiller-proxy is working and it list the `kubeapps` chart installed.

Execution:

```
▶ time helm test right-woodpecker

RUNNING: right-woodpecker-tiller-proxy-test
PASSED: right-woodpecker-tiller-proxy-test
RUNNING: right-woodpecker-chartsvc-test
PASSED: right-woodpecker-chartsvc-test
RUNNING: right-woodpecker-dashboard-test
PASSED: right-woodpecker-dashboard-test

helm 0.17s user 0.07s system 1% cpu 14.172 total
```
