### PR TITLE
[tiller-proxy] Improve release list behavior

### DIFF
--- a/cmd/tiller-proxy/README.md
+++ b/cmd/tiller-proxy/README.md
@@ -12,11 +12,18 @@ It is possible to configure this proxy with the following flags:
 
 ```
       --debug                           enable verbose output
-      --home string                     location of your Helm config. Overrides $HELM_HOME (default "/Users/andresmartinez/.helm")
+      --disable-auth                    Disable authorization check
+      --home string                     location of your Helm config. Overrides $HELM_HOME (default "/root/.helm")
       --host string                     address of Tiller. Overrides $HELM_HOST
       --kube-context string             name of the kubeconfig context to use
+      --list-max int                    maximum number of releases to fetch (default 256)
       --tiller-connection-timeout int   the duration (in seconds) Helm will wait to establish a connection to tiller (default 300)
       --tiller-namespace string         namespace of Tiller (default "kube-system")
+      --tls                             enable TLS for request
+      --tls-ca-cert string              path to TLS CA certificate file (default "/ca.crt")
+      --tls-cert string                 path to TLS certificate file (default "/tls.crt")
+      --tls-key string                  path to TLS key file (default "/tls.key")
+      --tls-verify                      enable TLS for request and verify remote
 ```
 
 # Routes

--- a/cmd/tiller-proxy/handler.go
+++ b/cmd/tiller-proxy/handler.go
@@ -225,7 +225,7 @@ func upgradeRelease(w http.ResponseWriter, req *http.Request, params Params) {
 }
 
 func listAllReleases(w http.ResponseWriter, req *http.Request) {
-	apps, err := proxy.ListReleases("")
+	apps, err := proxy.ListReleases("", listLimit)
 	if err != nil {
 		response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
 		return
@@ -234,7 +234,7 @@ func listAllReleases(w http.ResponseWriter, req *http.Request) {
 }
 
 func listReleases(w http.ResponseWriter, req *http.Request, params Params) {
-	apps, err := proxy.ListReleases(params["namespace"])
+	apps, err := proxy.ListReleases(params["namespace"], listLimit)
 	if err != nil {
 		response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
 		return

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -111,7 +111,7 @@ func main() {
 		log.Fatalf("Unable to connect to Tiller: %v", err)
 	}
 
-	proxy = tillerProxy.NewProxy(kubeClient, helmClient, listLimit)
+	proxy = tillerProxy.NewProxy(kubeClient, helmClient)
 
 	r := mux.NewRouter()
 

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -40,6 +40,7 @@ var (
 	proxy       *tillerProxy.Proxy
 	kubeClient  kubernetes.Interface
 	disableAuth bool
+	listLimit   int
 
 	tlsCaCertFile string // path to TLS CA certificate file
 	tlsCertFile   string // path to TLS certificate file
@@ -61,6 +62,7 @@ func init() {
 	pflag.BoolVar(&tlsVerify, "tls-verify", false, "enable TLS for request and verify remote")
 	pflag.BoolVar(&tlsEnable, "tls", false, "enable TLS for request")
 	pflag.BoolVar(&disableAuth, "disable-auth", false, "Disable authorization check")
+	pflag.IntVar(&listLimit, "list-max", 256, "maximum number of releases to fetch")
 }
 
 func main() {
@@ -109,7 +111,7 @@ func main() {
 		log.Fatalf("Unable to connect to Tiller: %v", err)
 	}
 
-	proxy = tillerProxy.NewProxy(kubeClient, helmClient)
+	proxy = tillerProxy.NewProxy(kubeClient, helmClient, listLimit)
 
 	r := mux.NewRouter()
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -66,11 +66,10 @@ func isNotFound(err error) bool {
 }
 
 // NewProxy creates a Proxy
-func NewProxy(kubeClient kubernetes.Interface, helmClient helm.Interface, releaseListLimit int) *Proxy {
+func NewProxy(kubeClient kubernetes.Interface, helmClient helm.Interface) *Proxy {
 	return &Proxy{
 		kubeClient: kubeClient,
 		helmClient: helmClient,
-		listLimit:  releaseListLimit,
 	}
 }
 
@@ -84,7 +83,7 @@ type AppOverview struct {
 
 func (p *Proxy) get(name, namespace string) (*release.Release, error) {
 	list, err := p.helmClient.ListReleases(
-		helm.ReleaseListLimit(p.listLimit),
+		helm.ReleaseListFilter(name),
 		helm.ReleaseListNamespace(namespace),
 		helm.ReleaseListStatuses(releaseStatuses),
 	)
@@ -135,9 +134,9 @@ func (p *Proxy) ResolveManifest(namespace, values string, ch *chart.Chart) (stri
 }
 
 // ListReleases list releases in a specific namespace if given
-func (p *Proxy) ListReleases(namespace string) ([]AppOverview, error) {
+func (p *Proxy) ListReleases(namespace string, releaseListLimit int) ([]AppOverview, error) {
 	list, err := p.helmClient.ListReleases(
-		helm.ReleaseListLimit(p.listLimit),
+		helm.ReleaseListLimit(releaseListLimit),
 		helm.ReleaseListNamespace(namespace),
 		helm.ReleaseListStatuses(releaseStatuses),
 	)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -44,7 +44,7 @@ func newFakeProxy(existingTillerReleases []AppOverview) *Proxy {
 		})
 	}
 	kubeClient := fake.NewSimpleClientset()
-	return NewProxy(kubeClient, &helmClient)
+	return NewProxy(kubeClient, &helmClient, 256)
 }
 
 func TestListAllReleases(t *testing.T) {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -44,7 +44,7 @@ func newFakeProxy(existingTillerReleases []AppOverview) *Proxy {
 		})
 	}
 	kubeClient := fake.NewSimpleClientset()
-	return NewProxy(kubeClient, &helmClient, 256)
+	return NewProxy(kubeClient, &helmClient)
 }
 
 func TestListAllReleases(t *testing.T) {
@@ -53,7 +53,7 @@ func TestListAllReleases(t *testing.T) {
 	proxy := newFakeProxy([]AppOverview{app1, app2})
 
 	// Should return all the releases if no namespace is given
-	releases, err := proxy.ListReleases("")
+	releases, err := proxy.ListReleases("", 256)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -71,7 +71,7 @@ func TestListNamespacedRelease(t *testing.T) {
 	proxy := newFakeProxy([]AppOverview{app1, app2})
 
 	// Should return all the releases if no namespace is given
-	releases, err := proxy.ListReleases(app1.Namespace)
+	releases, err := proxy.ListReleases(app1.Namespace, 256)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}


### PR DESCRIPTION
Fixes #435 

 - Re-implement listReleases(namespace) to not to rely on listing all elements in the namespace.
 - Re-implement get method to not to rely on the global list.
 - Add a flag to configure the max number of releases for the proxy to retrieve.

PD: It's not possible to create a unit test for the patch since the fake helm implementation ignores that limit.