### PR TITLE
Report unprocessable entity

### DIFF
--- a/cmd/tiller-proxy/handler.go
+++ b/cmd/tiller-proxy/handler.go
@@ -115,7 +115,11 @@ func isUnprocessable(err error) bool {
 }
 
 func errorCode(err error) int {
-	errCode := http.StatusInternalServerError
+	return errorCodeWithDefault(err, http.StatusInternalServerError)
+}
+
+func errorCodeWithDefault(err error, defaultCode int) int {
+	errCode := defaultCode
 	if isAlreadyExists(err) {
 		errCode = http.StatusConflict
 	} else if isNotFound(err) {
@@ -190,7 +194,7 @@ func createRelease(w http.ResponseWriter, req *http.Request, params Params) {
 	}
 	rel, err := proxy.CreateRelease(chartDetails.ReleaseName, params["namespace"], chartDetails.Values, ch)
 	if err != nil {
-		response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
+		response.NewErrorResponse(errorCodeWithDefault(err, http.StatusUnprocessableEntity), err.Error()).Write(w)
 		return
 	}
 	log.Printf("Installed release %s", rel.Name)
@@ -224,7 +228,7 @@ func upgradeRelease(w http.ResponseWriter, req *http.Request, params Params) {
 	}
 	rel, err := proxy.UpdateRelease(params["releaseName"], params["namespace"], chartDetails.Values, ch)
 	if err != nil {
-		response.NewErrorResponse(errorCode(err, err.Error()).Write(w)
+		response.NewErrorResponse(errorCodeWithDefault(err, http.StatusUnprocessableEntity), err.Error()).Write(w)
 		return
 	}
 	log.Printf("Upgraded release %s", rel.Name)

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as Modal from "react-modal";
 import { Redirect } from "react-router";
 
-import { ForbiddenError, IRBACRole } from "../../../shared/types";
+import { AppConflict, ForbiddenError, IRBACRole, UnprocessableEntity } from "../../../shared/types";
 import { PermissionsErrorAlert, UnexpectedErrorAlert } from "../../ErrorAlert";
 
 interface IAppRepoFormProps {
@@ -60,6 +60,8 @@ export const AppRepoForm = (props: IAppRepoFormProps) => {
                 value={name}
                 onChange={handleNameChange}
                 required={true}
+                pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+                title="Use lower case alphanumeric characters, '-' or '.'"
               />
             </label>
           </div>
@@ -155,6 +157,12 @@ export class AppRepoAddButton extends React.Component<
     const { error } = this.props;
     const { name } = this.state;
     switch (error && error.constructor) {
+      case AppConflict:
+        return (
+          <UnexpectedErrorAlert
+            text={`App Repository "${name}" already exists, try a different name.`}
+          />
+        );
       case ForbiddenError:
         return (
           <PermissionsErrorAlert
@@ -163,6 +171,8 @@ export class AppRepoAddButton extends React.Component<
             action={`create AppRepository "${name}"`}
           />
         );
+      case UnprocessableEntity:
+        return <UnexpectedErrorAlert text={error && error.message} raw={true} />;
       default:
         return <UnexpectedErrorAlert />;
     }

--- a/dashboard/src/components/DeploymentForm/DeploymentErrors.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentErrors.tsx
@@ -5,6 +5,7 @@ import {
   IRBACRole,
   MissingChart,
   NotFoundError,
+  UnprocessableEntity,
 } from "../../shared/types";
 import { NotFoundErrorAlert, PermissionsErrorAlert, UnexpectedErrorAlert } from "../ErrorAlert";
 
@@ -53,6 +54,8 @@ class DeploymentErrors extends React.Component<IDeploymentErrorProps> {
         return (
           <NotFoundErrorAlert resource={`Application "${releaseName}"`} namespace={namespace} />
         );
+      case UnprocessableEntity:
+        return <UnexpectedErrorAlert text={error && error.message} raw={true} />;
       default:
         return <UnexpectedErrorAlert />;
     }

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -129,6 +129,8 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
                 <label htmlFor="releaseName">Name</label>
                 <input
                   id="releaseName"
+                  pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+                  title="Use lower case alphanumeric characters, '-' or '.'"
                   onChange={this.handleReleaseNameChange}
                   value={this.state.releaseName}
                   required={true}

--- a/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.tsx
@@ -1,29 +1,53 @@
 import * as React from "react";
+import { X } from "react-feather";
 
 import ErrorPageHeader from "./ErrorAlertHeader";
 
-class UnexpectedErrorPage extends React.Component {
+interface IUnexpectedErrorPage {
+  raw?: boolean;
+  text?: string;
+}
+
+const genericMessage = (
+  <div>
+    <p>Troubleshooting:</p>
+    <ul className="error__troubleshooting">
+      <li>Check for network issues.</li>
+      <li>Check your browser's JavaScript console for errors.</li>
+      <li>
+        Check the health of Kubeapps components{" "}
+        <code>kubectl get po --all-namespaces -l created-by=kubeapps</code>.
+      </li>
+      <li>
+        <a href="https://github.com/kubeapps/kubeapps/issues/new" target="_blank">
+          Open an issue on GitHub
+        </a>{" "}
+        if you think you've encountered a bug.
+      </li>
+    </ul>
+  </div>
+);
+
+class UnexpectedErrorPage extends React.Component<IUnexpectedErrorPage> {
   public render() {
+    let message = genericMessage;
+    if (this.props.text) {
+      if (this.props.raw) {
+        message = (
+          <div className="error__content margin-l-enormous">
+            <section className="Terminal elevation-1">
+              <span className="type-color-white">{this.props.text}</span>
+            </section>
+          </div>
+        );
+      } else {
+        message = <p>{this.props.text}</p>;
+      }
+    }
     return (
       <div className="alert alert-error margin-t-bigger">
-        <ErrorPageHeader>Sorry! Something went wrong.</ErrorPageHeader>
-        <div className="error__content margin-l-enormous">
-          <p>Troubleshooting:</p>
-          <ul className="error__troubleshooting">
-            <li>Check for network issues.</li>
-            <li>Check your browser's JavaScript console for errors.</li>
-            <li>
-              Check the health of Kubeapps components{" "}
-              <code>kubectl get po --all-namespaces -l created-by=kubeapps</code>.
-            </li>
-            <li>
-              <a href="https://github.com/kubeapps/kubeapps/issues/new" target="_blank">
-                Open an issue on GitHub
-              </a>{" "}
-              if you think you've encountered a bug.
-            </li>
-          </ul>
-        </div>
+        <ErrorPageHeader icon={X}>Sorry! Something went wrong.</ErrorPageHeader>
+        <div className="error__content margin-l-enormous">{message}</div>
       </div>
     );
   }

--- a/dashboard/src/components/Footer/Footer.tsx
+++ b/dashboard/src/components/Footer/Footer.tsx
@@ -37,7 +37,7 @@ class Footer extends React.Component {
                   />
                 </svg>
               </a>
-              <a href="https://github.com/kubeapps" className="socialIcon margin-h-small">
+              <a href="https://github.com/kubeapps/kubeapps" className="socialIcon margin-h-small">
                 <svg
                   role="img"
                   aria-label="Kubeapps on GitHub"

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -1,5 +1,5 @@
 import Axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
-import { AppConflict, ForbiddenError, NotFoundError } from "./types";
+import { AppConflict, ForbiddenError, NotFoundError, UnprocessableEntity } from "./types";
 
 const AuthTokenKey = "kubeapps_auth_token";
 
@@ -74,6 +74,8 @@ function authenticatedAxiosInstance() {
           return Promise.reject(new NotFoundError(message));
         case 409:
           return Promise.reject(new AppConflict(message));
+        case 422:
+          return Promise.reject(new UnprocessableEntity(message));
         default:
           return Promise.reject(e);
       }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -36,6 +36,13 @@ export class AppConflict extends Error {
   }
 }
 
+export class UnprocessableEntity extends Error {
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
 export interface IRepo {
   name: string;
   url: string;

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -175,7 +175,7 @@ func (p *Proxy) CreateRelease(name, namespace, values string, ch *chart.Chart) (
 		helm.ReleaseName(name),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Unable create release: %v", err)
+		return nil, fmt.Errorf("Unable to create the release: %v", err)
 	}
 	log.Printf("%s successfully installed in %s", name, namespace)
 	return res.GetRelease(), nil
@@ -200,7 +200,7 @@ func (p *Proxy) UpdateRelease(name, namespace string, values string, ch *chart.C
 		//helm.UpgradeForce(true), ?
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to update release: %v", err)
+		return nil, fmt.Errorf("Unable to update the release: %v", err)
 	}
 	return res.GetRelease(), nil
 }
@@ -223,7 +223,7 @@ func (p *Proxy) DeleteRelease(name, namespace string) error {
 	}
 	_, err = p.helmClient.DeleteRelease(name, helm.DeletePurge(true))
 	if err != nil {
-		return fmt.Errorf("Unable to delete release: %v", err)
+		return fmt.Errorf("Unable to delete the release: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #318

 - In the Dashboard we now validate that the name given by the user passes the regex expected. If that is not the case, it shows a red border and hides the "Submit" button. TODO: Show a warning message explaining why the name is not valid:

<img width="805" alt="screen shot 2018-08-10 at 11 54 58" src="https://user-images.githubusercontent.com/4025665/43951810-5f1fea58-9c94-11e8-8222-b78df6e1e44d.png">

In case the basic validation doesn't catch the error:

 - The Tiller proxy returns now a 422 error (Unprocessable entity) if it fails to deploy a release.
 - The dashboard shows the raw error that Tiller returns for the user to debug:

![screen shot 2018-08-09 at 16 34 21](https://user-images.githubusercontent.com/4025665/43951848-86332dc6-9c94-11e8-8097-8a064092d1c3.png)

Apart from that the `AppRepositoryButton` now catches as well name conflicts and unprocessable entities as well.
