### PR TITLE
Allow to upgrade Kubeapps through the Dashboard

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -23,6 +23,8 @@ apprepository:
     url: https://kubernetes-charts-incubator.storage.googleapis.com
   - name: svc-cat
     url: https://svc-catalog-charts.storage.googleapis.com
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami
   resources: {}
     # limits:
     #  cpu: 100m


### PR DESCRIPTION
Fixes #465: Install `bitnami` repo by default
