### PR TITLE
Wrap console text

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -108,18 +108,16 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
     return (
       <div>
         <form className="container padding-b-bigger" onSubmit={this.handleDeploy}>
-          <div className="col-8">
-            {this.props.error && (
-              <DeploymentErrors
-                {...this.props}
-                kubeappsNamespace={kubeappsNamespace}
-                chartName={chartID.split("/")[0]}
-                releaseName={releaseName}
-                repo={chartID.split("/")[1]}
-                version={version.attributes.version}
-              />
-            )}
-          </div>
+          {this.props.error && (
+            <DeploymentErrors
+              {...this.props}
+              kubeappsNamespace={kubeappsNamespace}
+              chartName={chartID.split("/")[0]}
+              releaseName={releaseName}
+              repo={chartID.split("/")[1]}
+              version={version.attributes.version}
+            />
+          )}
           <div className="row">
             <div className="col-12">
               <h2>{this.props.chartID}</h2>

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -108,19 +108,19 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
     return (
       <div>
         <form className="container padding-b-bigger" onSubmit={this.handleDeploy}>
+          <div className="col-8">
+            {this.props.error && (
+              <DeploymentErrors
+                {...this.props}
+                kubeappsNamespace={kubeappsNamespace}
+                chartName={chartID.split("/")[0]}
+                releaseName={releaseName}
+                repo={chartID.split("/")[1]}
+                version={version.attributes.version}
+              />
+            )}
+          </div>
           <div className="row">
-            <div className="col-8">
-              {this.props.error && (
-                <DeploymentErrors
-                  {...this.props}
-                  kubeappsNamespace={kubeappsNamespace}
-                  chartName={chartID.split("/")[0]}
-                  releaseName={releaseName}
-                  repo={chartID.split("/")[1]}
-                  version={version.attributes.version}
-                />
-              )}
-            </div>
             <div className="col-12">
               <h2>{this.props.chartID}</h2>
             </div>

--- a/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.css
+++ b/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.css
@@ -1,0 +1,3 @@
+.terminal__error {
+  word-break: break-all;
+}

--- a/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { X } from "react-feather";
 
 import ErrorPageHeader from "./ErrorAlertHeader";
+import "./UnexpectedErrorAlert.css";
 
 interface IUnexpectedErrorPage {
   raw?: boolean;
@@ -35,10 +36,7 @@ class UnexpectedErrorPage extends React.Component<IUnexpectedErrorPage> {
       if (this.props.raw) {
         message = (
           <div className="error__content margin-l-enormous">
-            <section
-              className="Terminal elevation-1 type-color-white"
-              style={{ wordBreak: "break-all" }}
-            >
+            <section className="Terminal terminal__error elevation-1 type-color-white">
               {this.props.text}
             </section>
           </div>

--- a/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.tsx
@@ -35,8 +35,11 @@ class UnexpectedErrorPage extends React.Component<IUnexpectedErrorPage> {
       if (this.props.raw) {
         message = (
           <div className="error__content margin-l-enormous">
-            <section className="Terminal elevation-1">
-              <span className="type-color-white">{this.props.text}</span>
+            <section
+              className="Terminal elevation-1 type-color-white"
+              style={{ wordBreak: "break-all" }}
+            >
+              {this.props.text}
             </section>
           </div>
         );


### PR DESCRIPTION
Before this change a very long word in the `Terminal` error caused a very long line in the error message. Now it is truncated to respect the max width:

![screen shot 2018-08-16 at 12 14 47](https://user-images.githubusercontent.com/4025665/44203258-abfff700-a14e-11e8-82c5-33b474b3c251.png)

cc/ @Angelmmiguel 