### PR TITLE
Update documentation about enabling RBAC in minikube

### DIFF
--- a/docs/developer/tiller-proxy.md
+++ b/docs/developer/tiller-proxy.md
@@ -44,7 +44,7 @@ This builds the `tiller-proxy` binary in the working directory.
 If you are using Minikube it is important to start the cluster enabling RBAC (in order to check the authorization features):
 
 ```
-minikube start --extra-config=apiserver.Authorization.Mode=RBAC
+minikube start --extra-config=apiserver.authorization-mode=RBAC
 eval $(minikube docker-env)
 ```
 

--- a/docs/developer/tiller-proxy.md
+++ b/docs/developer/tiller-proxy.md
@@ -41,10 +41,10 @@ This builds the `tiller-proxy` binary in the working directory.
 
 ### Running in development
 
-If you are using Minikube it is important to start the cluster enabling RBAC (in order to check the authorization features):
+If you are using Minikube it is important to start the cluster enabling RBAC (on by default in Minikube 0.26+) in order to check the authorization features:
 
 ```
-minikube start --extra-config=apiserver.authorization-mode=RBAC
+minikube start
 eval $(minikube docker-env)
 ```
 


### PR DESCRIPTION
Minikube 0.26+ fails to start if the flag `--Authorization.Mode` is passed with the error

```
error: unknown flag: --Authorization.Mode
```

This updates the docs to use the configuration that Kubeadm understands.

https://github.com/kubernetes/minikube/issues/2712#issuecomment-381044516