### PR TITLE
Ignore empty kubernetes resources

### DIFF
--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -33,7 +33,6 @@ func ParseObjects(manifest string) ([]*unstructured.Unstructured, error) {
 	r := strings.NewReader(manifest)
 	decoder := yaml.NewYAMLReader(bufio.NewReader(r))
 	ret := []runtime.Object{}
-	nullResult := []byte("null")
 
 	for {
 		// This reader will return a single K8s resource at the time based on the --- separator
@@ -43,9 +42,7 @@ func ParseObjects(manifest string) ([]*unstructured.Unstructured, error) {
 		} else if err != nil {
 			return nil, err
 		}
-		if len(objManifest) == 0 {
-			continue
-		}
+
 		jsondata, err := yaml.ToJSON(objManifest)
 		if err != nil {
 			return nil, err
@@ -54,7 +51,7 @@ func ParseObjects(manifest string) ([]*unstructured.Unstructured, error) {
 		// It is also possible that the provided yaml file is empty from the point of view
 		// of the toJSON parser. For example if the yaml only contain comments.
 		// In which case the returned  will be "null"
-		if bytes.Equal(jsondata, nullResult) {
+		if bytes.Equal(jsondata, []byte("null")) {
 			continue
 		}
 

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -18,6 +18,7 @@ package yaml
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"strings"
 
@@ -32,20 +33,31 @@ func ParseObjects(manifest string) ([]*unstructured.Unstructured, error) {
 	r := strings.NewReader(manifest)
 	decoder := yaml.NewYAMLReader(bufio.NewReader(r))
 	ret := []runtime.Object{}
+	nullResult := []byte("null")
+
 	for {
-		bytes, err := decoder.Read()
+		// This reader will return a single K8s resource at the time based on the --- separator
+		objManifest, err := decoder.Read()
 		if err == io.EOF {
 			break
 		} else if err != nil {
 			return nil, err
 		}
-		if len(bytes) == 0 {
+		if len(objManifest) == 0 {
 			continue
 		}
-		jsondata, err := yaml.ToJSON(bytes)
+		jsondata, err := yaml.ToJSON(objManifest)
 		if err != nil {
 			return nil, err
 		}
+
+		// It is also possible that the provided yaml file is empty from the point of view
+		// of the toJSON parser. For example if the yaml only contain comments.
+		// In which case the returned  will be "null"
+		if bytes.Equal(jsondata, nullResult) {
+			continue
+		}
+
 		obj, _, err := unstructured.UnstructuredJSONScheme.Decode(jsondata, nil, nil)
 		if err != nil {
 			return nil, err

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -33,6 +33,7 @@ func ParseObjects(manifest string) ([]*unstructured.Unstructured, error) {
 	r := strings.NewReader(manifest)
 	decoder := yaml.NewYAMLReader(bufio.NewReader(r))
 	ret := []runtime.Object{}
+	nullResult := []byte("null")
 
 	for {
 		// This reader will return a single K8s resource at the time based on the --- separator
@@ -51,7 +52,7 @@ func ParseObjects(manifest string) ([]*unstructured.Unstructured, error) {
 		// It is also possible that the provided yaml file is empty from the point of view
 		// of the toJSON parser. For example if the yaml only contain comments.
 		// In which case the returned  will be "null"
-		if bytes.Equal(jsondata, []byte("null")) {
+		if bytes.Equal(jsondata, nullResult) {
 			continue
 		}
 

--- a/pkg/yaml/yaml_test.go
+++ b/pkg/yaml/yaml_test.go
@@ -29,6 +29,11 @@ func TestParseObjectsSuccess(t *testing.T) {
 		kinds           []string
 	}{
 		{
+			"returns nothing if manifest is empty",
+			"",
+			0, nil, nil,
+		},
+		{
 			"returns a single resource",
 			`
 apiVersion: v1

--- a/pkg/yaml/yaml_test.go
+++ b/pkg/yaml/yaml_test.go
@@ -21,27 +21,85 @@ import (
 )
 
 func TestParseObjectsSuccess(t *testing.T) {
-	m1 := `apiVersion: v1
+	testCases := []struct {
+		desc            string
+		manifest        string
+		numberResources int
+		apiVersions     []string
+		kinds           []string
+	}{
+		{
+			"returns a single resource",
+			`
+apiVersion: v1
 kind: Namespace
 metadata:
-  annotations: {}
-  labels:
-    name: kubeless
-  name: kubeless`
-	rs, err := ParseObjects(m1)
-	if err != nil {
-		t.Error(err)
-	}
-	if len(rs) != 1 {
-		t.Errorf("Expected 1 yaml element, got %v", len(rs))
+  name: kubeapps`,
+			1, []string{"v1"}, []string{"Namespace"},
+		},
+		{
+			"returns multiple resources",
+			`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeapps
+---
+apiVersion: extensions/v1beta1       
+kind: Deployment
+metadata:
+  name: kubeapps`,
+			2, []string{"v1", "extensions/v1beta1"}, []string{"Namespace", "Deployment"},
+		},
+		{
+			"ignores files with just comments",
+			`
+apiVersion: v1
+kind: LonelyNamespace
+metadata:
+  name: kubeapps
+---
+# This is a comment in yaml`,
+			1, []string{"v1"}, []string{"LonelyNamespace"},
+		},
+		{
+			"ignores empty files",
+			`
+apiVersion: v1
+kind: LonelyNamespace
+metadata:
+  name: kubeapps
+---
+---
+`,
+			1, []string{"v1"}, []string{"LonelyNamespace"},
+		},
 	}
 
-	// validate some fields of the parsed object
-	if rs[0].GetAPIVersion() != "v1" {
-		t.Errorf("Expected apiversion=v1, go %s", rs[0].GetAPIVersion())
-	}
-	if rs[0].GetKind() != "Namespace" {
-		t.Errorf("Expected kind = Namespace, go %s", rs[0].GetKind())
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			resources, err := ParseObjects(tt.manifest)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if got, want := len(resources), tt.numberResources; got != want {
+				t.Errorf("Expected %d yaml element, got %v", want, got)
+			}
+
+			for i, resource := range resources {
+				if got, want := resource.GetAPIVersion(), tt.apiVersions[i]; got != want {
+					t.Errorf("got %q, want %q", got, want)
+
+				}
+				if got, want := resource.GetAPIVersion(), tt.apiVersions[i]; got != want {
+					t.Errorf("got %q, want %q", got, want)
+				}
+				if got, want := resource.GetKind(), tt.kinds[i]; got != want {
+					t.Errorf("got %q, want %q", got, want)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This patch fixes the case in which the k8s manifest contains a valid yaml but useless from the POV of the YamlToJson parsing. This is the case for a manifest that only includes comments.


Fixes https://github.com/kubeapps/kubeapps/issues/487