### PR TITLE
chart: fix hook type in cleanup job

### DIFF
--- a/chart/kubeapps/templates/apprepository-jobs-cleanup-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-cleanup-rbac.yaml
@@ -26,7 +26,7 @@ kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.apprepository-jobs-cleanup.fullname" . }}
   annotations:
-    helm.sh/hook: pre-delete
+    helm.sh/hook: post-delete
     helm.sh/hook-delete-policy: hook-succeeded
     helm.sh/hook-weight: "-10"
   labels:


### PR DESCRIPTION
the hook type had a typo as pre-delete but I believe this should be post-delete like the other resources