### PR TITLE
ignore no charts error when filtering

### DIFF
--- a/dashboard/src/components/ChartList/ChartList.tsx
+++ b/dashboard/src/components/ChartList/ChartList.tsx
@@ -39,9 +39,9 @@ class ChartList extends React.Component<IChartListProps, IChartListState> {
   }
 
   public render() {
-    const { charts: { isFetching }, pushSearchFilter } = this.props;
-    const items = this.filteredCharts(this.props.charts.items, this.state.filter);
-    if (!isFetching && items.length === 0) {
+    const { charts: { isFetching, items: allItems }, pushSearchFilter } = this.props;
+    const items = this.filteredCharts(allItems, this.state.filter);
+    if (!isFetching && allItems.length === 0) {
       return (
         <NotFoundErrorAlert
           resource={"Charts"}


### PR DESCRIPTION
Previously, we would display the No Charts Found error alert if the
filtered chart array came back empty. However, this error only makes
sense to show when the charts from the server come back empty. This
patch fixes this to only show the error if there are no charts from
the server.

We may want to improve the way we show this message (for example, under
the Charts header), and we may also want to show a different alert if
the filter shows up empty in the future.

fixes #531