### PR TITLE
backport some Typescript 3.x types to fix compilation error

### DIFF
--- a/dashboard/src/backport.d.ts
+++ b/dashboard/src/backport.d.ts
@@ -1,0 +1,6 @@
+// This file contains a set of backports from typescript 3.x
+// TODO(miguel) Remove backports once we upgrade typescript https://github.com/kubeapps/kubeapps/issues/534
+type EventHandlerNonNull = (event: Event) => any;
+
+// @ts-ignore
+type BinaryType = "blob" | "arraybuffer";


### PR DESCRIPTION
This PR fixes the Typescript compilation error raised during `yarn run start`

```

Failed to compile.

/home/migmartri/go/src/github.com/kubeapps/kubeapps/dashboard/node_modules/mock-socket/index.d.ts
(21,13): Cannot find name 'EventHandlerNonNull'.

```

After some digging, it seems that the issue is that those definitions use Typescript 3.x features while our package.json loads the 2.x branch.

We did not notice of this issue because the production env uses a tsconfig that does not load the file that imported the 3.x definitions and also VSCode is using 3.x which compiles just fine.

We have backported some of the types required by `/mock-socket/index.d.ts` but should be removed once Typescript is upgraded https://github.com/kubeapps/kubeapps/issues/534