### PR TITLE
bump chart version for v1.0.0-alpha.6 release

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kubeapps
-version: 0.2.0
-appVersion: 1.0.0.alpha.5
+version: 0.3.0
+appVersion: 1.0.0.alpha.6
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png
 keywords:


### PR DESCRIPTION
The appVersion doesn't matter much, but the chart version needs to be bumped for the release.