### PR TITLE
Disable ordering rules for linter

### DIFF
--- a/dashboard/tslint.ci.json
+++ b/dashboard/tslint.ci.json
@@ -2,6 +2,9 @@
   "defaultSeverity": "error",
   "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
   "jsRules": {},
-  "rules": {},
+  "rules": {
+    "ordered-imports": false,
+    "object-literal-sort-keys": false
+  },
   "rulesDirectory": []
 }

--- a/dashboard/tslint.ci.json
+++ b/dashboard/tslint.ci.json
@@ -3,7 +3,6 @@
   "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
   "jsRules": {},
   "rules": {
-    "ordered-imports": false,
     "object-literal-sort-keys": false
   },
   "rulesDirectory": []


### PR DESCRIPTION
The ordering rules are not very consistent and difficult to follow.

It's not possible to automate the ordering and doesn't provide a lot of value.