### PR TITLE
updates Hex to v3.2.0

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -15,8 +15,6 @@
   <link rel="icon" type="image/png" href="%PUBLIC_URL%/favicon-16x16.png" sizes="16x16" />
   <link rel="icon" type="image/png" href="%PUBLIC_URL%/favicon-128.png" sizes="128x128" />
 
-  <script src="//unpkg.com/@bitnami/hex-js@3.2.0/dist/hex.min.js"></script>
-
   <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -15,6 +15,8 @@
   <link rel="icon" type="image/png" href="%PUBLIC_URL%/favicon-16x16.png" sizes="16x16" />
   <link rel="icon" type="image/png" href="%PUBLIC_URL%/favicon-128.png" sizes="128x128" />
 
+  <script src="//unpkg.com/@bitnami/hex-js@3.2.0/dist/hex.min.js"></script>
+
   <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/dashboard/src/components/Card/Card.css
+++ b/dashboard/src/components/Card/Card.css
@@ -8,6 +8,11 @@
   margin: 0 1% 1.5em;
 }
 
+.Card a,
+.Card a:hover {
+  text-decoration: none !important;
+}
+
 .Card__Icon img {
   max-height: 64px;
 }

--- a/dashboard/src/components/ChartView/ChartView.tsx
+++ b/dashboard/src/components/ChartView/ChartView.tsx
@@ -90,9 +90,13 @@ class ChartView extends React.Component<IChartViewProps> {
                     <div className="ChartViewSidebar__section">
                       <h2>Home</h2>
                       <div>
-                        <a href={chartAttrs.home} target="_blank">
-                          {chartAttrs.home}
-                        </a>
+                        <ul className="remove-style padding-l-reset margin-b-reset">
+                          <li>
+                            <a href={chartAttrs.home} target="_blank">
+                              {chartAttrs.home}
+                            </a>
+                          </li>
+                        </ul>
                       </div>
                     </div>
                   )}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -15,3 +15,9 @@ svg.icon {
   position: relative;
   bottom: -0.125em;
 }
+
+/* Override Hex underline text-decoration in buttons in alerts
+see: https://github.com/bitnami/hex/issues/216 */
+.alert .button {
+  text-decoration: none;
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1,6 +1,5 @@
 @import url("https://fonts.googleapis.com/css?family=Fira+Sans:300,400,700|Hind:300,400,700");
-@import url("https://d1d5nb8vlsbujg.cloudfront.net/bitnami-ui/3.0.0-alpha-20/bitnami.ui.min.css");
-@import url("https://d1d5nb8vlsbujg.cloudfront.net/bitnami-ui/3.0.0-alpha-20/bitnami.ui.components.min.css");
+@import url("//unpkg.com/@bitnami/hex@3.2.0/dist/hex.min.css");
 
 body {
   margin: 0;


### PR DESCRIPTION
fixes #342 

Note that the link colour has changed in Hex to a different blue, and some links are now underlined. This is part of the default Hex theme and matches https://design.bitnami.com/. For example:

![screen shot 2018-08-27 at 16 26 53](https://user-images.githubusercontent.com/1544861/44692127-5c56e080-aa16-11e8-938f-db54db277c6b.png)

![screen shot 2018-08-27 at 16 27 20](https://user-images.githubusercontent.com/1544861/44692134-611b9480-aa16-11e8-8f50-79cc6317c3f0.png)

I noticed some issues when trying to override this behaviour in the Cards and buttons and have filed issues in Hex: https://github.com/bitnami/hex/issues/216 and https://github.com/bitnami/hex/issues/217.