### PR TITLE
Automatically sync chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,11 @@ workflows:
             - build_chart_apprepository
             - build_dashboard
             - build_tiller_proxy
+      - sync_chart:
+          <<: *build_on_master
+          requires:
+            - GKE_1_9
+            - GKE_1_10
       - release:
           <<: *build_on_tag
           requires:
@@ -199,3 +204,18 @@ jobs:
     environment:
       HELM_VERSION: v2.9.1
       GKE_BRANCH: 1.10
+  sync_chart:
+    docker:
+      - image: circleci/golang:1.9
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "cc:ed:2d:1f:74:3b:32:c3:99:62:d7:7d:81:af:01:e0"
+      - run: |
+          if ls ~/.ssh/id_rsa_* 1> /dev/null 2>&1; then
+            # Change order to use configured ssh_key first
+            ssh-add -D
+            ssh-add ~/.ssh/id_rsa_* ~/.ssh/id_rsa
+          fi
+          ./script/chart_sync.sh kubernetes-bitnami kubernetes@bitnami.com

--- a/script/chart_sync.sh
+++ b/script/chart_sync.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Copyright (c) 2018 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+CHARTS_REPO="andresmgot/charts-1"
+CHART_REPO_PATH="bitnami/kubeapps"
+PROJECT_DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd`
+KUBEAPPS_CHART_DIR="${PROJECT_DIR}/chart/kubeapps"
+
+source $PROJECT_DIR/script/release_utils.sh
+
+changedVersion() {
+    local currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep "version:")
+    local externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO}/master/${CHART_REPO_PATH}/Chart.yaml | grep "version:")
+    # NOTE: If curl returns an error this will return always true
+    [[ "$currentVersion" != "$externalVersion" ]]
+}
+
+configUser() {
+    local targetRepo=${1:?}
+    local user=${2:?}
+    local email=${3:?}
+    cd $targetRepo
+    git config user.name "$user"
+    git config user.email "$email"
+    cd -
+}
+
+updateRepo() {
+    local targetRepo=${1:?}
+    local targetTag=${2:?}
+    if [ ! -f "${targetRepo}/${CHART_REPO_PATH}/Chart.yaml" ]; then
+        echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
+        return 1
+    fi
+    rm -rf "${targetRepo}/${CHART_REPO_PATH}"
+    cp -R "${KUBEAPPS_CHART_DIR}" "${targetRepo}/${CHART_REPO_PATH}"
+    # DANGER: This replaces any tag marked as latest
+    sed -i.bk 's/tag: latest/tag: '"${targetTag}"'/g' "${targetRepo}/${CHART_REPO_PATH}/values.yaml"
+    rm "${targetRepo}/${CHART_REPO_PATH}/values.yaml.bk"
+}
+
+commitAndPushChanges() {
+    local targetRepo=${1:?}
+    local token=${2:?}
+    local targetBranch=${2:-"master"}
+    if [ ! -f "${targetRepo}/${CHART_REPO_PATH}/Chart.yaml" ]; then
+        echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
+        return 1
+    fi
+    cd $targetRepo
+    if [[ ! $(git diff-index HEAD) ]]; then
+        echo "Not found any change to commit" > /dev/stderr
+        cd -
+        return 1
+    fi
+    git add --all .
+    git commit -m "Update Kubeapps chart"
+    # NOTE: This expects to have a loaded SSH key
+    git push origin $targetBranch
+    cd -
+}
+
+user=${1:?}
+email=${2:?}
+if changedVersion; then
+    tempDir=$(mktemp -u)/charts
+    mkdir -p $tempDir
+    git clone https://github.com/${CHARTS_REPO} $tempDir
+    configUser $tempDir $user $email
+    latestVersion=$(getLatestTag)
+    updateRepo $tempDir $latestVersion
+    commitAndPushChanges $tempDir master
+else
+    echo "Skipping Chart sync. The version has not changed"
+fi

--- a/script/chart_sync.sh
+++ b/script/chart_sync.sh
@@ -46,7 +46,10 @@ updateRepo() {
     fi
     rm -rf "${targetRepo}/${CHART_REPO_PATH}"
     cp -R "${KUBEAPPS_CHART_DIR}" "${targetRepo}/${CHART_REPO_PATH}"
-    # DANGER: This replaces any tag marked as latest
+    # Update Chart.yaml with new version
+    sed -i.bk 's/appVersion: DEVEL/appVersion: '"${targetTag}"'/g' "${targetRepo}/${CHART_REPO_PATH}/Chart.yaml"
+    rm "${targetRepo}/${CHART_REPO_PATH}/Chart.yaml.bk"
+    # DANGER: This replaces any tag marked as latest in the values.yaml
     sed -i.bk 's/tag: latest/tag: '"${targetTag}"'/g' "${targetRepo}/${CHART_REPO_PATH}/values.yaml"
     rm "${targetRepo}/${CHART_REPO_PATH}/values.yaml.bk"
 }

--- a/script/release_utils.sh
+++ b/script/release_utils.sh
@@ -1,16 +1,12 @@
 #!/bin/bash
 set -e
 
-function getLatestTag {
-  git fetch --tags
-  git describe --tags $(git rev-list --tags --max-count=1)
-}
-
 function commit_list {
   local tag=${1:?}
   local repo_domain=${2:?}
   local repo_name=${3:?}
-  local previous_tag=$(getLatestTag)
+  git fetch --tags
+  local previous_tag=`git describe --tags $(git rev-list --tags --max-count=1)`
   local commit_list=`git log $previous_tag..$tag --pretty=format:"- %s %H (%an)"`
   echo "$commit_list"
 }

--- a/script/release_utils.sh
+++ b/script/release_utils.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 set -e
 
+function getLatestTag {
+  git fetch --tags
+  git describe --tags $(git rev-list --tags --max-count=1)
+}
+
 function commit_list {
   local tag=${1:?}
   local repo_domain=${2:?}
   local repo_name=${3:?}
-  git fetch --tags
-  local previous_tag=`git describe --tags $(git rev-list --tags --max-count=1)`
+  local previous_tag=$(getLatestTag)
   local commit_list=`git log $previous_tag..$tag --pretty=format:"- %s %H (%an)"`
   echo "$commit_list"
 }


### PR DESCRIPTION
Fixes #414

Automatically release a chart in the repository `bitnami/charts` for Kubeapps. The process for updating a version is:

 1. Add a new tag for the repo (as always). This will generate all the images required for the new version.
 2. Increase the version number of the chart at `chart/kubeapps/Chart.yaml`. Once that change is in `master` CircleCI will update the status of the `bitnami/charts` repo with the files in this repository.

**IMPORTANT**: The script in 2. will automatically change the references to `tag: latest` in the file `chart/kubeapps/values.yaml` with the latest tag available (normally the tag released in 1.). 

Update example: https://github.com/andresmgot/charts-1/commit/d3c69181bf0e40428b0c83e86d66207d867a98ae