### PR TITLE
Fix previous tag retrieval

### DIFF
--- a/script/release_utils.sh
+++ b/script/release_utils.sh
@@ -6,8 +6,7 @@ function commit_list {
   local repo_domain=${2:?}
   local repo_name=${3:?}
   git fetch --tags
-  # Get latest two tags and filter the last one (which is the current commit)
-  local previous_tag=`git tag -l --sort=committerdate | tail -n 2 | head -n 1`
+  local previous_tag=`git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1)`
   local commit_list=`git log $previous_tag..$tag --pretty=format:"- %s %H (%an)"`
   echo "$commit_list"
 }

--- a/script/release_utils.sh
+++ b/script/release_utils.sh
@@ -6,7 +6,8 @@ function commit_list {
   local repo_domain=${2:?}
   local repo_name=${3:?}
   git fetch --tags
-  local previous_tag=`git describe --tags $(git rev-list --tags --max-count=1)`
+  # Get latest two tags and filter the last one (which is the current commit)
+  local previous_tag=`git tag -l --sort=committerdate | tail -n 2 | head -n 1`
   local commit_list=`git log $previous_tag..$tag --pretty=format:"- %s %H (%an)"`
   echo "$commit_list"
 }


### PR DESCRIPTION
Discovered at https://github.com/kubeapps/kubeapps/pull/552#discussion_r213500706

The current approach is being executed when the tag is already committed so it's retrieving the latest tag instead of the previous one. If `git describe --tags` is used with the previous commit it shows a dirty tag (something like `v1.0.0-alpha.5-fdskl`). To avoid that we can use just the `git tag` command and use the second-to-last. 