### PR TITLE
disable object-literal-sort-keys in dev tslint config

### DIFF
--- a/dashboard/tslint.json
+++ b/dashboard/tslint.json
@@ -5,7 +5,8 @@
   "rules": {
     "no-console": {
       "severity": "warning"
-    }
+    },
+    "object-literal-sort-keys": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
We disabled this in #544 but I think we forgot to disable it in the dev
tslint config.

cc @andresmgot