### PR TITLE
Show list-all checkbox in Apps view

### DIFF
--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -302,7 +302,11 @@ func (h *TillerProxy) DeleteRelease(w http.ResponseWriter, req *http.Request, pa
 			return
 		}
 	}
-	err := h.ProxyClient.DeleteRelease(params["releaseName"], params["namespace"])
+	purge := false
+	if req.URL.Query().Get("purge") == "1" || req.URL.Query().Get("purge") == "true" {
+		purge = true
+	}
+	err := h.ProxyClient.DeleteRelease(params["releaseName"], params["namespace"], purge)
 	if err != nil {
 		response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
 		return

--- a/cmd/tiller-proxy/internal/handler/handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/handler_test.go
@@ -209,6 +209,22 @@ func TestActions(t *testing.T) {
 			Params:       map[string]string{"namespace": "default", "releaseName": "foobar"},
 			// Expected result
 			StatusCode:        200,
+			RemainingReleases: []release.Release{release.Release{Name: "foobar", Namespace: "default", Info: &release.Info{Status: &release.Status{Code: release.Status_DELETED}}}},
+			ResponseBody:      "",
+		},
+		{
+			// Scenario params
+			Description:      "Delete and purge a simple release",
+			ExistingReleases: []release.Release{release.Release{Name: "foobar", Namespace: "default"}},
+			DisableAuth:      true,
+			ForbiddenActions: []auth.Action{},
+			// Request params
+			RequestBody:  "",
+			RequestQuery: "?purge=true",
+			Action:       "delete",
+			Params:       map[string]string{"namespace": "default", "releaseName": "foobar"},
+			// Expected result
+			StatusCode:        200,
 			RemainingReleases: []release.Release{},
 			ResponseBody:      "",
 		},

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -14,7 +14,7 @@ beforeEach(() => {
   const state: IAppState = {
     isFetching: false,
     items: [],
-    listAll: false,
+    listingAll: false,
   };
   store = mockStore({
     apps: {
@@ -23,32 +23,20 @@ beforeEach(() => {
   });
 });
 
-it("should toggle the listAll state", () => {
-  const expectedActions = [
-    {
-      type: getType(actions.apps.toggleListAllAction),
-    },
-  ];
-
-  return store.dispatch(actions.apps.toggleListAll()).then(() => {
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-});
-
 describe("fetches applications", () => {
-  const listApps = App.listApps;
+  const listAppsOrig = App.listApps;
   let listAppsMock: jest.Mock;
   beforeEach(() => {
-    App.listApps = jest.fn(() => []);
-    listAppsMock = App.listApps as jest.Mock;
+    listAppsMock = jest.fn(() => []);
+    App.listApps = listAppsMock;
   });
   afterEach(() => {
-    App.listApps = listApps;
+    App.listApps = listAppsOrig;
   });
   it("fetches all applications", async () => {
     const expectedActions = [
       { type: getType(actions.apps.listApps) },
-      { type: getType(actions.apps.receiveAppList), apps: [] },
+      { type: getType(actions.apps.receiveAppList), apps: [], listingAll: true },
     ];
     await store.dispatch(actions.apps.fetchApps("default", true));
     expect(store.getActions()).toEqual(expectedActions);
@@ -57,7 +45,7 @@ describe("fetches applications", () => {
   it("fetches default applications", () => {
     const expectedActions = [
       { type: getType(actions.apps.listApps) },
-      { type: getType(actions.apps.receiveAppList), apps: [] },
+      { type: getType(actions.apps.receiveAppList), apps: [], listingAll: false },
     ];
     return store.dispatch(actions.apps.fetchApps("default", false)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -53,3 +53,34 @@ describe("fetches applications", () => {
     });
   });
 });
+
+describe("delete applications", () => {
+  const deleteAppOrig = App.delete;
+  let deleteAppMock: jest.Mock;
+  beforeEach(() => {
+    deleteAppMock = jest.fn(() => []);
+    App.delete = deleteAppMock;
+  });
+  afterEach(() => {
+    App.delete = deleteAppOrig;
+  });
+  it("delete an application", async () => {
+    await store.dispatch(actions.apps.deleteApp("foo", "default", false));
+    expect(store.getActions()).toEqual([]);
+    expect(deleteAppMock.mock.calls[0]).toEqual(["foo", "default", false]);
+  });
+  it("delete and purge an application", async () => {
+    await store.dispatch(actions.apps.deleteApp("foo", "default", true));
+    expect(store.getActions()).toEqual([]);
+    expect(deleteAppMock.mock.calls[0]).toEqual(["foo", "default", true]);
+  });
+  it("delete and throw an error", async () => {
+    const error = new Error("something went wrong!");
+    const expectedActions = [{ type: getType(actions.apps.errorDeleteApp), err: error }];
+    deleteAppMock.mockImplementation(() => {
+      throw error;
+    });
+    expect(await store.dispatch(actions.apps.deleteApp("foo", "default", true))).toBe(false);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -36,19 +36,23 @@ it("should toggle the listAll state", () => {
 });
 
 describe("fetches applications", () => {
+  const listApps = App.listApps;
+  let listAppsMock: jest.Mock;
   beforeEach(() => {
     App.listApps = jest.fn(() => []);
+    listAppsMock = App.listApps as jest.Mock;
   });
-  it("fetches all applications", () => {
+  afterEach(() => {
+    App.listApps = listApps;
+  });
+  it("fetches all applications", async () => {
     const expectedActions = [
       { type: getType(actions.apps.listApps) },
       { type: getType(actions.apps.receiveAppList), apps: [] },
     ];
-    return store.dispatch(actions.apps.fetchApps("default", true)).then(() => {
-      const listAppsMock = App.listApps as jest.Mock;
-      expect(store.getActions()).toEqual(expectedActions);
-      expect(listAppsMock.mock.calls[0]).toEqual(["default", true]);
-    });
+    await store.dispatch(actions.apps.fetchApps("default", true));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(listAppsMock.mock.calls[0]).toEqual(["default", true]);
   });
   it("fetches default applications", () => {
     const expectedActions = [
@@ -56,7 +60,6 @@ describe("fetches applications", () => {
       { type: getType(actions.apps.receiveAppList), apps: [] },
     ];
     return store.dispatch(actions.apps.fetchApps("default", false)).then(() => {
-      const listAppsMock = App.listApps as jest.Mock;
       expect(store.getActions()).toEqual(expectedActions);
       expect(listAppsMock.mock.calls[0]).toEqual(["default", false]);
     });

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -1,0 +1,64 @@
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+import { getType } from "typesafe-actions";
+
+import actions from ".";
+import { App } from "../shared/App";
+import { IAppState } from "../shared/types";
+
+const mockStore = configureMockStore([thunk]);
+
+let store: any;
+
+beforeEach(() => {
+  const state: IAppState = {
+    isFetching: false,
+    items: [],
+    listAll: false,
+  };
+  store = mockStore({
+    apps: {
+      state,
+    },
+  });
+});
+
+it("should toggle the listAll state", () => {
+  const expectedActions = [
+    {
+      type: getType(actions.apps.toggleListAllAction),
+    },
+  ];
+
+  return store.dispatch(actions.apps.toggleListAll()).then(() => {
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe("fetches applications", () => {
+  beforeEach(() => {
+    App.listApps = jest.fn(() => []);
+  });
+  it("fetches all applications", () => {
+    const expectedActions = [
+      { type: getType(actions.apps.listApps) },
+      { type: getType(actions.apps.receiveAppList), apps: [] },
+    ];
+    return store.dispatch(actions.apps.fetchApps("default", true)).then(() => {
+      const listAppsMock = App.listApps as jest.Mock;
+      expect(store.getActions()).toEqual(expectedActions);
+      expect(listAppsMock.mock.calls[0]).toEqual(["default", true]);
+    });
+  });
+  it("fetches default applications", () => {
+    const expectedActions = [
+      { type: getType(actions.apps.listApps) },
+      { type: getType(actions.apps.receiveAppList), apps: [] },
+    ];
+    return store.dispatch(actions.apps.fetchApps("default", false)).then(() => {
+      const listAppsMock = App.listApps as jest.Mock;
+      expect(store.getActions()).toEqual(expectedActions);
+      expect(listAppsMock.mock.calls[0]).toEqual(["default", false]);
+    });
+  });
+});

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -35,8 +35,8 @@ describe("fetches applications", () => {
   });
   it("fetches all applications", async () => {
     const expectedActions = [
-      { type: getType(actions.apps.listApps) },
-      { type: getType(actions.apps.receiveAppList), apps: [], listingAll: true },
+      { type: getType(actions.apps.listApps), listingAll: true },
+      { type: getType(actions.apps.receiveAppList), apps: [] },
     ];
     await store.dispatch(actions.apps.fetchApps("default", true));
     expect(store.getActions()).toEqual(expectedActions);
@@ -44,8 +44,8 @@ describe("fetches applications", () => {
   });
   it("fetches default applications", () => {
     const expectedActions = [
-      { type: getType(actions.apps.listApps) },
-      { type: getType(actions.apps.receiveAppList), apps: [], listingAll: false },
+      { type: getType(actions.apps.listApps), listingAll: false },
+      { type: getType(actions.apps.receiveAppList), apps: [] },
     ];
     return store.dispatch(actions.apps.fetchApps("default", false)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -33,7 +33,7 @@ export const selectApp = createAction("SELECT_APP", (app: hapi.release.Release) 
     type: "SELECT_APP",
   };
 });
-export const toggleListAllAction = createAction("REQUEST_TOGGLE_LIST_ALL");
+export const toggleListAllAction = createAction("REQUEST_TOGGLE_APP_LIST_ALL");
 
 const allActions = [
   listApps,

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -62,10 +62,10 @@ export function getApp(releaseName: string, namespace: string) {
   };
 }
 
-export function deleteApp(releaseName: string, namespace: string) {
+export function deleteApp(releaseName: string, namespace: string, purge: boolean) {
   return async (dispatch: Dispatch<IStoreState>): Promise<boolean> => {
     try {
-      await App.delete(releaseName, namespace);
+      await App.delete(releaseName, namespace, purge);
       return true;
     } catch (e) {
       dispatch(errorDeleteApp(e));

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -13,12 +13,16 @@ export const receiveApps = createAction("RECEIVE_APPS", (apps: hapi.release.Rele
   };
 });
 export const listApps = createAction("REQUEST_APP_LIST");
-export const receiveAppList = createAction("RECEIVE_APP_LIST", (apps: IAppOverview[]) => {
-  return {
-    apps,
-    type: "RECEIVE_APP_LIST",
-  };
-});
+export const receiveAppList = createAction(
+  "RECEIVE_APP_LIST",
+  (apps: IAppOverview[], listingAll: boolean) => {
+    return {
+      apps,
+      listingAll,
+      type: "RECEIVE_APP_LIST",
+    };
+  },
+);
 export const errorApps = createAction("ERROR_APPS", (err: Error) => ({
   err,
   type: "ERROR_APPS",
@@ -33,14 +37,12 @@ export const selectApp = createAction("SELECT_APP", (app: hapi.release.Release) 
     type: "SELECT_APP",
   };
 });
-export const toggleListAllAction = createAction("REQUEST_TOGGLE_APP_LIST_ALL");
 
 const allActions = [
   listApps,
   requestApps,
   receiveApps,
   receiveAppList,
-  toggleListAllAction,
   errorApps,
   errorDeleteApp,
   selectApp,
@@ -71,7 +73,7 @@ export function deleteApp(releaseName: string, namespace: string) {
   };
 }
 
-export function fetchApps(ns?: string, all?: boolean) {
+export function fetchApps(ns?: string, all: boolean = false) {
   return async (dispatch: Dispatch<IStoreState>): Promise<void> => {
     if (ns && ns === "_all") {
       ns = undefined;
@@ -79,7 +81,7 @@ export function fetchApps(ns?: string, all?: boolean) {
     dispatch(listApps());
     try {
       const apps = await App.listApps(ns, all);
-      dispatch(receiveAppList(apps));
+      dispatch(receiveAppList(apps, all));
     } catch (e) {
       dispatch(errorApps(e));
     }
@@ -119,11 +121,5 @@ export function upgradeApp(
       dispatch(errorApps(e));
       return false;
     }
-  };
-}
-
-export function toggleListAll() {
-  return async (dispatch: Dispatch<IStoreState>): Promise<void> => {
-    dispatch(toggleListAllAction());
   };
 }

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -12,17 +12,18 @@ export const receiveApps = createAction("RECEIVE_APPS", (apps: hapi.release.Rele
     type: "RECEIVE_APPS",
   };
 });
-export const listApps = createAction("REQUEST_APP_LIST");
-export const receiveAppList = createAction(
-  "RECEIVE_APP_LIST",
-  (apps: IAppOverview[], listingAll: boolean) => {
-    return {
-      apps,
-      listingAll,
-      type: "RECEIVE_APP_LIST",
-    };
-  },
-);
+export const listApps = createAction("REQUEST_APP_LIST", (listingAll: boolean) => {
+  return {
+    listingAll,
+    type: "REQUEST_APP_LIST",
+  };
+});
+export const receiveAppList = createAction("RECEIVE_APP_LIST", (apps: IAppOverview[]) => {
+  return {
+    apps,
+    type: "RECEIVE_APP_LIST",
+  };
+});
 export const errorApps = createAction("ERROR_APPS", (err: Error) => ({
   err,
   type: "ERROR_APPS",
@@ -78,10 +79,10 @@ export function fetchApps(ns?: string, all: boolean = false) {
     if (ns && ns === "_all") {
       ns = undefined;
     }
-    dispatch(listApps());
+    dispatch(listApps(all));
     try {
       const apps = await App.listApps(ns, all);
-      dispatch(receiveAppList(apps, all));
+      dispatch(receiveAppList(apps));
     } catch (e) {
       dispatch(errorApps(e));
     }

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -33,12 +33,14 @@ export const selectApp = createAction("SELECT_APP", (app: hapi.release.Release) 
     type: "SELECT_APP",
   };
 });
+export const toggleListAllAction = createAction("REQUEST_TOGGLE_LIST_ALL");
 
 const allActions = [
   listApps,
   requestApps,
   receiveApps,
   receiveAppList,
+  toggleListAllAction,
   errorApps,
   errorDeleteApp,
   selectApp,
@@ -69,14 +71,14 @@ export function deleteApp(releaseName: string, namespace: string) {
   };
 }
 
-export function fetchApps(ns?: string) {
+export function fetchApps(ns?: string, all?: boolean) {
   return async (dispatch: Dispatch<IStoreState>): Promise<void> => {
     if (ns && ns === "_all") {
       ns = undefined;
     }
     dispatch(listApps());
     try {
-      const apps = await App.listApps(ns);
+      const apps = await App.listApps(ns, all);
       dispatch(receiveAppList(apps));
     } catch (e) {
       dispatch(errorApps(e));
@@ -117,5 +119,11 @@ export function upgradeApp(
       dispatch(errorApps(e));
       return false;
     }
+  };
+}
+
+export function toggleListAll() {
+  return async (dispatch: Dispatch<IStoreState>): Promise<void> => {
+    dispatch(toggleListAllAction());
   };
 }

--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -32,8 +32,8 @@ it("renders a loading message if it's fetching apps", () => {
         {
           isFetching: true,
           items: [],
-          listAll: false,
           listOverview: [],
+          listingAll: false,
         } as IAppState
       }
     />,
@@ -49,8 +49,8 @@ it("renders a welcome message if no apps are available", () => {
         {
           isFetching: false,
           items: [],
-          listAll: false,
           listOverview: [],
+          listingAll: false,
         } as IAppState
       }
     />,
@@ -66,12 +66,12 @@ it("renders a CardGrid with the available Apps", () => {
         {
           isFetching: false,
           items: [],
-          listAll: false,
           listOverview: [
             {
               releaseName: "foo",
             } as IAppOverview,
           ],
+          listingAll: false,
         } as IAppState
       }
     />,
@@ -93,7 +93,6 @@ it("filters apps", () => {
         {
           isFetching: false,
           items: [],
-          listAll: false,
           listOverview: [
             {
               releaseName: "foo",
@@ -102,6 +101,7 @@ it("filters apps", () => {
               releaseName: "bar",
             } as IAppOverview,
           ],
+          listingAll: false,
         } as IAppState
       }
       filter="bar"
@@ -120,22 +120,21 @@ it("clicking 'List All' checkbox should trigger toggleListAll", () => {
   const apps = {
     isFetching: false,
     items: [],
-    listAll: false,
     listOverview: [{ releaseName: "foo" } as IAppOverview],
+    listingAll: false,
   } as IAppState;
   const wrapper = shallow(
     <AppList
       {...defaultProps}
       apps={apps}
-      toggleListAll={jest.fn(() => {
-        apps.listAll = !apps.listAll;
+      toggleListAll={jest.fn((toggle: boolean) => {
+        apps.listingAll = toggle;
       })}
     />,
   );
   const checkbox = wrapper.find('input[type="checkbox"]');
-  expect(apps.listAll).toBe(false);
+  expect(apps.listingAll).toBe(false);
   checkbox.simulate("change");
-  expect(apps.listAll).toBe(true);
   // The last call to fetchApps should list all the apps
   const fetchCalls = defaultProps.fetchApps.mock.calls;
   expect(fetchCalls[fetchCalls.length - 1]).toEqual(["default", true]);

--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -6,13 +6,18 @@ import { CardGrid } from "../Card";
 import AppList from "./AppList";
 import AppListItem from "./AppListItem";
 
-const defaultProps = {
-  apps: {} as IAppState,
-  fetchApps: jest.fn(),
-  filter: "",
-  namespace: "default",
-  pushSearchFilter: jest.fn(),
-};
+let defaultProps = {} as any;
+
+beforeEach(() => {
+  defaultProps = {
+    apps: {} as IAppState,
+    fetchApps: jest.fn(),
+    filter: "",
+    namespace: "default",
+    pushSearchFilter: jest.fn(),
+    toggleListAll: jest.fn(),
+  };
+});
 
 it("renders a loading message if apps object is empty", () => {
   const wrapper = shallow(<AppList {...defaultProps} />);
@@ -27,6 +32,7 @@ it("renders a loading message if it's fetching apps", () => {
         {
           isFetching: true,
           items: [],
+          listAll: false,
           listOverview: [],
         } as IAppState
       }
@@ -43,6 +49,7 @@ it("renders a welcome message if no apps are available", () => {
         {
           isFetching: false,
           items: [],
+          listAll: false,
           listOverview: [],
         } as IAppState
       }
@@ -59,6 +66,7 @@ it("renders a CardGrid with the available Apps", () => {
         {
           isFetching: false,
           items: [],
+          listAll: false,
           listOverview: [
             {
               releaseName: "foo",
@@ -85,6 +93,7 @@ it("filters apps", () => {
         {
           isFetching: false,
           items: [],
+          listAll: false,
           listOverview: [
             {
               releaseName: "foo",
@@ -105,4 +114,29 @@ it("filters apps", () => {
       .find(AppListItem)
       .key(),
   ).toBe("bar");
+});
+
+it("clicking 'List All' checkbox should trigger toggleListAll", () => {
+  const apps = {
+    isFetching: false,
+    items: [],
+    listAll: false,
+    listOverview: [{ releaseName: "foo" } as IAppOverview],
+  } as IAppState;
+  const wrapper = shallow(
+    <AppList
+      {...defaultProps}
+      apps={apps}
+      toggleListAll={jest.fn(() => {
+        apps.listAll = !apps.listAll;
+      })}
+    />,
+  );
+  const checkbox = wrapper.find('input[type="checkbox"]');
+  expect(apps.listAll).toBe(false);
+  checkbox.simulate("change");
+  expect(apps.listAll).toBe(true);
+  // The last call to fetchApps should list all the apps
+  const fetchCalls = defaultProps.fetchApps.mock.calls;
+  expect(fetchCalls[fetchCalls.length - 1]).toEqual(["default", true]);
 });

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -48,31 +48,30 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
     return (
       <section className="AppList">
         <PageHeader>
-          <div className="col-7">
+          <div className="col-9">
             <div className="row">
               <h1>Applications</h1>
-              {listOverview.length > 0 && (
+              {listOverview.length > 0 && [
                 <SearchFilter
+                  key="searchFilter"
                   className="margin-l-big"
                   placeholder="search apps..."
                   onChange={this.handleFilterQueryChange}
                   value={this.state.filter}
                   onSubmit={pushSearchFilter}
-                />
-              )}
+                />,
+                <label className="checkbox margin-r-big margin-l-big margin-t-big" key="listall">
+                  <input type="checkbox" checked={!listingAll} onChange={this.toggleListAll} />
+                  <span>Show only deployed apps</span>
+                </label>,
+              ]}
             </div>
           </div>
           {listOverview.length > 0 && (
-            <div className="col-5">
-              <div className="text-r">
-                <label className="checkbox margin-r-big">
-                  <input type="checkbox" checked={listingAll} onChange={this.toggleListAll} />
-                  <span>Show all apps</span>
-                </label>
-                <Link to="/charts">
-                  <button className="button button-accent">Deploy App</button>
-                </Link>
-              </div>
+            <div className="col-3 text-r align-center">
+              <Link to="/charts">
+                <button className="button button-accent">Deploy App</button>
+              </Link>
             </div>
           )}
         </PageHeader>

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -15,7 +15,6 @@ interface IAppListProps {
   namespace: string;
   pushSearchFilter: (filter: string) => any;
   filter: string;
-  toggleListAll: () => Promise<void>;
 }
 
 interface IAppListState {
@@ -26,15 +25,15 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
   public state: IAppListState = { filter: "" };
   public componentDidMount() {
     const { fetchApps, filter, namespace, apps } = this.props;
-    fetchApps(namespace, apps.listAll);
+    fetchApps(namespace, apps.listingAll);
     this.setState({ filter });
   }
 
   public componentWillReceiveProps(nextProps: IAppListProps) {
-    const { apps: { error, listAll }, fetchApps, filter, namespace } = this.props;
+    const { apps: { error, listingAll }, fetchApps, filter, namespace } = this.props;
     // refetch if new namespace or error removed due to location change
     if (nextProps.namespace !== namespace || (error && !nextProps.apps.error)) {
-      fetchApps(nextProps.namespace, listAll);
+      fetchApps(nextProps.namespace, listingAll);
     }
     if (nextProps.filter !== filter) {
       this.setState({ filter: nextProps.filter });
@@ -42,7 +41,7 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
   }
 
   public render() {
-    const { pushSearchFilter, apps: { error, isFetching, listOverview, listAll } } = this.props;
+    const { pushSearchFilter, apps: { error, isFetching, listOverview, listingAll } } = this.props;
     if (!listOverview) {
       return <div>Loading</div>;
     }
@@ -67,8 +66,8 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
             <div className="col-5">
               <div className="text-r">
                 <label className="checkbox margin-r-big">
-                  <input type="checkbox" checked={listAll} onChange={this.toggleListAll} />
-                  <span>List all</span>
+                  <input type="checkbox" checked={listingAll} onChange={this.toggleListAll} />
+                  <span>Show all apps</span>
                 </label>
                 <Link to="/charts">
                   <button className="button button-accent">Deploy App</button>
@@ -123,8 +122,7 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
   }
 
   private toggleListAll = () => {
-    this.props.fetchApps(this.props.namespace, !this.props.apps.listAll);
-    this.props.toggleListAll();
+    this.props.fetchApps(this.props.namespace, !this.props.apps.listingAll);
   };
 
   private renderError(error: Error) {

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -20,11 +20,10 @@ interface IAppListProps {
 
 interface IAppListState {
   filter: string;
-  listAll: boolean;
 }
 
 class AppList extends React.Component<IAppListProps, IAppListState> {
-  public state: IAppListState = { filter: "", listAll: false };
+  public state: IAppListState = { filter: "" };
   public componentDidMount() {
     const { fetchApps, filter, namespace, apps } = this.props;
     fetchApps(namespace, apps.listAll);
@@ -39,9 +38,6 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
     }
     if (nextProps.filter !== filter) {
       this.setState({ filter: nextProps.filter });
-    }
-    if (nextProps.apps.listAll !== listAll) {
-      this.setState({ listAll: nextProps.apps.listAll });
     }
   }
 

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -61,8 +61,8 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
                   onSubmit={pushSearchFilter}
                 />,
                 <label className="checkbox margin-r-big margin-l-big margin-t-big" key="listall">
-                  <input type="checkbox" checked={!listingAll} onChange={this.toggleListAll} />
-                  <span>Show only deployed apps</span>
+                  <input type="checkbox" checked={listingAll} onChange={this.toggleListAll} />
+                  <span>Show deleted apps</span>
                 </label>,
               ]}
             </div>

--- a/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
+++ b/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders a welcome message if no apps are available 1`] = `
 >
   <PageHeader>
     <div
-      className="col-8"
+      className="col-7"
     >
       <div
         className="row"

--- a/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
+++ b/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders a welcome message if no apps are available 1`] = `
 >
   <PageHeader>
     <div
-      className="col-7"
+      className="col-9"
     >
       <div
         className="row"

--- a/dashboard/src/components/AppView/AppControls.tsx
+++ b/dashboard/src/components/AppView/AppControls.tsx
@@ -6,7 +6,7 @@ import ConfirmDialog from "../ConfirmDialog";
 
 interface IAppControlsProps {
   app: hapi.release.Release;
-  deleteApp: () => Promise<boolean>;
+  deleteApp: (purge: boolean) => Promise<boolean>;
 }
 
 interface IAppControlsState {
@@ -15,6 +15,7 @@ interface IAppControlsState {
   redirectToAppList: boolean;
   upgrade: boolean;
   deleting: boolean;
+  purge: boolean;
 }
 
 class AppControls extends React.Component<IAppControlsProps, IAppControlsState> {
@@ -22,6 +23,7 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
     deleting: false,
     migrate: false,
     modalIsOpen: false,
+    purge: false,
     redirectToAppList: false,
     upgrade: false,
   };
@@ -51,6 +53,14 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
           modalIsOpen={this.state.modalIsOpen}
           loading={this.state.deleting}
           closeModal={this.closeModal}
+          extraElem={
+            <div className="margin-v-small text-c">
+              <label className="checkbox margin-r-big">
+                <input type="checkbox" onChange={this.togglePurge} />
+                <span>Purge release</span>
+              </label>
+            </div>
+          }
         />
         {this.state.redirectToAppList && <Redirect to={`/apps/ns/${namespace}`} />}
       </div>
@@ -75,12 +85,16 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
 
   public handleDeleteClick = async () => {
     this.setState({ deleting: true });
-    const deleted = await this.props.deleteApp();
+    const deleted = await this.props.deleteApp(this.state.purge);
     const s: Partial<IAppControlsState> = { modalIsOpen: false };
     if (deleted) {
       s.redirectToAppList = true;
     }
     this.setState(s as IAppControlsState);
+  };
+
+  private togglePurge = () => {
+    this.setState({ purge: !this.state.purge });
   };
 }
 

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -22,7 +22,7 @@ export interface IAppViewProps {
   error: Error | undefined;
   deleteError: Error | undefined;
   getApp: (releaseName: string, namespace: string) => Promise<void>;
-  deleteApp: (releaseName: string, namespace: string) => Promise<boolean>;
+  deleteApp: (releaseName: string, namespace: string, purge: boolean) => Promise<boolean>;
 }
 
 interface IAppViewState {
@@ -224,8 +224,8 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
     return Object.keys(this.state.deployments).map(k => this.state.deployments[k]);
   }
 
-  private deleteApp = () => {
-    return this.props.deleteApp(this.props.releaseName, this.props.namespace);
+  private deleteApp = (purge: boolean) => {
+    return this.props.deleteApp(this.props.releaseName, this.props.namespace, purge);
   };
 }
 

--- a/dashboard/src/components/ConfirmDialog/index.tsx
+++ b/dashboard/src/components/ConfirmDialog/index.tsx
@@ -4,6 +4,7 @@ import * as Modal from "react-modal";
 interface IConfirmDialogProps {
   modalIsOpen: boolean;
   loading: boolean;
+  extraElem?: JSX.Element;
   onConfirm: () => Promise<any>;
   closeModal: () => Promise<any>;
 }
@@ -45,6 +46,7 @@ class ConfirmDialog extends React.Component<IConfirmDialogProps, IConfirmDialogS
           ) : (
             <div>
               <div> Are you sure you want to delete this? </div>
+              {this.props.extraElem}
               <button className="button" onClick={this.props.closeModal}>
                 Cancel
               </button>

--- a/dashboard/src/components/PageHeader/PageHeader.tsx
+++ b/dashboard/src/components/PageHeader/PageHeader.tsx
@@ -10,7 +10,7 @@ class PageHeader extends React.Component<IPageHeaderProps> {
   public render() {
     return (
       <header className="PageHeader">
-        <div className="row padding-t-big padding-b-small collapse-b-phone-land">
+        <div className="row padding-t-big padding-b-small collapse-b-phone-land align-center">
           {this.props.children}
         </div>
       </header>

--- a/dashboard/src/containers/AppListContainer/AppListContainer.tsx
+++ b/dashboard/src/containers/AppListContainer/AppListContainer.tsx
@@ -19,7 +19,6 @@ function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
     fetchApps: (ns: string, all: boolean) => dispatch(actions.apps.fetchApps(ns, all)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
-    toggleListAll: () => dispatch(actions.apps.toggleListAll()),
   };
 }
 

--- a/dashboard/src/containers/AppListContainer/AppListContainer.tsx
+++ b/dashboard/src/containers/AppListContainer/AppListContainer.tsx
@@ -17,8 +17,9 @@ function mapStateToProps({ apps, namespace }: IStoreState, { location }: RouteCo
 
 function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
-    fetchApps: (ns: string) => dispatch(actions.apps.fetchApps(ns)),
+    fetchApps: (ns: string, all: boolean) => dispatch(actions.apps.fetchApps(ns, all)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
+    toggleListAll: () => dispatch(actions.apps.toggleListAll()),
   };
 }
 

--- a/dashboard/src/containers/AppViewContainer/AppViewContainer.tsx
+++ b/dashboard/src/containers/AppViewContainer/AppViewContainer.tsx
@@ -26,8 +26,8 @@ function mapStateToProps({ apps }: IStoreState, { match: { params } }: IRoutePro
 
 function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
-    deleteApp: (releaseName: string, ns: string) =>
-      dispatch(actions.apps.deleteApp(releaseName, ns)),
+    deleteApp: (releaseName: string, ns: string, purge: boolean) =>
+      dispatch(actions.apps.deleteApp(releaseName, ns, purge)),
     getApp: (releaseName: string, ns: string) => dispatch(actions.apps.getApp(releaseName, ns)),
   };
 }

--- a/dashboard/src/index.tsx
+++ b/dashboard/src/index.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import * as Modal from "react-modal";
 import { createAxiosInterceptors } from "shared/AxiosInstance";
 import { axios } from "./shared/Auth";
 
@@ -19,3 +20,6 @@ ReactDOM.render(<Root />, document.getElementById("root") as HTMLElement);
 // the Dashboard and we no longer need the external link.
 
 // registerServiceWorker();
+
+// Set App Element for accessibilty
+Modal.setAppElement("#root");

--- a/dashboard/src/reducers/apps.test.ts
+++ b/dashboard/src/reducers/apps.test.ts
@@ -1,0 +1,50 @@
+import { getType } from "typesafe-actions";
+import actions from "../actions";
+import { IAppState } from "../shared/types";
+import appsReducer from "./apps";
+
+describe("authReducer", () => {
+  let initialState: IAppState;
+
+  const actionTypes = {
+    errorApps: getType(actions.apps.errorApps),
+    errorDeleteApp: getType(actions.apps.errorDeleteApp),
+    listApps: getType(actions.apps.listApps),
+    receiveAppList: getType(actions.apps.receiveAppList),
+    receiveApps: getType(actions.apps.receiveApps),
+    requestApps: getType(actions.apps.requestApps),
+    selectApp: getType(actions.apps.selectApp),
+    toggleListAllAction: getType(actions.apps.toggleListAllAction),
+  };
+
+  beforeEach(() => {
+    initialState = {
+      isFetching: false,
+      items: [],
+      listAll: false,
+    };
+  });
+
+  describe("reducer actions", () => {
+    it(`sets isFetching when requesting an app`, () => {
+      [true, false].forEach(e => {
+        expect(
+          appsReducer(undefined, {
+            type: actionTypes.requestApps as any,
+          }),
+        ).toEqual({ ...initialState, isFetching: true });
+      });
+    });
+
+    it(`toggles the listAll state`, () => {
+      let state = appsReducer(undefined, {
+        type: actionTypes.toggleListAllAction as any,
+      });
+      expect(state).toEqual({ ...initialState, listAll: true });
+      state = appsReducer(state, {
+        type: actionTypes.toggleListAllAction as any,
+      });
+      expect(state).toEqual({ ...initialState, listAll: false });
+    });
+  });
+});

--- a/dashboard/src/reducers/apps.test.ts
+++ b/dashboard/src/reducers/apps.test.ts
@@ -26,7 +26,7 @@ describe("authReducer", () => {
   });
 
   describe("reducer actions", () => {
-    it(`sets isFetching when requesting an app`, () => {
+    it("sets isFetching when requesting an app", () => {
       [true, false].forEach(e => {
         expect(
           appsReducer(undefined, {
@@ -36,7 +36,7 @@ describe("authReducer", () => {
       });
     });
 
-    it(`toggles the listAll state`, () => {
+    it("toggles the listAll state", () => {
       let state = appsReducer(undefined, {
         type: actionTypes.toggleListAllAction as any,
       });

--- a/dashboard/src/reducers/apps.test.ts
+++ b/dashboard/src/reducers/apps.test.ts
@@ -7,21 +7,15 @@ describe("authReducer", () => {
   let initialState: IAppState;
 
   const actionTypes = {
-    errorApps: getType(actions.apps.errorApps),
-    errorDeleteApp: getType(actions.apps.errorDeleteApp),
-    listApps: getType(actions.apps.listApps),
     receiveAppList: getType(actions.apps.receiveAppList),
-    receiveApps: getType(actions.apps.receiveApps),
     requestApps: getType(actions.apps.requestApps),
-    selectApp: getType(actions.apps.selectApp),
-    toggleListAllAction: getType(actions.apps.toggleListAllAction),
   };
 
   beforeEach(() => {
     initialState = {
       isFetching: false,
       items: [],
-      listAll: false,
+      listingAll: false,
     };
   });
 
@@ -38,13 +32,15 @@ describe("authReducer", () => {
 
     it("toggles the listAll state", () => {
       let state = appsReducer(undefined, {
-        type: actionTypes.toggleListAllAction as any,
+        listingAll: true,
+        type: actionTypes.receiveAppList as any,
       });
-      expect(state).toEqual({ ...initialState, listAll: true });
+      expect(state).toEqual({ ...initialState, listingAll: true });
       state = appsReducer(state, {
-        type: actionTypes.toggleListAllAction as any,
+        listingAll: false,
+        type: actionTypes.receiveAppList as any,
       });
-      expect(state).toEqual({ ...initialState, listAll: false });
+      expect(state).toEqual({ ...initialState, listingAll: false });
     });
   });
 });

--- a/dashboard/src/reducers/apps.test.ts
+++ b/dashboard/src/reducers/apps.test.ts
@@ -7,6 +7,7 @@ describe("authReducer", () => {
   let initialState: IAppState;
 
   const actionTypes = {
+    listApps: getType(actions.apps.listApps),
     receiveAppList: getType(actions.apps.receiveAppList),
     requestApps: getType(actions.apps.requestApps),
   };
@@ -33,14 +34,14 @@ describe("authReducer", () => {
     it("toggles the listAll state", () => {
       let state = appsReducer(undefined, {
         listingAll: true,
-        type: actionTypes.receiveAppList as any,
+        type: actionTypes.listApps as any,
       });
-      expect(state).toEqual({ ...initialState, listingAll: true });
+      expect(state).toEqual({ ...initialState, isFetching: true, listingAll: true });
       state = appsReducer(state, {
         listingAll: false,
-        type: actionTypes.receiveAppList as any,
+        type: actionTypes.listApps as any,
       });
-      expect(state).toEqual({ ...initialState, listingAll: false });
+      expect(state).toEqual({ ...initialState, isFetching: true, listingAll: false });
     });
   });
 });

--- a/dashboard/src/reducers/apps.ts
+++ b/dashboard/src/reducers/apps.ts
@@ -8,7 +8,7 @@ import { IAppState } from "../shared/types";
 const initialState: IAppState = {
   isFetching: false,
   items: [],
-  listAll: false,
+  listingAll: false,
 };
 
 const appsReducer = (
@@ -29,9 +29,12 @@ const appsReducer = (
     case getType(actions.apps.listApps):
       return { ...state, isFetching: true };
     case getType(actions.apps.receiveAppList):
-      return { ...state, isFetching: false, listOverview: action.apps };
-    case getType(actions.apps.toggleListAllAction):
-      return { ...state, listAll: !state.listAll };
+      return {
+        ...state,
+        isFetching: false,
+        listOverview: action.apps,
+        listingAll: action.listingAll,
+      };
     case LOCATION_CHANGE:
       return {
         ...state,

--- a/dashboard/src/reducers/apps.ts
+++ b/dashboard/src/reducers/apps.ts
@@ -1,6 +1,6 @@
 import { LOCATION_CHANGE, LocationChangeAction } from "react-router-redux";
-import { getType } from "typesafe-actions";
 
+import { getType } from "typesafe-actions";
 import actions from "../actions";
 import { AppsAction } from "../actions/apps";
 import { IAppState } from "../shared/types";
@@ -8,6 +8,7 @@ import { IAppState } from "../shared/types";
 const initialState: IAppState = {
   isFetching: false,
   items: [],
+  listAll: false,
 };
 
 const appsReducer = (
@@ -29,6 +30,8 @@ const appsReducer = (
       return { ...state, isFetching: true };
     case getType(actions.apps.receiveAppList):
       return { ...state, isFetching: false, listOverview: action.apps };
+    case getType(actions.apps.toggleListAllAction):
+      return { ...state, listAll: !state.listAll };
     case LOCATION_CHANGE:
       return {
         ...state,

--- a/dashboard/src/reducers/apps.ts
+++ b/dashboard/src/reducers/apps.ts
@@ -27,14 +27,9 @@ const appsReducer = (
     case getType(actions.apps.selectApp):
       return { ...state, isFetching: false, selected: action.app };
     case getType(actions.apps.listApps):
-      return { ...state, isFetching: true };
+      return { ...state, isFetching: true, listingAll: action.listingAll };
     case getType(actions.apps.receiveAppList):
-      return {
-        ...state,
-        isFetching: false,
-        listOverview: action.apps,
-        listingAll: action.listingAll,
-      };
+      return { ...state, isFetching: false, listOverview: action.apps };
     case LOCATION_CHANGE:
       return {
         ...state,

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -71,4 +71,30 @@ describe("App", () => {
       });
     });
   });
+  describe("delete", () => {
+    [
+      {
+        description: "should delete an app in a namespace",
+        expectedURL: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases/foo`,
+        purge: false,
+      },
+      {
+        description: "should delete and purge an app in a namespace",
+        expectedURL: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases/foo?purge=true`,
+        purge: true,
+      },
+    ].forEach(t => {
+      it(t.description, async () => {
+        moxios.stubRequest(/.*/, { response: "ok", status: 200 });
+        expect(await App.delete("foo", "default", t.purge)).toBe("ok");
+        expect(moxios.requests.mostRecent().url).toBe(t.expectedURL);
+      });
+    });
+    it("throws an error if returns an error 404", async () => {
+      moxios.stubRequest(/.*/, { status: 404 });
+      expect(App.delete("foo", "default", false)).rejects.toThrow(
+        "Request failed with status code 404",
+      );
+    });
+  });
 });

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -1,5 +1,5 @@
 import * as moxios from "moxios";
-import { App } from "./App";
+import { App, TILLER_PROXY_ROOT_URL } from "./App";
 import { axios } from "./Auth";
 import { IAppOverview } from "./types";
 
@@ -11,50 +11,64 @@ describe("App", () => {
     moxios.uninstall(axios);
   });
   describe("getResourceURL", () => {
-    it("returns the root API URL if no params are given", () => {
-      expect(App.getResourceURL()).toBe("/api/tiller-deploy/v1/releases");
-    });
-    it("returns namespaced URLs", () => {
-      expect(App.getResourceURL("default")).toBe(
-        "/api/tiller-deploy/v1/namespaces/default/releases",
-      );
-    });
-    it("returns a single release URL", () => {
-      expect(App.getResourceURL("default", "foo")).toBe(
-        "/api/tiller-deploy/v1/namespaces/default/releases/foo",
-      );
-    });
-    it("returns a URL with a query", () => {
-      expect(App.getResourceURL("default", undefined, "statuses=foo")).toBe(
-        "/api/tiller-deploy/v1/namespaces/default/releases?statuses=foo",
-      );
+    [
+      {
+        description: "returns the root API URL if no params are given",
+        result: `${TILLER_PROXY_ROOT_URL}/releases`,
+      },
+      {
+        description: "returns namespaced URLs",
+        namespace: "default",
+        result: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases`,
+      },
+      {
+        description: "returns a single release URL",
+        namespace: "default",
+        resourceName: "foo",
+        result: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases/foo`,
+      },
+      {
+        description: "returns a URL with a query",
+        namespace: "default",
+        query: "statuses=foo",
+        result: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases?statuses=foo`,
+      },
+    ].forEach(t => {
+      it(t.description, () => {
+        expect(App.getResourceURL(t.namespace, t.resourceName, t.query)).toBe(t.result);
+      });
     });
   });
 
   describe("listApps", () => {
-    it("should request all the releases if no namespace is given", async () => {
-      const apps = [{ releaseName: "foo" } as IAppOverview];
-      moxios.stubRequest("/api/tiller-deploy/v1/releases", {
+    const apps = [{ releaseName: "foo" } as IAppOverview];
+    beforeEach(() => {
+      moxios.stubRequest(/.*/, {
         response: { data: apps },
         status: 200,
       });
-      expect(await App.listApps()).toEqual(apps);
     });
-    it("should request the releases of a namespace", async () => {
-      const apps = [{ releaseName: "foo" } as IAppOverview];
-      moxios.stubRequest("/api/tiller-deploy/v1/namespaces/default/releases", {
-        response: { data: apps },
-        status: 200,
+    [
+      {
+        description: "should request all the releases if no namespace is given",
+        expectedURL: `${TILLER_PROXY_ROOT_URL}/releases`,
+      },
+      {
+        description: "should request the releases of a namespace",
+        expectedURL: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases`,
+        namespace: "default",
+      },
+      {
+        all: true,
+        description: "should request the releases of a namespace with any status",
+        expectedURL: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases?statuses=all`,
+        namespace: "default",
+      },
+    ].forEach(t => {
+      it(t.description, async () => {
+        expect(await App.listApps(t.namespace, t.all)).toEqual(apps);
+        expect(moxios.requests.mostRecent().url).toBe(t.expectedURL);
       });
-      expect(await App.listApps("default")).toEqual(apps);
-    });
-    it("should request the releases of a namespace with any status", async () => {
-      const apps = [{ releaseName: "foo" } as IAppOverview];
-      moxios.stubRequest("/api/tiller-deploy/v1/namespaces/default/releases?statuses=all", {
-        response: { data: apps },
-        status: 200,
-      });
-      expect(await App.listApps("default", true)).toEqual(apps);
     });
   });
 });

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -40,6 +40,14 @@ describe("App", () => {
       });
       expect(await App.listApps()).toEqual(apps);
     });
+    it("should request the releases of a namespace", async () => {
+      const apps = [{ releaseName: "foo" } as IAppOverview];
+      moxios.stubRequest("/api/tiller-deploy/v1/namespaces/default/releases", {
+        response: { data: apps },
+        status: 200,
+      });
+      expect(await App.listApps("default")).toEqual(apps);
+    });
     it("should request the releases of a namespace with any status", async () => {
       const apps = [{ releaseName: "foo" } as IAppOverview];
       moxios.stubRequest("/api/tiller-deploy/v1/namespaces/default/releases?statuses=all", {

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -1,0 +1,52 @@
+import * as moxios from "moxios";
+import { App } from "./App";
+import { axios } from "./Auth";
+import { IAppOverview } from "./types";
+
+describe("App", () => {
+  beforeEach(() => {
+    moxios.install(axios);
+  });
+  afterEach(() => {
+    moxios.uninstall(axios);
+  });
+  describe("getResourceURL", () => {
+    it("returns the root API URL if no params are given", () => {
+      expect(App.getResourceURL()).toBe("/api/tiller-deploy/v1/releases");
+    });
+    it("returns namespaced URLs", () => {
+      expect(App.getResourceURL("default")).toBe(
+        "/api/tiller-deploy/v1/namespaces/default/releases",
+      );
+    });
+    it("returns a single release URL", () => {
+      expect(App.getResourceURL("default", "foo")).toBe(
+        "/api/tiller-deploy/v1/namespaces/default/releases/foo",
+      );
+    });
+    it("returns a URL with a query", () => {
+      expect(App.getResourceURL("default", undefined, "statuses=foo")).toBe(
+        "/api/tiller-deploy/v1/namespaces/default/releases?statuses=foo",
+      );
+    });
+  });
+
+  describe("listApps", () => {
+    it("should request all the releases if no namespace is given", async () => {
+      const apps = [{ releaseName: "foo" } as IAppOverview];
+      moxios.stubRequest("/api/tiller-deploy/v1/releases", {
+        response: { data: apps },
+        status: 200,
+      });
+      expect(await App.listApps()).toEqual(apps);
+    });
+    it("should request the releases of a namespace with any status", async () => {
+      const apps = [{ releaseName: "foo" } as IAppOverview];
+      moxios.stubRequest("/api/tiller-deploy/v1/namespaces/default/releases?statuses=all", {
+        response: { data: apps },
+        status: 200,
+      });
+      expect(await App.listApps("default", true)).toEqual(apps);
+    });
+  });
+});

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -4,7 +4,7 @@ import { hapi } from "./hapi/release";
 import { IAppOverview, IChartVersion } from "./types";
 
 export class App {
-  public static getResourceURL(namespace?: string, name?: string) {
+  public static getResourceURL(namespace?: string, name?: string, query?: string) {
     let url = "/api/tiller-deploy/v1";
     if (namespace) {
       url += `/namespaces/${namespace}`;
@@ -12,6 +12,9 @@ export class App {
     url += "/releases";
     if (name) {
       url += `/${name}`;
+    }
+    if (query) {
+      url += `?${query}`;
     }
     return url;
   }
@@ -65,8 +68,14 @@ export class App {
     return data;
   }
 
-  public static async listApps(namespace?: string) {
-    const { data } = await axios.get<{ data: IAppOverview[] }>(App.getResourceURL(namespace));
+  public static async listApps(namespace?: string, allStatuses?: boolean) {
+    let query;
+    if (allStatuses) {
+      query = "statuses=all";
+    }
+    const { data } = await axios.get<{ data: IAppOverview[] }>(
+      App.getResourceURL(namespace, undefined, query),
+    );
     return data.data;
   }
 

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -65,8 +65,12 @@ export class App {
     return data;
   }
 
-  public static async delete(releaseName: string, namespace: string) {
-    const { data } = await axios.delete(App.getResourceURL(namespace, releaseName));
+  public static async delete(releaseName: string, namespace: string, purge: boolean) {
+    let purgeQuery;
+    if (purge) {
+      purgeQuery = "purge=true";
+    }
+    const { data } = await axios.delete(App.getResourceURL(namespace, releaseName, purgeQuery));
     return data;
   }
 

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -3,9 +3,11 @@ import { axios } from "./Auth";
 import { hapi } from "./hapi/release";
 import { IAppOverview, IChartVersion } from "./types";
 
+export const TILLER_PROXY_ROOT_URL = "/api/tiller-deploy/v1";
+
 export class App {
   public static getResourceURL(namespace?: string, name?: string, query?: string) {
-    let url = "/api/tiller-deploy/v1";
+    let url = TILLER_PROXY_ROOT_URL;
     if (namespace) {
       url += `/namespaces/${namespace}`;
     }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -165,6 +165,7 @@ export interface IAppState {
   deleteError?: Error;
   // currently items are always Helm releases
   items: hapi.release.Release[];
+  listAll: boolean;
   listOverview?: IAppOverview[];
   selected?: hapi.release.Release;
 }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -165,7 +165,7 @@ export interface IAppState {
   deleteError?: Error;
   // currently items are always Helm releases
   items: hapi.release.Release[];
-  listAll: boolean;
+  listingAll: boolean;
   listOverview?: IAppOverview[];
   selected?: hapi.release.Release;
 }

--- a/pkg/proxy/fake/proxy.go
+++ b/pkg/proxy/fake/proxy.go
@@ -91,11 +91,20 @@ func (f *FakeProxy) GetRelease(name, namespace string) (*release.Release, error)
 	return nil, fmt.Errorf("Release %s not found", name)
 }
 
-func (f *FakeProxy) DeleteRelease(name, namespace string) error {
+func (f *FakeProxy) DeleteRelease(name, namespace string, purge bool) error {
 	for i, r := range f.Releases {
 		if r.Name == name {
-			f.Releases[i] = f.Releases[len(f.Releases)-1]
-			f.Releases = f.Releases[:len(f.Releases)-1]
+			if purge {
+				f.Releases[i] = f.Releases[len(f.Releases)-1]
+				f.Releases = f.Releases[:len(f.Releases)-1]
+			} else {
+				r.Info = &release.Info{
+					Status: &release.Status{
+						Code: release.Status_DELETED,
+					},
+				}
+				f.Releases[i] = r
+			}
 			return nil
 		}
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -287,7 +287,7 @@ func (p *Proxy) GetRelease(name, namespace string) (*release.Release, error) {
 }
 
 // DeleteRelease deletes a release
-func (p *Proxy) DeleteRelease(name, namespace string) error {
+func (p *Proxy) DeleteRelease(name, namespace string, purge bool) error {
 	lock(name)
 	defer unlock(name)
 	// Validate that the release actually belongs to the namespace
@@ -295,7 +295,7 @@ func (p *Proxy) DeleteRelease(name, namespace string) error {
 	if err != nil {
 		return err
 	}
-	_, err = p.helmClient.DeleteRelease(name, helm.DeletePurge(true))
+	_, err = p.helmClient.DeleteRelease(name, helm.DeletePurge(purge))
 	if err != nil {
 		return fmt.Errorf("Unable to delete the release: %v", err)
 	}
@@ -310,5 +310,5 @@ type TillerClient interface {
 	CreateRelease(name, namespace, values string, ch *chart.Chart) (*release.Release, error)
 	UpdateRelease(name, namespace string, values string, ch *chart.Chart) (*release.Release, error)
 	GetRelease(name, namespace string) (*release.Release, error)
-	DeleteRelease(name, namespace string) error
+	DeleteRelease(name, namespace string, purge bool) error
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -329,7 +329,8 @@ func TestHelmReleaseDeleted(t *testing.T) {
 	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
 	proxy := newFakeProxy([]AppOverview{app})
 
-	err := proxy.DeleteRelease(app.ReleaseName, app.Namespace)
+	// TODO: Add a test for a non-purged release when the fake helm cli supports it
+	err := proxy.DeleteRelease(app.ReleaseName, app.Namespace, true)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
@@ -346,7 +347,7 @@ func TestDeleteMissingHelmRelease(t *testing.T) {
 	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
 	proxy := newFakeProxy([]AppOverview{app})
 
-	err := proxy.DeleteRelease(app.ReleaseName, "other_ns")
+	err := proxy.DeleteRelease(app.ReleaseName, "other_ns", true)
 	if err == nil {
 		t.Error("Delete should fail, there is not a release in the namespace specified")
 	}
@@ -395,7 +396,7 @@ func TestEnsureThreadSafety(t *testing.T) {
 			}
 		},
 		func() {
-			err := proxy.DeleteRelease(rs, ns)
+			err := proxy.DeleteRelease(rs, ns, true)
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}


### PR DESCRIPTION
Issue ref: #481
Continuation of #557 

Now that tiller-proxy support status filtering, add the possibility to show all the apps regardless of the status from the UI:

![list-all](https://user-images.githubusercontent.com/4025665/44860378-52cbb380-ac76-11e8-8f05-0162edaaad25.gif)
