### PR TITLE
Chart update: Tiller Proxy namespace awareness and rbac support

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.3.1
+version: 0.3.2
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/tiller-proxy-deployment.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-deployment.yaml
@@ -31,9 +31,6 @@ spec:
         {{- if .Values.tillerProxy.tls.verify }}
         - --tls-verify
         {{- end }}
-        env:
-        - name: HELM_HOME
-          value: /etc/certs
         volumeMounts:
         - name: tiller-certs
           mountPath: /etc/certs
@@ -41,6 +38,15 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.chartsvc.service.port }}
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- if .Values.tillerProxy.tls }}
+        - name: HELM_HOME
+          value: /etc/certs
+        {{- end }}
         resources:
 {{ toYaml .Values.tillerProxy.resources | indent 12 }}
       {{- if .Values.tillerProxy.tls }}

--- a/chart/kubeapps/templates/tiller-proxy-deployment.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app: {{ template "kubeapps.tiller-proxy.fullname" . }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ template "kubeapps.tiller-proxy.fullname" . }}
       containers:
       - name: proxy
         image: {{ template "kubeapps.image" .Values.tillerProxy.image }}

--- a/chart/kubeapps/templates/tiller-proxy-rbac.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-rbac.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "kubeapps.tiller-proxy.fullname" . }}
+  labels:
+    app: {{ template "kubeapps.tiller-proxy.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "kubeapps.tiller-proxy.fullname" . }}
+  labels:
+    app: {{ template "kubeapps.tiller-proxy.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kubeapps.tiller-proxy.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kubeapps.tiller-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/chart/kubeapps/templates/tiller-proxy-serviceaccount.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "kubeapps.tiller-proxy.fullname" . }}
+  labels:
+    app: {{ template "kubeapps.tiller-proxy.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}


### PR DESCRIPTION
When a repository contains an authentication header, Tiller Proxy needs to read this header from the repo associate k8s secret placed in the RELEASE_NAMESPACE.

This namespace is decided via the POD_NAMESPACE env variable https://github.com/kubeapps/kubeapps/blob/master/pkg/chart/chart.go#L231-L236

This patch injects the namespace in which the pod is running via the k8s downstream API as well as extend Tiller-proxy's RBAC support (serviceAccount, role and rolebinding) to be able to read from those secrets.   

Upgrades have been tested successfully in Minikube