### PR TITLE
[CI] Avoid getting stuck while checking if the cluster is available

### DIFF
--- a/script/start-gke-env.sh
+++ b/script/start-gke-env.sh
@@ -29,10 +29,14 @@ fi
 
 echo "Creating cluster $CLUSTER in $ZONE (v$VERSION)"
 gcloud container clusters create --cluster-version=$VERSION --zone $ZONE $CLUSTER --num-nodes 5 --machine-type=n1-standard-2
-# Wait for the cluster to respond
+echo "Waiting for the cluster to respond..."
 cnt=20
-until kubectl get pods; do
-    ((cnt=cnt-1)) || (echo "Waited 20 seconds but cluster is not reachable" && exit 1)
+until kubectl get pods > /dev/null 2>&1; do
+    ((cnt=cnt-1))
+    if [[ "$cnt" -eq 0 ]]; then
+        echo "Waited 20 seconds but cluster is not reachable"
+        exit 1
+    fi
     sleep 1
 done
 

--- a/script/start-gke-env.sh
+++ b/script/start-gke-env.sh
@@ -34,7 +34,7 @@ cnt=20
 until kubectl get pods > /dev/null 2>&1; do
     ((cnt=cnt-1))
     if [[ "$cnt" -eq 0 ]]; then
-        echo "Waited 20 seconds but cluster is not reachable"
+        echo "Tried 20 times but the cluster is not reachable"
         exit 1
     fi
     sleep 1


### PR DESCRIPTION
Fixes #571

The notation `((cnt=cnt-1)) || (echo "Waited 20 seconds but cluster is not reachable" && exit 1)` was not working so I changed that with a boring `if` clause. I have also redirected the output of `kubectl get pods` to `/dev/null` so in case the condition somehow fails CircleCI will purge the job after 10 minutes without output.

I tried the changes in the CircleCI env:

```
circleci@9ed20a708281:~/project$ ./s.sh
Waiting for the cluster to respond...
Waited 20 seconds but cluster is not reachable
circleci@9ed20a708281:~/project$ echo $?
1
```