### PR TITLE
Allow to not purge applications when deleting them

### DIFF
--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -302,7 +302,11 @@ func (h *TillerProxy) DeleteRelease(w http.ResponseWriter, req *http.Request, pa
 			return
 		}
 	}
-	err := h.ProxyClient.DeleteRelease(params["releaseName"], params["namespace"])
+	purge := false
+	if req.URL.Query().Get("purge") == "1" || req.URL.Query().Get("purge") == "true" {
+		purge = true
+	}
+	err := h.ProxyClient.DeleteRelease(params["releaseName"], params["namespace"], purge)
 	if err != nil {
 		response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
 		return

--- a/cmd/tiller-proxy/internal/handler/handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/handler_test.go
@@ -209,6 +209,22 @@ func TestActions(t *testing.T) {
 			Params:       map[string]string{"namespace": "default", "releaseName": "foobar"},
 			// Expected result
 			StatusCode:        200,
+			RemainingReleases: []release.Release{release.Release{Name: "foobar", Namespace: "default", Info: &release.Info{Status: &release.Status{Code: release.Status_DELETED}}}},
+			ResponseBody:      "",
+		},
+		{
+			// Scenario params
+			Description:      "Delete and purge a simple release",
+			ExistingReleases: []release.Release{release.Release{Name: "foobar", Namespace: "default"}},
+			DisableAuth:      true,
+			ForbiddenActions: []auth.Action{},
+			// Request params
+			RequestBody:  "",
+			RequestQuery: "?purge=true",
+			Action:       "delete",
+			Params:       map[string]string{"namespace": "default", "releaseName": "foobar"},
+			// Expected result
+			StatusCode:        200,
 			RemainingReleases: []release.Release{},
 			ResponseBody:      "",
 		},

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -55,14 +55,14 @@ describe("fetches applications", () => {
 });
 
 describe("delete applications", () => {
-  const deleteApp = App.delete;
+  const deleteAppOrig = App.delete;
   let deleteAppMock: jest.Mock;
   beforeEach(() => {
-    App.delete = jest.fn(() => []);
-    deleteAppMock = App.delete as jest.Mock;
+    deleteAppMock = jest.fn(() => []);
+    App.delete = deleteAppMock;
   });
   afterEach(() => {
-    App.delete = deleteApp;
+    App.delete = deleteAppOrig;
   });
   it("delete an application", async () => {
     await store.dispatch(actions.apps.deleteApp("foo", "default", false));

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -53,3 +53,34 @@ describe("fetches applications", () => {
     });
   });
 });
+
+describe("delete applications", () => {
+  const deleteApp = App.delete;
+  let deleteAppMock: jest.Mock;
+  beforeEach(() => {
+    App.delete = jest.fn(() => []);
+    deleteAppMock = App.delete as jest.Mock;
+  });
+  afterEach(() => {
+    App.delete = deleteApp;
+  });
+  it("delete an application", async () => {
+    await store.dispatch(actions.apps.deleteApp("foo", "default", false));
+    expect(store.getActions()).toEqual([]);
+    expect(deleteAppMock.mock.calls[0]).toEqual(["foo", "default", false]);
+  });
+  it("delete and purge an application", async () => {
+    await store.dispatch(actions.apps.deleteApp("foo", "default", true));
+    expect(store.getActions()).toEqual([]);
+    expect(deleteAppMock.mock.calls[0]).toEqual(["foo", "default", true]);
+  });
+  it("delete and throw an error", async () => {
+    const error = new Error("something went wrong!");
+    const expectedActions = [{ type: getType(actions.apps.errorDeleteApp), err: error }];
+    deleteAppMock.mockImplementation(() => {
+      throw error;
+    });
+    expect(await store.dispatch(actions.apps.deleteApp("foo", "default", true))).toBe(false);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -61,10 +61,10 @@ export function getApp(releaseName: string, namespace: string) {
   };
 }
 
-export function deleteApp(releaseName: string, namespace: string) {
+export function deleteApp(releaseName: string, namespace: string, purge: boolean) {
   return async (dispatch: Dispatch<IStoreState>): Promise<boolean> => {
     try {
-      await App.delete(releaseName, namespace);
+      await App.delete(releaseName, namespace, purge);
       return true;
     } catch (e) {
       dispatch(errorDeleteApp(e));

--- a/dashboard/src/components/AppView/AppControls.test.tsx
+++ b/dashboard/src/components/AppView/AppControls.test.tsx
@@ -71,7 +71,7 @@ it("calls delete function with additional purge", () => {
   const app = new hapi.release.Release({ name, namespace });
   const deleteApp = jest.fn(() => false); // Return "false" to avoid redirect when mounting
   // mount() is necessary to render the Modal
-  const wrapper = mount(<AppControls app={app} deleteApp={deleteApp} />);
+  const wrapper = mount(<AppControls app={app} deleteApp={deleteApp} ariaHideApp={false} />);
   wrapper.setState({ modalIsOpen: true });
   wrapper.update();
 

--- a/dashboard/src/components/AppView/AppControls.test.tsx
+++ b/dashboard/src/components/AppView/AppControls.test.tsx
@@ -1,5 +1,6 @@
 import { mount, shallow } from "enzyme";
 import * as React from "react";
+import * as ReactModal from "react-modal";
 import { Redirect } from "react-router";
 import { hapi } from "../../shared/hapi/release";
 import ConfirmDialog from "../ConfirmDialog";
@@ -71,7 +72,8 @@ it("calls delete function with additional purge", () => {
   const app = new hapi.release.Release({ name, namespace });
   const deleteApp = jest.fn(() => false); // Return "false" to avoid redirect when mounting
   // mount() is necessary to render the Modal
-  const wrapper = mount(<AppControls app={app} deleteApp={deleteApp} ariaHideApp={false} />);
+  const wrapper = mount(<AppControls app={app} deleteApp={deleteApp} />);
+  ReactModal.setAppElement(document.createElement("div"));
   wrapper.setState({ modalIsOpen: true });
   wrapper.update();
 

--- a/dashboard/src/components/AppView/AppControls.test.tsx
+++ b/dashboard/src/components/AppView/AppControls.test.tsx
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import * as React from "react";
 import { Redirect } from "react-router";
 import { hapi } from "../../shared/hapi/release";
@@ -63,4 +63,28 @@ it("calls delete function when clicking the button", done => {
     });
     done();
   }, 1);
+});
+
+it("calls delete function with additional purge", () => {
+  const name = "foo";
+  const namespace = "bar";
+  const app = new hapi.release.Release({ name, namespace });
+  const deleteApp = jest.fn(() => false); // Return "false" to avoid redirect when mounting
+  // mount() is necessary to render the Modal
+  const wrapper = mount(<AppControls app={app} deleteApp={deleteApp} />);
+  wrapper.setState({ modalIsOpen: true });
+  wrapper.update();
+
+  // Check that the checkbox changes the AppControls state
+  const confirm = wrapper.find(ConfirmDialog);
+  expect(confirm.exists()).toBe(true);
+  const checkbox = wrapper.find('input[type="checkbox"]');
+  expect(checkbox.exists()).toBe(true);
+  expect(wrapper.state().purge).toBe(false);
+  checkbox.simulate("change");
+  expect(wrapper.state().purge).toBe(true);
+
+  // Check that the "purge" state is forwarded to deleteApp
+  confirm.props().onConfirm(); // Simulate confirmation
+  expect(deleteApp.mock.calls[0]).toEqual([true]);
 });

--- a/dashboard/src/components/AppView/AppControls.tsx
+++ b/dashboard/src/components/AppView/AppControls.tsx
@@ -6,6 +6,7 @@ import ConfirmDialog from "../ConfirmDialog";
 
 interface IAppControlsProps {
   app: hapi.release.Release;
+  ariaHideApp?: boolean;
   deleteApp: (purge: boolean) => Promise<boolean>;
 }
 
@@ -53,6 +54,7 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
           modalIsOpen={this.state.modalIsOpen}
           loading={this.state.deleting}
           closeModal={this.closeModal}
+          ariaHideApp={this.props.ariaHideApp}
           extraElem={
             <div className="margin-v-small text-c">
               <label className="checkbox margin-r-big">

--- a/dashboard/src/components/AppView/AppControls.tsx
+++ b/dashboard/src/components/AppView/AppControls.tsx
@@ -6,7 +6,6 @@ import ConfirmDialog from "../ConfirmDialog";
 
 interface IAppControlsProps {
   app: hapi.release.Release;
-  ariaHideApp?: boolean;
   deleteApp: (purge: boolean) => Promise<boolean>;
 }
 
@@ -54,7 +53,6 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
           modalIsOpen={this.state.modalIsOpen}
           loading={this.state.deleting}
           closeModal={this.closeModal}
-          ariaHideApp={this.props.ariaHideApp}
           extraElem={
             <div className="margin-v-small text-c">
               <label className="checkbox margin-r-big">

--- a/dashboard/src/components/AppView/AppControls.tsx
+++ b/dashboard/src/components/AppView/AppControls.tsx
@@ -6,7 +6,7 @@ import ConfirmDialog from "../ConfirmDialog";
 
 interface IAppControlsProps {
   app: hapi.release.Release;
-  deleteApp: () => Promise<boolean>;
+  deleteApp: (purge: boolean) => Promise<boolean>;
 }
 
 interface IAppControlsState {
@@ -15,6 +15,7 @@ interface IAppControlsState {
   redirectToAppList: boolean;
   upgrade: boolean;
   deleting: boolean;
+  purge: boolean;
 }
 
 class AppControls extends React.Component<IAppControlsProps, IAppControlsState> {
@@ -22,6 +23,7 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
     deleting: false,
     migrate: false,
     modalIsOpen: false,
+    purge: false,
     redirectToAppList: false,
     upgrade: false,
   };
@@ -51,6 +53,14 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
           modalIsOpen={this.state.modalIsOpen}
           loading={this.state.deleting}
           closeModal={this.closeModal}
+          extraElem={
+            <div className="margin-v-small text-c">
+              <label className="checkbox margin-r-big">
+                <input type="checkbox" onChange={this.togglePurge} />
+                <span>Purge release</span>
+              </label>
+            </div>
+          }
         />
         {this.state.redirectToAppList && <Redirect to={`/apps/ns/${namespace}`} />}
       </div>
@@ -75,12 +85,16 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
 
   public handleDeleteClick = async () => {
     this.setState({ deleting: true });
-    const deleted = await this.props.deleteApp();
+    const deleted = await this.props.deleteApp(this.state.purge);
     const s: Partial<IAppControlsState> = { modalIsOpen: false };
     if (deleted) {
       s.redirectToAppList = true;
     }
     this.setState(s as IAppControlsState);
+  };
+
+  private togglePurge = () => {
+    this.setState({ purge: !this.state.purge });
   };
 }
 

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -22,7 +22,7 @@ export interface IAppViewProps {
   error: Error | undefined;
   deleteError: Error | undefined;
   getApp: (releaseName: string, namespace: string) => Promise<void>;
-  deleteApp: (releaseName: string, namespace: string) => Promise<boolean>;
+  deleteApp: (releaseName: string, namespace: string, purge: boolean) => Promise<boolean>;
 }
 
 interface IAppViewState {
@@ -152,7 +152,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
       return <div>Loading</div>;
     }
     return (
-      <section className="AppView padding-b-big">
+      <section id="appview" className="AppView padding-b-big">
         <main>
           <div className="container">
             {this.props.deleteError && this.renderError(this.props.deleteError, "delete")}
@@ -224,8 +224,8 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
     return Object.keys(this.state.deployments).map(k => this.state.deployments[k]);
   }
 
-  private deleteApp = () => {
-    return this.props.deleteApp(this.props.releaseName, this.props.namespace);
+  private deleteApp = (purge: boolean) => {
+    return this.props.deleteApp(this.props.releaseName, this.props.namespace, purge);
   };
 }
 

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -152,7 +152,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
       return <div>Loading</div>;
     }
     return (
-      <section id="appview" className="AppView padding-b-big">
+      <section className="AppView padding-b-big">
         <main>
           <div className="container">
             {this.props.deleteError && this.renderError(this.props.deleteError, "delete")}

--- a/dashboard/src/components/ConfirmDialog/index.tsx
+++ b/dashboard/src/components/ConfirmDialog/index.tsx
@@ -5,6 +5,7 @@ interface IConfirmDialogProps {
   modalIsOpen: boolean;
   loading: boolean;
   extraElem?: JSX.Element;
+  ariaHideApp?: boolean;
   onConfirm: () => Promise<any>;
   closeModal: () => Promise<any>;
 }
@@ -37,7 +38,7 @@ class ConfirmDialog extends React.Component<IConfirmDialogProps, IConfirmDialogS
           isOpen={this.props.modalIsOpen}
           onRequestClose={this.closeModal}
           contentLabel="Modal"
-          ariaHideApp={false}
+          ariaHideApp={this.props.ariaHideApp === false ? false : true}
         >
           {this.state.error && (
             <div className="padding-big margin-b-big bg-action">{this.state.error}</div>

--- a/dashboard/src/components/ConfirmDialog/index.tsx
+++ b/dashboard/src/components/ConfirmDialog/index.tsx
@@ -5,7 +5,6 @@ interface IConfirmDialogProps {
   modalIsOpen: boolean;
   loading: boolean;
   extraElem?: JSX.Element;
-  ariaHideApp?: boolean;
   onConfirm: () => Promise<any>;
   closeModal: () => Promise<any>;
 }
@@ -38,7 +37,6 @@ class ConfirmDialog extends React.Component<IConfirmDialogProps, IConfirmDialogS
           isOpen={this.props.modalIsOpen}
           onRequestClose={this.closeModal}
           contentLabel="Modal"
-          ariaHideApp={this.props.ariaHideApp === false ? false : true}
         >
           {this.state.error && (
             <div className="padding-big margin-b-big bg-action">{this.state.error}</div>

--- a/dashboard/src/components/ConfirmDialog/index.tsx
+++ b/dashboard/src/components/ConfirmDialog/index.tsx
@@ -4,6 +4,7 @@ import * as Modal from "react-modal";
 interface IConfirmDialogProps {
   modalIsOpen: boolean;
   loading: boolean;
+  extraElem?: JSX.Element;
   onConfirm: () => Promise<any>;
   closeModal: () => Promise<any>;
 }
@@ -36,6 +37,7 @@ class ConfirmDialog extends React.Component<IConfirmDialogProps, IConfirmDialogS
           isOpen={this.props.modalIsOpen}
           onRequestClose={this.closeModal}
           contentLabel="Modal"
+          ariaHideApp={false}
         >
           {this.state.error && (
             <div className="padding-big margin-b-big bg-action">{this.state.error}</div>
@@ -45,6 +47,7 @@ class ConfirmDialog extends React.Component<IConfirmDialogProps, IConfirmDialogS
           ) : (
             <div>
               <div> Are you sure you want to delete this? </div>
+              {this.props.extraElem}
               <button className="button" onClick={this.props.closeModal}>
                 Cancel
               </button>

--- a/dashboard/src/containers/AppViewContainer/AppViewContainer.tsx
+++ b/dashboard/src/containers/AppViewContainer/AppViewContainer.tsx
@@ -26,8 +26,8 @@ function mapStateToProps({ apps }: IStoreState, { match: { params } }: IRoutePro
 
 function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
-    deleteApp: (releaseName: string, ns: string) =>
-      dispatch(actions.apps.deleteApp(releaseName, ns)),
+    deleteApp: (releaseName: string, ns: string, purge: boolean) =>
+      dispatch(actions.apps.deleteApp(releaseName, ns, purge)),
     getApp: (releaseName: string, ns: string) => dispatch(actions.apps.getApp(releaseName, ns)),
   };
 }

--- a/dashboard/src/index.tsx
+++ b/dashboard/src/index.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import * as Modal from "react-modal";
 import { createAxiosInterceptors } from "shared/AxiosInstance";
 import { axios } from "./shared/Auth";
 
@@ -19,3 +20,6 @@ ReactDOM.render(<Root />, document.getElementById("root") as HTMLElement);
 // the Dashboard and we no longer need the external link.
 
 // registerServiceWorker();
+
+// Set App Element for accessibilty
+Modal.setAppElement("#root");

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -71,4 +71,20 @@ describe("App", () => {
       });
     });
   });
+  describe("delete", () => {
+    it("should delete an app in a namespace", async () => {
+      moxios.stubRequest("/api/tiller-deploy/v1/namespaces/default/releases/foo", {
+        response: "ok",
+        status: 200,
+      });
+      expect(await App.delete("foo", "default", false)).toBe("ok");
+    });
+    it("should delete and purge an app in a namespace", async () => {
+      moxios.stubRequest("/api/tiller-deploy/v1/namespaces/default/releases/foo?purge=true", {
+        response: "ok",
+        status: 200,
+      });
+      expect(await App.delete("foo", "default", true)).toBe("ok");
+    });
+  });
 });

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -65,8 +65,12 @@ export class App {
     return data;
   }
 
-  public static async delete(releaseName: string, namespace: string) {
-    const { data } = await axios.delete(App.getResourceURL(namespace, releaseName));
+  public static async delete(releaseName: string, namespace: string, purge: boolean) {
+    let purgeQuery;
+    if (purge) {
+      purgeQuery = "purge=true";
+    }
+    const { data } = await axios.delete(App.getResourceURL(namespace, releaseName, purgeQuery));
     return data;
   }
 

--- a/pkg/proxy/fake/proxy.go
+++ b/pkg/proxy/fake/proxy.go
@@ -91,11 +91,20 @@ func (f *FakeProxy) GetRelease(name, namespace string) (*release.Release, error)
 	return nil, fmt.Errorf("Release %s not found", name)
 }
 
-func (f *FakeProxy) DeleteRelease(name, namespace string) error {
+func (f *FakeProxy) DeleteRelease(name, namespace string, purge bool) error {
 	for i, r := range f.Releases {
 		if r.Name == name {
-			f.Releases[i] = f.Releases[len(f.Releases)-1]
-			f.Releases = f.Releases[:len(f.Releases)-1]
+			if purge {
+				f.Releases[i] = f.Releases[len(f.Releases)-1]
+				f.Releases = f.Releases[:len(f.Releases)-1]
+			} else {
+				r.Info = &release.Info{
+					Status: &release.Status{
+						Code: release.Status_DELETED,
+					},
+				}
+				f.Releases[i] = r
+			}
 			return nil
 		}
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -287,7 +287,7 @@ func (p *Proxy) GetRelease(name, namespace string) (*release.Release, error) {
 }
 
 // DeleteRelease deletes a release
-func (p *Proxy) DeleteRelease(name, namespace string) error {
+func (p *Proxy) DeleteRelease(name, namespace string, purge bool) error {
 	lock(name)
 	defer unlock(name)
 	// Validate that the release actually belongs to the namespace
@@ -295,7 +295,7 @@ func (p *Proxy) DeleteRelease(name, namespace string) error {
 	if err != nil {
 		return err
 	}
-	_, err = p.helmClient.DeleteRelease(name, helm.DeletePurge(true))
+	_, err = p.helmClient.DeleteRelease(name, helm.DeletePurge(purge))
 	if err != nil {
 		return fmt.Errorf("Unable to delete the release: %v", err)
 	}
@@ -310,5 +310,5 @@ type TillerClient interface {
 	CreateRelease(name, namespace, values string, ch *chart.Chart) (*release.Release, error)
 	UpdateRelease(name, namespace string, values string, ch *chart.Chart) (*release.Release, error)
 	GetRelease(name, namespace string) (*release.Release, error)
-	DeleteRelease(name, namespace string) error
+	DeleteRelease(name, namespace string, purge bool) error
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -329,7 +329,8 @@ func TestHelmReleaseDeleted(t *testing.T) {
 	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
 	proxy := newFakeProxy([]AppOverview{app})
 
-	err := proxy.DeleteRelease(app.ReleaseName, app.Namespace)
+	// TODO: Add a test for a non-purged release when the fake helm cli supports it
+	err := proxy.DeleteRelease(app.ReleaseName, app.Namespace, true)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
@@ -346,7 +347,7 @@ func TestDeleteMissingHelmRelease(t *testing.T) {
 	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
 	proxy := newFakeProxy([]AppOverview{app})
 
-	err := proxy.DeleteRelease(app.ReleaseName, "other_ns")
+	err := proxy.DeleteRelease(app.ReleaseName, "other_ns", true)
 	if err == nil {
 		t.Error("Delete should fail, there is not a release in the namespace specified")
 	}
@@ -395,7 +396,7 @@ func TestEnsureThreadSafety(t *testing.T) {
 			}
 		},
 		func() {
-			err := proxy.DeleteRelease(rs, ns)
+			err := proxy.DeleteRelease(rs, ns, true)
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}


### PR DESCRIPTION
Closes: #481
Requires: #563

 - Adds a query parameter "purge" for the `DELETE` API call in tiller-proxy.
 - Show a checkbox  when deleting an app in the UI to purge or not the application.

<img width="394" alt="screen shot 2018-08-31 at 18 13 57" src="https://user-images.githubusercontent.com/4025665/44923811-a8bd5b80-ad49-11e8-9ed1-2b524b3050f7.png">
