### PR TITLE
[CI] Push and use temporary images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,11 @@ workflows:
           requires:
             - GKE_1_9
             - GKE_1_10
+      - push_images:
+          <<: *build_on_master
+          requires:
+            - GKE_1_9
+            - GKE_1_10
       - release:
           <<: *build_on_tag
           requires:
@@ -89,7 +94,8 @@ exports: &exports
   run: |
     # It is not possible to resolve env vars in the environment section:
     # https://circleci.com/docs/2.0/env-vars/#using-bash_env-to-set-environment-variables
-    echo "export VERSION=${CIRCLE_TAG:-build-$CIRCLE_WORKFLOW_ID}" >> $BASH_ENV
+    echo "export DEV_TAG=build-${CIRCLE_SHA1}" >> $BASH_ENV
+    echo "export PROD_TAG=${CIRCLE_TAG:-latest}" >> $BASH_ENV
 build_image: &build_image
   machine: true
   working_directory: /home/circleci/.go_workspace/src/github.com/kubeapps/kubeapps
@@ -98,17 +104,11 @@ build_image: &build_image
   steps:
     - checkout
     - <<: *exports
-    - run: make VERSION="$VERSION" $IMAGE
+    - run: make VERSION="$DEV_TAG" $IMAGE
     - run: |
-        if [[ -z "$CIRCLE_PULL_REQUEST" ]]; then
+        if [[ -z "$CIRCLE_PULL_REQUEST" && -n "$DOCKER_USERNAME" && -n "$DOCKER_PASSWORD" ]]; then
           docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-          if [[ -n "$CIRCLE_TAG" ]]; then 
-            docker push $IMAGE:$VERSION
-          fi
-          if [[ "$CIRCLE_BRANCH" == "master"  ]]; then
-            docker tag $IMAGE:$VERSION $IMAGE:latest
-            docker push $IMAGE:latest
-          fi
+          docker push $IMAGE:$DEV_TAG
         fi
 gke_test: &gke_test
   docker:
@@ -142,7 +142,7 @@ gke_test: &gke_test
         tar zxf helm-$HELM_VERSION-linux-amd64.tar.gz
         sudo mv linux-amd64/helm /usr/local/bin/
         helm init
-    - run: ./script/e2e-test.sh
+    - run: ./script/e2e-test.sh $DEV_TAG
     - run:
         name: Cleanup GKE Cluster
         command: gcloud container clusters delete --async --zone $GKE_ZONE $ESCAPED_GKE_CLUSTER
@@ -219,3 +219,16 @@ jobs:
             ssh-add ~/.ssh/id_rsa_* ~/.ssh/id_rsa
           fi
           ./script/chart_sync.sh kubernetes-bitnami kubernetes@bitnami.com
+  push_images:
+    machine: true
+    steps:
+      - <<: *exports
+      - run: |
+          if [[ -z "$CIRCLE_PULL_REQUEST" && -n "$DOCKER_USERNAME" && -n "$DOCKER_PASSWORD" ]]; then
+            docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+            for IMAGE in kubeapps/chart-repo kubeapps/chartsvc kubeapps/apprepository-controller kubeapps/dashboard kubeapps/tiller-proxy; do
+              docker pull $IMAGE:$DEV_TAG
+              docker tag $IMAGE:$DEV_TAG $IMAGE:$PROD_TAG
+              docker push $IMAGE:$PROD_TAG
+            done
+          fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ workflows:
             - GKE_1_9
             - GKE_1_10
       - push_images:
-          <<: *build_on_master
+          <<: *build_always
           requires:
             - GKE_1_9
             - GKE_1_10
@@ -94,21 +94,25 @@ exports: &exports
   run: |
     # It is not possible to resolve env vars in the environment section:
     # https://circleci.com/docs/2.0/env-vars/#using-bash_env-to-set-environment-variables
+    # DEV_TAG and PROD_TAG are the tags used for the Kubeapps docker images
     echo "export DEV_TAG=build-${CIRCLE_SHA1}" >> $BASH_ENV
     echo "export PROD_TAG=${CIRCLE_TAG:-latest}" >> $BASH_ENV
+    # Apart than using a DEV_TAG we use a different image ID to avoid polluting the tag
+    # history of the production tag
+    echo "export IMG_MODIFIER=-ci" >> $BASH_ENV
 build_image: &build_image
-  machine: true
-  working_directory: /home/circleci/.go_workspace/src/github.com/kubeapps/kubeapps
-  environment:
-    GOPATH: /home/circleci/.go_workspace
+  working_directory: /go/src/github.com/kubeapps/kubeapps
+  docker:
+    - image: circleci/golang:1.9
   steps:
+    - setup_remote_docker
     - checkout
     - <<: *exports
-    - run: make VERSION="$DEV_TAG" $IMAGE
+    - run: make IMG_MODIFIER="$IMG_MODIFIER" VERSION="${DEV_TAG}" ${IMAGE}
     - run: |
-        if [[ -z "$CIRCLE_PULL_REQUEST" && -n "$DOCKER_USERNAME" && -n "$DOCKER_PASSWORD" ]]; then
+        if [[ -z "${CIRCLE_PULL_REQUEST}" && -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
           docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-          docker push $IMAGE:$DEV_TAG
+          docker push ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
         fi
 gke_test: &gke_test
   docker:
@@ -141,8 +145,8 @@ gke_test: &gke_test
         wget https://storage.googleapis.com/kubernetes-helm/helm-$HELM_VERSION-linux-amd64.tar.gz
         tar zxf helm-$HELM_VERSION-linux-amd64.tar.gz
         sudo mv linux-amd64/helm /usr/local/bin/
-        helm init
-    - run: ./script/e2e-test.sh $DEV_TAG
+        helm init --wait
+    - run: ./script/e2e-test.sh $IMG_MODIFIER $DEV_TAG
     - run:
         name: Cleanup GKE Cluster
         command: gcloud container clusters delete --async --zone $GKE_ZONE $ESCAPED_GKE_CLUSTER
@@ -220,15 +224,17 @@ jobs:
           fi
           ./script/chart_sync.sh kubernetes-bitnami kubernetes@bitnami.com
   push_images:
-    machine: true
+    docker:
+      - image: circleci/golang:1.9
     steps:
+      - setup_remote_docker
       - <<: *exports
       - run: |
           if [[ -z "$CIRCLE_PULL_REQUEST" && -n "$DOCKER_USERNAME" && -n "$DOCKER_PASSWORD" ]]; then
             docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
             for IMAGE in kubeapps/chart-repo kubeapps/chartsvc kubeapps/apprepository-controller kubeapps/dashboard kubeapps/tiller-proxy; do
-              docker pull $IMAGE:$DEV_TAG
-              docker tag $IMAGE:$DEV_TAG $IMAGE:$PROD_TAG
-              docker push $IMAGE:$PROD_TAG
+              docker pull ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
+              docker tag ${IMAGE}${IMG_MODIFIER}:${DEV_TAG} ${IMAGE}:${PROD_TAG}
+              docker push ${IMAGE}:${PROD_TAG}
             done
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ exports: &exports
     # DEV_TAG and PROD_TAG are the tags used for the Kubeapps docker images
     echo "export DEV_TAG=build-${CIRCLE_SHA1}" >> $BASH_ENV
     echo "export PROD_TAG=${CIRCLE_TAG:-latest}" >> $BASH_ENV
-    # Apart than using a DEV_TAG we use a different image ID to avoid polluting the tag
+    # Apart from using a DEV_TAG we use a different image ID to avoid polluting the tag
     # history of the production tag
     echo "export IMG_MODIFIER=-ci" >> $BASH_ENV
 build_image: &build_image

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ IMPORT_PATH:= github.com/kubeapps/kubeapps
 GO = /usr/bin/env go
 GOFMT = /usr/bin/env gofmt
 VERSION ?= dev-$(shell date +%FT%H-%M-%S-%Z)
+IMG_MODIFIER ?= 
 
 GO_PACKAGES = ./...
 GO_FILES := $(shell find $(shell $(GO) list -f '{{.Dir}}' $(GO_PACKAGES)) -name \*.go)
@@ -12,14 +13,14 @@ all: kubeapps/dashboard kubeapps/chartsvc kubeapps/chart-repo kubeapps/appreposi
 
 # TODO(miguel) Create Makefiles per component
 kubeapps/%:
-	docker build -t kubeapps/$*:$(VERSION) -f cmd/$*/Dockerfile .
+	docker build -t kubeapps/$*$(IMG_MODIFIER):$(VERSION) -f cmd/$*/Dockerfile .
 
 kubeapps/dashboard:
-	docker build -t kubeapps/dashboard:$(VERSION) -f dashboard/Dockerfile dashboard/
+	docker build -t kubeapps/dashboard$(IMG_MODIFIER):$(VERSION) -f dashboard/Dockerfile dashboard/
 
 kubeapps/tiller-proxy:
 	CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -o ./cmd/tiller-proxy/proxy-static ./cmd/tiller-proxy
-	docker build -t kubeapps/tiller-proxy:$(VERSION) -f cmd/tiller-proxy/Dockerfile cmd/tiller-proxy
+	docker build -t kubeapps/tiller-proxy$(IMG_MODIFIER):$(VERSION) -f cmd/tiller-proxy/Dockerfile cmd/tiller-proxy
 
 test:
 	$(GO) test $(GO_PACKAGES)

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -17,6 +17,7 @@
 set -e
 
 ROOT_DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd`
+DEV_TAG=${1:?}
 
 source $ROOT_DIR/script/libtest.sh
 
@@ -29,9 +30,19 @@ k8s_wait_for_pod_ready kube-system app=helm,name=tiller
 wait_for_tiller
 
 # Install Kubeapps
-# TODO: Use just built images
 helm dep up $ROOT_DIR/chart/kubeapps/
-helm install --name kubeapps-ci --namespace kubeapps $ROOT_DIR/chart/kubeapps
+helm install --name kubeapps-ci --namespace kubeapps $ROOT_DIR/chart/kubeapps \
+  --set apprepository.image.tag=$DEV_TAG \
+  --set apprepository.syncImage.tag=$DEV_TAG \
+  --set chartsvc.image.tag=$DEV_TAG \
+  --set dashboard.image.tag=$DEV_TAG \
+  --set tillerProxy.image.tag=$DEV_TAG
+
+# Ensure that we are testing the correct image
+k8s_ensure_image kubeapps kubeapps-ci-apprepository-controller $DEV_TAG
+k8s_ensure_image kubeapps kubeapps-ci-chartsvc $DEV_TAG
+k8s_ensure_image kubeapps kubeapps-ci-dashboard $DEV_TAG
+k8s_ensure_image kubeapps kubeapps-ci-tiller-proxy $DEV_TAG
 
 # Wait for Kubeapps Pods
 k8s_wait_for_pod_ready kubeapps app=kubeapps-ci

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -17,7 +17,8 @@
 set -e
 
 ROOT_DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd`
-DEV_TAG=${1:?}
+IMG_MODIFIER=${1:?}
+DEV_TAG=${2:?}
 
 source $ROOT_DIR/script/libtest.sh
 
@@ -25,18 +26,19 @@ source $ROOT_DIR/script/libtest.sh
 kubectl get clusterrolebinding kube-dns-admin >& /dev/null || \
     kubectl create clusterrolebinding kube-dns-admin --serviceaccount=kube-system:default --clusterrole=cluster-admin 
 
-# Wait for Tiller
-k8s_wait_for_pod_ready kube-system app=helm,name=tiller
-wait_for_tiller
-
 # Install Kubeapps
 helm dep up $ROOT_DIR/chart/kubeapps/
 helm install --name kubeapps-ci --namespace kubeapps $ROOT_DIR/chart/kubeapps \
   --set apprepository.image.tag=$DEV_TAG \
+  --set apprepository.image.repository=kubeapps/apprepository-controller$IMG_MODIFIER \
   --set apprepository.syncImage.tag=$DEV_TAG \
+  --set apprepository.syncImage.repository=kubeapps/chart-repo$IMG_MODIFIER \
   --set chartsvc.image.tag=$DEV_TAG \
+  --set chartsvc.image.repository=kubeapps/chartsvc$IMG_MODIFIER \
   --set dashboard.image.tag=$DEV_TAG \
-  --set tillerProxy.image.tag=$DEV_TAG
+  --set dashboard.image.repository=kubeapps/dashboard$IMG_MODIFIER \
+  --set tillerProxy.image.tag=$DEV_TAG \
+  --set tillerProxy.image.repository=kubeapps/tiller-proxy$IMG_MODIFIER
 
 # Ensure that we are testing the correct image
 k8s_ensure_image kubeapps kubeapps-ci-apprepository-controller $DEV_TAG

--- a/script/libtest.sh
+++ b/script/libtest.sh
@@ -45,11 +45,20 @@ k8s_wait_for_pod_completed() {
     k8s_wait_for_pod $namespace $labelSelector Completed
 }
 
+k8s_ensure_image() {
+    namespace=${1:?}
+    deployment=${2:?}
+    expectedPattern=${3:?}
+    jsonpath=${4:-'{.spec.template.spec.containers[0].image}'}
+    echo "Checking image for $deployment"
+    kubectl get deployment -n $namespace $deployment -o jsonpath="$jsonpath" | grep $expectedPattern
+}
+
 ## helm specific helper functions
 wait_for_tiller() {
     echo "Waiting for Tiller to be ready ... "
     local -i cnt=${TEST_MAX_WAIT_SEC:?}
-    until helm version "${@}"; do
+    until helm version --tiller-connection-timeout 5 "${@}"; do
         ((cnt=cnt-1)) || return 1
         sleep 1
     done

--- a/script/libtest.sh
+++ b/script/libtest.sh
@@ -50,16 +50,11 @@ k8s_ensure_image() {
     deployment=${2:?}
     expectedPattern=${3:?}
     jsonpath=${4:-'{.spec.template.spec.containers[0].image}'}
-    echo "Checking image for $deployment"
-    kubectl get deployment -n $namespace $deployment -o jsonpath="$jsonpath" | grep $expectedPattern
-}
-
-## helm specific helper functions
-wait_for_tiller() {
-    echo "Waiting for Tiller to be ready ... "
-    local -i cnt=${TEST_MAX_WAIT_SEC:?}
-    until helm version --tiller-connection-timeout 5 "${@}"; do
-        ((cnt=cnt-1)) || return 1
-        sleep 1
-    done
+    echo "Checking that $deployment mathes $expectedPattern"
+    if kubectl get deployment -n $namespace $deployment -o jsonpath="$jsonpath" | grep $expectedPattern; then
+        return 0
+    else
+        echo "Failed to found $expectedPattern"
+        return 1
+    fi
 }


### PR DESCRIPTION
Fixes #537

For the end-to-end tests:

 - Build and push images using as tag `build-<git commit sha1>`
 - Test the helm chart and set the tag to the images just built
 - Ensure that we are using the correct tag
 - If the e2e tests success push the images with another tag (`latest` or `v.*` for tagged builds)

Test: https://circleci.com/workflow-run/c369a345-eefb-46d5-a5ee-bc2e42c3fa45
