### PR TITLE
[Chart] frontend service annotation

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.3.2
+version: 0.3.3
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/kubeapps-frontend-service.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "kubeapps.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.frontend.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.frontend.service.type }}
   ports:

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -92,6 +92,7 @@ frontend:
   service:
     port: 80
     type: ClusterIP
+    # annotations: {}
   livenessProbe:
     httpGet:
       path: /healthz


### PR DESCRIPTION
It sdds support for metadata annotations to the frontend service.

This is useful if the user opts for exposing kubeapps via a LoadBalancer but want to tweak it by making it for example internal `'service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0'`

I have not modified the Readme because in my opinion, this is a power user feature, disabled by default, and not commonly required. 