### PR TITLE
Chart deploy. Show an error message if namespace is not selected

### DIFF
--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -4,6 +4,7 @@ import { getType } from "typesafe-actions";
 
 import actions from ".";
 import { App } from "../shared/App";
+import { definedNamespaces } from "../shared/Namespace";
 import { IAppState, UnprocessableEntity } from "../shared/types";
 
 const mockStore = configureMockStore([thunk]);
@@ -110,7 +111,7 @@ describe("deploy chart", () => {
 
   it("returns false and dispatches UnprocessableEntity if the namespace is _all", async () => {
     const res = await store.dispatch(
-      actions.apps.deployChart("my-version" as any, "my-release", "_all"),
+      actions.apps.deployChart("my-version" as any, "my-release", definedNamespaces.all),
     );
     expect(res).toBe(false);
     expect(store.getActions().length).toBe(1);

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -97,9 +97,10 @@ export function deployChart(
 ) {
   return async (dispatch: Dispatch<IStoreState>, getState: () => IStoreState): Promise<boolean> => {
     try {
+      // You can not deploy applications unless the namespace is set
       if (namespace === definedNamespaces.all) {
         throw new UnprocessableEntity(
-          "Namespace not selected. You need to select a namespace using the selector on the top right corner.",
+          "Namespace not selected. Please select a namespace using the selector on the top right corner.",
         );
       }
 

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -1,8 +1,8 @@
 import { Dispatch } from "redux";
 import { createAction, getReturnOfExpression } from "typesafe-actions";
-
 import { App } from "../shared/App";
 import { hapi } from "../shared/hapi/release";
+import { definedNamespaces } from "../shared/Namespace";
 import { IAppOverview, IChartVersion, IStoreState } from "../shared/types";
 
 export const requestApps = createAction("REQUEST_APPS");
@@ -76,7 +76,7 @@ export function deleteApp(releaseName: string, namespace: string, purge: boolean
 
 export function fetchApps(ns?: string, all: boolean = false) {
   return async (dispatch: Dispatch<IStoreState>): Promise<void> => {
-    if (ns && ns === "_all") {
+    if (ns && ns === definedNamespaces.all) {
       ns = undefined;
     }
     dispatch(listApps(all));

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -100,7 +100,7 @@ export function deployChart(
       // You can not deploy applications unless the namespace is set
       if (namespace === definedNamespaces.all) {
         throw new UnprocessableEntity(
-          "Namespace not selected. Please select a namespace using the selector on the top right corner.",
+          "Namespace not selected. Please select a namespace using the selector in the top right corner.",
         );
       }
 

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -3,7 +3,7 @@ import { createAction, getReturnOfExpression } from "typesafe-actions";
 import { App } from "../shared/App";
 import { hapi } from "../shared/hapi/release";
 import { definedNamespaces } from "../shared/Namespace";
-import { IAppOverview, IChartVersion, IStoreState } from "../shared/types";
+import { IAppOverview, IChartVersion, IStoreState, UnprocessableEntity } from "../shared/types";
 
 export const requestApps = createAction("REQUEST_APPS");
 export const receiveApps = createAction("RECEIVE_APPS", (apps: hapi.release.Release[]) => {
@@ -97,6 +97,12 @@ export function deployChart(
 ) {
   return async (dispatch: Dispatch<IStoreState>, getState: () => IStoreState): Promise<boolean> => {
     try {
+      if (namespace === definedNamespaces.all) {
+        throw new UnprocessableEntity(
+          "Namespace not selected. You need to select a namespace using the selector on the top right corner.",
+        );
+      }
+
       const { config: { namespace: kubeappsNamespace } } = getState();
       await App.create(releaseName, namespace, kubeappsNamespace, chartVersion, values);
       return true;

--- a/dashboard/src/actions/catalog.ts
+++ b/dashboard/src/actions/catalog.ts
@@ -2,6 +2,7 @@ import { Dispatch } from "redux";
 import { createAction, getReturnOfExpression } from "typesafe-actions";
 
 import { IClusterServiceClass } from "../shared/ClusterServiceClass";
+import { definedNamespaces } from "../shared/Namespace";
 import { IServiceBindingWithSecret, ServiceBinding } from "../shared/ServiceBinding";
 import { IServiceBroker, IServicePlan, ServiceCatalog } from "../shared/ServiceCatalog";
 import { IServiceInstance, ServiceInstance } from "../shared/ServiceInstance";
@@ -140,7 +141,7 @@ export type ServiceCatalogAction = typeof actions[number];
 
 export function getBindings(ns?: string) {
   return async (dispatch: Dispatch<IStoreState>) => {
-    if (ns && ns === "_all") {
+    if (ns && ns === definedNamespaces.all) {
       ns = undefined;
     }
     dispatch(requestBindingsWithSecrets());
@@ -182,7 +183,7 @@ export function getClasses() {
 
 export function getInstances(ns?: string) {
   return async (dispatch: Dispatch<IStoreState>) => {
-    if (ns && ns === "_all") {
+    if (ns && ns === definedNamespaces.all) {
       ns = undefined;
     }
     dispatch(requestInstances());

--- a/dashboard/src/actions/functions.ts
+++ b/dashboard/src/actions/functions.ts
@@ -3,6 +3,7 @@ import { createAction, getReturnOfExpression } from "typesafe-actions";
 
 import Function from "../shared/Function";
 import KubelessConfig from "../shared/KubelessConfig";
+import { definedNamespaces } from "../shared/Namespace";
 import { IFunction, IRuntime, IStoreState } from "../shared/types";
 
 export const requestFunctions = createAction("REQUEST_FUNCTIONS");
@@ -44,7 +45,7 @@ export type FunctionsAction = typeof allActions[number];
 
 export function fetchFunctions(ns?: string) {
   return async (dispatch: Dispatch<IStoreState>) => {
-    if (ns && ns === "_all") {
+    if (ns && definedNamespaces.all) {
       ns = undefined;
     }
     dispatch(requestFunctions());

--- a/dashboard/src/components/ChartView/ChartDeployButton.test.tsx
+++ b/dashboard/src/components/ChartView/ChartDeployButton.test.tsx
@@ -30,15 +30,18 @@ it("renders a button to deploy the chart version", () => {
 
 it("renders a redirect with the correct URL when the button is clicked", () => {
   const testCases = [
-    { namespace: "test", url: "/apps/ns/test/new/testrepo/test/versions/1.2.3" },
-    // If the namespace is _all we redirect to default
-    { namespace: "_all", url: "/apps/ns/default/new/testrepo/test/versions/1.2.3" },
+    { namespace: "test", version: "1.2.3", url: "/apps/ns/test/new/testrepo/test/versions/1.2.3" },
+    {
+      namespace: "foo",
+      version: "alpha-0",
+      url: "/apps/ns/foo/new/testrepo/test/versions/alpha-0",
+    },
   ];
 
   testCases.forEach(t => {
-    const wrapper = shallow(
-      <ChartDeployButton version={testChartVersion} namespace={t.namespace} />,
-    );
+    const chartVersion = Object.assign({}, testChartVersion);
+    chartVersion.attributes.version = t.version;
+    const wrapper = shallow(<ChartDeployButton version={chartVersion} namespace={t.namespace} />);
     const button = wrapper.find("button");
     expect(button.exists()).toBe(true);
     expect(wrapper.find(Redirect).exists()).toBe(false);

--- a/dashboard/src/components/ChartView/ChartDeployButton.test.tsx
+++ b/dashboard/src/components/ChartView/ChartDeployButton.test.tsx
@@ -28,17 +28,27 @@ it("renders a button to deploy the chart version", () => {
   expect(button.text()).toBe("Deploy using Helm");
 });
 
-it("renders a redirect when the button is clicked", () => {
-  const wrapper = shallow(<ChartDeployButton version={testChartVersion} namespace="test" />);
-  const button = wrapper.find("button");
-  expect(button.exists()).toBe(true);
-  expect(wrapper.find(Redirect).exists()).toBe(false);
+it("renders a redirect with the correct URL when the button is clicked", () => {
+  const testCases = [
+    { namespace: "test", url: "/apps/ns/test/new/testrepo/test/versions/1.2.3" },
+    // If the namespace is _all we redirect to default
+    { namespace: "_all", url: "/apps/ns/default/new/testrepo/test/versions/1.2.3" },
+  ];
 
-  button.simulate("click");
-  const redirect = wrapper.find(Redirect);
-  expect(redirect.exists()).toBe(true);
-  expect(redirect.props()).toMatchObject({
-    push: true,
-    to: "/apps/ns/test/new/testrepo/test/versions/1.2.3",
+  testCases.forEach(t => {
+    const wrapper = shallow(
+      <ChartDeployButton version={testChartVersion} namespace={t.namespace} />,
+    );
+    const button = wrapper.find("button");
+    expect(button.exists()).toBe(true);
+    expect(wrapper.find(Redirect).exists()).toBe(false);
+
+    button.simulate("click");
+    const redirect = wrapper.find(Redirect);
+    expect(redirect.exists()).toBe(true);
+    expect(redirect.props()).toMatchObject({
+      push: true,
+      to: t.url,
+    });
   });
 });

--- a/dashboard/src/components/ChartView/ChartDeployButton.tsx
+++ b/dashboard/src/components/ChartView/ChartDeployButton.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Redirect } from "react-router";
+import { definedNamespaces } from "../../shared/Namespace";
 import { IChartVersion } from "../../shared/types";
 
 interface IChartDeployButtonProps {
@@ -17,10 +18,16 @@ class ChartDeployButton extends React.Component<IChartDeployButtonProps, IChartD
   };
 
   public render() {
-    const { namespace, version } = this.props;
+    const { version } = this.props;
+    let { namespace } = this.props;
     const repoName = version.relationships.chart.data.repo.name;
     const chartName = version.relationships.chart.data.name;
     const versionStr = version.attributes.version;
+
+    // If our current namespace is not set a.k.a '_all' we actually set the default one
+    if (namespace === definedNamespaces.all) {
+      namespace = definedNamespaces.default;
+    }
 
     return (
       <div className="ChartDeployButton">

--- a/dashboard/src/components/ChartView/ChartDeployButton.tsx
+++ b/dashboard/src/components/ChartView/ChartDeployButton.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Redirect } from "react-router";
-import { definedNamespaces } from "../../shared/Namespace";
 import { IChartVersion } from "../../shared/types";
 
 interface IChartDeployButtonProps {
@@ -19,15 +18,10 @@ class ChartDeployButton extends React.Component<IChartDeployButtonProps, IChartD
 
   public render() {
     const { version } = this.props;
-    let { namespace } = this.props;
+    const { namespace } = this.props;
     const repoName = version.relationships.chart.data.repo.name;
     const chartName = version.relationships.chart.data.name;
     const versionStr = version.attributes.version;
-
-    // If our current namespace is not set a.k.a '_all' we actually set the default one
-    if (namespace === definedNamespaces.all) {
-      namespace = definedNamespaces.default;
-    }
 
     return (
       <div className="ChartDeployButton">

--- a/dashboard/src/components/ClassList/index.tsx
+++ b/dashboard/src/components/ClassList/index.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 
 import { IClusterServiceClass } from "../../shared/ClusterServiceClass";
+import { definedNamespaces } from "../../shared/Namespace";
 import { ForbiddenError, IRBACRole } from "../../shared/types";
 import Card, { CardContent, CardFooter, CardGrid, CardIcon } from "../Card";
 import { PermissionsErrorAlert, UnexpectedErrorAlert } from "../ErrorAlert";
@@ -74,7 +75,7 @@ export class ClassList extends React.Component<IClassListProps> {
       <PermissionsErrorAlert
         action="list Service Classes"
         roles={RequiredRBACRoles}
-        namespace="_all"
+        namespace={definedNamespaces.all}
       />
     ) : (
       <UnexpectedErrorAlert />

--- a/dashboard/src/components/ClassView/index.tsx
+++ b/dashboard/src/components/ClassView/index.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { RouterAction } from "react-router-redux";
 
 import { IClusterServiceClass } from "../../shared/ClusterServiceClass";
+import { definedNamespaces } from "../../shared/Namespace";
 import { IServicePlan } from "../../shared/ServiceCatalog";
 import { ForbiddenError, IRBACRole } from "../../shared/types";
 import { PermissionsErrorAlert, UnexpectedErrorAlert } from "../ErrorAlert";
@@ -137,7 +138,7 @@ export class ClassView extends React.Component<IClassViewProps> {
       <PermissionsErrorAlert
         action="list Service Plans"
         roles={RequiredRBACRoles}
-        namespace="_all"
+        namespace={definedNamespaces.all}
       />
     ) : (
       <UnexpectedErrorAlert />

--- a/dashboard/src/components/Config/ServiceBrokerList/ServiceBrokerList.tsx
+++ b/dashboard/src/components/Config/ServiceBrokerList/ServiceBrokerList.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { definedNamespaces } from "../../../shared/Namespace";
 import { IServiceBroker } from "../../../shared/ServiceCatalog";
 import { ForbiddenError, IRBACRole } from "../../../shared/types";
 import Card, { CardContent, CardFooter, CardGrid } from "../../Card";
@@ -82,7 +83,7 @@ class ServiceBrokerList extends React.Component<IServiceBrokerListProps> {
     return error instanceof ForbiddenError ? (
       <PermissionsErrorAlert
         action={`${action} Service Brokers`}
-        namespace="_all"
+        namespace={definedNamespaces.all}
         roles={RequiredRBACRoles[action]}
       />
     ) : (

--- a/dashboard/src/components/DeploymentForm/DeploymentErrors.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentErrors.tsx
@@ -59,7 +59,7 @@ class DeploymentErrors extends React.Component<IDeploymentErrorProps> {
           <UnexpectedErrorAlert
             text={error && error.message}
             raw={true}
-            title="Invalid deployment"
+            title="Failed installation"
           />
         );
       default:

--- a/dashboard/src/components/DeploymentForm/DeploymentErrors.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentErrors.tsx
@@ -55,7 +55,13 @@ class DeploymentErrors extends React.Component<IDeploymentErrorProps> {
           <NotFoundErrorAlert resource={`Application "${releaseName}"`} namespace={namespace} />
         );
       case UnprocessableEntity:
-        return <UnexpectedErrorAlert text={error && error.message} raw={true} />;
+        return (
+          <UnexpectedErrorAlert
+            text={error && error.message}
+            raw={true}
+            title="Invalid deployment"
+          />
+        );
       default:
         return <UnexpectedErrorAlert />;
     }

--- a/dashboard/src/components/ErrorAlert/NotFoundErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/NotFoundErrorAlert.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { X } from "react-feather";
 
+import { definedNamespaces } from "../../shared/Namespace";
 import ErrorPageHeader from "./ErrorAlertHeader";
 import { namespaceText } from "./helpers";
 
@@ -25,7 +26,7 @@ class NotFoundErrorPage extends React.Component<INotFoundErrorPageProps> {
             </span>
           )}
         </ErrorPageHeader>
-        {namespace === "_all" && (
+        {namespace === definedNamespaces.all && (
           <div className="error__content margin-l-enormous">
             <p>You may need to select a namespace.</p>
           </div>

--- a/dashboard/src/components/ErrorAlert/PermissionsListItem.tsx
+++ b/dashboard/src/components/ErrorAlert/PermissionsListItem.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { IRBACRole } from "shared/types";
+import { definedNamespaces } from "../../shared/Namespace";
 
 import { namespaceText } from "./helpers";
 
@@ -11,7 +12,9 @@ interface IPermissionsListItemProps {
 class PermissionsListItem extends React.Component<IPermissionsListItemProps> {
   public render() {
     const { role } = this.props;
-    const namespace = role.clusterWide ? "_all" : role.namespace || this.props.namespace;
+    const namespace = role.clusterWide
+      ? definedNamespaces.all
+      : role.namespace || this.props.namespace;
     return (
       <li>
         {role.verbs.join(", ")} <code>{role.resource}</code>{" "}

--- a/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.test.tsx
+++ b/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.test.tsx
@@ -1,0 +1,42 @@
+import { mount, shallow } from "enzyme";
+import * as React from "react";
+
+import UnexpectedErrorAlert from "./UnexpectedErrorAlert";
+
+describe("when no text is passed", () => {
+  it("renders a default troubleshooting info", () => {
+    const wrapper = shallow(<UnexpectedErrorAlert />);
+    expect(wrapper.text()).toContain("Troubleshooting");
+    expect(wrapper.text()).toContain("Open an issue on GitHub");
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe("when text is passed", () => {
+  const defaultProps = {
+    text: "This is my error message",
+  };
+
+  it("renders the message in a paragraph unless raw", () => {
+    const wrapper = shallow(<UnexpectedErrorAlert {...defaultProps} />);
+    const messageWrapper = wrapper.find("p");
+    expect(messageWrapper).toExist();
+    expect(messageWrapper.text()).toContain(defaultProps.text);
+  });
+
+  it("renders the message in a terminal if raw", () => {
+    const wrapper = shallow(<UnexpectedErrorAlert {...defaultProps} raw={true} />);
+    const messageWrapper = wrapper.find(".Terminal");
+    expect(messageWrapper).toExist();
+    expect(messageWrapper.text()).toContain(defaultProps.text);
+  });
+
+  it("uses the passed title or fallbacks to the default one", () => {
+    let wrapper = mount(<UnexpectedErrorAlert {...defaultProps} />);
+    expect(wrapper.text()).toContain("Sorry! Something went wrong");
+
+    wrapper = mount(<UnexpectedErrorAlert {...defaultProps} title="My error" />);
+    expect(wrapper.text()).not.toContain("Sorry! Something went wrong");
+    expect(wrapper.text()).toContain("My error");
+  });
+});

--- a/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/UnexpectedErrorAlert.tsx
@@ -7,6 +7,7 @@ import "./UnexpectedErrorAlert.css";
 interface IUnexpectedErrorPage {
   raw?: boolean;
   text?: string;
+  title?: string;
 }
 
 const genericMessage = (
@@ -30,6 +31,9 @@ const genericMessage = (
 );
 
 class UnexpectedErrorPage extends React.Component<IUnexpectedErrorPage> {
+  public static defaultProps: Partial<IUnexpectedErrorPage> = {
+    title: "Sorry! Something went wrong.",
+  };
   public render() {
     let message = genericMessage;
     if (this.props.text) {
@@ -45,9 +49,12 @@ class UnexpectedErrorPage extends React.Component<IUnexpectedErrorPage> {
         message = <p>{this.props.text}</p>;
       }
     }
+    // NOTE(miguel) We are using the non-undefined "!" token in `props.title` because our current version of
+    // typescript does not support react's defaultProps and we are running it in strictNullChecks mode.
+    // Newer versions of it seems to support it https://github.com/Microsoft/TypeScript/wiki/Roadmap#30-july-2018
     return (
       <div className="alert alert-error margin-t-bigger">
-        <ErrorPageHeader icon={X}>Sorry! Something went wrong.</ErrorPageHeader>
+        <ErrorPageHeader icon={X}>{this.props.title!}</ErrorPageHeader>
         <div className="error__content margin-l-enormous">{message}</div>
       </div>
     );

--- a/dashboard/src/components/ErrorAlert/__snapshots__/UnexpectedErrorAlert.test.tsx.snap
+++ b/dashboard/src/components/ErrorAlert/__snapshots__/UnexpectedErrorAlert.test.tsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`when no text is passed renders a default troubleshooting info 1`] = `
+<div
+  className="alert alert-error margin-t-bigger"
+>
+  <ErrorPageHeader
+    icon={[Function]}
+  >
+    Sorry! Something went wrong.
+  </ErrorPageHeader>
+  <div
+    className="error__content margin-l-enormous"
+  >
+    <div>
+      <p>
+        Troubleshooting:
+      </p>
+      <ul
+        className="error__troubleshooting"
+      >
+        <li>
+          Check for network issues.
+        </li>
+        <li>
+          Check your browser's JavaScript console for errors.
+        </li>
+        <li>
+          Check the health of Kubeapps components
+           
+          <code>
+            kubectl get po --all-namespaces -l created-by=kubeapps
+          </code>
+          .
+        </li>
+        <li>
+          <a
+            href="https://github.com/kubeapps/kubeapps/issues/new"
+            target="_blank"
+          >
+            Open an issue on GitHub
+          </a>
+           
+          if you think you've encountered a bug.
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/dashboard/src/components/ErrorAlert/helpers.tsx
+++ b/dashboard/src/components/ErrorAlert/helpers.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { definedNamespaces } from "../../shared/Namespace";
 
 export function namespaceText(namespace?: string) {
   if (!namespace) {
     return "";
   }
-  if (namespace === "_all") {
+  if (namespace === definedNamespaces.all) {
     return "all namespaces";
   } else {
     return (

--- a/dashboard/src/components/Header/NamespaceSelector.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as Select from "react-select";
 
 import { INamespaceState } from "../../reducers/namespace";
+import { definedNamespaces } from "../../shared/Namespace";
 
 import "./NamespaceSelector.css";
 
@@ -19,9 +20,10 @@ class NamespaceSelector extends React.Component<INamespaceSelectorProps> {
   public render() {
     const { namespace: { current, namespaces } } = this.props;
     const options = namespaces.map(n => ({ value: n, label: n }));
-    const allOption = { value: "_all", label: "All Namespaces" };
+    const allOption = { value: definedNamespaces.all, label: "All Namespaces" };
     options.unshift(allOption);
-    const value = current === "_all" ? allOption : { value: current, label: current };
+    const value =
+      current === definedNamespaces.all ? allOption : { value: current, label: current };
     return (
       <div className="NamespaceSelector margin-r-normal">
         <label className="NamespaceSelector__label type-tiny">NAMESPACE</label>

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -11,3 +11,9 @@ export default class Namespace {
   private static APIBase: string = "/api/kube";
   private static APIEndpoint: string = `${Namespace.APIBase}/api/v1/namespaces`;
 }
+
+// Set of namespaces used accross the applications as default and "all ns" placeholders
+export const definedNamespaces = {
+  default: "default",
+  all: "_all",
+};

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -1,4 +1,5 @@
 import { axios } from "./Auth";
+import { definedNamespaces } from "./Namespace";
 import { IOwnerReference, ISecret } from "./types";
 
 export default class Secret {
@@ -6,7 +7,7 @@ export default class Secret {
     name: string,
     secrets: { [s: string]: string },
     owner: IOwnerReference | undefined,
-    namespace: string = "default",
+    namespace: string = definedNamespaces.default,
   ) {
     const url = Secret.getLink(namespace);
     const { data } = await axios.post<ISecret>(url, {
@@ -22,18 +23,18 @@ export default class Secret {
     return data;
   }
 
-  public static async delete(name: string, namespace: string = "default") {
+  public static async delete(name: string, namespace: string = definedNamespaces.default) {
     const url = this.getLink(namespace, name);
     return axios.delete(url);
   }
 
-  public static async get(name: string, namespace: string = "default") {
+  public static async get(name: string, namespace: string = definedNamespaces.default) {
     const url = this.getLink(namespace, name);
     const { data } = await axios.get<ISecret>(url);
     return data;
   }
 
-  public static async list(namespace: string = "default") {
+  public static async list(namespace: string = definedNamespaces.default) {
     const url = Secret.getLink(namespace);
     const { data } = await axios.get<ISecret>(url);
     return data;

--- a/dashboard/src/shared/ServiceBinding.ts
+++ b/dashboard/src/shared/ServiceBinding.ts
@@ -1,4 +1,5 @@
 import { axios } from "./Auth";
+import { definedNamespaces } from "./Namespace";
 import { ICondition, ServiceCatalog } from "./ServiceCatalog";
 
 interface IK8sApiSecretResponse {
@@ -105,7 +106,7 @@ export class ServiceBinding {
     }/servicebindings${name ? `/${name}` : ""}`;
   }
 
-  private static secretEndpoint(namespace: string = "default"): string {
+  private static secretEndpoint(namespace: string = definedNamespaces.default): string {
     return `/api/kube/api/v1/namespaces/${namespace}/secrets/`;
   }
 }

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -1,3 +1,4 @@
+import { definedNamespaces } from "./Namespace";
 import { IServiceBroker } from "./ServiceCatalog";
 import { IChartVersion } from "./types";
 
@@ -13,7 +14,7 @@ export const app = {
 export const api = {
   apprepostories: {
     base: "/api/kube/apis/kubeapps.com/v1alpha1",
-    create: (namespace = "default") =>
+    create: (namespace = definedNamespaces.default) =>
       `${api.apprepostories.base}/namespaces/${namespace}/apprepositories`,
   },
 
@@ -32,7 +33,7 @@ export const api = {
 
   serviceinstances: {
     base: "/api/kube/apis/servicecatalog.k8s.io/v1beta1",
-    create: (namespace = "default") =>
+    create: (namespace = definedNamespaces.default) =>
       `${api.serviceinstances.base}/namespaces/${namespace}/serviceinstances`,
   },
 


### PR DESCRIPTION
**DEPRECATED**, see updated section below

It sets the deploy chart link to include the default namespace in the route instead of the _all placeholder. It also contains some refactoring to start storing some hardcoded defined namespaces into a shared module.

The meat itself is in here https://github.com/kubeapps/kubeapps/pull/595/files#diff-4

NOTE: I decided to set modify the link instead of redirect within the NewApp container to not to add extra code to handle this behavior. At the end of the day it seems that today we only access to deploy app from that button, if that changes we can revisit it.

Also, I did not add a regexp in the route `/apps/new` that excludes `/ns/_all` because it seems that so far we are being permissive in that route so I thought that it was not worth it.

Fixes https://github.com/kubeapps/kubeapps/issues/566

**UPDATE**

After a round of feedback, the implementation of this feature has changed from doing a redirect when the user clicked deploy to show an error message during that edge case and not to make assumptions about where to redirect the user. More info here https://github.com/kubeapps/kubeapps/pull/595#issuecomment-419499734

![selection_273](https://user-images.githubusercontent.com/24523/45246331-9006f580-b2b5-11e8-936a-3eaeb10b41df.png)

It also contains:

* Raise of UnprocessableEntity if the namespace is not valid. This matches usual API responses during validation errors.
* Refactor of minor namespace definitions
* Extension of the `UnexpectedErrorPage` to support an optional title since "Something went wrong" did not match a 422 error in my opinion.
* I do not like that I am using the "raw" mode which shows a terminal but it is the way the component is bundled and will require more work to untangle it. I think it's not worth it since we might eventually move to another notification method.

