### PR TITLE
Make annotations defaults consistent

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.4.0
+version: 0.4.1
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -92,7 +92,7 @@ frontend:
   service:
     port: 80
     type: ClusterIP
-    # annotations: {}
+    annotations: {}
   livenessProbe:
     httpGet:
       path: /healthz
@@ -142,7 +142,7 @@ tillerProxy:
 
 ingress:
   enabled: false
-  # annotations: {}
+  annotations: {}
   path: /
   hosts:
   - kubeapps.local


### PR DESCRIPTION
Based on this discussion https://github.com/kubeapps/kubeapps/pull/587/files#r215954708


See below the comparative based on the template render before and after the change with ingress enabled:

```bash
helm template . --set ingress.enabled=true > /tmp/[before/after]_change.yaml
```
The change does not affect the default outputs, the mongoDB password is expected to be generated

```bash
diff /tmp/before_change.yaml /tmp/after_change.yaml 
14c14
<   mongodb-root-password: "TTI2Qlc0dXY2Sg=="
---
>   mongodb-root-password: "NVplRXVTVVRvcQ=="
```