### PR TITLE
rename kubeapps-dashboard svc to sound more internal

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.4.1
+version: 0.4.2
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -51,42 +51,42 @@ Create chart name and version as used by the chart label.
 Create name for the apprepository-controller based on the fullname
 */}}
 {{- define "kubeapps.apprepository.fullname" -}}
-{{ template "kubeapps.fullname" . }}-apprepository-controller
+{{ template "kubeapps.fullname" . }}-internal-apprepository-controller
 {{- end -}}
 
 {{/*
 Create name for the apprepository bootstrap job
 */}}
 {{- define "kubeapps.apprepository-jobs-bootstrap.fullname" -}}
-{{ template "kubeapps.fullname" . }}-apprepository-jobs-bootstrap
+{{ template "kubeapps.fullname" . }}-internal-apprepository-jobs-bootstrap
 {{- end -}}
 
 {{/*
 Create name for the apprepository cleanup job
 */}}
 {{- define "kubeapps.apprepository-jobs-cleanup.fullname" -}}
-{{ template "kubeapps.fullname" . }}-apprepository-jobs-cleanup
+{{ template "kubeapps.fullname" . }}-internal-apprepository-jobs-cleanup
 {{- end -}}
 
 {{/*
 Create name for the chartsvc based on the fullname
 */}}
 {{- define "kubeapps.chartsvc.fullname" -}}
-{{ template "kubeapps.fullname" . }}-chartsvc
+{{ template "kubeapps.fullname" . }}-internal-chartsvc
 {{- end -}}
 
 {{/*
 Create name for the dashboard based on the fullname
 */}}
 {{- define "kubeapps.dashboard.fullname" -}}
-{{ template "kubeapps.fullname" . }}-dashboard
+{{ template "kubeapps.fullname" . }}-internal-dashboard
 {{- end -}}
 
 {{/*
 Create name for the dashboard config based on the fullname
 */}}
 {{- define "kubeapps.dashboard-config.fullname" -}}
-{{ template "kubeapps.fullname" . }}-dashboard-config
+{{ template "kubeapps.fullname" . }}-internal-dashboard-config
 {{- end -}}
 
 {{/*
@@ -100,5 +100,5 @@ Create name for the frontend config based on the fullname
 Create name for the tiller-proxy based on the fullname
 */}}
 {{- define "kubeapps.tiller-proxy.fullname" -}}
-{{ template "kubeapps.fullname" . }}-tiller-proxy
+{{ template "kubeapps.fullname" . }}-internal-tiller-proxy
 {{- end -}}

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -79,14 +79,14 @@ Create name for the chartsvc based on the fullname
 Create name for the dashboard based on the fullname
 */}}
 {{- define "kubeapps.dashboard.fullname" -}}
-{{ template "kubeapps.fullname" . }}-dashboard
+{{ template "kubeapps.fullname" . }}-react
 {{- end -}}
 
 {{/*
 Create name for the dashboard config based on the fullname
 */}}
 {{- define "kubeapps.dashboard-config.fullname" -}}
-{{ template "kubeapps.fullname" . }}-dashboard-config
+{{ template "kubeapps.fullname" . }}-react-config
 {{- end -}}
 
 {{/*

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -79,14 +79,14 @@ Create name for the chartsvc based on the fullname
 Create name for the dashboard based on the fullname
 */}}
 {{- define "kubeapps.dashboard.fullname" -}}
-{{ template "kubeapps.fullname" . }}-react
+{{ template "kubeapps.fullname" . }}-dashboard
 {{- end -}}
 
 {{/*
 Create name for the dashboard config based on the fullname
 */}}
 {{- define "kubeapps.dashboard-config.fullname" -}}
-{{ template "kubeapps.fullname" . }}-react-config
+{{ template "kubeapps.fullname" . }}-dashboard-config
 {{- end -}}
 
 {{/*

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1,88 +1,16 @@
-# Default values for kubeapps.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-apprepository:
-  image:
-    registry: docker.io
-    repository: kubeapps/apprepository-controller
-    tag: latest
-  # Image used to perform chart repository syncs
-  syncImage:
-    registry: docker.io
-    repository: kubeapps/chart-repo
-    tag: latest
-  # This image is used in a Helm post-install hook to bootstrap the initialRepos below
-  jobsImage:
-    registry: docker.io
-    repository: lachlanevenson/k8s-kubectl
-    tag: v1.9.9
-  initialRepos:
-  - name: stable
-    url: https://kubernetes-charts.storage.googleapis.com
-  - name: incubator
-    url: https://kubernetes-charts-incubator.storage.googleapis.com
-  - name: svc-cat
-    url: https://svc-catalog-charts.storage.googleapis.com
-  - name: bitnami
-    url: https://charts.bitnami.com/bitnami
-  resources: {}
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
-  
-chartsvc:
-  image:
-    registry: docker.io
-    repository: kubeapps/chartsvc
-    tag: latest
-  service:
-    port: 8080
-  resources: {}
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
-
-dashboard:
-  image:
-    registry: docker.io
-    repository: kubeapps/dashboard
-    tag: latest
-  service:
-    port: 8080
-  livenessProbe:
-    httpGet:
-      path: /
-      port: 8080
-    initialDelaySeconds: 60
-    timeoutSeconds: 5
-  readinessProbe:
-    httpGet:
-      path: /
-      port: 8080
-    initialDelaySeconds: 0
-    timeoutSeconds: 5
-  resources: {}
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
+# The frontend service is the main reverse proxy used to access the Kubeapps UI
+# To expose Kubeapps externally either configure the ingress object below or
+# set frontend.service.type=LoadBalancer in the frontend configuration.
+ingress:
+  enabled: false
+  annotations: {}
+  path: /
+  hosts:
+  - kubeapps.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 frontend:
   image:
@@ -116,6 +44,46 @@ frontend:
   tolerations: []
   affinity: {}
 
+# AppRepository Controller is the controller used to manage the repositories to
+# sync. Set apprepository.initialRepos to configure the initial set of
+# repositories to use when first installing Kubeapps.
+  image:
+    registry: docker.io
+    repository: kubeapps/apprepository-controller
+    tag: latest
+  # Image used to perform chart repository syncs
+  syncImage:
+    registry: docker.io
+    repository: kubeapps/chart-repo
+    tag: latest
+  # This image is used in a Helm post-install hook to bootstrap the initialRepos below
+  jobsImage:
+    registry: docker.io
+    repository: lachlanevenson/k8s-kubectl
+    tag: v1.9.9
+  initialRepos:
+  - name: stable
+    url: https://kubernetes-charts.storage.googleapis.com
+  - name: incubator
+    url: https://kubernetes-charts-incubator.storage.googleapis.com
+  - name: svc-cat
+    url: https://svc-catalog-charts.storage.googleapis.com
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Tiller Proxy is a secure REST API on top of Helm's Tiller component used to
+# manage Helm chart releases in the cluster from Kubeapps. Set tillerProxy.host
+# to configure a different Tiller host to use.
 tillerProxy:
   image:
     registry: docker.io
@@ -140,16 +108,57 @@ tillerProxy:
   tolerations: []
   affinity: {}
 
-ingress:
-  enabled: false
-  annotations: {}
-  path: /
-  hosts:
-  - kubeapps.local
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+# Chartsvc is used to serve chart metadata over a REST API.
+chartsvc:
+  image:
+    registry: docker.io
+    repository: kubeapps/chartsvc
+    tag: latest
+  service:
+    port: 8080
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Dashboard serves the compiled static React frontend application. This is an
+# internal service used by the main frontend reverse-proxy and should not be
+# accessed directly.
+dashboard:
+  image:
+    registry: docker.io
+    repository: kubeapps/dashboard
+    tag: latest
+  service:
+    port: 8080
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 8080
+    initialDelaySeconds: 60
+    timeoutSeconds: 5
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 8080
+    initialDelaySeconds: 0
+    timeoutSeconds: 5
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 mongodb:
   # Kubeapps uses MongoDB as a cache and persistence is not required


### PR DESCRIPTION
In order to avoid confusion around the `kubeapps-dashboard` and
`kubeapps` Service, we should rename the `kubeapps-dashboard` Service
to sound like more of an internal component rather than a possible
entrypoint to the dashboard.

fixes #602 