### PR TITLE
Check missing chart repository

### DIFF
--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -3,7 +3,7 @@ import thunk from "redux-thunk";
 import { getType } from "typesafe-actions";
 
 import actions from ".";
-import { MissingChart } from "../shared/types";
+import { NotFoundError } from "../shared/types";
 
 const mockStore = configureMockStore([thunk]);
 
@@ -40,10 +40,11 @@ describe("fetchCharts", () => {
     expect(store.getActions()).toEqual(expectedActions);
     expect(fetchMock.mock.calls[0][0]).toBe("/api/chartsvc/v1/charts/foo");
   });
+
   it("returns a 404 error", async () => {
     const expectedActions = [
       { type: getType(actions.charts.requestCharts) },
-      { type: getType(actions.charts.errorChart), err: new MissingChart("not found") },
+      { type: getType(actions.charts.errorChart), err: new NotFoundError("not found") },
     ];
     fetchMock = jest.fn(() => {
       return {
@@ -58,6 +59,7 @@ describe("fetchCharts", () => {
     await store.dispatch(actions.charts.fetchCharts("foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
+
   it("returns a generic error", async () => {
     const expectedActions = [
       { type: getType(actions.charts.requestCharts) },
@@ -116,11 +118,12 @@ describe("fetchChartVersionsAndSelectVersion", () => {
     expect(store.getActions()).toEqual(expectedActions);
     expect(fetchMock.mock.calls[0][0]).toBe("/api/chartsvc/v1/charts/foo/versions");
   });
+
   it("returns a not found error", async () => {
     response = [{ id: "foo", attributes: { version: "1.0.0" } }];
     const expectedActions = [
       { type: getType(actions.charts.requestCharts) },
-      { type: getType(actions.charts.errorChart), err: new MissingChart("not found") },
+      { type: getType(actions.charts.errorChart), err: new NotFoundError("not found") },
     ];
     fetchMock = jest.fn(() => {
       return {

--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -1,0 +1,139 @@
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+import { getType } from "typesafe-actions";
+
+import actions from ".";
+import { MissingChart } from "../shared/types";
+
+const mockStore = configureMockStore([thunk]);
+
+let store: any;
+const fetchOrig = window.fetch;
+let fetchMock: jest.Mock;
+let response: any;
+
+beforeEach(() => {
+  store = mockStore();
+  fetchMock = jest.fn(() => {
+    return {
+      ok: true,
+      json: () => {
+        return { data: response };
+      },
+    };
+  });
+  window.fetch = fetchMock;
+});
+
+afterEach(() => {
+  window.fetch = fetchOrig;
+});
+
+describe("fetchCharts", () => {
+  it("fetches charts from a repo", async () => {
+    response = [{ id: "foo" }];
+    const expectedActions = [
+      { type: getType(actions.charts.requestCharts) },
+      { type: getType(actions.charts.receiveCharts), charts: response },
+    ];
+    await store.dispatch(actions.charts.fetchCharts("foo"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/chartsvc/v1/charts/foo");
+  });
+  it("returns a 404 error", async () => {
+    const expectedActions = [
+      { type: getType(actions.charts.requestCharts) },
+      { type: getType(actions.charts.errorChart), err: new MissingChart("not found") },
+    ];
+    fetchMock = jest.fn(() => {
+      return {
+        ok: false,
+        status: 404,
+        json: () => {
+          return { data: "not found" };
+        },
+      };
+    });
+    window.fetch = fetchMock;
+    await store.dispatch(actions.charts.fetchCharts("foo"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+  it("returns a generic error", async () => {
+    const expectedActions = [
+      { type: getType(actions.charts.requestCharts) },
+      { type: getType(actions.charts.errorChart), err: new Error("something went wrong") },
+    ];
+    fetchMock = jest.fn(() => {
+      return {
+        ok: false,
+        status: 500,
+        json: () => {
+          return { data: "something went wrong" };
+        },
+      };
+    });
+    window.fetch = fetchMock;
+    await store.dispatch(actions.charts.fetchCharts("foo"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe("fetchChartVersions", () => {
+  it("fetches chart versions", async () => {
+    response = [{ id: "foo" }];
+    const expectedActions = [
+      { type: getType(actions.charts.requestCharts) },
+      { type: getType(actions.charts.receiveChartVersions), versions: response },
+    ];
+    await store.dispatch(actions.charts.fetchChartVersions("foo"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/chartsvc/v1/charts/foo/versions");
+  });
+});
+
+describe("getChartVersion", () => {
+  it("gets a chart version", async () => {
+    response = { id: "foo" };
+    const expectedActions = [
+      { type: getType(actions.charts.requestCharts) },
+      { type: getType(actions.charts.selectChartVersion), chartVersion: response },
+    ];
+    await store.dispatch(actions.charts.getChartVersion("foo", "1.0.0"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/chartsvc/v1/charts/foo/versions/1.0.0");
+  });
+});
+
+describe("fetchChartVersionsAndSelectVersion", () => {
+  it("fetches charts and select a version", async () => {
+    response = [{ id: "foo", attributes: { version: "1.0.0" } }];
+    const expectedActions = [
+      { type: getType(actions.charts.requestCharts) },
+      { type: getType(actions.charts.receiveChartVersions), versions: response },
+      { type: getType(actions.charts.selectChartVersion), chartVersion: response[0] },
+    ];
+    await store.dispatch(actions.charts.fetchChartVersionsAndSelectVersion("foo", "1.0.0"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/chartsvc/v1/charts/foo/versions");
+  });
+  it("returns a not found error", async () => {
+    response = [{ id: "foo", attributes: { version: "1.0.0" } }];
+    const expectedActions = [
+      { type: getType(actions.charts.requestCharts) },
+      { type: getType(actions.charts.errorChart), err: new MissingChart("not found") },
+    ];
+    fetchMock = jest.fn(() => {
+      return {
+        ok: false,
+        status: 404,
+        json: () => {
+          return { data: "not found" };
+        },
+      };
+    });
+    window.fetch = fetchMock;
+    await store.dispatch(actions.charts.fetchChartVersionsAndSelectVersion("foo", "1.0.0"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/chartsvc/v1/charts/foo/versions");
+  });
+});

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -57,49 +57,62 @@ const allActions = [
 ].map(getReturnOfExpression);
 export type ChartsAction = typeof allActions[number];
 
+async function httpGet(dispatch: Dispatch<IStoreState>, targetURL: string) {
+  try {
+    const response = await fetch(targetURL);
+    const json = await response.json();
+    if (!response.ok) {
+      const error = json.data || response.statusText;
+      if (response.status === 404) {
+        dispatch(errorChart(new MissingChart(error)));
+      } else {
+        dispatch(errorChart(new Error(error)));
+      }
+    } else {
+      return json.data;
+    }
+  } catch (e) {
+    dispatch(errorChart(e));
+  }
+}
+
 export function fetchCharts(repo: string) {
-  return (dispatch: Dispatch<IStoreState>): Promise<{}> => {
+  return async (dispatch: Dispatch<IStoreState>): Promise<{}> => {
     dispatch(requestCharts());
-    return fetch(url.api.charts.list(repo))
-      .then(response => response.json())
-      .then(json => dispatch(receiveCharts(json.data)));
+    const response = await httpGet(dispatch, url.api.charts.list(repo));
+    if (response) {
+      dispatch(receiveCharts(response));
+    }
+    return response;
   };
 }
 
 export function fetchChartVersions(id: string) {
-  return (dispatch: Dispatch<IStoreState>): Promise<{}> => {
+  return async (dispatch: Dispatch<IStoreState>): Promise<{}> => {
     dispatch(requestCharts());
-    return fetch(url.api.charts.listVersions(id))
-      .then(response => response.json())
-      .then(json => dispatch(receiveChartVersions(json.data)));
+    const response = await httpGet(dispatch, url.api.charts.listVersions(id));
+    if (response) {
+      dispatch(receiveChartVersions(response));
+    }
+    return response;
   };
 }
 
 export function getChartVersion(id: string, version: string) {
-  return async (dispatch: Dispatch<IStoreState>) => {
+  return async (dispatch: Dispatch<IStoreState>): Promise<{}> => {
     dispatch(requestCharts());
-    try {
-      const response = await fetch(url.api.charts.getVersion(id, version));
-      const json = await response.json();
-      if (!response.ok) {
-        const error = json.data || response.statusText;
-        if (response.status === 404) {
-          dispatch(errorChart(new MissingChart(error)));
-        } else {
-          dispatch(errorChart(new Error(error)));
-        }
-      }
-      dispatch(selectChartVersion(json.data));
-    } catch (e) {
-      dispatch(errorChart(e));
+    const response = await httpGet(dispatch, url.api.charts.getVersion(id, version));
+    if (response) {
+      dispatch(selectChartVersion(response));
     }
+    return response;
   };
 }
 
 export function fetchChartVersionsAndSelectVersion(id: string, version?: string) {
-  return (dispatch: Dispatch<IStoreState>): Promise<{}> => {
-    return dispatch(fetchChartVersions(id)).then((action: any) => {
-      const versions: IChartVersion[] = action.versions;
+  return async (dispatch: Dispatch<IStoreState>) => {
+    const versions = (await dispatch(fetchChartVersions(id))) as IChartVersion[];
+    if (versions) {
       let cv: IChartVersion = versions[0];
       if (version) {
         const found = versions.find(v => v.attributes.version === version);
@@ -108,8 +121,8 @@ export function fetchChartVersionsAndSelectVersion(id: string, version?: string)
         }
         cv = found;
       }
-      return dispatch(selectChartVersion(cv));
-    });
+      dispatch(selectChartVersion(cv));
+    }
   };
 }
 

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -2,7 +2,7 @@ import { Dispatch } from "redux";
 import { createAction, getReturnOfExpression } from "typesafe-actions";
 
 import Chart from "../shared/Chart";
-import { IChart, IChartVersion, IStoreState, MissingChart } from "../shared/types";
+import { IChart, IChartVersion, IStoreState, NotFoundError } from "../shared/types";
 import * as url from "../shared/url";
 
 export const requestCharts = createAction("REQUEST_CHARTS");
@@ -64,7 +64,7 @@ async function httpGet(dispatch: Dispatch<IStoreState>, targetURL: string) {
     if (!response.ok) {
       const error = json.data || response.statusText;
       if (response.status === 404) {
-        dispatch(errorChart(new MissingChart(error)));
+        dispatch(errorChart(new NotFoundError(error)));
       } else {
         dispatch(errorChart(new Error(error)));
       }

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -5,7 +5,7 @@ import { AppRepository } from "../shared/AppRepository";
 import Secret from "../shared/Secret";
 import * as url from "../shared/url";
 
-import { IAppRepository, IOwnerReference, IStoreState, MissingChart } from "../shared/types";
+import { IAppRepository, IOwnerReference, IStoreState, NotFoundError } from "../shared/types";
 
 export const addRepo = createAction("ADD_REPO");
 export const addedRepo = createAction("ADDED_REPO", (added: IAppRepository) => ({
@@ -168,7 +168,7 @@ export function checkChart(repo: string, chartName: string) {
       dispatch(receiveRepo(appRepository));
     } else {
       dispatch(
-        errorChart(new MissingChart(`Chart ${chartName} not found in the repository ${repo}.`)),
+        errorChart(new NotFoundError(`Chart ${chartName} not found in the repository ${repo}.`)),
       );
     }
   };

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -31,7 +31,7 @@ interface IAppUpgradeProps {
   fetchChartVersions: (id: string) => Promise<{}>;
   getApp: (releaseName: string, namespace: string) => Promise<void>;
   getBindings: () => Promise<IServiceBindingWithSecret[]>;
-  getChartVersion: (id: string, chartVersion: string) => Promise<void>;
+  getChartVersion: (id: string, chartVersion: string) => Promise<{}>;
   getChartValues: (id: string, chartVersion: string) => Promise<any>;
   push: (location: string) => RouterAction;
   fetchRepositories: () => Promise<void>;

--- a/dashboard/src/components/ChartView/ChartView.test.tsx
+++ b/dashboard/src/components/ChartView/ChartView.test.tsx
@@ -1,7 +1,9 @@
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import { IChartState, IChartVersion } from "../../shared/types";
+import { IChartState, IChartVersion, NotFoundError } from "../../shared/types";
+import NotFoundErrorPage from "../ErrorAlert/NotFoundErrorAlert";
+import UnexpectedErrorPage from "../ErrorAlert/UnexpectedErrorAlert";
 import ChartDeployButton from "./ChartDeployButton";
 import ChartHeader from "./ChartHeader";
 import ChartMaintainers from "./ChartMaintainers";
@@ -184,4 +186,15 @@ it("renders the sources links when set", () => {
       </a>,
     ),
   ).toBe(true);
+});
+
+describe("renders errors", () => {
+  it("renders a not found error if it exists", () => {
+    const wrapper = shallow(<ChartView {...props} selected={{ error: new NotFoundError() }} />);
+    expect(wrapper.find(NotFoundErrorPage).exists()).toBe(true);
+  });
+  it("renders a generic error if it exists", () => {
+    const wrapper = shallow(<ChartView {...props} selected={{ error: new Error() }} />);
+    expect(wrapper.find(UnexpectedErrorPage).exists()).toBe(true);
+  });
 });

--- a/dashboard/src/components/ChartView/ChartView.tsx
+++ b/dashboard/src/components/ChartView/ChartView.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { IChartState, IChartVersion, MissingChart, NotFoundError } from "../../shared/types";
+import { IChartState, IChartVersion, NotFoundError } from "../../shared/types";
 import { NotFoundErrorAlert, UnexpectedErrorAlert } from "../ErrorAlert";
 import ChartDeployButton from "./ChartDeployButton";
 import ChartHeader from "./ChartHeader";
@@ -146,7 +146,6 @@ class ChartView extends React.Component<IChartViewProps> {
   private renderError(error: Error, action: string = "view") {
     const { chartID } = this.props;
     switch (error.constructor) {
-      case MissingChart:
       case NotFoundError:
         return <NotFoundErrorAlert resource={`Chart "${chartID}"`} />;
       default:

--- a/dashboard/src/components/ChartView/ChartView.tsx
+++ b/dashboard/src/components/ChartView/ChartView.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
-import { IChartState, IChartVersion } from "../../shared/types";
+import { IChartState, IChartVersion, MissingChart, NotFoundError } from "../../shared/types";
+import { NotFoundErrorAlert, UnexpectedErrorAlert } from "../ErrorAlert";
 import ChartDeployButton from "./ChartDeployButton";
 import ChartHeader from "./ChartHeader";
 import ChartMaintainers from "./ChartMaintainers";
@@ -10,7 +11,7 @@ import "./ChartView.css";
 
 interface IChartViewProps {
   chartID: string;
-  fetchChartVersionsAndSelectVersion: (id: string, version?: string) => Promise<{}>;
+  fetchChartVersionsAndSelectVersion: (id: string, version?: string) => Promise<void>;
   isFetching: boolean;
   selected: IChartState["selected"];
   selectChartVersion: (version: IChartVersion) => any;
@@ -45,7 +46,10 @@ class ChartView extends React.Component<IChartViewProps> {
 
   public render() {
     const { isFetching, getChartReadme, namespace } = this.props;
-    const { version, readme, readmeError, versions } = this.props.selected;
+    const { version, readme, error, readmeError, versions } = this.props.selected;
+    if (error) {
+      return this.renderError(error);
+    }
     if (isFetching || !version) {
       return <div>Loading</div>;
     }
@@ -137,6 +141,17 @@ class ChartView extends React.Component<IChartViewProps> {
       repoURL === "https://kubernetes-charts.storage.googleapis.com" ||
       repoURL === "https://kubernetes-charts-incubator.storage.googleapis.com"
     );
+  }
+
+  private renderError(error: Error, action: string = "view") {
+    const { chartID } = this.props;
+    switch (error.constructor) {
+      case MissingChart:
+      case NotFoundError:
+        return <NotFoundErrorAlert resource={`Chart "${chartID}"`} />;
+      default:
+        return <UnexpectedErrorAlert />;
+    }
   }
 }
 

--- a/dashboard/src/components/DeploymentForm/DeploymentErrors.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentErrors.tsx
@@ -3,7 +3,6 @@ import {
   AppConflict,
   ForbiddenError,
   IRBACRole,
-  MissingChart,
   NotFoundError,
   UnprocessableEntity,
 } from "../../shared/types";
@@ -21,7 +20,7 @@ interface IDeploymentErrorProps {
 
 class DeploymentErrors extends React.Component<IDeploymentErrorProps> {
   public render() {
-    const { chartName, error, namespace, releaseName, repo, version } = this.props;
+    const { error, namespace, releaseName } = this.props;
     switch (error && error.constructor) {
       case AppConflict:
         return (
@@ -45,10 +44,6 @@ class DeploymentErrors extends React.Component<IDeploymentErrorProps> {
             roles={roles}
             action={`deploy the application "${releaseName}"`}
           />
-        );
-      case MissingChart:
-        return (
-          <NotFoundErrorAlert header={`Chart ${chartName} (v${version}) not found in ${repo}`} />
         );
       case NotFoundError:
         return (

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -1,6 +1,6 @@
 import { shallow } from "enzyme";
 import * as React from "react";
-import { IChartState, IChartVersion, MissingChart } from "../../shared/types";
+import { IChartState, IChartVersion, NotFoundError } from "../../shared/types";
 import NotFoundErrorPage from "../ErrorAlert/NotFoundErrorAlert";
 import UnexpectedErrorPage from "../ErrorAlert/UnexpectedErrorAlert";
 import DeploymentForm from "./DeploymentForm";
@@ -30,7 +30,7 @@ describe("renders an error", () => {
     const wrapper = shallow(
       <DeploymentForm
         {...defaultProps}
-        selected={{ error: new MissingChart() } as IChartState["selected"]}
+        selected={{ error: new NotFoundError() } as IChartState["selected"]}
       />,
     );
     expect(wrapper.find(NotFoundErrorPage).exists()).toBe(true);

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -1,0 +1,55 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+import { IChartState, IChartVersion, MissingChart } from "../../shared/types";
+import NotFoundErrorPage from "../ErrorAlert/NotFoundErrorAlert";
+import UnexpectedErrorPage from "../ErrorAlert/UnexpectedErrorAlert";
+import DeploymentForm from "./DeploymentForm";
+
+const defaultProps = {
+  kubeappsNamespace: "kubeapps",
+  bindingsWithSecrets: [],
+  chartID: "foo",
+  chartVersion: "1.0.0",
+  error: undefined,
+  selected: {} as IChartState["selected"],
+  deployChart: jest.fn(),
+  push: jest.fn(),
+  fetchChartVersions: jest.fn(),
+  getBindings: jest.fn(),
+  getChartVersion: jest.fn(),
+  getChartValues: jest.fn(),
+  namespace: "default",
+};
+it("renders a loading message if the selected chart is not ready", () => {
+  const wrapper = shallow(<DeploymentForm {...defaultProps} />);
+  expect(wrapper.text()).toContain("Loading");
+});
+
+describe("renders an error", () => {
+  it("renders an error if it cannot find the given chart", () => {
+    const wrapper = shallow(
+      <DeploymentForm
+        {...defaultProps}
+        selected={{ error: new MissingChart() } as IChartState["selected"]}
+      />,
+    );
+    expect(wrapper.find(NotFoundErrorPage).exists()).toBe(true);
+  });
+  it("renders a generic error", () => {
+    const wrapper = shallow(
+      <DeploymentForm
+        {...defaultProps}
+        selected={{ error: new Error() } as IChartState["selected"]}
+      />,
+    );
+    expect(wrapper.find(UnexpectedErrorPage).exists()).toBe(true);
+  });
+});
+
+it("renders the full DeploymentForm", () => {
+  const versions = [{ id: "foo", attributes: { version: "1.2.3" } }] as IChartVersion[];
+  const wrapper = shallow(
+    <DeploymentForm {...defaultProps} selected={{ versions, version: versions[0] }} />,
+  );
+  expect(wrapper).toMatchSnapshot();
+});

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -20,6 +20,7 @@ const defaultProps = {
   getChartValues: jest.fn(),
   namespace: "default",
 };
+
 it("renders a loading message if the selected chart is not ready", () => {
   const wrapper = shallow(<DeploymentForm {...defaultProps} />);
   expect(wrapper.text()).toContain("Loading");
@@ -35,6 +36,7 @@ describe("renders an error", () => {
     );
     expect(wrapper.find(NotFoundErrorPage).exists()).toBe(true);
   });
+
   it("renders a generic error", () => {
     const wrapper = shallow(
       <DeploymentForm

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -3,7 +3,7 @@ import AceEditor from "react-ace";
 import { RouterAction } from "react-router-redux";
 
 import { IServiceBindingWithSecret } from "../../shared/ServiceBinding";
-import { IChartState, IChartVersion, MissingChart, NotFoundError } from "../../shared/types";
+import { IChartState, IChartVersion, NotFoundError } from "../../shared/types";
 import DeploymentBinding from "./DeploymentBinding";
 import DeploymentErrors from "./DeploymentErrors";
 
@@ -213,11 +213,10 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   };
 
   private renderSelectedError(error: Error) {
-    const { chartID } = this.props;
+    const { chartID, chartVersion } = this.props;
     switch (error.constructor) {
-      case MissingChart:
       case NotFoundError:
-        return <NotFoundErrorAlert resource={`Chart "${chartID}"`} />;
+        return <NotFoundErrorAlert resource={`Chart "${chartID}" (${chartVersion})`} />;
       default:
         return <UnexpectedErrorAlert />;
     }

--- a/dashboard/src/components/DeploymentForm/__snapshots__/DeploymentForm.test.tsx.snap
+++ b/dashboard/src/components/DeploymentForm/__snapshots__/DeploymentForm.test.tsx.snap
@@ -1,0 +1,130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders the full DeploymentForm 1`] = `
+<div>
+  <form
+    className="container padding-b-bigger"
+    onSubmit={[Function]}
+  >
+    <div
+      className="row"
+    >
+      <div
+        className="col-12"
+      >
+        <h2>
+          foo
+        </h2>
+      </div>
+      <div
+        className="col-8"
+      >
+        <div>
+          <label
+            htmlFor="releaseName"
+          >
+            Name
+          </label>
+          <input
+            id="releaseName"
+            onChange={[Function]}
+            pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+            required={true}
+            title="Use lower case alphanumeric characters, '-' or '.'"
+            value=""
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="chartVersion"
+          >
+            Version
+          </label>
+          <select
+            id="chartVersion"
+            onChange={[Function]}
+            required={true}
+            value="1.2.3"
+          >
+            <option
+              key="foo"
+              value="1.2.3"
+            >
+              1.2.3
+               
+            </option>
+          </select>
+        </div>
+        <div
+          style={
+            Object {
+              "marginBottom": "1em",
+            }
+          }
+        >
+          <label
+            htmlFor="values"
+          >
+            Values (YAML)
+          </label>
+          <ReactAce
+            cursorStart={1}
+            editorProps={
+              Object {
+                "$blockScrolling": Infinity,
+              }
+            }
+            enableBasicAutocompletion={false}
+            enableLiveAutocompletion={false}
+            focus={false}
+            fontSize={12}
+            height="500px"
+            highlightActiveLine={true}
+            maxLines={null}
+            minLines={null}
+            mode="yaml"
+            name="values"
+            onChange={[Function]}
+            onLoad={null}
+            onPaste={null}
+            onScroll={null}
+            readOnly={false}
+            scrollMargin={
+              Array [
+                0,
+                0,
+                0,
+                0,
+              ]
+            }
+            setOptions={
+              Object {
+                "showPrintMargin": false,
+              }
+            }
+            showGutter={true}
+            showPrintMargin={true}
+            style={Object {}}
+            tabSize={4}
+            theme="xcode"
+            value=""
+            width="100%"
+            wrapEnabled={false}
+          />
+        </div>
+        <div>
+          <button
+            className="button button-primary"
+            type="submit"
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+      <div
+        className="col-4"
+      />
+    </div>
+  </form>
+</div>
+`;

--- a/dashboard/src/components/UpgradeForm/SelectRepoForm.tsx
+++ b/dashboard/src/components/UpgradeForm/SelectRepoForm.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { ForbiddenError, IAppRepository, IRBACRole, MissingChart } from "../../shared/types";
+import { ForbiddenError, IAppRepository, IRBACRole, NotFoundError } from "../../shared/types";
 
 import { NotFoundErrorAlert, PermissionsErrorAlert, UnexpectedErrorAlert } from "../ErrorAlert";
 
@@ -83,7 +83,7 @@ class SelectRepoForm extends React.Component<ISelectRepoFormProps, ISelectRepoFo
   private renderError() {
     if (this.props.error) {
       switch (this.props.error.constructor) {
-        case MissingChart:
+        case NotFoundError:
           return <NotFoundErrorAlert header={this.props.error.message} />;
         case ForbiddenError:
           return (

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -30,7 +30,7 @@ interface IDeploymentFormProps {
   push: (location: string) => RouterAction;
   fetchChartVersions: (id: string) => Promise<{}>;
   getBindings: (ns: string) => Promise<IServiceBindingWithSecret[]>;
-  getChartVersion: (id: string, chartVersion: string) => Promise<void>;
+  getChartVersion: (id: string, chartVersion: string) => Promise<{}>;
   getChartValues: (id: string, chartVersion: string) => Promise<any>;
   clearRepo: () => any;
 }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -22,8 +22,6 @@ export class UnauthorizedError extends CustomError {}
 
 export class NotFoundError extends CustomError {}
 
-export class MissingChart extends CustomError {}
-
 export class AppConflict extends CustomError {}
 
 export class UnprocessableEntity extends CustomError {}


### PR DESCRIPTION
Fixes: #511

Show a "Not found" error when the chart or the chart repository doesn't exist. It covers the chart view (e.g. `/charts/foo/bar`) and the deployment form (e.g. `apps/ns/default/new/foo/aerospike/versions/0.1.7`) components.

Caveat: This fixes #511 but I think we should refactor the way we handle errors in the views. I think that we can probably move the error checking to an upper lever to avoid having to reimplement the error handling in all the possible views.

<img width="813" alt="screen shot 2018-09-10 at 14 57 05" src="https://user-images.githubusercontent.com/4025665/45298782-d48acf00-b509-11e8-85e0-818827b41016.png">
