### PR TITLE
Fix tests in master due to stale snapshot

### DIFF
--- a/dashboard/src/components/ErrorAlert/__snapshots__/UnexpectedErrorAlert.test.tsx.snap
+++ b/dashboard/src/components/ErrorAlert/__snapshots__/UnexpectedErrorAlert.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`when no text is passed renders a default troubleshooting info 1`] = `
           Check the health of Kubeapps components
            
           <code>
-            kubectl get po --all-namespaces -l created-by=kubeapps
+            helm status &lt;kubeapps_release_name&gt;
           </code>
           .
         </li>


### PR DESCRIPTION
A stale version of a snapshot was added to master because a piece of code that updated a view and created its snapshot https://github.com/kubeapps/kubeapps/commit/f575efd9d44cafc1b888585f136f1fb1d8e709ea#diff-44512796d7db632d9db40ee9176e9aa3 was merged without rebasing master. In master there was already another commit that modified the same view https://github.com/kubeapps/kubeapps/commit/624bf97792e00eda8f3d49a13f49d86be03c3f00