### PR TITLE
Always show filter options

### DIFF
--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -139,3 +139,20 @@ it("clicking 'List All' checkbox should trigger toggleListAll", () => {
   const fetchCalls = defaultProps.fetchApps.mock.calls;
   expect(fetchCalls[fetchCalls.length - 1]).toEqual(["default", true]);
 });
+
+it("renders the 'Show deleted apps' even if the app list is empty", () => {
+  const wrapper = shallow(
+    <AppList
+      {...defaultProps}
+      apps={
+        {
+          isFetching: false,
+          items: [],
+          listOverview: [],
+          listingAll: false,
+        } as IAppState
+      }
+    />,
+  );
+  expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true);
+});

--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -140,7 +140,7 @@ it("clicking 'List All' checkbox should trigger toggleListAll", () => {
   expect(fetchCalls[fetchCalls.length - 1]).toEqual(["default", true]);
 });
 
-it("renders the 'Show deleted apps' even if the app list is empty", () => {
+it("renders the 'Show deleted apps' button even if the app list is empty", () => {
   const wrapper = shallow(
     <AppList
       {...defaultProps}

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -51,29 +51,25 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
           <div className="col-9">
             <div className="row">
               <h1>Applications</h1>
-              {listOverview.length > 0 && [
-                <SearchFilter
-                  key="searchFilter"
-                  className="margin-l-big"
-                  placeholder="search apps..."
-                  onChange={this.handleFilterQueryChange}
-                  value={this.state.filter}
-                  onSubmit={pushSearchFilter}
-                />,
-                <label className="checkbox margin-r-big margin-l-big margin-t-big" key="listall">
-                  <input type="checkbox" checked={listingAll} onChange={this.toggleListAll} />
-                  <span>Show deleted apps</span>
-                </label>,
-              ]}
+              <SearchFilter
+                key="searchFilter"
+                className="margin-l-big"
+                placeholder="search apps..."
+                onChange={this.handleFilterQueryChange}
+                value={this.state.filter}
+                onSubmit={pushSearchFilter}
+              />
+              <label className="checkbox margin-r-big margin-l-big margin-t-big" key="listall">
+                <input type="checkbox" checked={listingAll} onChange={this.toggleListAll} />
+                <span>Show deleted apps</span>
+              </label>
             </div>
           </div>
-          {listOverview.length > 0 && (
-            <div className="col-3 text-r align-center">
-              <Link to="/charts">
-                <button className="button button-accent">Deploy App</button>
-              </Link>
-            </div>
-          )}
+          <div className="col-3 text-r align-center">
+            <Link to="/charts">
+              <button className="button button-accent">Deploy App</button>
+            </Link>
+          </div>
         </PageHeader>
         <main>
           {isFetching ? (
@@ -90,18 +86,14 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
 
   public appListItems(items: IAppState["listOverview"]) {
     if (items) {
-      if (items.length === 0) {
+      const filteredItems = this.filteredApps(items, this.state.filter);
+      if (filteredItems.length === 0) {
         return (
           <MessageAlert header="Supercharge your Kubernetes cluster">
             <div>
               <p className="margin-v-normal">
                 Deploy applications on your Kubernetes cluster with a single click.
               </p>
-              <div className="padding-b-normal">
-                <Link className="button button-accent" to="/charts">
-                  Deploy App
-                </Link>
-              </div>
             </div>
           </MessageAlert>
         );
@@ -109,7 +101,7 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
         return (
           <div>
             <CardGrid>
-              {this.filteredApps(items, this.state.filter).map(r => {
+              {filteredItems.map(r => {
                 return <AppListItem key={r.releaseName} app={r} />;
               })}
             </CardGrid>

--- a/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
+++ b/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
@@ -14,7 +14,42 @@ exports[`renders a welcome message if no apps are available 1`] = `
         <h1>
           Applications
         </h1>
+        <SearchFilter
+          className="margin-l-big"
+          key="searchFilter"
+          onChange={[Function]}
+          onSubmit={[MockFunction]}
+          placeholder="search apps..."
+          value=""
+        />
+        <label
+          className="checkbox margin-r-big margin-l-big margin-t-big"
+          key="listall"
+        >
+          <input
+            checked={false}
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <span>
+            Show deleted apps
+          </span>
+        </label>
       </div>
+    </div>
+    <div
+      className="col-3 text-r align-center"
+    >
+      <Link
+        replace={false}
+        to="/charts"
+      >
+        <button
+          className="button button-accent"
+        >
+          Deploy App
+        </button>
+      </Link>
     </div>
   </PageHeader>
   <main>
@@ -27,17 +62,6 @@ exports[`renders a welcome message if no apps are available 1`] = `
         >
           Deploy applications on your Kubernetes cluster with a single click.
         </p>
-        <div
-          className="padding-b-normal"
-        >
-          <Link
-            className="button button-accent"
-            replace={false}
-            to="/charts"
-          >
-            Deploy App
-          </Link>
-        </div>
       </div>
     </MessageAlertPage>
   </main>


### PR DESCRIPTION
Fixes #593

- Always show filter options even if the current list is empty
- Always show the `Deploy` button in the top-right corner.
- Remove `Deploy` button from welcome message to avoid duplicity

![gif_2018-09-11_13 33 1536665629](https://user-images.githubusercontent.com/4025665/45358004-5b05e600-b5c8-11e8-9ab0-746d697208c5.gif)
