### PR TITLE
[chart] Edit NOTES to use more compatible command

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.4.1
+version: 0.4.2
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/NOTES.txt
+++ b/chart/kubeapps/templates/NOTES.txt
@@ -41,7 +41,8 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
 {{- else if contains "ClusterIP" .Values.frontend.service.type }}
 
    echo "Kubeapps URL: http://127.0.0.1:8080"
-   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "kubeapps.fullname" . }} 8080:{{ .Values.frontend.service.port }}
+   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kubeapps.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+   kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:8080
 
 {{- end }}
 {{- end }}

--- a/chart/kubeapps/templates/NOTES.txt
+++ b/chart/kubeapps/templates/NOTES.txt
@@ -41,7 +41,7 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
 {{- else if contains "ClusterIP" .Values.frontend.service.type }}
 
    echo "Kubeapps URL: http://127.0.0.1:8080"
-   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kubeapps.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kubeapps.fullname" . }}" -o name)
    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:8080
 
 {{- end }}


### PR DESCRIPTION
Fixes https://kubernetes.slack.com/archives/C9D3TSUG4/p1536328485000100

`kubectl port-forward` to a service is only available with `kubectl` +1.11. Use the previous approach to ensure that users won't see an error when trying those commands.