### PR TITLE
API error handling in releases list

### DIFF
--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -7,6 +7,7 @@ import AppList from "./AppList";
 import AppListItem from "./AppListItem";
 
 let defaultProps = {} as any;
+let props = {} as any;
 
 beforeEach(() => {
   defaultProps = {
@@ -19,70 +20,82 @@ beforeEach(() => {
   };
 });
 
-it("renders a loading message if apps object is empty", () => {
-  const wrapper = shallow(<AppList {...defaultProps} />);
-  expect(wrapper.text()).toBe("Loading");
+describe("while fetching apps", () => {
+  beforeEach(() => {
+    props = { ...defaultProps, apps: { isFetching: true } };
+  });
+
+  it("matches the snapshot", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders a loading message", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper.text()).toContain("Loading");
+  });
+
+  it("renders a Application header", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper.find("h1").text()).toContain("Applications");
+  });
+
+  it("does not show the search filter nor deploy button", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper.find("SearchFilter")).not.toExist();
+    expect(wrapper.find("label.checkbox")).not.toExist();
+    expect(wrapper.find(".deploy-button")).not.toExist();
+  });
 });
 
-it("renders a loading message if it's fetching apps", () => {
-  const wrapper = shallow(
-    <AppList
-      {...defaultProps}
-      apps={
-        {
-          isFetching: true,
-          items: [],
-          listOverview: [],
-          listingAll: false,
-        } as IAppState
-      }
-    />,
-  );
-  expect(wrapper.text()).toContain("Loading");
+describe("when fetched but not apps available", () => {
+  beforeEach(() => {
+    props = { ...defaultProps, apps: { listOverview: [] } };
+  });
+
+  it("matches the snapshot", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders a welcome message", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper.find("MessageAlertPage")).toExist();
+  });
+
+  it("shows the search filter, show deleted checkbox and deploy button", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper.find("SearchFilter")).toExist();
+    expect(wrapper.find("label.checkbox").key()).toEqual("listall");
+    expect(wrapper.find(".deploy-button")).toExist();
+  });
 });
 
-it("renders a welcome message if no apps are available", () => {
-  const wrapper = shallow(
-    <AppList
-      {...defaultProps}
-      apps={
-        {
-          isFetching: false,
-          items: [],
-          listOverview: [],
-          listingAll: false,
-        } as IAppState
-      }
-    />,
-  );
-  expect(wrapper).toMatchSnapshot();
-});
+describe("when apps available", () => {
+  beforeEach(() => {
+    props = {
+      ...defaultProps,
+      apps: {
+        listOverview: [
+          {
+            releaseName: "foo",
+          } as IAppOverview,
+        ],
+      },
+    };
+  });
 
-it("renders a CardGrid with the available Apps", () => {
-  const wrapper = shallow(
-    <AppList
-      {...defaultProps}
-      apps={
-        {
-          isFetching: false,
-          items: [],
-          listOverview: [
-            {
-              releaseName: "foo",
-            } as IAppOverview,
-          ],
-          listingAll: false,
-        } as IAppState
-      }
-    />,
-  );
-  expect(
-    wrapper
-      .find(CardGrid)
-      .children()
-      .find(AppListItem)
-      .key(),
-  ).toBe("foo");
+  it("matches the snapshot", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders a CardGrid with the available Apps", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    const itemList = wrapper.find(AppListItem);
+    expect(itemList).toExist();
+    expect(itemList.key()).toBe("foo");
+  });
 });
 
 it("filters apps", () => {

--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -40,11 +40,11 @@ describe("while fetching apps", () => {
     expect(wrapper.find("h1").text()).toContain("Applications");
   });
 
-  it("does not show the search filter nor deploy button", () => {
+  it("shows the search filter, show deleted checkbox and deploy button", () => {
     const wrapper = shallow(<AppList {...props} />);
-    expect(wrapper.find("SearchFilter")).not.toExist();
-    expect(wrapper.find("label.checkbox")).not.toExist();
-    expect(wrapper.find(".deploy-button")).not.toExist();
+    expect(wrapper.find("SearchFilter")).toExist();
+    expect(wrapper.find("label.checkbox").key()).toEqual("listall");
+    expect(wrapper.find(".deploy-button")).toExist();
   });
 });
 
@@ -68,6 +68,34 @@ describe("when fetched but not apps available", () => {
     expect(wrapper.find("SearchFilter")).toExist();
     expect(wrapper.find("label.checkbox").key()).toEqual("listall");
     expect(wrapper.find(".deploy-button")).toExist();
+  });
+});
+
+describe("when error present", () => {
+  beforeEach(() => {
+    props = { ...defaultProps, apps: { error: "Boom!" } };
+  });
+
+  it("matches the snapshot", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders a generic error message", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper.find("UnexpectedErrorPage")).toExist();
+  });
+
+  it("renders a Application header", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper.find("h1").text()).toContain("Applications");
+  });
+
+  it("does not show the search filter nor show deleted checkbox nor deploy button", () => {
+    const wrapper = shallow(<AppList {...props} />);
+    expect(wrapper.find("SearchFilter")).not.toExist();
+    expect(wrapper.find("label.checkbox")).not.toExist();
+    expect(wrapper.find(".deploy-button")).not.toExist();
   });
 });
 

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -54,7 +54,7 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
           <div className="col-3 text-r align-center">
             {listOverview && (
               <Link to="/charts">
-                <button className="button button-accent">Deploy App</button>
+                <button className="deploy-button button button-accent">Deploy App</button>
               </Link>
             )}
           </div>

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -48,11 +48,11 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
           <div className="col-9">
             <div className="row">
               <h1>Applications</h1>
-              {listOverview && this.appListControls()}
+              {!error && this.appListControls()}
             </div>
           </div>
           <div className="col-3 text-r align-center">
-            {listOverview && (
+            {!error && (
               <Link to="/charts">
                 <button className="deploy-button button button-accent">Deploy App</button>
               </Link>

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -41,34 +41,22 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
   }
 
   public render() {
-    const { pushSearchFilter, apps: { error, isFetching, listOverview, listingAll } } = this.props;
-    if (!listOverview) {
-      return <div>Loading</div>;
-    }
+    const { apps: { error, isFetching, listOverview } } = this.props;
     return (
       <section className="AppList">
         <PageHeader>
           <div className="col-9">
             <div className="row">
               <h1>Applications</h1>
-              <SearchFilter
-                key="searchFilter"
-                className="margin-l-big"
-                placeholder="search apps..."
-                onChange={this.handleFilterQueryChange}
-                value={this.state.filter}
-                onSubmit={pushSearchFilter}
-              />
-              <label className="checkbox margin-r-big margin-l-big margin-t-big" key="listall">
-                <input type="checkbox" checked={listingAll} onChange={this.toggleListAll} />
-                <span>Show deleted apps</span>
-              </label>
+              {listOverview && this.appListControls()}
             </div>
           </div>
           <div className="col-3 text-r align-center">
-            <Link to="/charts">
-              <button className="button button-accent">Deploy App</button>
-            </Link>
+            {listOverview && (
+              <Link to="/charts">
+                <button className="button button-accent">Deploy App</button>
+              </Link>
+            )}
           </div>
         </PageHeader>
         <main>
@@ -81,6 +69,26 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
           )}
         </main>
       </section>
+    );
+  }
+
+  public appListControls() {
+    const { pushSearchFilter, apps: { listingAll } } = this.props;
+    return (
+      <React.Fragment>
+        <SearchFilter
+          key="searchFilter"
+          className="margin-l-big"
+          placeholder="search apps..."
+          onChange={this.handleFilterQueryChange}
+          value={this.state.filter}
+          onSubmit={pushSearchFilter}
+        />
+        <label className="checkbox margin-r-big margin-l-big margin-t-big" key="listall">
+          <input type="checkbox" checked={listingAll} onChange={this.toggleListAll} />
+          <span>Show deleted apps</span>
+        </label>
+      </React.Fragment>
     );
   }
 

--- a/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
+++ b/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a welcome message if no apps are available 1`] = `
+exports[`when apps available matches the snapshot 1`] = `
 <section
   className="AppList"
 >
@@ -14,27 +14,28 @@ exports[`renders a welcome message if no apps are available 1`] = `
         <h1>
           Applications
         </h1>
-        <SearchFilter
-          className="margin-l-big"
-          key="searchFilter"
-          onChange={[Function]}
-          onSubmit={[MockFunction]}
-          placeholder="search apps..."
-          value=""
-        />
-        <label
-          className="checkbox margin-r-big margin-l-big margin-t-big"
-          key="listall"
-        >
-          <input
-            checked={false}
+        <React.Fragment>
+          <SearchFilter
+            className="margin-l-big"
+            key="searchFilter"
             onChange={[Function]}
-            type="checkbox"
+            onSubmit={[MockFunction]}
+            placeholder="search apps..."
+            value=""
           />
-          <span>
-            Show deleted apps
-          </span>
-        </label>
+          <label
+            className="checkbox margin-r-big margin-l-big margin-t-big"
+            key="listall"
+          >
+            <input
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <span>
+              Show deleted apps
+            </span>
+          </label>
+        </React.Fragment>
       </div>
     </div>
     <div
@@ -45,7 +46,77 @@ exports[`renders a welcome message if no apps are available 1`] = `
         to="/charts"
       >
         <button
-          className="button button-accent"
+          className="deploy-button button button-accent"
+        >
+          Deploy App
+        </button>
+      </Link>
+    </div>
+  </PageHeader>
+  <main>
+    <div>
+      <CardGrid>
+        <AppListItem
+          app={
+            Object {
+              "releaseName": "foo",
+            }
+          }
+          key="foo"
+        />
+      </CardGrid>
+    </div>
+  </main>
+</section>
+`;
+
+exports[`when fetched but not apps available matches the snapshot 1`] = `
+<section
+  className="AppList"
+>
+  <PageHeader>
+    <div
+      className="col-9"
+    >
+      <div
+        className="row"
+      >
+        <h1>
+          Applications
+        </h1>
+        <React.Fragment>
+          <SearchFilter
+            className="margin-l-big"
+            key="searchFilter"
+            onChange={[Function]}
+            onSubmit={[MockFunction]}
+            placeholder="search apps..."
+            value=""
+          />
+          <label
+            className="checkbox margin-r-big margin-l-big margin-t-big"
+            key="listall"
+          >
+            <input
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <span>
+              Show deleted apps
+            </span>
+          </label>
+        </React.Fragment>
+      </div>
+    </div>
+    <div
+      className="col-3 text-r align-center"
+    >
+      <Link
+        replace={false}
+        to="/charts"
+      >
+        <button
+          className="deploy-button button button-accent"
         >
           Deploy App
         </button>
@@ -64,6 +135,34 @@ exports[`renders a welcome message if no apps are available 1`] = `
         </p>
       </div>
     </MessageAlertPage>
+  </main>
+</section>
+`;
+
+exports[`while fetching apps matches the snapshot 1`] = `
+<section
+  className="AppList"
+>
+  <PageHeader>
+    <div
+      className="col-9"
+    >
+      <div
+        className="row"
+      >
+        <h1>
+          Applications
+        </h1>
+      </div>
+    </div>
+    <div
+      className="col-3 text-r align-center"
+    />
+  </PageHeader>
+  <main>
+    <div>
+      Loading
+    </div>
   </main>
 </section>
 `;

--- a/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
+++ b/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
@@ -70,6 +70,34 @@ exports[`when apps available matches the snapshot 1`] = `
 </section>
 `;
 
+exports[`when error present matches the snapshot 1`] = `
+<section
+  className="AppList"
+>
+  <PageHeader>
+    <div
+      className="col-9"
+    >
+      <div
+        className="row"
+      >
+        <h1>
+          Applications
+        </h1>
+      </div>
+    </div>
+    <div
+      className="col-3 text-r align-center"
+    />
+  </PageHeader>
+  <main>
+    <UnexpectedErrorPage
+      title="Sorry! Something went wrong."
+    />
+  </main>
+</section>
+`;
+
 exports[`when fetched but not apps available matches the snapshot 1`] = `
 <section
   className="AppList"
@@ -153,11 +181,44 @@ exports[`while fetching apps matches the snapshot 1`] = `
         <h1>
           Applications
         </h1>
+        <React.Fragment>
+          <SearchFilter
+            className="margin-l-big"
+            key="searchFilter"
+            onChange={[Function]}
+            onSubmit={[MockFunction]}
+            placeholder="search apps..."
+            value=""
+          />
+          <label
+            className="checkbox margin-r-big margin-l-big margin-t-big"
+            key="listall"
+          >
+            <input
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <span>
+              Show deleted apps
+            </span>
+          </label>
+        </React.Fragment>
       </div>
     </div>
     <div
       className="col-3 text-r align-center"
-    />
+    >
+      <Link
+        replace={false}
+        to="/charts"
+      >
+        <button
+          className="deploy-button button button-accent"
+        >
+          Deploy App
+        </button>
+      </Link>
+    </div>
   </PageHeader>
   <main>
     <div>

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -46,8 +46,4 @@ export class Auth {
   }
 }
 
-const requestConfig = {
-  timeout: 5000, // After the timeout the request gets canceled (default no-timeout)
-};
-
-export const axios = Axios.create(requestConfig);
+export const axios = Axios.create();

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -46,4 +46,8 @@ export class Auth {
   }
 }
 
-export const axios = Axios.create();
+const requestConfig = {
+  timeout: 5000, // After the timeout the request gets canceled (default no-timeout)
+};
+
+export const axios = Axios.create(requestConfig);


### PR DESCRIPTION
Looking into https://github.com/kubeapps/kubeapps/issues/546 I noticed that the main issue is that the releases page was not handling correctly errors from the API, regardless of being 503, 500. This is because our loading banner was being rendered as long as appOverview was empty.

This does some refactoring and tweaks in that page that:

### Loading state

* We show the "Applications" header so the viewport vertical space does not jump, this way the user always has the context.
* The deploy button nor the filtering options are shown.

![selection_696](https://user-images.githubusercontent.com/24523/45388813-f69a5500-b5ce-11e8-919d-0c3df80f4e76.png)

### Error state

* We show a message and like in the loading state we do not show the controls.

![selection_697](https://user-images.githubusercontent.com/24523/45388834-087bf800-b5cf-11e8-867c-2ede8313cd35.png)

I have tested it by making the tiller-proxy crash and even disabling it all together.

### Apps loaded state

* The view is shown as before, nothing has changed here.

![selection_698](https://user-images.githubusercontent.com/24523/45388897-277a8a00-b5cf-11e8-8ef3-e211fe36191d.png)

* Note that I have added a 5 seconds to Axios to give the user quicker feedback in case that something goes wrong. 5 seconds should be plenty of time for pretty much any operation we do, I think. 

Fixes https://github.com/kubeapps/kubeapps/issues/546