### PR TITLE
Tiller TLS CA validation

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.4.2
+version: 0.4.3
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/tiller-proxy-secret.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-secret.yaml
@@ -1,6 +1,6 @@
 # The tls ca certificate is only required when tls.verify is set to true, we fail otherwise.
 {{-  if .Values.tillerProxy.tls -}}
-{{ required "A valid CA certificate \".Values.tillerProxy.tls.ca\" needs to be provided if tls-verify is set to true" (and (.Values.tillerProxy.tls.verify) .Values.tillerProxy.tls.ca) }} 
+{{ required "A valid CA certificate \".Values.tillerProxy.tls.ca\" needs to be provided if tls-verify is set to true" (and .Values.tillerProxy.tls.verify .Values.tillerProxy.tls.ca) }} 
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/kubeapps/templates/tiller-proxy-secret.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-secret.yaml
@@ -1,4 +1,8 @@
+# The tls ca certificate is only required when tls.verify is set to true, we fail otherwise.
 {{-  if .Values.tillerProxy.tls -}}
+{{- if and (.Values.tillerProxy.tls.verify) (not (.Values.tillerProxy.tls.ca)) -}}
+{{ fail "tillerProxy.tls.ca: A valid CA certificate needs to be provided if tls-verify is set to true." }}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,8 +13,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+{{- if .Values.tillerProxy.tls.ca }}
   ca.crt: |-
 {{ .Values.tillerProxy.tls.ca | b64enc | indent 4 }}
+{{- end }}
   tls.crt: |-
 {{ .Values.tillerProxy.tls.cert | b64enc | indent 4 }}
   tls.key: |-

--- a/chart/kubeapps/templates/tiller-proxy-secret.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-secret.yaml
@@ -1,8 +1,6 @@
 # The tls ca certificate is only required when tls.verify is set to true, we fail otherwise.
 {{-  if .Values.tillerProxy.tls -}}
-{{- if and (.Values.tillerProxy.tls.verify) (not (.Values.tillerProxy.tls.ca)) -}}
-{{ fail "tillerProxy.tls.ca: A valid CA certificate needs to be provided if tls-verify is set to true." }}
-{{- end -}}
+{{ required "A valid CA certificate \".Values.tillerProxy.tls.ca\" needs to be provided if tls-verify is set to true" (and (.Values.tillerProxy.tls.verify) .Values.tillerProxy.tls.ca) }} 
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
As mentioned in the attached issue, the CA certificate is only useful if tls-verify is set. Before this patch, regardless of the value of tls-verify we were requiring it to be set.

This patch also validates that the CA is present if tls-verify is set.

Fixes https://github.com/kubeapps/kubeapps/issues/547

Examples:

### tls.verify = false, tls.ca not set

The secret does not contain the data.ca key and it is not enforced.

```bash
helm template --set tillerProxy.tls.verify=false --set tillerProxy.tls.key="my-key"  --set tillerProxy.tls.cert="my-cert" . | grep kubeapps/templates/tiller-proxy-secret.yaml -A 20
# Source: kubeapps/templates/tiller-proxy-secret.yaml
# The tls ca certificate is only required when tls.verify is set to true, we fail otherwise.apiVersion: v1
kind: Secret
metadata:
  name: RELEASE-NAME-kubeapps-tiller-proxy
  labels:
    app: RELEASE-NAME-kubeapps-tiller-proxy
    chart: kubeapps-0.4.1
    release: RELEASE-NAME
    heritage: Tiller
data:
  tls.crt: |-
    bXktY2VydA==
  tls.key: |-
    bXkta2V5
---
```

### tls.verify = true, tls.ca not set

The installation fails.

```bash
helm template --set tillerProxy.tls.verify=true --set tillerProxy.tls.key="my-key" --set tillerProxy.tls.cert="my-cert" .
Error: render error in "kubeapps/templates/tiller-proxy-secret.yaml": template: kubeapps/templates/tiller-proxy-secret.yaml:4:3: executing "kubeapps/templates/tiller-proxy-secret.yaml" at <fail "tillerProxy.tl...>: error calling fail: tillerProxy.tls.ca: A valid CA certificate needs to be provided if tls-verify is set to true.
```

### tls.verify = true, tls.ca set

The ca.crt key is set as expected.

```
 helm template --set tillerProxy.tls.verify=true --set tillerProxy.tls.key="my-key" --set tillerProxy.tls.cert="my-cert" --set tillerProxy.tls.ca="my-ca" . | grep kubeapps/templates/tiller-proxy-secret.yaml -A 20
# Source: kubeapps/templates/tiller-proxy-secret.yaml
# The tls ca certificate is only required when tls.verify is set to true, we fail otherwise.apiVersion: v1
kind: Secret
metadata:
  name: RELEASE-NAME-kubeapps-tiller-proxy
  labels:
    app: RELEASE-NAME-kubeapps-tiller-proxy
    chart: kubeapps-0.4.1
    release: RELEASE-NAME
    heritage: Tiller
data:
  ca.crt: |-
    bXktY2E=
  tls.crt: |-
    bXktY2VydA==
  tls.key: |-
    bXkta2V5
```