### PR TITLE
fix chart missing value

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -47,6 +47,7 @@ frontend:
 # AppRepository Controller is the controller used to manage the repositories to
 # sync. Set apprepository.initialRepos to configure the initial set of
 # repositories to use when first installing Kubeapps.
+apprepository:
   image:
     registry: docker.io
     repository: kubeapps/apprepository-controller


### PR DESCRIPTION
fixes the current failing master build: https://circleci.com/gh/kubeapps/kubeapps/1641.

I haven't bumped the chart since the current chart version has not been pushed to bitnami/charts yet due to the failed build.