### PR TITLE
Fix chart tiller proxy

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.4.4
+version: 0.4.5
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/tiller-proxy-secret.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-secret.yaml
@@ -1,6 +1,8 @@
 # The tls ca certificate is only required when tls.verify is set to true, we fail otherwise.
 {{-  if .Values.tillerProxy.tls -}}
-{{ required "A valid CA certificate \".Values.tillerProxy.tls.ca\" needs to be provided if tls-verify is set to true" (and .Values.tillerProxy.tls.verify .Values.tillerProxy.tls.ca) }} 
+{{- if and (.Values.tillerProxy.tls.verify) (not (.Values.tillerProxy.tls.ca)) -}}
+{{ fail "tillerProxy.tls.ca: A valid CA certificate needs to be provided if tls-verify is set to true." }}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
The code added here to validate that a CA was provided if tls.verify was true was buggy in the case in which tls.verify was not set (which is the default)

This means that if you try to install a chart setting the tiller proxy tls and did not set tls.verify to false you were forced to pass a CA. This bug did not have a big impact because it was only visible if tillerProxy.tls was set and in previous versions the CA was required anyways.

The bug was related to the way I was using the requires + the conditional. So I went back to a simpler to understand and maintain version of the code.