### PR TITLE
Fix API version being merged into the comment

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.4.5
+version: 0.4.6
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/tiller-proxy-secret.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-secret.yaml
@@ -2,7 +2,7 @@
 {{-  if .Values.tillerProxy.tls -}}
 {{- if and (.Values.tillerProxy.tls.verify) (not (.Values.tillerProxy.tls.ca)) -}}
 {{ fail "tillerProxy.tls.ca: A valid CA certificate needs to be provided if tls-verify is set to true." }}
-{{- end -}}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Without this fix, the apiVersion was being swamped as part of the comment
```
# The tls ca certificate is only required when tls.verify is set to true, we fail otherwise.apiVersion: v1
```
This was not detected by my local template tests, but would have been detected by e2e tests using tilelr-proxy tls, so I am going to bump priority on that one.
