### PR TITLE
Remove spurious semicolon from charts list

### DIFF
--- a/dashboard/src/components/ChartList/ChartList.tsx
+++ b/dashboard/src/components/ChartList/ChartList.tsx
@@ -70,7 +70,7 @@ class ChartList extends React.Component<IChartListProps, IChartListState> {
         </PageHeader>
         <LoadingWrapper loaded={!isFetching}>
           <CardGrid>{chartItems}</CardGrid>
-        </LoadingWrapper>;
+        </LoadingWrapper>
       </section>
     );
   }

--- a/dashboard/src/components/ChartList/__snapshots__/ChartList.test.tsx.snap
+++ b/dashboard/src/components/ChartList/__snapshots__/ChartList.test.tsx.snap
@@ -40,7 +40,6 @@ exports[`renderization when charts available should render the list of charts 1`
       />
     </CardGrid>
   </LoadingWrapper>
-  ;
 </section>
 `;
 
@@ -65,7 +64,6 @@ exports[`renderization when fetching apps loading spinner matches the snapshot 1
   >
     <CardGrid />
   </LoadingWrapper>
-  ;
 </section>
 `;
 


### PR DESCRIPTION
I added this spurious semicolon by mistake during the latest application of the feedback received here https://github.com/kubeapps/kubeapps/pull/644/files#diff-10

Sorry about that. Thanks @prydonius for catching it up.