### PR TITLE
Catch error when parsing YAML manifests

### DIFF
--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -7,7 +7,7 @@ import { hapi } from "../../shared/hapi/release";
 import itBehavesLike from "../../shared/specs";
 import { ForbiddenError, IResource, NotFoundError } from "../../shared/types";
 import DeploymentStatus from "../DeploymentStatus";
-import { NotFoundErrorAlert, PermissionsErrorAlert } from "../ErrorAlert";
+import { NotFoundErrorAlert, PermissionsErrorAlert, UnexpectedErrorAlert } from "../ErrorAlert";
 import AppControls from "./AppControls";
 import AppDetails from "./AppDetails";
 import AppNotes from "./AppNotes";
@@ -131,6 +131,18 @@ describe("AppViewComponent", () => {
 
       const sockets: WebSocket[] = wrapper.state("sockets");
       expect(sockets.length).toEqual(0);
+    });
+
+    it("catches errors in the manifest", () => {
+      const wrapper = shallow(<AppViewComponent {...validProps} />);
+      const manifest = "key: value\nkey: other-value";
+
+      validProps.app.manifest = manifest;
+      wrapper.setProps(validProps);
+      wrapper.update();
+
+      const err = wrapper.find(UnexpectedErrorAlert);
+      expect(err.props().text).toContain("duplicated mapping key");
     });
   });
 


### PR DESCRIPTION
Fixes: #635

Add `manifestError` to the AppView state for setting it if the manifest cannot be parsed:

<img width="910" alt="screen shot 2018-09-18 at 17 38 15" src="https://user-images.githubusercontent.com/4025665/45699406-28c92b00-bb6a-11e8-8570-ff516639fd07.png">
