### PR TITLE
Increase number of replicas and allow its configuration

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.4.8
+version: 0.4.9
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.4.7
+version: 0.4.8
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.apprepository.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "kubeapps.apprepository.fullname" . }}

--- a/chart/kubeapps/templates/chartsvc-deployment.yaml
+++ b/chart/kubeapps/templates/chartsvc-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.chartsvc.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "kubeapps.chartsvc.fullname" . }}

--- a/chart/kubeapps/templates/dashboard-deployment.yaml
+++ b/chart/kubeapps/templates/dashboard-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.dashboard.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "kubeapps.dashboard.fullname" . }}

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.frontend.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "kubeapps.fullname" . }}

--- a/chart/kubeapps/templates/tiller-proxy-deployment.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.tillerProxy.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "kubeapps.tiller-proxy.fullname" . }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -49,7 +49,7 @@ frontend:
 # sync. Set apprepository.initialRepos to configure the initial set of
 # repositories to use when first installing Kubeapps.
 apprepository:
-  replicaCount: 2
+  replicaCount: 1
   image:
     registry: docker.io
     repository: kubeapps/apprepository-controller

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -49,6 +49,7 @@ frontend:
 # sync. Set apprepository.initialRepos to configure the initial set of
 # repositories to use when first installing Kubeapps.
 apprepository:
+  # Running a single controller replica to avoid sync job duplication
   replicaCount: 1
   image:
     registry: docker.io

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -13,6 +13,7 @@ ingress:
   #      - chart-example.local
 
 frontend:
+  replicaCount: 2
   image:
     registry: docker.io
     repository: bitnami/nginx
@@ -48,6 +49,7 @@ frontend:
 # sync. Set apprepository.initialRepos to configure the initial set of
 # repositories to use when first installing Kubeapps.
 apprepository:
+  replicaCount: 2
   image:
     registry: docker.io
     repository: kubeapps/apprepository-controller
@@ -86,6 +88,7 @@ apprepository:
 # manage Helm chart releases in the cluster from Kubeapps. Set tillerProxy.host
 # to configure a different Tiller host to use.
 tillerProxy:
+  replicaCount: 2
   image:
     registry: docker.io
     repository: kubeapps/tiller-proxy
@@ -111,6 +114,7 @@ tillerProxy:
 
 # Chartsvc is used to serve chart metadata over a REST API.
 chartsvc:
+  replicaCount: 2
   image:
     registry: docker.io
     repository: kubeapps/chartsvc
@@ -144,6 +148,7 @@ chartsvc:
 # internal service used by the main frontend reverse-proxy and should not be
 # accessed directly.
 dashboard:
+  replicaCount: 2
   image:
     registry: docker.io
     repository: kubeapps/dashboard


### PR DESCRIPTION
Closes https://github.com/kubeapps/kubeapps/issues/643

Diff of rendered template before/after the change.

```bash
 multidoc_yamldiff /tmp/before.yaml /tmp/after.yaml 
@@ .. @@
    name: "RELEASE-NAME-kubeapps",
   },
   spec: {
-   replicas: 1,
+   replicas: 2,
    selector: {
     matchLabels: {
      app: "RELEASE-NAME-kubeapps",
@@ .. @@
    name: "RELEASE-NAME-kubeapps-internal-apprepository-controller",
   },
   spec: {
-   replicas: 1,
+   replicas: 2,
    selector: {
     matchLabels: {
      app: "RELEASE-NAME-kubeapps-internal-apprepository-controller",
@@ .. @@
    name: "RELEASE-NAME-kubeapps-internal-chartsvc",
   },
   spec: {
-   replicas: 1,
+   replicas: 2,
    selector: {
     matchLabels: {
      app: "RELEASE-NAME-kubeapps-internal-chartsvc",
@@ .. @@
    name: "RELEASE-NAME-kubeapps-internal-dashboard",
   },
   spec: {
-   replicas: 1,
+   replicas: 2,
    selector: {
     matchLabels: {
      app: "RELEASE-NAME-kubeapps-internal-dashboard",
@@ .. @@
    name: "RELEASE-NAME-kubeapps-internal-tiller-proxy",
   },
   spec: {
-   replicas: 1,
+   replicas: 2,
    selector: {
     matchLabels: {
      app: "RELEASE-NAME-kubeapps-internal-tiller-proxy",
@@ .. @@
  {
   apiVersion: "v1",
   data: {
-   mongodb-root-password: "SmRMOEg4Nzg5TQ==",
+   mongodb-root-password: "ZTZyOThrQld5RQ==",
   },
   kind: "Secret",
   metadata: {
```

After upgrade

```bash
 k get deployment
NAME                                                DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
miguel-kubeapps                                     2         2         2            2           6d
miguel-kubeapps-internal-apprepository-controller   2         2         2            2           6d
miguel-kubeapps-internal-chartsvc                   2         2         2            2           6d
miguel-kubeapps-internal-dashboard                  2         2         2            2           6d
miguel-kubeapps-internal-tiller-proxy               2         2         2            2           6d
miguel-kubeapps-mongodb                             1         1         1            1           2m
```