### PR TITLE
Fix port reference in tiller-proxy deployment manifest

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.4.7
+version: 0.4.9
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.4.9
+version: 0.5.0
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/tiller-proxy-deployment.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         {{- end }}
         ports:
         - name: http
-          containerPort: {{ .Values.chartsvc.service.port }}
+          containerPort: {{ .Values.tillerProxy.service.port }}
         env:
         - name: POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
No changes as expected since the port for chartsvc and tiller proxy are the same.

Bumping two versions so this PR will wait until this other one is landed https://github.com/kubeapps/kubeapps/pull/660

```
 diff /tmp/before.yaml /tmp/after.yaml 
14c14
<   mongodb-root-password: "enVCdFRiZDZYRw=="
---
>   mongodb-root-password: "TzVseUNqZjFqWg=="
```