### PR TITLE
Apply limits and requests

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.5.0
+version: 0.5.1
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -37,10 +37,10 @@ frontend:
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
   resources:
     limits:
-      cpu: 500m
+      cpu: 250m
       memory: 128Mi
     requests:
-      cpu: 50m
+      cpu: 25m
       memory: 32Mi
   nodeSelector: {}
   tolerations: []
@@ -78,10 +78,10 @@ apprepository:
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
   resources:
     limits:
-      cpu: 500m
+      cpu: 250m
       memory: 128Mi
     requests:
-      cpu: 50m
+      cpu: 25m
       memory: 32Mi
   nodeSelector: {}
   tolerations: []
@@ -107,10 +107,10 @@ tillerProxy:
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
   resources:
     limits:
-      cpu: 500m
+      cpu: 250m
       memory: 128Mi
     requests:
-      cpu: 50m
+      cpu: 25m
       memory: 32Mi
   nodeSelector: {}
   tolerations: []
@@ -128,10 +128,10 @@ chartsvc:
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
   resources:
     limits:
-      cpu: 500m
+      cpu: 250m
       memory: 128Mi
     requests:
-      cpu: 50m
+      cpu: 25m
       memory: 32Mi
   livenessProbe:
     httpGet:
@@ -175,10 +175,10 @@ dashboard:
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
   resources:
     limits:
-      cpu: 500m
+      cpu: 250m
       memory: 128Mi
     requests:
-      cpu: 50m
+      cpu: 25m
       memory: 32Mi
   nodeSelector: {}
   tolerations: []
@@ -194,7 +194,7 @@ mongodb:
       cpu: 500m
       memory: 512Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 256Mi
 
 nodeSelector: {}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -40,7 +40,7 @@ frontend:
       cpu: 500m
       memory: 128Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 32Mi
   nodeSelector: {}
   tolerations: []
@@ -81,7 +81,7 @@ apprepository:
       cpu: 500m
       memory: 128Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 32Mi
   nodeSelector: {}
   tolerations: []
@@ -110,7 +110,7 @@ tillerProxy:
       cpu: 500m
       memory: 128Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 32Mi
   nodeSelector: {}
   tolerations: []
@@ -131,7 +131,7 @@ chartsvc:
       cpu: 500m
       memory: 128Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 32Mi
   livenessProbe:
     httpGet:
@@ -178,7 +178,7 @@ dashboard:
       cpu: 500m
       memory: 128Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 32Mi
   nodeSelector: {}
   tolerations: []

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -34,13 +34,14 @@ frontend:
       port: 8080
     initialDelaySeconds: 0
     timeoutSeconds: 5
-  resources: {}
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
+  # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 32Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -74,13 +75,14 @@ apprepository:
     url: https://svc-catalog-charts.storage.googleapis.com
   - name: bitnami
     url: https://charts.bitnami.com/bitnami
-  resources: {}
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
+  # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 32Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -102,13 +104,14 @@ tillerProxy:
     # cert:
     # key:
     # verify: false
-  resources: {}
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
+  # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 32Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -122,13 +125,14 @@ chartsvc:
     tag: latest
   service:
     port: 8080
-  resources: {}
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
+  # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 32Mi
   livenessProbe:
     httpGet:
       path: /live
@@ -168,13 +172,14 @@ dashboard:
       port: 8080
     initialDelaySeconds: 0
     timeoutSeconds: 5
-  resources: {}
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
+  # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 32Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -183,18 +188,14 @@ mongodb:
   # Kubeapps uses MongoDB as a cache and persistence is not required
   persistence:
     enabled: false
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
 
 nodeSelector: {}
 
@@ -212,4 +213,3 @@ testImage:
   registry: docker.io
   repository: bitnami/nginx
   tag: 1.14.0-r27
-


### PR DESCRIPTION
See https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262 for some context.

Closes https://github.com/kubeapps/kubeapps/issues/478

After applying this patch pods moved to `burstable` as expected

```
k get pods -n kubeapps -l release=kubeapps -o jsonpath="{range .items[*]} ====> {.metadata.name} {'\n\n'}{'\t'}{.status.qosClass} | Requests: {.spec.containers[0].resources.requests} | Limits: {.spec.containers[0].resources.limits}{'\n\n'}{end}"
 ====> kubeapps-6b4dd6fdcd-9vb65 

        Burstable | Requests: map[cpu:100m memory:32Mi] | Limits: map[cpu:500m memory:128Mi]

 ====> kubeapps-6b4dd6fdcd-rvmk4 

        Burstable | Requests: map[memory:32Mi cpu:100m] | Limits: map[cpu:500m memory:128Mi]

 ====> kubeapps-internal-apprepository-controller-745879f84c-8trj5 

        Burstable | Requests: map[cpu:100m memory:32Mi] | Limits: map[cpu:500m memory:128Mi]

 ====> kubeapps-internal-chartsvc-b46c8f458-66px7 

        Burstable | Requests: map[cpu:100m memory:32Mi] | Limits: map[cpu:500m memory:128Mi]

 ====> kubeapps-internal-chartsvc-b46c8f458-cmxjg 

        Burstable | Requests: map[cpu:100m memory:32Mi] | Limits: map[cpu:500m memory:128Mi]

 ====> kubeapps-internal-dashboard-58dcf96b47-kfxzk 

        Burstable | Requests: map[cpu:100m memory:32Mi] | Limits: map[cpu:500m memory:128Mi]

 ====> kubeapps-internal-dashboard-58dcf96b47-nmtl4 

        Burstable | Requests: map[cpu:100m memory:32Mi] | Limits: map[cpu:500m memory:128Mi]

 ====> kubeapps-internal-tiller-proxy-6cf9c7d9f5-d9vvd 

        Burstable | Requests: map[memory:32Mi cpu:100m] | Limits: map[cpu:500m memory:128Mi]

 ====> kubeapps-internal-tiller-proxy-6cf9c7d9f5-ptgkf 

        Burstable | Requests: map[cpu:100m memory:32Mi] | Limits: map[cpu:500m memory:128Mi]

 ====> kubeapps-mongodb-84dc946c67-jdqj5 

        Burstable | Requests: map[cpu:100m memory:256Mi] | Limits: map[cpu:500m memory:512Mi]
```

Tried in both AWS and Minikube