### PR TITLE
chart: update NOTES.txt so select first pod to port-forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The above commands will deploy Kubeapps into the `kubeapps` namespace in your cl
 Once it has been deployed and the Kubeapps pods are running, port-forward to access the Dashboard:
 
 ```bash
-export POD_NAME=$(kubectl get pods -n kubeapps -l "app=kubeapps,release=kubeapps" -o name)
+export POD_NAME=$(kubectl get pods -n kubeapps -l "app=kubeapps,release=kubeapps" -o jsonpath="{.items[0].metadata.name}")
 echo "Visit http://127.0.0.1:8080 in your browser to access the Kubeapps Dashboard"
 kubectl port-forward -n kubeapps $POD_NAME 8080:8080
 ```

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.5.1
+version: 0.5.2
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/NOTES.txt
+++ b/chart/kubeapps/templates/NOTES.txt
@@ -41,7 +41,7 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
 {{- else if contains "ClusterIP" .Values.frontend.service.type }}
 
    echo "Kubeapps URL: http://127.0.0.1:8080"
-   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kubeapps.fullname" . }}" -o name)
+   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kubeapps.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:8080
 
 {{- end }}

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -66,7 +66,7 @@ NOTE: It's not recommended to create `cluster-admin` users for Kubeapps. Please 
 Once Kubeapps is installed, securely access the Kubeapps Dashboard from your system by running:
 
 ```bash
-export POD_NAME=$(kubectl get pods -n kubeapps -l "app=kubeapps,release=kubeapps" -o name)
+export POD_NAME=$(kubectl get pods -n kubeapps -l "app=kubeapps,release=kubeapps" -o jsonpath="{.items[0].metadata.name}")
 echo "Visit http://127.0.0.1:8080 in your browser to access the Kubeapps Dashboard"
 kubectl port-forward -n kubeapps $POD_NAME 8080:8080
 ```


### PR DESCRIPTION
The `-o name` output lists both pods now that we have 2 replicas, which
the `port-forward` command does not like. This commit changes the NOTES
to use a jsonpath template to get the first pod's name only.