### PR TITLE
Refactor purge UX for deleted apps

### DIFF
--- a/dashboard/src/components/AppView/AppControls.test.tsx
+++ b/dashboard/src/components/AppView/AppControls.test.tsx
@@ -90,7 +90,7 @@ it("calls delete function with additional purge", () => {
 
   // Check that the "purge" state is forwarded to deleteApp
   confirm.props().onConfirm(); // Simulate confirmation
-  expect(deleteApp.mock.calls[0]).toEqual([true]);
+  expect(deleteApp).toHaveBeenCalledWith(true);
 });
 
 context("when name or namespace do not exist", () => {
@@ -146,6 +146,6 @@ context("when the application has been already deleted", () => {
 
     // Check that the "purge" is forwarded to deleteApp
     confirm.props().onConfirm(); // Simulate confirmation
-    expect(deleteApp.mock.calls[0]).toEqual([true]);
+    expect(deleteApp).toHaveBeenCalledWith(true);
   });
 });

--- a/dashboard/src/components/AppView/AppControls.tsx
+++ b/dashboard/src/components/AppView/AppControls.tsx
@@ -55,12 +55,16 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
           loading={this.state.deleting}
           closeModal={this.closeModal}
           extraElem={
-            <div className="margin-v-small text-c">
-              <label className="checkbox margin-r-big">
-                <input type="checkbox" onChange={this.togglePurge} />
-                <span>Purge release</span>
-              </label>
-            </div>
+            deleted ? (
+              undefined
+            ) : (
+              <div className="margin-b-normal text-c">
+                <label className="checkbox margin-r-big">
+                  <input type="checkbox" onChange={this.togglePurge} />
+                  <span>Purge release</span>
+                </label>
+              </div>
+            )
           }
         />
         {this.state.redirectToAppList && <Redirect to={`/apps/ns/${namespace}`} />}
@@ -86,7 +90,9 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
 
   public handleDeleteClick = async () => {
     this.setState({ deleting: true });
-    const deleted = await this.props.deleteApp(this.state.purge);
+    // Purge the release if the application has been already deleted
+    const alreadyDeleted = this.props.app.info && !!this.props.app.info.deleted;
+    const deleted = await this.props.deleteApp(alreadyDeleted || this.state.purge);
     const s: Partial<IAppControlsState> = { modalIsOpen: false };
     if (deleted) {
       s.redirectToAppList = true;

--- a/dashboard/src/components/ConfirmDialog/index.tsx
+++ b/dashboard/src/components/ConfirmDialog/index.tsx
@@ -52,7 +52,7 @@ class ConfirmDialog extends React.Component<IConfirmDialogProps, IConfirmDialogS
             </div>
           ) : (
             <div>
-              <div> Are you sure you want to delete this? </div>
+              <div className="margin-b-normal"> Are you sure you want to delete this? </div>
               {this.props.extraElem}
               <button className="button" onClick={this.props.closeModal}>
                 Cancel


### PR DESCRIPTION
Fixes #655

Don't show the `purge` check box when the application has been already deleted. Force to purge it if the user deletes it again.