### PR TITLE
Remove logo from chart title

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/kubeapps/kubeapps/raw/master/docs/img/logo.png" width="40" align="left"> Kubeapps
+# Kubeapps
 
 [![Build Status](https://travis-ci.org/kubeapps/kubeapps.svg?branch=master)](https://travis-ci.org/kubeapps/kubeapps)
 


### PR DESCRIPTION
I realized that the logo is not properly rendered in the chart view of kubeapps:

<img width="1260" alt="screen shot 2018-09-27 at 11 43 35" src="https://user-images.githubusercontent.com/4025665/46137953-fb0b7280-c24a-11e8-8aef-8b6c54dbbc85.png">

The logo is already there at the top and I haven't seen any other chart that includes the logo in the title so I think it's better to remove it.