### PR TITLE
Add Slack link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/kubeapps/kubeapps/tree/master.svg?style=svg)](https://circleci.com/gh/kubeapps/kubeapps/tree/master)
 
+
 Kubeapps is a web-based UI for deploying and managing applications in Kubernetes clusters. Kubeapps allows you to:
 
 - Browse and deploy [Helm](https://github.com/helm/helm) charts from chart repositories
@@ -94,3 +95,7 @@ For a more detailed and step-by-step introduction to Kubeapps, read our [introdu
 * [Detailed installation instructions](chart/kubeapps/README.md)
 * [Kubeapps Dashboard documentation](docs/user/dashboard.md)
 * [Kubeapps components](docs/architecture/overview.md)
+
+## Community
+
+* [#kubeapps on Kubernetes Slack](https://kubernetes.slack.com/messages/C9D3TSUG4)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CircleCI](https://circleci.com/gh/kubeapps/kubeapps/tree/master.svg?style=svg)](https://circleci.com/gh/kubeapps/kubeapps/tree/master)
 
-
 Kubeapps is a web-based UI for deploying and managing applications in Kubernetes clusters. Kubeapps allows you to:
 
 - Browse and deploy [Helm](https://github.com/helm/helm) charts from chart repositories

--- a/README.md
+++ b/README.md
@@ -97,4 +97,6 @@ For a more detailed and step-by-step introduction to Kubeapps, read our [introdu
 
 ## Community
 
-* [#kubeapps on Kubernetes Slack](https://kubernetes.slack.com/messages/C9D3TSUG4)
+* [#kubeapps on Kubernetes Slack](https://kubernetes.slack.com/messages/kubeapps)
+
+Click [here](http://slack.k8s.io) to sign up to the Kubernetes Slack org.


### PR DESCRIPTION
Followed a similar approach as seen in other projects like Minikube.

NOTE: I decided not to add this badge but let me know if you think otherwise

[![Slack](https://img.shields.io/badge/-%23kubeapps-00437B.svg?longCache=true&style=flat-square&logo=slack)](https://kubernetes.slack.com/messages/C9D3TSUG4)

Closes https://github.com/kubeapps/kubeapps/issues/610 