### PR TITLE
Sync Chart version

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.6.1
+version: 0.6.2
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png


### PR DESCRIPTION
The Kubeapps chart version has been upgraded (by mistake I believe) in https://github.com/bitnami/charts/commit/a3cccff4fd868eca938b975270dd499f23fc54b9#diff-4412bb84ce5dfe442cbc3b4c64341900

Bumping the version here as well to avoid changes in the version 0.6.2