### PR TITLE
Show URL for ingress objects

### DIFF
--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLIngressItem.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLIngressItem.test.tsx
@@ -1,0 +1,76 @@
+import { IHTTPIngressPath, IIngressRule, IIngressSpec, IResource } from "shared/types";
+import { GetURLItemFromIngress } from "./AccessURLIngressItem";
+
+describe("GetURLItemFromIngress", () => {
+  interface Itest {
+    description: string;
+    hosts: string[];
+    paths: IHTTPIngressPath[];
+    tlsHosts: string[];
+    expectedURLs: string[];
+  }
+  const tests: Itest[] = [
+    {
+      description: "it should show the host without port",
+      hosts: ["foo.bar"],
+      paths: [],
+      tlsHosts: [],
+      expectedURLs: ["http://foo.bar"],
+    },
+    {
+      description: "it should show several hosts without port",
+      hosts: ["foo.bar", "not-foo.bar"],
+      paths: [],
+      tlsHosts: [],
+      expectedURLs: ["http://foo.bar", "http://not-foo.bar"],
+    },
+    {
+      description: "it should show the host with the different paths",
+      hosts: ["foo.bar"],
+      paths: [{ path: "/one" }, { path: "/two" }],
+      tlsHosts: [],
+      expectedURLs: ["http://foo.bar/one", "http://foo.bar/two"],
+    },
+    {
+      description: "it should show TLS hosts with https",
+      hosts: ["foo.bar", "not-foo.bar"],
+      paths: [],
+      tlsHosts: ["foo.bar"],
+      expectedURLs: ["https://foo.bar", "http://not-foo.bar"],
+    },
+  ];
+  tests.forEach(test => {
+    it(test.description, () => {
+      const ingress = {
+        metadata: {
+          name: "foo",
+        },
+        spec: {
+          rules: [],
+        } as IIngressSpec,
+      } as IResource;
+      test.hosts.forEach(h => {
+        const rule = {
+          host: h,
+          http: {
+            paths: [],
+          },
+        } as IIngressRule;
+        if (test.paths.length > 0) {
+          rule.http.paths = test.paths;
+        }
+        ingress.spec.rules.push(rule);
+      });
+      if (test.tlsHosts.length > 0) {
+        ingress.spec.tls = [
+          {
+            hosts: test.tlsHosts,
+          },
+        ];
+      }
+      const ingressItem = GetURLItemFromIngress(ingress);
+      expect(ingressItem.isLink).toBe(true);
+      expect(ingressItem.URLs).toEqual(test.expectedURLs);
+    });
+  });
+});

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLIngressItem.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLIngressItem.tsx
@@ -1,0 +1,40 @@
+import { IIngressSpec, IIngressTLS, IResource } from "shared/types";
+import { IURLItem } from "./IURLItem";
+
+// URLs returns the list of URLs obtained from the service status
+function URLs(ingress: IResource): string[] {
+  const spec = ingress.spec as IIngressSpec;
+  const res: string[] = [];
+  spec.rules.forEach(r => {
+    if (r.http.paths.length > 0) {
+      r.http.paths.forEach(p => {
+        res.push(getURL(r.host, spec.tls, p.path));
+      });
+    } else {
+      res.push(getURL(r.host, spec.tls));
+    }
+  });
+  return res;
+}
+
+// getURL returns a full URL based on a hostname, a TLS configuration and a optional path
+function getURL(hostname: string, tls?: IIngressTLS[], path?: string) {
+  // If the hostname is configured within the TLS hosts it will use HTTPS
+  const protocol =
+    tls &&
+    tls.some(tlsRule => {
+      return tlsRule.hosts.indexOf(hostname) > -1;
+    })
+      ? "https"
+      : "http";
+  return `${protocol}://${hostname}${path || ""}`;
+}
+
+export function GetURLItemFromIngress(ingress: IResource) {
+  return {
+    name: ingress.metadata.name,
+    type: "Ingress",
+    isLink: true,
+    URLs: URLs(ingress),
+  } as IURLItem;
+}

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLItem.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLItem.test.tsx
@@ -1,111 +1,28 @@
 import { shallow } from "enzyme";
-import context from "jest-plugin-context";
 import * as React from "react";
 
-import { IResource, IServiceSpec, IServiceStatus } from "shared/types";
 import AccessURLItem from "./AccessURLItem";
+import { IURLItem } from "./IURLItem";
 
-context("when the status is empty", () => {
-  const service = {
-    metadata: {
-      name: "foo",
-    },
-    spec: {
-      type: "LoadBalancer",
-      ports: [{ port: 8080 }],
-    } as IServiceSpec,
-    status: {
-      loadBalancer: {},
-    } as IServiceStatus,
-  } as IResource;
-
-  it("should show a Pending text", () => {
-    const wrapper = shallow(<AccessURLItem loadBalancerService={service} />);
-    expect(wrapper.text()).toContain("Pending");
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it("should not include a link", () => {
-    const wrapper = shallow(<AccessURLItem loadBalancerService={service} />);
-    expect(wrapper.find(".ServiceItem")).toExist();
-    const link = wrapper.find(".ServiceItem").find("a");
-    expect(link).not.toExist();
-  });
+it("should show only a message (without a link) if the item is not a link", () => {
+  const item = { name: "foo", isLink: false, URLs: ["Pending"] } as IURLItem;
+  const wrapper = shallow(<AccessURLItem URLItem={item} />);
+  expect(wrapper.text()).toContain("Pending");
+  expect(wrapper).toMatchSnapshot();
+  const link = wrapper.find(".ServiceItem").find("a");
+  expect(link).not.toExist();
 });
 
-context("when the status is populated", () => {
-  interface Itest {
-    description: string;
-    ports: any[];
-    ingress: any[];
-    expectedURLs: string[];
-  }
-  const tests: Itest[] = [
-    {
-      description: "it should show the IP and port if it's not known",
-      ports: [{ port: 8080 }],
-      ingress: [{ ip: "1.2.3.4" }],
-      expectedURLs: ["http://1.2.3.4:8080"],
-    },
-    {
-      description: "it should show the hostname and port if it's not known",
-      ports: [{ port: 8080 }],
-      ingress: [{ hostname: "1.2.3.4" }],
-      expectedURLs: ["http://1.2.3.4:8080"],
-    },
-    {
-      description: "it should show the IP and skip the port if it's known",
-      ports: [{ port: 80 }],
-      ingress: [{ ip: "1.2.3.4" }],
-      expectedURLs: ["http://1.2.3.4"],
-    },
-    {
-      description: "it should show the https URL if the port is 443",
-      ports: [{ port: 443 }],
-      ingress: [{ ip: "1.2.3.4" }],
-      expectedURLs: ["https://1.2.3.4"],
-    },
-    {
-      description: "it should show several URLs if there are multipe ports",
-      ports: [{ port: 8080 }, { port: 8081 }],
-      ingress: [{ ip: "1.2.3.4" }],
-      expectedURLs: ["http://1.2.3.4:8080", "http://1.2.3.4:8081"],
-    },
-    {
-      description: "it should show several URLs if there are ingress ports",
-      ports: [{ port: 8080 }, { port: 8081 }],
-      ingress: [{ ip: "1.2.3.4" }, { hostname: "foo.bar" }],
-      expectedURLs: [
-        "http://1.2.3.4:8080",
-        "http://1.2.3.4:8081",
-        "http://foo.bar:8080",
-        "http://foo.bar:8081",
-      ],
-    },
-  ];
-  tests.forEach(test => {
-    it(test.description, () => {
-      const service = {
-        metadata: {
-          name: "foo",
-        },
-        spec: {
-          type: "LoadBalancer",
-          ports: test.ports,
-        },
-        status: {
-          loadBalancer: {
-            ingress: test.ingress,
-          },
-        } as IServiceStatus,
-      } as IResource;
-      const wrapper = shallow(<AccessURLItem loadBalancerService={service} />);
-      test.expectedURLs.forEach(url => {
-        expect(wrapper.find(".ServiceItem")).toExist();
-        const link = wrapper.find(".ServiceItem").find("a");
-        expect(link).toExist();
-        expect(wrapper.text()).toContain(url);
-      });
-    });
-  });
+it("should show only an URL with a link", () => {
+  const item = {
+    name: "foo",
+    isLink: true,
+    URLs: ["http://1.2.3.4:8080", "https://foo.bar"],
+  } as IURLItem;
+  const wrapper = shallow(<AccessURLItem URLItem={item} />);
+  expect(wrapper.text()).toContain("http://1.2.3.4:8080");
+  expect(wrapper.text()).toContain("https://foo.bar");
+  expect(wrapper).toMatchSnapshot();
+  const link = wrapper.find(".ServiceItem").find("a");
+  expect(link).toExist();
 });

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLItem.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLItem.tsx
@@ -1,82 +1,38 @@
 import * as React from "react";
 
-import { IResource, IServiceSpec, IServiceStatus } from "../../../../shared/types";
 import "./AccessURLItem.css";
+import { IURLItem } from "./IURLItem";
 
 interface IAccessURLItem {
-  loadBalancerService: IResource;
+  URLItem: IURLItem;
 }
 
-class AccessURLItem extends React.Component<IAccessURLItem> {
-  public render() {
-    const { loadBalancerService } = this.props;
-    const isLink = this.isLink();
-    return (
-      <tr>
-        <td>{loadBalancerService.metadata.name}</td>
-        <td>{loadBalancerService.spec.type}</td>
-        <td>
-          {this.URLs().map(l => (
-            <span
-              key={l}
-              className={`ServiceItem ${
-                isLink ? "ServiceItem--with-link" : ""
-              } type-small margin-r-small padding-tiny padding-h-normal`}
-            >
-              {isLink ? (
-                <a className="padding-tiny padding-h-normal" href={l} target="_blank">
-                  {l}
-                </a>
-              ) : (
-                l
-              )}
-            </span>
-          ))}
-        </td>
-      </tr>
-    );
-  }
-
-  // isLink returns true if there are any link in the Item
-  private isLink(): boolean {
-    if (
-      this.props.loadBalancerService.status.loadBalancer.ingress &&
-      this.props.loadBalancerService.status.loadBalancer.ingress.length
-    ) {
-      return true;
-    }
-    return false;
-  }
-
-  // URLs returns the list of URLs obtained from the service status
-  private URLs(): string[] {
-    const URLs: string[] = [];
-    const { loadBalancerService } = this.props;
-    const status: IServiceStatus = loadBalancerService.status;
-    if (status.loadBalancer.ingress && status.loadBalancer.ingress.length) {
-      status.loadBalancer.ingress.forEach(i => {
-        (loadBalancerService.spec as IServiceSpec).ports.forEach(port => {
-          if (i.hostname) {
-            URLs.push(this.getURL(i.hostname, port.port));
-          }
-          if (i.ip) {
-            URLs.push(this.getURL(i.ip, port.port));
-          }
-        });
-      });
-    } else {
-      URLs.push("Pending");
-    }
-    return URLs;
-  }
-
-  // getURL returns a full URL adding the protocol and the port if needed
-  private getURL(base: string, port: number) {
-    const protocol = port === 443 ? "https" : "http";
-    // Only show the port in the URL if it's not a standard HTTP/HTTPS port
-    const portSuffix = port === 443 || port === 80 ? "" : `:${port}`;
-    return `${protocol}://${base}${portSuffix}`;
-  }
-}
+const AccessURLItem: React.SFC<IAccessURLItem> = props => {
+  const { URLItem } = props;
+  return (
+    <tr>
+      <td>{URLItem.name}</td>
+      <td>{URLItem.type}</td>
+      <td>
+        {URLItem.URLs.map(l => (
+          <span
+            key={l}
+            className={`ServiceItem ${
+              URLItem.isLink ? "ServiceItem--with-link" : ""
+            } type-small margin-r-small padding-tiny padding-h-normal`}
+          >
+            {URLItem.isLink ? (
+              <a className="padding-tiny padding-h-normal" href={l} target="_blank">
+                {l}
+              </a>
+            ) : (
+              l
+            )}
+          </span>
+        ))}
+      </td>
+    </tr>
+  );
+};
 
 export default AccessURLItem;

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLServiceItem.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLServiceItem.test.tsx
@@ -1,0 +1,89 @@
+import { IResource, IServiceStatus } from "shared/types";
+import { GetURLItemFromService } from "./AccessURLServiceItem";
+
+describe("GetURLItemFromService", () => {
+  interface Itest {
+    description: string;
+    ports: any[];
+    ingress: any[];
+    expectedLink: boolean;
+    expectedURLs: string[];
+  }
+  const tests: Itest[] = [
+    {
+      description: "it not return a link if the ingress definition is empty",
+      ports: [{ port: 8080 }],
+      ingress: [],
+      expectedLink: false,
+      expectedURLs: ["Pending"],
+    },
+    {
+      description: "it should show the IP and port if it's not known",
+      ports: [{ port: 8080 }],
+      ingress: [{ ip: "1.2.3.4" }],
+      expectedLink: true,
+      expectedURLs: ["http://1.2.3.4:8080"],
+    },
+    {
+      description: "it should show the hostname and port if it's not known",
+      ports: [{ port: 8080 }],
+      ingress: [{ hostname: "1.2.3.4" }],
+      expectedLink: true,
+      expectedURLs: ["http://1.2.3.4:8080"],
+    },
+    {
+      description: "it should show the IP and skip the port if it's known",
+      ports: [{ port: 80 }],
+      ingress: [{ ip: "1.2.3.4" }],
+      expectedLink: true,
+      expectedURLs: ["http://1.2.3.4"],
+    },
+    {
+      description: "it should show the https URL if the port is 443",
+      ports: [{ port: 443 }],
+      ingress: [{ ip: "1.2.3.4" }],
+      expectedLink: true,
+      expectedURLs: ["https://1.2.3.4"],
+    },
+    {
+      description: "it should show several URLs if there are multipe ports",
+      ports: [{ port: 8080 }, { port: 8081 }],
+      ingress: [{ ip: "1.2.3.4" }],
+      expectedLink: true,
+      expectedURLs: ["http://1.2.3.4:8080", "http://1.2.3.4:8081"],
+    },
+    {
+      description: "it should show several URLs if there are ingress ports",
+      ports: [{ port: 8080 }, { port: 8081 }],
+      ingress: [{ ip: "1.2.3.4" }, { hostname: "foo.bar" }],
+      expectedLink: true,
+      expectedURLs: [
+        "http://1.2.3.4:8080",
+        "http://1.2.3.4:8081",
+        "http://foo.bar:8080",
+        "http://foo.bar:8081",
+      ],
+    },
+  ];
+  tests.forEach(test => {
+    it(test.description, () => {
+      const service = {
+        metadata: {
+          name: "foo",
+        },
+        spec: {
+          type: "LoadBalancer",
+          ports: test.ports,
+        },
+        status: {
+          loadBalancer: {
+            ingress: test.ingress,
+          },
+        } as IServiceStatus,
+      } as IResource;
+      const svcItem = GetURLItemFromService(service);
+      expect(test.expectedLink).toEqual(svcItem.isLink);
+      expect(test.expectedURLs).toEqual(svcItem.URLs);
+    });
+  });
+});

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLServiceItem.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/AccessURLServiceItem.tsx
@@ -1,0 +1,51 @@
+import { IResource, IServiceSpec, IServiceStatus } from "shared/types";
+import { IURLItem } from "./IURLItem";
+
+// isLink returns true if there are any link in the Item
+function isLink(loadBalancerService: IResource): boolean {
+  if (
+    loadBalancerService.status.loadBalancer.ingress &&
+    loadBalancerService.status.loadBalancer.ingress.length
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// URLs returns the list of URLs obtained from the service status
+function URLs(loadBalancerService: IResource): string[] {
+  const res: string[] = [];
+  const status: IServiceStatus = loadBalancerService.status;
+  if (status.loadBalancer.ingress && status.loadBalancer.ingress.length) {
+    status.loadBalancer.ingress.forEach(i => {
+      (loadBalancerService.spec as IServiceSpec).ports.forEach(port => {
+        if (i.hostname) {
+          res.push(getURL(i.hostname, port.port));
+        }
+        if (i.ip) {
+          res.push(getURL(i.ip, port.port));
+        }
+      });
+    });
+  } else {
+    res.push("Pending");
+  }
+  return res;
+}
+
+// getURL returns a full URL adding the protocol and the port if needed
+function getURL(base: string, port: number) {
+  const protocol = port === 443 ? "https" : "http";
+  // Only show the port in the URL if it's not a standard HTTP/HTTPS port
+  const portSuffix = port === 443 || port === 80 ? "" : `:${port}`;
+  return `${protocol}://${base}${portSuffix}`;
+}
+
+export function GetURLItemFromService(loadBalancerService: IResource) {
+  return {
+    name: loadBalancerService.metadata.name,
+    type: "Service LoadBalancer",
+    isLink: isLink(loadBalancerService),
+    URLs: URLs(loadBalancerService),
+  } as IURLItem;
+}

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/IURLItem.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/IURLItem.tsx
@@ -1,0 +1,6 @@
+export interface IURLItem {
+  name: string;
+  type: string;
+  isLink: boolean;
+  URLs: string[];
+}

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/__snapshots__/AccessURLItem.test.tsx.snap
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLItem/__snapshots__/AccessURLItem.test.tsx.snap
@@ -1,19 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`when the status is empty should show a Pending text 1`] = `
+exports[`should show only a message (without a link) if the item is not a link 1`] = `
 <tr>
   <td>
     foo
   </td>
-  <td>
-    LoadBalancer
-  </td>
+  <td />
   <td>
     <span
       className="ServiceItem  type-small margin-r-small padding-tiny padding-h-normal"
       key="Pending"
     >
       Pending
+    </span>
+  </td>
+</tr>
+`;
+
+exports[`should show only an URL with a link 1`] = `
+<tr>
+  <td>
+    foo
+  </td>
+  <td />
+  <td>
+    <span
+      className="ServiceItem ServiceItem--with-link type-small margin-r-small padding-tiny padding-h-normal"
+      key="http://1.2.3.4:8080"
+    >
+      <a
+        className="padding-tiny padding-h-normal"
+        href="http://1.2.3.4:8080"
+        target="_blank"
+      >
+        http://1.2.3.4:8080
+      </a>
+    </span>
+    <span
+      className="ServiceItem ServiceItem--with-link type-small margin-r-small padding-tiny padding-h-normal"
+      key="https://foo.bar"
+    >
+      <a
+        className="padding-tiny padding-h-normal"
+        href="https://foo.bar"
+        target="_blank"
+      >
+        https://foo.bar
+      </a>
     </span>
   </td>
 </tr>

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
@@ -1,45 +1,112 @@
 import { shallow } from "enzyme";
+import context from "jest-plugin-context";
 import * as React from "react";
 
-import { IResource, IServiceSpec, IServiceStatus } from "shared/types";
+import { IIngressSpec, IResource, IServiceSpec, IServiceStatus } from "shared/types";
 import AccessURLItem from "./AccessURLItem";
 import AccessURLTable from "./AccessURLTable";
 
-it("should omit the Service Table if there are no public services", () => {
-  const service = {
-    metadata: {
-      name: "foo",
-    },
-    spec: {
-      type: "ClusterIP",
-      ports: [{ port: 8080 }],
-    } as IServiceSpec,
-    status: {
-      loadBalancer: {},
-    } as IServiceStatus,
-  } as IResource;
-  const services = {};
-  services[service.metadata.name] = service;
-  const wrapper = shallow(<AccessURLTable services={services} />);
-  expect(wrapper.text()).toBe("");
+context("when the app contain services", () => {
+  it("should omit the Service Table if there are no public services", () => {
+    const service = {
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        type: "ClusterIP",
+        ports: [{ port: 8080 }],
+      } as IServiceSpec,
+      status: {
+        loadBalancer: {},
+      } as IServiceStatus,
+    } as IResource;
+    const services = {};
+    services[service.metadata.name] = service;
+    const wrapper = shallow(<AccessURLTable services={services} ingresses={{}} />);
+    expect(wrapper.text()).toBe("");
+  });
+
+  it("should show the table if any service is a LoadBalancer", () => {
+    const service = {
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        type: "LoadBalancer",
+        ports: [{ port: 8080 }],
+      } as IServiceSpec,
+      status: {
+        loadBalancer: {},
+      } as IServiceStatus,
+    } as IResource;
+    const services = {};
+    services[service.metadata.name] = service;
+    const wrapper = shallow(<AccessURLTable services={services} ingresses={{}} />);
+    expect(wrapper.find(AccessURLItem)).toExist();
+    expect(wrapper).toMatchSnapshot();
+  });
 });
 
-it("should show the table if any service is a LoadBalancer", () => {
-  const service = {
-    metadata: {
-      name: "foo",
-    },
-    spec: {
-      type: "LoadBalancer",
-      ports: [{ port: 8080 }],
-    } as IServiceSpec,
-    status: {
-      loadBalancer: {},
-    } as IServiceStatus,
-  } as IResource;
-  const services = {};
-  services[service.metadata.name] = service;
-  const wrapper = shallow(<AccessURLTable services={services} />);
-  expect(wrapper.find(AccessURLItem)).toExist();
-  expect(wrapper).toMatchSnapshot();
+context("when the app contain ingresses", () => {
+  it("should show the table with available ingresses", () => {
+    const ingress = {
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        rules: [
+          {
+            host: "foo.bar",
+            http: {
+              paths: [{ path: "/ready" }],
+            },
+          },
+        ],
+      } as IIngressSpec,
+    };
+    const ingresses = {};
+    ingresses[ingress.metadata.name] = ingress;
+    const wrapper = shallow(<AccessURLTable services={{}} ingresses={ingresses} />);
+    expect(wrapper.find(AccessURLItem)).toExist();
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
+context("when the app contain services and ingresses", () => {
+  it("should show the table with available svcs and ingresses", () => {
+    const service = {
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        type: "LoadBalancer",
+        ports: [{ port: 8080 }],
+      } as IServiceSpec,
+      status: {
+        loadBalancer: {},
+      } as IServiceStatus,
+    } as IResource;
+    const services = {};
+    services[service.metadata.name] = service;
+    const ingress = {
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        rules: [
+          {
+            host: "foo.bar",
+            http: {
+              paths: [{ path: "/ready" }],
+            },
+          },
+        ],
+      } as IIngressSpec,
+    };
+    const ingresses = {};
+    ingresses[ingress.metadata.name] = ingress;
+    const wrapper = shallow(<AccessURLTable services={services} ingresses={ingresses} />);
+    expect(wrapper.find(AccessURLItem)).toExist();
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
@@ -2,17 +2,20 @@ import * as React from "react";
 
 import { IResource, IServiceSpec } from "../../../shared/types";
 import AccessURLItem from "./AccessURLItem";
+import { GetURLItemFromIngress } from "./AccessURLItem/AccessURLIngressItem";
+import { GetURLItemFromService } from "./AccessURLItem/AccessURLServiceItem";
 
 interface IServiceTableProps {
   services: { [s: string]: IResource };
+  ingresses: { [i: string]: IResource };
 }
 
 class AccessURLTable extends React.Component<IServiceTableProps> {
   public render() {
-    const { services } = this.props;
+    const { services, ingresses } = this.props;
     const publicServices = this.publicServices();
     return (
-      publicServices.length > 0 && (
+      (publicServices.length > 0 || Object.keys(ingresses).length > 0) && (
         <table>
           <thead>
             <tr>
@@ -23,7 +26,10 @@ class AccessURLTable extends React.Component<IServiceTableProps> {
           </thead>
           <tbody>
             {publicServices.map((k: string) => (
-              <AccessURLItem key={k} loadBalancerService={services[k]} />
+              <AccessURLItem key={k} URLItem={GetURLItemFromService(services[k])} />
+            ))}
+            {Object.keys(ingresses).map((k: string) => (
+              <AccessURLItem key={k} URLItem={GetURLItemFromIngress(ingresses[k])} />
             ))}
           </tbody>
         </table>

--- a/dashboard/src/components/AppView/AccessURLTable/__snapshots__/AccessURLTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/AccessURLTable/__snapshots__/AccessURLTable.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should show the table if any service is a LoadBalancer 1`] = `
+exports[`when the app contain ingresses should show the table with available ingresses 1`] = `
 <table>
   <thead>
     <tr>
@@ -17,25 +17,96 @@ exports[`should show the table if any service is a LoadBalancer 1`] = `
   </thead>
   <tbody>
     <AccessURLItem
-      key="foo"
-      loadBalancerService={
+      URLItem={
         Object {
-          "metadata": Object {
-            "name": "foo",
-          },
-          "spec": Object {
-            "ports": Array [
-              Object {
-                "port": 8080,
-              },
-            ],
-            "type": "LoadBalancer",
-          },
-          "status": Object {
-            "loadBalancer": Object {},
-          },
+          "URLs": Array [
+            "http://foo.bar/ready",
+          ],
+          "isLink": true,
+          "name": "foo",
+          "type": "Ingress",
         }
       }
+      key="foo"
+    />
+  </tbody>
+</table>
+`;
+
+exports[`when the app contain services and ingresses should show the table with available svcs and ingresses 1`] = `
+<table>
+  <thead>
+    <tr>
+      <th>
+        NAME
+      </th>
+      <th>
+        TYPE
+      </th>
+      <th>
+        URL
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <AccessURLItem
+      URLItem={
+        Object {
+          "URLs": Array [
+            "Pending",
+          ],
+          "isLink": false,
+          "name": "foo",
+          "type": "Service LoadBalancer",
+        }
+      }
+      key="foo"
+    />
+    <AccessURLItem
+      URLItem={
+        Object {
+          "URLs": Array [
+            "http://foo.bar/ready",
+          ],
+          "isLink": true,
+          "name": "foo",
+          "type": "Ingress",
+        }
+      }
+      key="foo"
+    />
+  </tbody>
+</table>
+`;
+
+exports[`when the app contain services should show the table if any service is a LoadBalancer 1`] = `
+<table>
+  <thead>
+    <tr>
+      <th>
+        NAME
+      </th>
+      <th>
+        TYPE
+      </th>
+      <th>
+        URL
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <AccessURLItem
+      URLItem={
+        Object {
+          "URLs": Array [
+            "Pending",
+          ],
+          "isLink": false,
+          "name": "foo",
+          "type": "Service LoadBalancer",
+        }
+      }
+      key="foo"
     />
   </tbody>
 </table>

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -111,6 +111,26 @@ export interface IPort {
   nodePort: string;
 }
 
+export interface IHTTPIngressPath {
+  path: string;
+}
+export interface IIngressHTTP {
+  paths: IHTTPIngressPath[];
+}
+export interface IIngressRule {
+  host: string;
+  http: IIngressHTTP;
+}
+
+export interface IIngressTLS {
+  hosts: string[];
+}
+
+export interface IIngressSpec {
+  rules: IIngressRule[];
+  tls?: IIngressTLS[];
+}
+
 export interface IResource {
   apiVersion: string;
   kind: string;


### PR DESCRIPTION
Closes #674 

Show in the URL table elements for the ingress rules as well:

<img width="604" alt="screen shot 2018-10-05 at 15 53 36" src="https://user-images.githubusercontent.com/4025665/46540212-f123e800-c8b8-11e8-994a-aa65be634187.png">

The design was discussed here: #673

Implementation details:

 - Now `AccessURLServiceItem` and `AccessURLIngressItem` returns a type `IURLItem`.
 - `AccessURLItem` renders a `IURLItem`.
 - `AccessURLTable` receives a list of ingresses and services, parses them as `IURLItems` and renders them as `AccessURLItem`.