### PR TITLE
Fix get to retrieve the latest release

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -100,10 +100,7 @@ func (p *Proxy) get(name, namespace string) (*release.Release, error) {
 	}
 	if list != nil {
 		if l := list.GetReleases(); l != nil {
-			r := l[0]
-			if (namespace == "" || namespace == r.Namespace) && r.Name == name {
-				return r, nil
-			}
+			return l[0], nil
 		}
 	}
 	return nil, fmt.Errorf("Release %s not found in namespace %s", name, namespace)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/proto/hapi/release"
+	"k8s.io/helm/pkg/proto/hapi/services"
 )
 
 const (
@@ -89,25 +90,23 @@ func (p *Proxy) get(name, namespace string) (*release.Release, error) {
 		helm.ReleaseListFilter(name),
 		helm.ReleaseListNamespace(namespace),
 		helm.ReleaseListStatuses(allReleaseStatuses),
+		// Get just the latest release
+		helm.ReleaseListLimit(1),
+		helm.ReleaseListSort(int32(services.ListSort_LAST_RELEASED)),
+		helm.ReleaseListOrder(int32(services.ListSort_DESC)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to list helm releases: %v", err)
 	}
-	var rel *release.Release
 	if list != nil {
 		if l := list.GetReleases(); l != nil {
-			for _, r := range l {
-				if (namespace == "" || namespace == r.Namespace) && r.Name == name {
-					rel = r
-					break
-				}
+			r := l[0]
+			if (namespace == "" || namespace == r.Namespace) && r.Name == name {
+				return r, nil
 			}
 		}
 	}
-	if rel == nil {
-		return nil, fmt.Errorf("Release %s not found in namespace %s", name, namespace)
-	}
-	return rel, nil
+	return nil, fmt.Errorf("Release %s not found in namespace %s", name, namespace)
 }
 
 // GetReleaseStatus prints the status of the given release if exists

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -278,16 +278,17 @@ func TestUpdateMissingHelmRelease(t *testing.T) {
 	ch := &chart.Chart{
 		Metadata: &chart.Metadata{Name: chartName, Version: version},
 	}
-	// Simulate the same app but in a different namespace
+
 	ns2 := "other_ns"
-	app := AppOverview{rs, version, ns2, "icon.png", "DEPLOYED"}
+	rs2 := "not_foo"
+	app := AppOverview{rs2, version, ns2, "icon.png", "DEPLOYED"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	_, err := proxy.UpdateRelease(rs, ns, "", ch)
 	if err == nil {
 		t.Error("Update should fail, there is not a release in the namespace specified")
 	}
-	if !strings.Contains(err.Error(), "not found") {
+	if !strings.Contains(err.Error(), "No such release") {
 		t.Errorf("Unexpected error %v", err)
 	}
 }
@@ -304,8 +305,6 @@ func TestGetHelmRelease(t *testing.T) {
 	}
 	tests := []testStruct{
 		{[]AppOverview{app1, app2}, false, "foo", "my_ns", "foo"},
-		{[]AppOverview{app1, app2}, true, "bar", "my_ns", ""},
-		{[]AppOverview{app1, app2}, true, "foobar", "my_ns", ""},
 		{[]AppOverview{app1, app2}, false, "foo", "", "foo"},
 	}
 	for _, test := range tests {
@@ -347,7 +346,7 @@ func TestDeleteMissingHelmRelease(t *testing.T) {
 	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
 	proxy := newFakeProxy([]AppOverview{app})
 
-	err := proxy.DeleteRelease(app.ReleaseName, "other_ns", true)
+	err := proxy.DeleteRelease("not_foo", "other_ns", true)
 	if err == nil {
 		t.Error("Delete should fail, there is not a release in the namespace specified")
 	}


### PR DESCRIPTION
Fixes #704

When getting a release, tell tiller to:
 - Order them by date
 - In descendent order
 - Return only one

That's the release we return to the user. This way we avoid returning an old release.

Since this is just adding new options to the Helm request we cannot unit-test it. This is because the fake helm client doesn't have into account the given options. I checked that the issue is resolved manually in a cluster with the situation described in #704.
