### PR TITLE
Add "id" to headings

### DIFF
--- a/dashboard/src/components/ChartView/ChartReadme.test.tsx
+++ b/dashboard/src/components/ChartView/ChartReadme.test.tsx
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import context from "jest-plugin-context";
 import * as React from "react";
 import * as ReactMarkdown from "react-markdown";
@@ -56,4 +56,17 @@ it("renders an error when hasError is set", () => {
     <ChartReadme getChartReadme={jest.fn()} hasError={true} version="1.2.3" />,
   );
   expect(wrapper.text()).toContain("No README found");
+});
+
+it("renders the ReactMarkdown content adding IDs for the titles", () => {
+  const wrapper = mount(
+    <ChartReadme
+      getChartReadme={jest.fn()}
+      hasError={false}
+      version="1.2.3"
+      readme="# _Markdown_ 'Readme_or_not'!"
+    />,
+  );
+  const component = wrapper.find("#markdown-readme_or_not");
+  expect(component).toExist();
 });

--- a/dashboard/src/components/ChartView/ChartReadme.tsx
+++ b/dashboard/src/components/ChartView/ChartReadme.tsx
@@ -3,6 +3,7 @@ import { FileText } from "react-feather";
 import * as ReactMarkdown from "react-markdown";
 
 import LoadingWrapper from "../LoadingWrapper";
+import HeadingRenderer from "./HeadingRenderer";
 
 import "./ChartReadme.css";
 
@@ -11,23 +12,6 @@ interface IChartReadmeProps {
   hasError: boolean;
   readme?: string;
   version: string;
-}
-
-// Code from https://github.com/rexxars/react-markdown/issues/69
-function flatten(text: string, child: any): any {
-  return typeof child === "string"
-    ? text + child
-    : React.Children.toArray(child.props.children).reduce(flatten, text);
-}
-
-function HeadingRenderer(props: any) {
-  const children = React.Children.toArray(props.children);
-  const text = children.reduce(flatten, "");
-  const slug = text
-    .toLowerCase()
-    .replace(/[^a-zA-Z0-9_\s]/g, "") // remove punctuation
-    .replace(/\s/g, "-"); // replace spaces with dash
-  return React.createElement("h" + props.level, { id: slug }, props.children);
 }
 
 class ChartReadme extends React.Component<IChartReadmeProps> {

--- a/dashboard/src/components/ChartView/ChartReadme.tsx
+++ b/dashboard/src/components/ChartView/ChartReadme.tsx
@@ -13,6 +13,23 @@ interface IChartReadmeProps {
   version: string;
 }
 
+// Code from https://github.com/rexxars/react-markdown/issues/69
+function flatten(text: string, child: any): any {
+  return typeof child === "string"
+    ? text + child
+    : React.Children.toArray(child.props.children).reduce(flatten, text);
+}
+
+function HeadingRenderer(props: any) {
+  const children = React.Children.toArray(props.children);
+  const text = children.reduce(flatten, "");
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9_\s]/g, "") // remove punctuation
+    .replace(/\s/g, "-"); // replace spaces with dash
+  return React.createElement("h" + props.level, { id: slug }, props.children);
+}
+
 class ChartReadme extends React.Component<IChartReadmeProps> {
   public componentWillMount() {
     const { getChartReadme, version } = this.props;
@@ -35,7 +52,7 @@ class ChartReadme extends React.Component<IChartReadmeProps> {
       <LoadingWrapper loaded={!!readme}>
         {readme && (
           <div className="ChartReadme">
-            <ReactMarkdown source={readme} />
+            <ReactMarkdown source={readme} renderers={{ heading: HeadingRenderer }} />
           </div>
         )}
       </LoadingWrapper>

--- a/dashboard/src/components/ChartView/HeadingRenderer.tsx
+++ b/dashboard/src/components/ChartView/HeadingRenderer.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+// Code from https://github.com/rexxars/react-markdown/issues/69
+function flatten(text: string, child: any): any {
+  return typeof child === "string"
+    ? text + child
+    : React.Children.toArray(child.props.children).reduce(flatten, text);
+}
+
+const HeadingRenderer: React.SFC<{}> = (props: any) => {
+  const children = React.Children.toArray(props.children);
+  const text = children.reduce(flatten, "");
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9_\s]/g, "") // remove punctuation
+    .replace(/\s/g, "-"); // replace spaces with dash
+  return React.createElement("h" + props.level, { id: slug }, props.children);
+};
+
+export default HeadingRenderer;


### PR DESCRIPTION
Fixes #702

Add the "id" property to the headings when parsing markdown. The approach to do that is specified here:
https://github.com/rexxars/react-markdown/issues/69

The logic to transform the heading text into a link is the same than GitHub: https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb#L42