### PR TITLE
e2e test: remove check for chartsvc image

### DIFF
--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -63,7 +63,6 @@ helm install --name kubeapps-ci --namespace kubeapps $ROOT_DIR/chart/kubeapps \
 
 # Ensure that we are testing the correct image
 k8s_ensure_image kubeapps kubeapps-ci-internal-apprepository-controller $DEV_TAG
-k8s_ensure_image kubeapps kubeapps-ci-internal-chartsvc $DEV_TAG
 k8s_ensure_image kubeapps kubeapps-ci-internal-dashboard $DEV_TAG
 k8s_ensure_image kubeapps kubeapps-ci-internal-tiller-proxy $DEV_TAG
 


### PR DESCRIPTION
We use the upstream built image for chartsvc and no longer build it in
the CI, so we shouldn't check for the image tag