### PR TITLE
[Kubeapps Chart] Simplify ingress configuration for cert-manager

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.8.0
+version: 1.0.0
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kubeapps
 version: 0.8.0
-appVersion: v1.0.0-beta.2
+appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png
 keywords:

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 1.0.0
+version: 0.9.0
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kubeapps
-version: 0.7.0
-appVersion: DEVEL
+version: 0.8.0
+appVersion: v1.0.0-beta.2
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png
 keywords:

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -171,7 +171,7 @@ To enable ingress integration, please set `ingress.enabled` to `true`
 
 ##### Hosts
 
-Most likely you will only want to have one hostname that maps to this Kubeapps installation, however, it is possible to have more than one host.  To facilitate this, the `ingress.hosts` object is an array.
+Most likely you will only want to have one hostname that maps to this Kubeapps installation, however, it is possible to have more than one host. To facilitate this, the `ingress.hosts` object is an array.
 
 ##### Annotations
 
@@ -179,7 +179,9 @@ For annotations, please see [this document](https://github.com/kubernetes/ingres
 
 ##### TLS
 
-TLS can be configured using the `ingress.tls` object in the same format that the Kubernetes Ingress requests. Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls) for more information.
+TLS can be configured using setting the `ingress.hosts[].tls` boolean of the corresponding hostname to true, then you can choose the TLS secret name setting `ingress.hosts[].tlsSecret`. Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls) for more information.
+
+If your cluster has a [cert-manager](https://github.com/jetstack/cert-manager) add-on to automate the management and issuance of TLS certificates, set `ingress.hosts[].certManager` boolean to true to enable the corresponding annotations for cert-manager. Otherwise, you can provide your own certificates using the `ingress.secrets` object.
 
 ## Troubleshooting
 

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -181,7 +181,16 @@ For annotations, please see [this document](https://github.com/kubernetes/ingres
 
 TLS can be configured using setting the `ingress.hosts[].tls` boolean of the corresponding hostname to true, then you can choose the TLS secret name setting `ingress.hosts[].tlsSecret`. Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls) for more information.
 
-If your cluster has a [cert-manager](https://github.com/jetstack/cert-manager) add-on to automate the management and issuance of TLS certificates, set `ingress.hosts[].certManager` boolean to true to enable the corresponding annotations for cert-manager. Otherwise, you can provide your own certificates using the `ingress.secrets` object.
+You can provide your own certificates using the `ingress.secrets` object. If your cluster has a [cert-manager](https://github.com/jetstack/cert-manager) add-on to automate the management and issuance of TLS certificates, set `ingress.hosts[].certManager` boolean to true to enable the corresponding annotations for cert-manager as shown in the example below:
+
+```console
+helm install --name kubeapps --namespace kubeapps bitnami/kubeapps \
+  --set ingress.enabled=true \
+  --set ingress.certManager=true \
+  --set ingress.hosts[0].name=kubeapps.custom.domain \
+  --set ingress.hosts[0].tls=true \
+  --set ingress.hosts[0].tlsSecret=kubeapps-tls
+```
 
 ## Troubleshooting
 

--- a/chart/kubeapps/templates/ingress.yaml
+++ b/chart/kubeapps/templates/ingress.yaml
@@ -1,38 +1,36 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "kubeapps.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
+{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ template "kubeapps.fullname" $ }}
   labels:
-    app: {{ include "kubeapps.name" . }}
-    chart: {{ include "kubeapps.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-{{- with .Values.ingress.annotations }}
+    app: {{ template "kubeapps.name" $ }}
+    chart: {{ template "kubeapps.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
-      http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
-  {{- end }}
+  - host: {{ .name }}
+    http:
+      paths:
+      - path: {{ default "/" .path }}
+        backend:
+          serviceName: {{ template "kubeapps.fullname" $ }}
+          servicePort: http
+{{- if .tls }}
+  tls:
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
 {{- end }}

--- a/chart/kubeapps/templates/ingress.yaml
+++ b/chart/kubeapps/templates/ingress.yaml
@@ -2,12 +2,12 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "kubeapps.fullname" $ }}
+  name: {{ template "kubeapps.fullname" . }}
   labels:
-    app: {{ template "kubeapps.name" $ }}
-    chart: {{ template "kubeapps.chart" $ }}
-    release: {{ $.Release.Name }}
-    heritage: {{ $.Release.Service }}
+    app: {{ template "kubeapps.name" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
@@ -34,5 +34,4 @@ spec:
     secretName: {{ .tlsSecret }}
   {{- end }}
   {{- end }}
----
 {{- end }}

--- a/chart/kubeapps/templates/ingress.yaml
+++ b/chart/kubeapps/templates/ingress.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.ingress.enabled -}}
-{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -10,14 +9,15 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
   annotations:
-    {{- if .certManager }}
+    {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .annotations }}
+    {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
+  {{- range .Values.ingress.hosts }}
   - host: {{ .name }}
     http:
       paths:
@@ -25,12 +25,14 @@ spec:
         backend:
           serviceName: {{ template "kubeapps.fullname" $ }}
           servicePort: http
-{{- if .tls }}
+  {{- end }}
   tls:
+  {{- range .Values.ingress.hosts }}
+  {{- if .tls }}
   - hosts:
     - {{ .name }}
     secretName: {{ .tlsSecret }}
-{{- end }}
+  {{- end }}
+  {{- end }}
 ---
-{{- end }}
 {{- end }}

--- a/chart/kubeapps/templates/tls-secrets.yaml
+++ b/chart/kubeapps/templates/tls-secrets.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "kubeapps.fullname" $ }}
+  name: {{ .name }}
   labels:
     app: {{ template "kubeapps.name" $ }}
     chart: {{ template "kubeapps.chart" $ }}
@@ -13,6 +13,5 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}
   tls.key: {{ .key | b64enc }}
----
 {{- end }}
 {{- end }}

--- a/chart/kubeapps/templates/tls-secrets.yaml
+++ b/chart/kubeapps/templates/tls-secrets.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kubeapps.fullname" $ }}
+  labels:
+    app: {{ template "kubeapps.name" $ }}
+    chart: {{ template "kubeapps.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -12,26 +12,28 @@ ingress:
   # Set to true to enable ingress record generation
   enabled: false
 
+  # Set this to true in order to add the corresponding annotations for cert-manager
+  certManager: false
+
+  # Ingress annotations done as key:value pairs
+  # For a full list of possible ingress annotations, please see
+  # ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  #
+  # If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  annotations:
+  #  kubernetes.io/ingress.class: nginx
+    
   # The list of hostnames to be covered with this ingress record.
   # Most likely this will be just one host, but in the event more hosts are needed, this is an array
   hosts:
   - name: kubeapps.local
     path: /
+
     # Set this to true in order to enable TLS on the ingress record
     tls: false
-    # Set this to true in order to add the corresponding annotations for cert-manager
-    certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
     tlsSecret: kubeapps.local-tls
-
-    # Ingress annotations done as key:value pairs
-    # For a full list of possible ingress annotations, please see
-    # ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
-    #
-    # If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-    annotations:
-    #  kubernetes.io/ingress.class: nginx
 
   secrets:
   # If you're providing your own certificates, please use this to add the certificates as secrets
@@ -90,7 +92,7 @@ apprepository:
   image:
     registry: docker.io
     repository: kubeapps/apprepository-controller
-    tag: v1.0.0-beta.2
+    tag: latest
   # Image used to perform chart repository syncs
   syncImage:
     registry: docker.io
@@ -136,7 +138,7 @@ tillerProxy:
   image:
     registry: docker.io
     repository: kubeapps/tiller-proxy
-    tag: v1.0.0-beta.2
+    tag: latest
   service:
     port: 8080
   host: tiller-deploy.kube-system:44134
@@ -198,7 +200,7 @@ dashboard:
   image:
     registry: docker.io
     repository: kubeapps/dashboard
-    tag: v1.0.0-beta.2
+    tag: latest
   service:
     port: 8080
   livenessProbe:

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -6,16 +6,46 @@
 # The frontend service is the main reverse proxy used to access the Kubeapps UI
 # To expose Kubeapps externally either configure the ingress object below or
 # set frontend.service.type=LoadBalancer in the frontend configuration.
+# ref: http://kubernetes.io/docs/user-guide/ingress/
+#
 ingress:
+  # Set to true to enable ingress record generation
   enabled: false
-  annotations: {}
-  path: /
+
+  # The list of hostnames to be covered with this ingress record.
+  # Most likely this will be just one host, but in the event more hosts are needed, this is an array
   hosts:
-  - kubeapps.local
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+  - name: kubeapps.local
+    path: /
+    # Set this to true in order to enable TLS on the ingress record
+    tls: false
+    # Set this to true in order to add the corresponding annotations for cert-manager
+    certManager: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: kubeapps.local-tls
+
+    # Ingress annotations done as key:value pairs
+    # For a full list of possible ingress annotations, please see
+    # ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    #
+    # If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+
+  secrets:
+  # If you're providing your own certificates, please use this to add the certificates as secrets
+  # key and certificate should start with -----BEGIN CERTIFICATE----- or
+  # -----BEGIN RSA PRIVATE KEY-----
+  #
+  # name should line up with a tlsSecret set further up
+  # If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  #
+  # It is also possible to create and manage the certificates outside of this helm chart
+  # Please see README.md for more information
+  # - name: kubeapps.local-tls
+  #   key:
+  #   certificate:
 
 frontend:
   replicaCount: 2
@@ -60,7 +90,7 @@ apprepository:
   image:
     registry: docker.io
     repository: kubeapps/apprepository-controller
-    tag: latest
+    tag: v1.0.0-beta.2
   # Image used to perform chart repository syncs
   syncImage:
     registry: docker.io
@@ -106,7 +136,7 @@ tillerProxy:
   image:
     registry: docker.io
     repository: kubeapps/tiller-proxy
-    tag: latest
+    tag: v1.0.0-beta.2
   service:
     port: 8080
   host: tiller-deploy.kube-system:44134
@@ -168,7 +198,7 @@ dashboard:
   image:
     registry: docker.io
     repository: kubeapps/dashboard
-    tag: latest
+    tag: v1.0.0-beta.2
   service:
     port: 8080
   livenessProbe:


### PR DESCRIPTION
### What this PR does / why we need it:

This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so.

E.g.:

```
helm install --name kubeapps --namespace kubeapps bitnami/kubeapps \
  --set ingress.enabled=true \
  --set ingress.hosts[0].name=kubeapps.custom.domain \
  --set ingress.hosts[0].tls=true \
  --set ingress.hosts[0].tlsSecret=kubeapps-tls \
  --set ingress.hosts[0].certManager=true
```

This will generate the following ingress:

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: kubeapps
  namespace: kubeapps
  labels:
    app: kubeapps
    chart: kubeapps-0.8.0
    release: kubeapps
    heritage: Tiller
  annotations:
    kubernetes.io/tls-acme: "true"
spec:
  rules:
  - host: kubeapps.custom.domain
    http:
      paths:
      - path: /
        backend:
          serviceName: kubeapps
          servicePort: http
  tls:
  - hosts:
    - kubeapps.custom.domain 
    secretName: kubeapps-tls
```

See also https://github.com/bitnami/charts/pull/882