### PR TITLE
Fix quay.io images FQDN

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.9.0
+version: 0.9.1
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -95,8 +95,8 @@ apprepository:
     tag: latest
   # Image used to perform chart repository syncs
   syncImage:
-    registry: docker.io
-    repository: quay.io/helmpack/chart-repo
+    registry: quay.io
+    repository: helmpack/chart-repo
     tag: v1.0.0
   initialRepos:
   - name: stable
@@ -163,8 +163,8 @@ tillerProxy:
 chartsvc:
   replicaCount: 2
   image:
-    registry: docker.io
-    repository: quay.io/helmpack/chartsvc
+    registry: quay.io
+    repository: helmpack/chartsvc
     tag: v1.0.0
   service:
     port: 8080


### PR DESCRIPTION
Fixes our chart to be able to pull images from quay

NOTE: It seems that this is not an issue in regular K8s but it is in Openshift. I reproduced the fix there.

```
diff /tmp/before.txt /tmp/after.txt 
<         - --repo-sync-image=docker.io/quay.io/helmpack/chart-repo:v1.0.0
---
>         - --repo-sync-image=quay.io/helmpack/chart-repo:v1.0.0
950c950
<         image: docker.io/quay.io/helmpack/chartsvc:v1.0.0
---
>         image: quay.io/helmpack/chartsvc:v1.0.0

```
Closes https://github.com/kubeapps/kubeapps/issues/750