### PR TITLE
Adapt Notes.txt to new Ingress configuration

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.9.1
+version: 0.9.2
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/NOTES.txt
+++ b/chart/kubeapps/templates/NOTES.txt
@@ -14,11 +14,11 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
 
 1. Get the Kubeapps URL and associate Kubeapps hostname to your cluster external IP:
 
-{{- range .Values.ingress.hosts }}
    export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
-   echo "Kubeapps URL: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}"
-   echo "$CLUSTER_IP  {{ . }}" | sudo tee -a /etc/hosts
-{{- end }}
+   {{- range .Values.ingress.hosts }}
+   echo "Kubeapps URL: http{{ if .tls }}s{{ end }}://{{ .name }}{{ default "/" .path }}"
+   echo "$CLUSTER_IP  {{ .name }}" | sudo tee -a /etc/hosts
+   {{- end }}
 
 {{- else }}
 


### PR DESCRIPTION
Notes shown after installing the chart are not fine when enabling Ingress as a consequence of https://github.com/kubeapps/kubeapps/pull/740

```
To access Kubeapps from outside your K8s cluster, follow the steps below:

1. Get the Kubeapps URL and associate Kubeapps hostname to your cluster external IP:
   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
   echo "Kubeapps URL: http://map[tlsSecret:kubeapps-tls certManager:true name:kubeapps.two-k8s-1-10-8.aks.fuloi.com tls:true]"
   echo "$CLUSTER_IP  map[certManager:true name:kubeapps.two-k8s-1-10-8.aks.fuloi.com tls:true tlsSecret:kubeapps-tls]" | sudo tee -a /etc/hosts
```

This PR adapts **NOTES.txt** to the new way of configuring ingress