### PR TITLE
bumps chart-repo and chartsvc to v1.0.1

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -97,7 +97,7 @@ apprepository:
   syncImage:
     registry: quay.io
     repository: helmpack/chart-repo
-    tag: v1.0.0
+    tag: v1.0.1
   initialRepos:
   - name: stable
     url: https://kubernetes-charts.storage.googleapis.com
@@ -165,7 +165,7 @@ chartsvc:
   image:
     registry: quay.io
     repository: helmpack/chartsvc
-    tag: v1.0.0
+    tag: v1.0.1
   service:
     port: 8080
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262


### PR DESCRIPTION
Fixes an issue with syncing updated chart tarballs (#659) and the
timeout for connecting to MongoDB.

See https://github.com/helm/monocular/releases/tag/v1.0.1.

fixes #659