### PR TITLE
namespace apprepo-controller kube informer

### DIFF
--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -1,44 +1,4 @@
 {{- if .Values.rbac.create -}}
-# Need a cluster role because client-go v5.0.1 does not support namespaced
-# informers
-# TODO: remove when we update to client-go v6.0.0
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: {{ template "kubeapps.apprepository.fullname" . }}
-  labels:
-    app: {{ template "kubeapps.apprepository.fullname" . }}
-    chart: {{ template "kubeapps.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-rules:
-- apiGroups:
-  - batch
-  resources:
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ template "kubeapps.apprepository.fullname" . }}
-  labels:
-    app: {{ template "kubeapps.apprepository.fullname" . }}
-    chart: {{ template "kubeapps.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "kubeapps.apprepository.fullname" . }}
-subjects:
-- kind: ServiceAccount
-  name: {{ template "kubeapps.apprepository.fullname" . }}
-  namespace: {{ .Release.Namespace }}
----
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -141,8 +141,9 @@ func NewController(
 	// Set up an event handler for when CronJob resources get deleted. This
 	// handler will lookup the owner of the given CronJob, and if it is owned by a
 	// AppRepository resource will enqueue that AppRepository resource for
-	// processing. This way, we don't need to implement custom logic for handling
-	// CronJob resources. More info on this pattern:
+	// processing so the CronJob gets correctly recreated. This way, we don't need
+	// to implement custom logic for handling CronJob resources. More info on this
+	// pattern:
 	// https://github.com/kubernetes/community/blob/8cafef897a22026d42f5e5bb3f104febe7e29830/contributors/devel/controllers.md
 	cronjobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: controller.handleObject,

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -62,7 +62,7 @@ func main() {
 		glog.Fatalf("Error building apprepo clientset: %s", err.Error())
 	}
 
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+	kubeInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(kubeClient, 0, namespace, nil)
 	apprepoInformerFactory := informers.NewFilteredSharedInformerFactory(apprepoClient, 0, namespace, nil)
 
 	controller := NewController(kubeClient, apprepoClient, kubeInformerFactory, apprepoInformerFactory)


### PR DESCRIPTION
The NewFilteredSharedInformerFactory was not available in previous versions
of client-go we were using. Now that we've upgraded, we can correctly
filter down to the namespace this controller is interested in
(the one Kubeapps is installed in).

chart: remove clusterrole for apprepository-controller

Now that we are able to watch on the specific namespace Kubeapps was
installed in, we no longer need the clusterrole to watch cluster-wide
CronJobs.

fixes #504