### PR TITLE
Show correct release name in case of error

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -60,12 +60,35 @@ describe("renders an error", () => {
         error={new UnprocessableEntity("wrong format!")}
       />,
     );
-    wrapper.setState({ releaseName: "my-app" });
+    wrapper.setState({ latestSubmittedReleaseName: "my-app" });
     expect(wrapper.find(ErrorSelector).exists()).toBe(true);
     expect(wrapper.find(ErrorSelector).html()).toContain(
       "Sorry! Something went wrong processing my-app",
     );
     expect(wrapper.find(ErrorSelector).html()).toContain("wrong format!");
+  });
+
+  it("the error does not change if the release name changes", () => {
+    const expectedErrorMsg = "Sorry! Something went wrong processing my-app";
+
+    const wrapper = shallow(
+      <DeploymentForm
+        {...defaultProps}
+        selected={
+          {
+            version: { attributes: {} },
+            versions: [{ id: "foo", attributes: {} }],
+          } as IChartState["selected"]
+        }
+        error={new UnprocessableEntity("wrong format!")}
+      />,
+    );
+
+    wrapper.setState({ latestSubmittedReleaseName: "my-app" });
+    expect(wrapper.find(ErrorSelector).exists()).toBe(true);
+    expect(wrapper.find(ErrorSelector).html()).toContain(expectedErrorMsg);
+    wrapper.setState({ releaseName: "my-app2" });
+    expect(wrapper.find(ErrorSelector).html()).toContain(expectedErrorMsg);
   });
 });
 

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -87,7 +87,7 @@ describe("renders an error", () => {
     wrapper.setState({ latestSubmittedReleaseName: "my-app" });
     expect(wrapper.find(ErrorSelector).exists()).toBe(true);
     expect(wrapper.find(ErrorSelector).html()).toContain(expectedErrorMsg);
-    wrapper.setState({ releaseName: "my-app2" });
+    wrapper.setState({ releaseName: "another-app" });
     expect(wrapper.find(ErrorSelector).html()).toContain(expectedErrorMsg);
   });
 });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -107,7 +107,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   public render() {
     const { selected, bindingsWithSecrets, chartID, chartVersion, namespace } = this.props;
     const { version, versions } = selected;
-    const { appValues } = this.state;
+    const { appValues, latestSubmittedReleaseName } = this.state;
     if (selected.error) {
       return (
         <ErrorSelector error={selected.error} resource={`Chart "${chartID}" (${chartVersion})`} />
@@ -125,7 +125,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
               namespace={namespace}
               defaultRequiredRBACRoles={{ create: this.requiredRBACRoles() }}
               action="create"
-              resource={this.state.latestSubmittedReleaseName}
+              resource={latestSubmittedReleaseName}
             />
           )}
           <div className="row">


### PR DESCRIPTION
This patch decouples the releaseName used in the controlled field in the form from the releaseName shown in the error message.
![peek 2018-11-07 11-46](https://user-images.githubusercontent.com/24523/48156735-d3182180-e282-11e8-833c-fad16f232d56.gif)

Fixes https://github.com/kubeapps/kubeapps/issues/757