### PR TITLE
Add component information in app and service lists

### DIFF
--- a/cmd/tiller-proxy/internal/handler/handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/handler_test.go
@@ -332,7 +332,7 @@ func TestActions(t *testing.T) {
 				release.Release{Name: "foobar", Namespace: "default"},
 				release.Release{Name: "foo", Namespace: "not-default"},
 			},
-			ResponseBody: `{"data":[{"releaseName":"foobar","version":"","namespace":"default","status":"DEPLOYED"},{"releaseName":"foo","version":"","namespace":"not-default","status":"DEPLOYED"}]}`,
+			ResponseBody: `{"data":[{"releaseName":"foobar","version":"","namespace":"default","status":"DEPLOYED","chart":""},{"releaseName":"foo","version":"","namespace":"not-default","status":"DEPLOYED","chart":""}]}`,
 		},
 		{
 			// Scenario params
@@ -354,7 +354,7 @@ func TestActions(t *testing.T) {
 				release.Release{Name: "foobar", Namespace: "default"},
 				release.Release{Name: "foo", Namespace: "not-default"},
 			},
-			ResponseBody: `{"data":[{"releaseName":"foobar","version":"","namespace":"default","status":"DEPLOYED"}]}`,
+			ResponseBody: `{"data":[{"releaseName":"foobar","version":"","namespace":"default","status":"DEPLOYED","chart":""}]}`,
 		},
 		{
 			// Scenario params
@@ -376,7 +376,7 @@ func TestActions(t *testing.T) {
 				release.Release{Name: "foobar", Namespace: "default", Info: &release.Info{Status: &release.Status{Code: release.Status_DEPLOYED}}},
 				release.Release{Name: "foo", Namespace: "default", Info: &release.Info{Status: &release.Status{Code: release.Status_DELETED}}},
 			},
-			ResponseBody: `{"data":[{"releaseName":"foobar","version":"","namespace":"default","status":"DEPLOYED"}]}`,
+			ResponseBody: `{"data":[{"releaseName":"foobar","version":"","namespace":"default","status":"DEPLOYED","chart":""}]}`,
 		},
 	}
 	for _, test := range tests {

--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -23,7 +23,7 @@ it("renders a app item", () => {
   const card = wrapper.find(InfoCard).shallow();
   expect(card.find(Link).props().title).toBe("foo");
   expect(card.find(Link).props().to).toBe("/apps/ns/default/foo");
-  expect(card.find(".type-color-light-blue").text()).toBe("myapp/v1.0.0");
+  expect(card.find(".type-color-light-blue").text()).toBe("myapp v1.0.0");
   expect(card.find(".deployed").exists()).toBe(true);
   expect(card.find(".ListItem__content__info_tag-1").text()).toBe("default");
   expect(card.find(".ListItem__content__info_tag-2").text()).toBe("deployed");

--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -15,6 +15,7 @@ it("renders a app item", () => {
           releaseName: "foo",
           status: "DEPLOYED",
           version: "1.0.0",
+          chart: "myapp",
         } as IAppOverview
       }
     />,
@@ -22,7 +23,7 @@ it("renders a app item", () => {
   const card = wrapper.find(InfoCard).shallow();
   expect(card.find(Link).props().title).toBe("foo");
   expect(card.find(Link).props().to).toBe("/apps/ns/default/foo");
-  expect(card.find(".type-color-light-blue").text()).toBe("1.0.0");
+  expect(card.find(".type-color-light-blue").text()).toBe("myapp/v1.0.0");
   expect(card.find(".deployed").exists()).toBe(true);
   expect(card.find(".ListItem__content__info_tag-1").text()).toBe("default");
   expect(card.find(".ListItem__content__info_tag-2").text()).toBe("deployed");

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -20,7 +20,7 @@ class AppListItem extends React.Component<IAppListItemProps> {
         link={`/apps/ns/${app.namespace}/${app.releaseName}`}
         title={app.releaseName}
         icon={icon}
-        info={app.version || "-"}
+        info={`${app.chart}/v${app.version || "-"}`}
         tag1Content={app.namespace}
         tag2Content={app.status.toLocaleLowerCase()}
         tag2Class={app.status.toLocaleLowerCase()}

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -20,7 +20,7 @@ class AppListItem extends React.Component<IAppListItemProps> {
         link={`/apps/ns/${app.namespace}/${app.releaseName}`}
         title={app.releaseName}
         icon={icon}
-        info={`${app.chart}/v${app.version || "-"}`}
+        info={`${app.chart} v${app.version || "-"}`}
         tag1Content={app.namespace}
         tag2Content={app.status.toLocaleLowerCase()}
         tag2Class={app.status.toLocaleLowerCase()}

--- a/dashboard/src/components/ServiceInstanceList/ServiceInstanceCard.test.tsx
+++ b/dashboard/src/components/ServiceInstanceList/ServiceInstanceCard.test.tsx
@@ -12,7 +12,8 @@ it("should render a Card", () => {
       namespace="foobar"
       link="/a/link/somewhere"
       icon="an-icon.png"
-      servicePlanName="database"
+      serviceClassName="database"
+      servicePlanName="large"
       statusReason="Provisioned"
     />,
   );
@@ -27,7 +28,8 @@ it("should avoid the status tag if it's not defined", () => {
       namespace="foobar"
       icon="an-icon.png"
       link="/a/link/somewhere"
-      servicePlanName="database"
+      serviceClassName="database"
+      servicePlanName="large"
       statusReason={undefined}
     />,
   );
@@ -60,7 +62,8 @@ describe("uses a different class and tag name depending on the status", () => {
           namespace="foobar"
           link="/a/link/somewhere"
           icon="an-icon.png"
-          servicePlanName="database"
+          serviceClassName="database"
+          servicePlanName="large"
           statusReason={test.status}
         />,
       );

--- a/dashboard/src/components/ServiceInstanceList/ServiceInstanceCard.tsx
+++ b/dashboard/src/components/ServiceInstanceList/ServiceInstanceCard.tsx
@@ -8,6 +8,7 @@ export interface IServiceInstanceCardProps {
   name: string;
   namespace: string;
   servicePlanName: string;
+  serviceClassName: string;
   statusReason: string | undefined;
   link?: string;
   icon?: string;
@@ -24,13 +25,13 @@ function generalizeStatus(status: string) {
 }
 
 const ServiceInstanceCard: React.SFC<IServiceInstanceCardProps> = props => {
-  const { name, namespace, link, icon, servicePlanName, statusReason } = props;
+  const { name, namespace, link, icon, serviceClassName, servicePlanName, statusReason } = props;
   return (
     <InfoCard
       title={name}
       link={link}
       icon={icon}
-      info={servicePlanName}
+      info={`${serviceClassName}/${servicePlanName}`}
       tag1Content={namespace}
       tag2Class={statusReason && generalizeStatus(statusReason)}
       tag2Content={statusReason && generalizeStatus(statusReason)}

--- a/dashboard/src/components/ServiceInstanceList/ServiceInstanceCard.tsx
+++ b/dashboard/src/components/ServiceInstanceList/ServiceInstanceCard.tsx
@@ -31,7 +31,7 @@ const ServiceInstanceCard: React.SFC<IServiceInstanceCardProps> = props => {
       title={name}
       link={link}
       icon={icon}
-      info={`${serviceClassName}/${servicePlanName}`}
+      info={`${servicePlanName} ${serviceClassName}`}
       tag1Content={namespace}
       tag2Class={statusReason && generalizeStatus(statusReason)}
       tag2Content={statusReason && generalizeStatus(statusReason)}

--- a/dashboard/src/components/ServiceInstanceList/ServiceInstanceCardList.tsx
+++ b/dashboard/src/components/ServiceInstanceList/ServiceInstanceCardList.tsx
@@ -45,6 +45,7 @@ const ServiceInstanceCardList: React.SFC<IServiceInstanceCardListProps> = props 
                   namespace={instance.metadata.namespace}
                   link={link}
                   icon={icon}
+                  serviceClassName={(svcClass && svcClass.spec.externalName) || "-"}
                   servicePlanName={instance.spec.clusterServicePlanExternalName}
                   statusReason={status && status.reason}
                 />

--- a/dashboard/src/components/ServiceInstanceList/__snapshots__/ServiceInstanceCard.test.tsx.snap
+++ b/dashboard/src/components/ServiceInstanceList/__snapshots__/ServiceInstanceCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`should render a Card 1`] = `
 <InfoCard
   icon="an-icon.png"
-  info="database/large"
+  info="large database"
   link="/a/link/somewhere"
   tag1Content="foobar"
   tag2Class="Provisioned"

--- a/dashboard/src/components/ServiceInstanceList/__snapshots__/ServiceInstanceCard.test.tsx.snap
+++ b/dashboard/src/components/ServiceInstanceList/__snapshots__/ServiceInstanceCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`should render a Card 1`] = `
 <InfoCard
   icon="an-icon.png"
-  info="database"
+  info="database/large"
   link="/a/link/somewhere"
   tag1Content="foobar"
   tag2Class="Provisioned"

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -321,4 +321,5 @@ export interface IAppOverview {
   version: string;
   icon?: string;
   status: string;
+  chart: string;
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -76,6 +76,7 @@ type AppOverview struct {
 	Namespace   string `json:"namespace"`
 	Icon        string `json:"icon,omitempty"`
 	Status      string `json:"status"`
+	Chart       string `json:"chart"`
 }
 
 func (p *Proxy) getRelease(name, namespace string) (*release.Release, error) {
@@ -205,6 +206,7 @@ func (p *Proxy) ListReleases(namespace string, releaseListLimit int, status stri
 					Namespace:   r.Namespace,
 					Icon:        r.Chart.Metadata.Icon,
 					Status:      r.Info.Status.Code.String(),
+					Chart:       r.Chart.Metadata.Name,
 				})
 			}
 		}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -55,6 +55,7 @@ func newFakeProxy(existingTillerReleases []AppOverview) *Proxy {
 				Metadata: &chart.Metadata{
 					Version: r.Version,
 					Icon:    r.Icon,
+					Name:    r.Chart,
 				},
 			},
 			Info: &release.Info{
@@ -69,8 +70,8 @@ func newFakeProxy(existingTillerReleases []AppOverview) *Proxy {
 }
 
 func TestListAllReleases(t *testing.T) {
-	app1 := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
-	app2 := AppOverview{"bar", "1.0.0", "other_ns", "icon2.png", "DELETED"}
+	app1 := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress"}
+	app2 := AppOverview{"bar", "1.0.0", "other_ns", "icon2.png", "DELETED", "wordpress"}
 	proxy := newFakeProxy([]AppOverview{app1, app2})
 
 	// Should return all the releases if no namespace is given
@@ -87,8 +88,8 @@ func TestListAllReleases(t *testing.T) {
 }
 
 func TestListNamespacedRelease(t *testing.T) {
-	app1 := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
-	app2 := AppOverview{"bar", "1.0.0", "other_ns", "icon2.png", "DELETED"}
+	app1 := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress"}
+	app2 := AppOverview{"bar", "1.0.0", "other_ns", "icon2.png", "DELETED", "wordpress"}
 	proxy := newFakeProxy([]AppOverview{app1, app2})
 
 	// Should return all the releases if no namespace is given
@@ -105,8 +106,8 @@ func TestListNamespacedRelease(t *testing.T) {
 }
 
 func TestListOldRelease(t *testing.T) {
-	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
-	appUpgraded := AppOverview{"foo", "1.0.1", "my_ns", "icon.png", "FAILED"}
+	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress"}
+	appUpgraded := AppOverview{"foo", "1.0.1", "my_ns", "icon.png", "FAILED", "wordpress"}
 	proxy := newFakeProxy([]AppOverview{app, appUpgraded})
 
 	// Should avoid old release versions
@@ -126,11 +127,11 @@ func TestListOldRelease(t *testing.T) {
 }
 
 func TestMultipleOldReleases(t *testing.T) {
-	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
-	appUpgraded := AppOverview{"foo", "1.0.1", "my_ns", "icon.png", "FAILED"}
-	app2 := AppOverview{"bar", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
-	app2Outdated := AppOverview{"bar", "1.0.2", "my_ns", "icon.png", "DEPLOYED"}
-	app2Upgraded := AppOverview{"bar", "1.0.2", "my_ns", "icon.png", "FAILED"}
+	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress"}
+	appUpgraded := AppOverview{"foo", "1.0.1", "my_ns", "icon.png", "FAILED", "wordpress"}
+	app2 := AppOverview{"bar", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress"}
+	app2Outdated := AppOverview{"bar", "1.0.2", "my_ns", "icon.png", "DEPLOYED", "wordpress"}
+	app2Upgraded := AppOverview{"bar", "1.0.2", "my_ns", "icon.png", "FAILED", "wordpress"}
 	proxy := newFakeProxy([]AppOverview{app, appUpgraded, app2, app2Outdated, app2Upgraded})
 
 	// Should avoid old release versions
@@ -227,7 +228,7 @@ func TestCreateConflictingHelmRelease(t *testing.T) {
 		Metadata: &chart.Metadata{Name: chartName, Version: version},
 	}
 	ns2 := "other_ns"
-	app := AppOverview{rs, version, ns2, "icon.png", "DEPLOYED"}
+	app := AppOverview{rs, version, ns2, "icon.png", "DEPLOYED", "wordpress"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	_, err := proxy.CreateRelease(rs, ns, "", ch)
@@ -247,7 +248,7 @@ func TestHelmReleaseUpdated(t *testing.T) {
 	ch := &chart.Chart{
 		Metadata: &chart.Metadata{Name: chartName, Version: version},
 	}
-	app := AppOverview{rs, version, ns, "icon.png", "DEPLOYED"}
+	app := AppOverview{rs, version, ns, "icon.png", "DEPLOYED", "wordpress"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	result, err := proxy.UpdateRelease(rs, ns, "", ch)
@@ -282,7 +283,7 @@ func TestUpdateMissingHelmRelease(t *testing.T) {
 
 	ns2 := "other_ns"
 	rs2 := "not_foo"
-	app := AppOverview{rs2, version, ns2, "icon.png", "DEPLOYED"}
+	app := AppOverview{rs2, version, ns2, "icon.png", "DEPLOYED", "wordpress"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	_, err := proxy.UpdateRelease(rs, ns, "", ch)
@@ -295,8 +296,8 @@ func TestUpdateMissingHelmRelease(t *testing.T) {
 }
 
 func TestGetHelmRelease(t *testing.T) {
-	app1 := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
-	app2 := AppOverview{"bar", "1.0.0", "other_ns", "icon2.png", "DELETED"}
+	app1 := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress"}
+	app2 := AppOverview{"bar", "1.0.0", "other_ns", "icon2.png", "DELETED", "wordpress"}
 	type testStruct struct {
 		existingApps    []AppOverview
 		shouldFail      bool
@@ -328,7 +329,7 @@ func TestGetHelmRelease(t *testing.T) {
 }
 
 func TestHelmReleaseDeleted(t *testing.T) {
-	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
+	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	// TODO: Add a test for a non-purged release when the fake helm cli supports it
@@ -346,7 +347,7 @@ func TestHelmReleaseDeleted(t *testing.T) {
 }
 
 func TestDeleteMissingHelmRelease(t *testing.T) {
-	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED"}
+	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress"}
 	proxy := newFakeProxy([]AppOverview{app})
 
 	err := proxy.DeleteRelease("not_foo", "other_ns", true)


### PR DESCRIPTION
Fixes #764 

Add the chart name to the app list and the service name in the service instance list:

<img width="305" alt="screenshot 2018-11-09 at 11 23 16" src="https://user-images.githubusercontent.com/4025665/48257126-f58c7500-e411-11e8-8eeb-bfe75ed0e445.png">
<img width="957" alt="screenshot 2018-11-09 at 11 23 33" src="https://user-images.githubusercontent.com/4025665/48257127-f58c7500-e411-11e8-958a-f05f708e999f.png">

Note that changes in tiller-proxy were required in order to return the chart name in the list overview.
