### PR TITLE
relax YAML parsing for Helm release manifests

### DIFF
--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -144,6 +144,7 @@ describe("AppViewComponent", () => {
       expect(sockets.length).toEqual(0);
     });
 
+    // See https://github.com/kubeapps/kubeapps/issues/632
     it("handles manifests with duplicate keys", () => {
       const wrapper = shallow(<AppViewComponent {...validProps} />);
       const manifest = `

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -145,7 +145,7 @@ describe("AppViewComponent", () => {
     });
 
     // See https://github.com/kubeapps/kubeapps/issues/632
-    it("handles manifests with duplicate keys", () => {
+    it("supports manifests with duplicated keys", () => {
       const wrapper = shallow(<AppViewComponent {...validProps} />);
       const manifest = `
       apiVersion: v1

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -1,6 +1,6 @@
 import { mount, shallow } from "enzyme";
 import context from "jest-plugin-context";
-import { safeDump as yamlSafeDump } from "js-yaml";
+import { safeDump as yamlSafeDump, YAMLException } from "js-yaml";
 import * as React from "react";
 
 import { hapi } from "../../shared/hapi/release";
@@ -142,6 +142,23 @@ describe("AppViewComponent", () => {
 
       const sockets: WebSocket[] = wrapper.state("sockets");
       expect(sockets.length).toEqual(0);
+    });
+
+    it("handles manifests with duplicate keys", () => {
+      const wrapper = shallow(<AppViewComponent {...validProps} />);
+      const manifest = `
+      apiVersion: v1
+      metadata:
+        name: cm-one
+        labels:
+          chart: cm-1.2.3
+          chart: cm-1.2.3
+`;
+
+      validProps.app.manifest = manifest;
+      expect(() => {
+        wrapper.setProps(validProps);
+      }).not.toThrow(YAMLException);
     });
   });
 

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -63,7 +63,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
     getApp(releaseName, namespace);
   }
 
-  public async componentWillReceiveProps(nextProps: IAppViewProps) {
+  public componentWillReceiveProps(nextProps: IAppViewProps) {
     const { releaseName, getApp, namespace } = this.props;
     if (nextProps.namespace !== namespace) {
       getApp(releaseName, nextProps.namespace);
@@ -78,7 +78,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
     if (!newApp) {
       return;
     }
-    let manifest: IResource[] = yaml.safeLoadAll(newApp.manifest);
+    let manifest: IResource[] = yaml.loadAll(newApp.manifest, undefined, { json: true });
     // Filter out elements in the manifest that does not comply
     // with { kind: foo }
     manifest = manifest.filter(r => r && r.kind);

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -78,6 +78,10 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
     if (!newApp) {
       return;
     }
+    // TODO(prydonius): Okay to use non-safe load here since we assume the
+    // manifest is pre-parsed by Helm and Kubernetes. Look into switching back
+    // to safeLoadAll once https://github.com/nodeca/js-yaml/issues/456 is
+    // resolved.
     let manifest: IResource[] = yaml.loadAll(newApp.manifest, undefined, { json: true });
     // Filter out elements in the manifest that does not comply
     // with { kind: foo }


### PR DESCRIPTION
- enables JSON.parse behaviour for YAML parsing (allows manifests with
  duplicate keys)
- switches to yaml.loadAll as safeLoadAll does not seem to support the
  JSON.parse behaviour (https://github.com/kubeapps/kubeapps/issues/636#issuecomment-437197500). Ideally we can switch this back once this is
  fixed upstream.

fixes #636