### PR TITLE
Revert "namespace apprepo-controller kube informer (#787)"

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.9.6
+version: 0.9.7
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -1,4 +1,44 @@
 {{- if .Values.rbac.create -}}
+# Need a cluster role because client-go v5.0.1 does not support namespaced
+# informers
+# TODO: remove when we update to client-go v6.0.0
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "kubeapps.apprepository.fullname" . }}
+  labels:
+    app: {{ template "kubeapps.apprepository.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "kubeapps.apprepository.fullname" . }}
+  labels:
+    app: {{ template "kubeapps.apprepository.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kubeapps.apprepository.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kubeapps.apprepository.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -141,9 +141,8 @@ func NewController(
 	// Set up an event handler for when CronJob resources get deleted. This
 	// handler will lookup the owner of the given CronJob, and if it is owned by a
 	// AppRepository resource will enqueue that AppRepository resource for
-	// processing so the CronJob gets correctly recreated. This way, we don't need
-	// to implement custom logic for handling CronJob resources. More info on this
-	// pattern:
+	// processing. This way, we don't need to implement custom logic for handling
+	// CronJob resources. More info on this pattern:
 	// https://github.com/kubernetes/community/blob/8cafef897a22026d42f5e5bb3f104febe7e29830/contributors/devel/controllers.md
 	cronjobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: controller.handleObject,

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -60,7 +60,7 @@ func main() {
 		glog.Fatalf("Error building apprepo clientset: %s", err.Error())
 	}
 
-	kubeInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(kubeClient, 0, namespace, nil)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
 	apprepoInformerFactory := informers.NewFilteredSharedInformerFactory(apprepoClient, 0, namespace, nil)
 
 	controller := NewController(kubeClient, apprepoClient, kubeInformerFactory, apprepoInformerFactory)


### PR DESCRIPTION
This reverts commit 9c6ac74e20b96f41461d476cf41d3d3e06db195e, since it
contains a change in the chart that was not yet ready to release and is
currently causing the apprepository-controller fail due to insufficient
permissions.