### PR TITLE
Tiller proxy user agent support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,11 @@ build_images: &build_images
     - <<: *exports
     - run: |
         read -ra IMG_ARRAY <<< "$IMAGES"
+        if [[ -n "${CIRCLE_TAG}" ]]; then
+          makeArgs="VERSION=${CIRCLE_TAG}"
+        fi
         for IMAGE in "${IMG_ARRAY[@]}"; do
-          make IMG_MODIFIER="$IMG_MODIFIER" VERSION="${DEV_TAG}" ${IMAGE}
+          make IMG_MODIFIER="$IMG_MODIFIER" IMAGE_TAG="${DEV_TAG}" $makeArgs ${IMAGE}
           if [[ -z "${CIRCLE_PULL_REQUEST}" && -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
             docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
             docker push ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 IMPORT_PATH:= github.com/kubeapps/kubeapps
 GO = /usr/bin/env go
 GOFMT = /usr/bin/env gofmt
-VERSION ?= dev-$(shell date +%FT%H-%M-%S-%Z)
+IMAGE_TAG ?= dev-$(shell date +%FT%H-%M-%S-%Z)
+VERSION ?= $$(git rev-parse HEAD)
+
 IMG_MODIFIER ?= 
 
 GO_PACKAGES = ./...
@@ -13,10 +15,10 @@ all: kubeapps/dashboard kubeapps/apprepository-controller
 
 # TODO(miguel) Create Makefiles per component
 kubeapps/%:
-	docker build -t kubeapps/$*$(IMG_MODIFIER):$(VERSION) -f cmd/$*/Dockerfile .
+	docker build -t kubeapps/$*$(IMG_MODIFIER):$(IMAGE_TAG) --build-arg "VERSION=${VERSION}" -f cmd/$*/Dockerfile .
 
 kubeapps/dashboard:
-	docker build -t kubeapps/dashboard$(IMG_MODIFIER):$(VERSION) -f dashboard/Dockerfile dashboard/
+	docker build -t kubeapps/dashboard$(IMG_MODIFIER):$(IMAGE_TAG) -f dashboard/Dockerfile dashboard/
 
 test:
 	$(GO) test $(GO_PACKAGES)

--- a/cmd/tiller-proxy/Dockerfile
+++ b/cmd/tiller-proxy/Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:1.11 as builder
 COPY . /go/src/github.com/kubeapps/kubeapps
 WORKDIR /go/src/github.com/kubeapps/kubeapps
-RUN CGO_ENABLED=0 go build -a -installsuffix cgo ./cmd/tiller-proxy
+
+ARG VERSION
+RUN CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-X main.version=$VERSION" ./cmd/tiller-proxy
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -26,13 +26,12 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/kubeapps/common/response"
-	log "github.com/sirupsen/logrus"
-	"github.com/urfave/negroni"
-	"k8s.io/helm/pkg/proto/hapi/chart"
-
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
 	proxy "github.com/kubeapps/kubeapps/pkg/proxy"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/negroni"
+	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
 // Context key type for request contexts

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -61,12 +61,6 @@ var (
 	tlsKeyDefault    = fmt.Sprintf("%s/tls.key", os.Getenv("HELM_HOME"))
 )
 
-// clientWithDefaultUserAgent implements chart.HTTPClient interface
-// and includes an override of the Do method which injects an User-Agent
-type clientWithDefaultUserAgent struct {
-	http.Client
-}
-
 func init() {
 	settings.AddFlags(pflag.CommandLine)
 	// TLS Flags

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -77,6 +77,7 @@ func init() {
 	pflag.BoolVar(&tlsEnable, "tls", false, "enable TLS for request")
 	pflag.BoolVar(&disableAuth, "disable-auth", false, "Disable authorization check")
 	pflag.IntVar(&listLimit, "list-max", 256, "maximum number of releases to fetch")
+	pflag.StringVar(&userAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
 
 	netClient = &clientWithDefaultUserAgent{
 		Client: http.Client{

--- a/cmd/tiller-proxy/version.go
+++ b/cmd/tiller-proxy/version.go
@@ -26,6 +26,12 @@ var (
 	userAgentComment string
 )
 
+// clientWithDefaultUserAgent implements chart.HTTPClient interface
+// and includes an override of the Do method which injects an User-Agent
+type clientWithDefaultUserAgent struct {
+	http.Client
+}
+
 // Returns the user agent to be used during calls to the chart repositories
 // Examples:
 // tiller-proxy/devel

--- a/cmd/tiller-proxy/version.go
+++ b/cmd/tiller-proxy/version.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) 2018 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+var (
+	version          = "devel"
+	userAgentComment string
+)
+
+// Returns the user agent to be used during calls to the chart repositories
+// Examples:
+// tiller-proxy/devel
+// chart-repo/1.0
+// tiller-proxy/1.0 (monocular v1.0-beta4)
+// More info here https://github.com/kubeapps/kubeapps/issues/767#issuecomment-436835938
+func userAgent() string {
+	ua := "tiller-proxy/" + version
+	if userAgentComment != "" {
+		ua = fmt.Sprintf("%s (%s)", ua, userAgentComment)
+	}
+	return ua
+}
+
+func (c *clientWithDefaultUserAgent) Do(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", userAgent())
+
+	return c.Client.Do(req)
+}

--- a/cmd/tiller-proxy/version_test.go
+++ b/cmd/tiller-proxy/version_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright (c) 2018 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/tiller-proxy/version_test.go
+++ b/cmd/tiller-proxy/version_test.go
@@ -56,9 +56,11 @@ func Test_userAgent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Override global variables used to generate the userAgent
 			if tt.version != "" {
+				defer func(origVersion string) { version = origVersion }(version)
 				version = tt.version
 			}
 			if tt.userAgentComment != "" {
+				defer func(origAgent string) { userAgentComment = origAgent }(userAgentComment)
 				userAgentComment = tt.userAgentComment
 			}
 			assert.Equal(t, tt.expectedResult, userAgent(), "expected user agent")

--- a/cmd/tiller-proxy/version_test.go
+++ b/cmd/tiller-proxy/version_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/arschles/assert"
+)
+
+func Test_userAgent(t *testing.T) {
+	tests := []struct {
+		name             string
+		version          string
+		userAgentComment string
+		expectedResult   string
+	}{
+		{
+			name:             "Shows default User-Agent unless comment nor version provided",
+			version:          "",
+			userAgentComment: "",
+			expectedResult:   "tiller-proxy/devel",
+		},
+		{
+			name:             "Shows just custom version unless comment provided",
+			version:          "v4.4.4",
+			userAgentComment: "",
+			expectedResult:   "tiller-proxy/v4.4.4",
+		},
+		{
+			name:             "Shows custom version plus comment if provided",
+			version:          "v4.4.4",
+			userAgentComment: "Kubeapps/v2.3.4",
+			expectedResult:   "tiller-proxy/v4.4.4 (Kubeapps/v2.3.4)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Override global variables used to generate the userAgent
+			if tt.version != "" {
+				version = tt.version
+			}
+			if tt.userAgentComment != "" {
+				userAgentComment = tt.userAgentComment
+			}
+			assert.Equal(t, tt.expectedResult, userAgent(), "expected user agent")
+		})
+	}
+}
+
+func Test_clientWithDefaultUserAgentOverride(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "tiller-proxy/devel", req.Header.Get("User-Agent"), "expected user agent")
+	}))
+	// Close the server when test finishes
+	defer server.Close()
+
+	serverURL, _ := url.Parse(server.URL)
+
+	netClient = &clientWithDefaultUserAgent{}
+	_, err := netClient.Do(&http.Request{
+		URL:    serverURL,
+		Header: map[string][]string{},
+	})
+
+	assert.NoErr(t, err)
+}

--- a/docs/developer/apprepository-controller.md
+++ b/docs/developer/apprepository-controller.md
@@ -78,5 +78,5 @@ To build the `kubeapps/apprepository-controller` docker image with the docker im
 
 ```bash
 cd $KUBEAPPS_DIR
-make VERSION=myver kubeapps/apprepository-controller
+make IMAGE_TAG=myver kubeapps/apprepository-controller
 ```

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -29,23 +29,23 @@ cd $KUBEAPPS_DIR
 Kubeapps consists of a number of in-cluster components. To build all these components in one go:
 
 ```bash
-make VERSION=myver all
+make IMAGE_TAG=myver all
 ```
 
 Or if you wish to build specific component(s):
 
 ```bash
 # to build the kubeapps binary
-make VERSION=myver kubeapps
+make IMAGE_TAG=myver kubeapps
 
 # to build the kubeapps/dashboard docker image
-make VERSION=myver kubeapps/dashboard
+make IMAGE_TAG=myver kubeapps/dashboard
 
 # to build the kubeapps/apprepository-controller docker image
-make VERSION=myver kubeapps/apprepository-controller
+make IMAGE_TAG=myver kubeapps/apprepository-controller
 
 # to build the kubeapps/tiller-proxy docker image
-make VERSION=myver kubeapps/tiller-proxy
+make IMAGE_TAG=myver kubeapps/tiller-proxy
 ```
 
 ## Running tests

--- a/docs/developer/tiller-proxy.md
+++ b/docs/developer/tiller-proxy.md
@@ -57,7 +57,7 @@ kubectl patch deployment kubeapps-internal-tiller-proxy -n kubeapps --type=json 
 The easiest way to create the `tiller-proxy` image is execute the Makefile task to do so:
 
 ```bash
-VERSION=dev make kubeapps/tiller-proxy
+IMAGE_TAG=dev make kubeapps/tiller-proxy
 ```
 
 This will generate an image `kubeapps/tiller-proxy:dev` that you can use in the current deployment:


### PR DESCRIPTION
User Agent support in Tiller-proxy, 

* Support to bake the tiller-proxy version during release
* Support to receive user-agent comment that will injected via the chart
* Updated circle-ci config to bake the version

See below some example of the user-agent seen at the repository end

Tiller-proxy built in the CI during 1.2 release and ran inside the version 1.1.1 of the Kubeapps chart

```
> 100.100.0.23 - - [13/Nov/2018:21:53:30 +0000] "GET /index.yaml HTTP/1.1" 200 1555 "-" "tiller-proxy/1.2 (Kubeapps/v1.1.1)
```
Tiller built locally and run outside of the scope of Kubeapps
```
> 100.117.0.48 - - [13/Nov/2018:21:56:42 +0000] "GET /index.yaml HTTP/1.1" 200 1555 "-" "tiller-proxy/8a1ed0f59f59d4599307c96c23bd1da4d833946c
```


Refs #767 