### PR TITLE
Enables user-agents overrides

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.9.7
+version: 0.9.8
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         - /apprepository-controller
         args:
         - --logtostderr
+        - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
         - --repo-sync-image={{ template "kubeapps.image" (list .Values.apprepository.syncImage .Values.global) }}
         - --namespace={{ .Release.Namespace }}
         - --mongo-url={{ template "kubeapps.mongodb.fullname" . }}

--- a/chart/kubeapps/templates/tiller-proxy-deployment.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         - /proxy
         args:
         - --host={{ .Values.tillerProxy.host }}
+        - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
         {{- if .Values.tillerProxy.tls }}
         - --tls
         {{- if .Values.tillerProxy.tls.verify }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -97,7 +97,7 @@ apprepository:
   syncImage:
     registry: quay.io
     repository: helmpack/chart-repo
-    tag: v1.0.1
+    tag: v1.0.2
   initialRepos:
   - name: stable
     url: https://kubernetes-charts.storage.googleapis.com
@@ -165,7 +165,7 @@ chartsvc:
   image:
     registry: quay.io
     repository: helmpack/chartsvc
-    tag: v1.0.1
+    tag: v1.0.2
   service:
     port: 8080
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262


### PR DESCRIPTION
Injects the User-Agent comment based on the version of Kubeapps used. Before merging this change we need to do a build of Kubeapps itself to be sure that tiller-proxy has support for the new flag

```
multidoc_yamldiff /tmp/before.yaml /tmp/after.yaml 
@@ .. @@
   metadata: {
    labels: {
     app: "RELEASE-NAME-kubeapps-internal-apprepository-controller",
-    chart: "kubeapps-0.9.7",
+    chart: "kubeapps-0.9.8",
     heritage: "Tiller",
     release: "RELEASE-NAME",
    },
@@ .. @@
       {
        args: [
         "--logtostderr",
+        "--user-agent-comment=kubeapps/DEVEL",
         "--repo-sync-image=docker.io/quay.io/helmpack/chart-repo:v1.0.2",
         "--namespace=miguel",
         "--mongo-url=RELEASE-NAME-mongodb",
@@ .. @@
   metadata: {
    labels: {
     app: "RELEASE-NAME-kubeapps-internal-tiller-proxy",
-    chart: "kubeapps-0.9.7",
+    chart: "kubeapps-0.9.8",
     heritage: "Tiller",
     release: "RELEASE-NAME",
    },
@@ .. @@
       {
        args: [
         "--host=tiller-deploy.kube-system:44134",
+        "--user-agent-comment=kubeapps/DEVEL",
        ],
        command: [
         "/proxy",

``` 

Closes #767 