### PR TITLE
Install app-repository CRD via a hook

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.9.7
+version: 0.9.8
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/apprepository-crd.yaml
+++ b/chart/kubeapps/templates/apprepository-crd.yaml
@@ -1,4 +1,4 @@
-{{- if or (not (.Capabilities.APIVersions.Has "kubeapps.com/v1alpha1")) (.Release.IsUpgrade) -}}
+{{- if not (.Capabilities.APIVersions.Has "kubeapps.com/v1alpha1") -}}
 # The condition above will be true if another instance of Kubeapps is
 # already installed 
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -6,7 +6,8 @@ kind: CustomResourceDefinition
 metadata:
   name: apprepositories.kubeapps.com
   annotations:
-    "helm.sh/resource-policy": keep
+    # We also install it pre-upgrade in the case that the user has removed the CRD before upgrading
+    "helm.sh/hook": pre-install,post-upgrade
   labels:
     app: {{ template "kubeapps.apprepository.fullname" . }}
     chart: {{ template "kubeapps.chart" . }}


### PR DESCRIPTION
This patch basically moves the creation of the CRD to the hook lifecycle so Helm will not try to upgrade it causing the issue described here https://github.com/kubeapps/kubeapps/issues/812

I manually tested it

```bash
# No CRDs installed in my cluster
$ k get crd
No resources found.

# Install the first instance of kubeapps in namespace-1
$ helm install -n kubeapps-1 --namespace namespace-1 chart/kubeapps/

# The apprepositories.kubeapps.com crd is now "installed" and belongs to kubeapps-1
$ k get crd apprepositories.kubeapps.com -o jsonpath={.metadata.labels.release}
kubeapps-1

# Install the second instance of kubeapps in namespace-2
$ helm install -n kubeapps-2 --namespace namespace-2 chart/kubeapps/

# And now I got two releases installed
$ helm list
NAME      	REVISION	UPDATED                 	STATUS  	CHART         	NAMESPACE  
kubeapps-1	1       	Tue Nov 13 15:56:02 2018	DEPLOYED	kubeapps-0.9.7	namespace-1
kubeapps-2	1       	Tue Nov 13 15:56:44 2018	DEPLOYED	kubeapps-0.9.7	namespace-2

# The apprepositories.kubeapps.com crd still belongs to kubeapps-1 as expected
$ k get crd apprepositories.kubeapps.com -o jsonpath={.metadata.labels.release}
kubeapps-1

# Upgrading kubeapps-1 works
$ helm upgrade kubeapps-1 chart/kubeapps/
=> OK

# ====> Before this patch, here is where it used to fail

# kubeapps-2 upgrades successfully 
$ helm upgrade kubeapps-2 chart/kubeapps/
=> OK

# I can also delete the CRD before upgrading kubeapps-2 and this release will create the required CRDs
$ k delete crd apprepositories.kubeapps.com
$ helm upgrade kubeapps-2 chart/kubeapps/
=> OK
$ k get crd apprepositories.kubeapps.com -o jsonpath={.metadata.labels.release}
kubeapps-2

# Upgrading kubeapps-1 works fine as expected too
$ helm upgrade kubeapps-1 chart/kubeapps/
=> OK
```

The main issue about this approach is that this way we are not "updating CRDs" so any change in the chart that affects those CRDs will not be applied. We should do a follow up task that could `kubectl apply` the changes by using a job.

Fixes https://github.com/kubeapps/kubeapps/issues/812