### PR TITLE
Add e2e tests with stable images if a new chart is been released

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,8 +110,6 @@ exports: &exports
     # Apart from using a DEV_TAG we use a different image ID to avoid polluting the tag
     # history of the production tag
     echo "export IMG_MODIFIER=-ci" >> $BASH_ENV
-    # Latest published release
-    echo "export LATEST_RELEASE_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1))" >> $BASH_ENV
 build_images: &build_images
   steps:
     - setup_remote_docker
@@ -170,7 +168,8 @@ gke_test: &gke_test
     - run: |
         # If we want to test the latest version instead we override the image to be used
         if [[ -n "$TEST_LATEST_RELEASE" ]]; then
-          DEV_TAG=$LATEST_RELEASE_TAG
+          # latestReleaseTag was sourced in the first step via chart_sync_utils
+          DEV_TAG=$(latestReleaseTag)
           IMG_MODIFIER=""
         fi
         ./script/e2e-test.sh $DEV_TAG $IMG_MODIFIER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ gke_test: &gke_test
         # Cancel job if this is a test stable release job but
         # the chart version has not been bumped
         if [[ -n "$TEST_LATEST_RELEASE" ]] && ! changedVersion; then
-          echo Step "aborted, we are not releasing a new version of the chart"
+          echo "Step aborted, we are not releasing a new version of the chart"
           circleci step halt
         fi
     - <<: *exports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,9 @@ build_on_master: &build_on_master
     tags:
       only: /^v.*/
     branches:
-      only: master
+      only: 
+      - master
+      - 825-add-e2e-tests-with-stable
 # Build only in tags (release)
 build_on_tag: &build_on_tag
   filters:
@@ -35,14 +37,28 @@ workflows:
           <<: *build_always
       - build_dashboard:
           <<: *build_always
-      - GKE_1_9:
+      - GKE_1_9_MASTER:
           <<: *build_on_master
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_10:
+      - GKE_1_10_MASTER:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - GKE_1_9_LATEST_RELEASE:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - GKE_1_10_LATEST_RELEASE:
           <<: *build_on_master
           requires:
             - test_go
@@ -52,18 +68,25 @@ workflows:
       - sync_chart:
           <<: *build_on_master
           requires:
-            - GKE_1_9
-            - GKE_1_10
+            - GKE_1_9_MASTER
+            - GKE_1_10_MASTER
+            - GKE_1_9_LATEST_RELEASE
+            - GKE_1_10_LATEST_RELEASE
       - push_images:
           <<: *build_always
           requires:
-            - GKE_1_9
-            - GKE_1_10
+            - GKE_1_9_MASTER
+            - GKE_1_10_MASTER
+            - GKE_1_9_LATEST_RELEASE
+            - GKE_1_10_LATEST_RELEASE
       - release:
           <<: *build_on_tag
           requires:
-            - GKE_1_9
-            - GKE_1_10
+            - GKE_1_9_MASTER
+            - GKE_1_10_MASTER
+            - GKE_1_9_LATEST_RELEASE
+            - GKE_1_10_LATEST_RELEASE
+      
 
 ## Definitions
 install_gcloud_sdk: &install_gcloud_sdk
@@ -89,6 +112,8 @@ exports: &exports
     # Apart from using a DEV_TAG we use a different image ID to avoid polluting the tag
     # history of the production tag
     echo "export IMG_MODIFIER=-ci" >> $BASH_ENV
+    # Latest published release
+    echo "export LATEST_RELEASE_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1))" >> $BASH_ENV
 build_images: &build_images
   steps:
     - setup_remote_docker
@@ -110,13 +135,23 @@ gke_test: &gke_test
   docker:
     - image: circleci/golang:1.11
   steps:
+    - checkout
     - run: |
+        source ./script/chart_sync_utils.sh
+
         # In case of GKE we will only want to build if it is
         # a build of a branch in the kubeapps repository
         if [[ -z "$GKE_ADMIN" ]]; then
+          echo "Step aborted, we are not in the Kubeapps repository"
           circleci step halt
         fi
-    - checkout
+
+        # Cancel job if this is a test stable release job but
+        # the chart version has not been bumped
+        if [[ -n "$TEST_LATEST_RELEASE" ]] && ! changedVersion; then
+          echo Step "aborted, we are not releasing a new version of the chart"
+          circleci step halt
+        fi
     - <<: *exports
     - <<: *install_gcloud_sdk
     # Install kubectl
@@ -130,11 +165,17 @@ gke_test: &gke_test
           gcloud -q auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS;
         fi
     # A GKE cluster name cannot contain non-alphanumeric characters (nor uppercase letters)
-    - run: echo "export ESCAPED_GKE_CLUSTER=$(echo ${GKE_CLUSTER}-${CIRCLE_BRANCH:-$CIRCLE_TAG}-${GKE_BRANCH}-ci | sed 's/[^a-z0-9-]//g')" >> $BASH_ENV
+    - run: echo "export ESCAPED_GKE_CLUSTER=$(echo ${GKE_CLUSTER}-${CIRCLE_BRANCH:-$CIRCLE_TAG}-${TEST_LATEST_RELEASE}-${GKE_BRANCH}-ci | sed 's/[^a-z0-9-]//g')" >> $BASH_ENV
     - run: ./script/start-gke-env.sh $ESCAPED_GKE_CLUSTER $GKE_ZONE $GKE_BRANCH $GKE_ADMIN > /dev/null
     # Install helm
     - <<: *install_helm_cli
-    - run: ./script/e2e-test.sh $DEV_TAG $IMG_MODIFIER
+    - run: |
+        # If we want to test the latest version instead we override the image to be used
+        if [[ -n "$TEST_LATEST_RELEASE" ]]; then
+          DEV_TAG=$LATEST_RELEASE_TAG
+          IMG_MODIFIER=""
+        fi
+        ./script/e2e-test.sh $DEV_TAG $IMG_MODIFIER
     - run:
         name: Cleanup GKE Cluster
         command: gcloud container clusters delete --async --zone $GKE_ZONE $ESCAPED_GKE_CLUSTER
@@ -190,16 +231,29 @@ jobs:
     steps:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
-  GKE_1_9:
+  GKE_1_9_MASTER:
     <<: *gke_test
     environment:
       HELM_VERSION: v2.11.0
       GKE_BRANCH: 1.9
-  GKE_1_10:
+  GKE_1_10_MASTER:
     <<: *gke_test
     environment:
       HELM_VERSION: v2.11.0
       GKE_BRANCH: 1.10
+  GKE_1_9_LATEST_RELEASE:
+    <<: *gke_test
+    environment:
+      HELM_VERSION: v2.11.0
+      GKE_BRANCH: 1.9
+      # We want to also test the chart with the current release of the images
+      TEST_LATEST_RELEASE: 1
+  GKE_1_10_LATEST_RELEASE:
+    <<: *gke_test
+    environment:
+      HELM_VERSION: v2.11.0
+      GKE_BRANCH: 1.10
+      TEST_LATEST_RELEASE: 1
   sync_chart:
     docker:
       - image: circleci/golang:1.11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,7 @@ build_on_master: &build_on_master
     tags:
       only: /^v.*/
     branches:
-      only: 
-      - master
-      - 825-add-e2e-tests-with-stable
+      only: master
 # Build only in tags (release)
 build_on_tag: &build_on_tag
   filters:

--- a/script/chart_sync.sh
+++ b/script/chart_sync.sh
@@ -16,68 +16,7 @@
 set -e
 
 CHARTS_REPO="bitnami/charts"
-CHART_REPO_PATH="bitnami/kubeapps"
-PROJECT_DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd`
-KUBEAPPS_CHART_DIR="${PROJECT_DIR}/chart/kubeapps"
-
-changedVersion() {
-    local currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep "version:")
-    local externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO}/master/${CHART_REPO_PATH}/Chart.yaml | grep "version:")
-    # NOTE: If curl returns an error this will return always true
-    [[ "$currentVersion" != "$externalVersion" ]]
-}
-
-configUser() {
-    local targetRepo=${1:?}
-    local user=${2:?}
-    local email=${3:?}
-    cd $targetRepo
-    git config user.name "$user"
-    git config user.email "$email"
-    cd -
-}
-
-updateRepo() {
-    local targetRepo=${1:?}
-    local targetTag=${2:?}
-    local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
-    local chartYaml="${targetChartPath}/Chart.yaml"
-    if [ ! -f "${chartYaml}" ]; then
-        echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
-        return 1
-    fi
-    rm -rf "${targetChartPath}"
-    cp -R "${KUBEAPPS_CHART_DIR}" "${targetChartPath}"
-    # Update Chart.yaml with new version
-    sed -i.bk 's/appVersion: DEVEL/appVersion: '"${targetTag}"'/g' "${chartYaml}"
-    rm "${targetChartPath}/Chart.yaml.bk"
-    # DANGER: This replaces any tag marked as latest in the values.yaml
-    sed -i.bk 's/tag: latest/tag: '"${targetTag}"'/g' "${targetChartPath}/values.yaml"
-    rm "${targetChartPath}/values.yaml.bk"
-}
-
-commitAndPushChanges() {
-    local targetRepo=${1:?}
-    local targetBranch=${2:-"master"}
-    local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
-    local chartYaml="${targetChartPath}/Chart.yaml"
-    if [ ! -f "${chartYaml}" ]; then
-        echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
-        return 1
-    fi
-    cd $targetRepo
-    if [[ ! $(git diff-index HEAD) ]]; then
-        echo "Not found any change to commit" > /dev/stderr
-        cd -
-        return 1
-    fi
-    local chartVersion=$(grep -w version: ${chartYaml} | awk '{print $2}')
-    git add --all .
-    git commit -m "kubeapps: bump chart version to $chartVersion"
-    # NOTE: This expects to have a loaded SSH key
-    git push origin $targetBranch
-    cd -
-}
+source $(dirname $0)/chart_sync_utils.sh
 
 user=${1:?}
 email=${2:?}

--- a/script/chart_sync.sh
+++ b/script/chart_sync.sh
@@ -26,7 +26,7 @@ if changedVersion; then
     git clone https://github.com/${CHARTS_REPO} $tempDir
     configUser $tempDir $user $email
     git fetch --tags
-    latestVersion=$(git describe --tags $(git rev-list --tags --max-count=1))
+    latestVersion=$(latestReleaseTag)
     updateRepo $tempDir $latestVersion
     commitAndPushChanges $tempDir master
 else

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -20,6 +20,11 @@ CHART_REPO_PATH="bitnami/kubeapps"
 PROJECT_DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd`
 KUBEAPPS_CHART_DIR="${PROJECT_DIR}/chart/kubeapps"
 
+# Returns the tag for the latest release
+latestReleaseTag() {
+  git describe --tags $(git rev-list --tags --max-count=1)
+}
+
 changedVersion() {
     local currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep "version:")
     local externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO}/master/${CHART_REPO_PATH}/Chart.yaml | grep "version:")

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright (c) 2018 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+CHARTS_REPO="bitnami/charts"
+CHART_REPO_PATH="bitnami/kubeapps"
+PROJECT_DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd`
+KUBEAPPS_CHART_DIR="${PROJECT_DIR}/chart/kubeapps"
+
+changedVersion() {
+    local currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep "version:")
+    local externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO}/master/${CHART_REPO_PATH}/Chart.yaml | grep "version:")
+    # NOTE: If curl returns an error this will return always true
+    [[ "$currentVersion" != "$externalVersion" ]]
+}
+
+configUser() {
+    local targetRepo=${1:?}
+    local user=${2:?}
+    local email=${3:?}
+    cd $targetRepo
+    git config user.name "$user"
+    git config user.email "$email"
+    cd -
+}
+
+updateRepo() {
+    local targetRepo=${1:?}
+    local targetTag=${2:?}
+    local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
+    local chartYaml="${targetChartPath}/Chart.yaml"
+    if [ ! -f "${chartYaml}" ]; then
+        echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
+        return 1
+    fi
+    rm -rf "${targetChartPath}"
+    cp -R "${KUBEAPPS_CHART_DIR}" "${targetChartPath}"
+    # Update Chart.yaml with new version
+    sed -i.bk 's/appVersion: DEVEL/appVersion: '"${targetTag}"'/g' "${chartYaml}"
+    rm "${targetChartPath}/Chart.yaml.bk"
+    # DANGER: This replaces any tag marked as latest in the values.yaml
+    sed -i.bk 's/tag: latest/tag: '"${targetTag}"'/g' "${targetChartPath}/values.yaml"
+    rm "${targetChartPath}/values.yaml.bk"
+}
+
+commitAndPushChanges() {
+    local targetRepo=${1:?}
+    local targetBranch=${2:-"master"}
+    local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
+    local chartYaml="${targetChartPath}/Chart.yaml"
+    if [ ! -f "${chartYaml}" ]; then
+        echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
+        return 1
+    fi
+    cd $targetRepo
+    if [[ ! $(git diff-index HEAD) ]]; then
+        echo "Not found any change to commit" > /dev/stderr
+        cd -
+        return 1
+    fi
+    local chartVersion=$(grep -w version: ${chartYaml} | awk '{print $2}')
+    git add --all .
+    git commit -m "kubeapps: bump chart version to $chartVersion"
+    # NOTE: This expects to have a loaded SSH key
+    git push origin $targetBranch
+    cd -
+}

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -24,6 +24,9 @@ HELM_CLIENT_TLS_FLAGS="--tls --tls-cert ${CERTS_DIR}/helm.cert.pem --tls-key ${C
 
 source $ROOT_DIR/script/libtest.sh
 
+echo "IMAGE TAG TO BE TESTED: $DEV_TAG"
+echo "IMAGE_REPO_SUFFIX: $IMG_MODIFIER"
+
 # Install Tiller with TLS support
 helm init \
   --tiller-tls \


### PR DESCRIPTION
* Adds e2e tests support with current version images when releasing a new chart version. These parallel jobs only run if we are releasing a new chart version.

See https://circleci.com/workflow-run/0d20793b-c606-42ce-b44a-5cb5fcbc6da7 for an example. 


Closes https://github.com/kubeapps/kubeapps/issues/825