### PR TITLE
K8s helpers improvements

### DIFF
--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -66,13 +66,11 @@ k8s_ensure_image kubeapps kubeapps-ci-internal-apprepository-controller $DEV_TAG
 k8s_ensure_image kubeapps kubeapps-ci-internal-dashboard $DEV_TAG
 k8s_ensure_image kubeapps kubeapps-ci-internal-tiller-proxy $DEV_TAG
 
-# Wait for Kubeapps Pods
-k8s_wait_for_pod_ready kubeapps app=kubeapps-ci
-k8s_wait_for_pod_ready kubeapps app=kubeapps-ci-internal-apprepository-controller
-k8s_wait_for_pod_ready kubeapps app=kubeapps-ci-internal-chartsvc
-k8s_wait_for_pod_ready kubeapps app=kubeapps-ci-internal-tiller-proxy
-k8s_wait_for_pod_ready kubeapps app=mongodb
-k8s_wait_for_pod_completed kubeapps apprepositories.kubeapps.com/repo-name=stable
+# Wait for release to have been rolled out
+k8s_wait_for_deployments_rollout kubeapps
+
+# Wait for the import job to have finished
+k8s_wait_for_job_completed kubeapps apprepositories.kubeapps.com/repo-name=stable
 
 # Run helm tests
 helm test ${HELM_CLIENT_TLS_FLAGS} --cleanup kubeapps-ci

--- a/script/libtest.sh
+++ b/script/libtest.sh
@@ -12,37 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export TEST_MAX_WAIT_SEC=300
+export TEST_MAX_WAIT_SEC=15
 
 ## k8s specific Helper functions
-k8s_wait_for_pod() {
+
+# Waits for a set of jobs matching the provided tag to be Completed.
+# It retries up to $TEST_MAX_WAIT_SEC
+k8s_wait_for_job_completed() {
     namespace=${1:?}
     labelSelector=${2:?}
-    condition=${3:?}
-    echo "Waiting for pod '${@:2}' to be ${condition} ... "
-    local -i cnt=${TEST_MAX_WAIT_SEC:?}
 
-    # Retries just in case it is not stable
-    local -i successCount=0
-    while [ "$successCount" -lt "3" ]; do
-        if kubectl get pod -a -n "$namespace" -l "$labelSelector" | grep -q "$condition"; then
-            ((successCount=successCount+1))
+    local -i retryTimeSeconds=${TEST_MAX_WAIT_SEC:?}
+    local -i retryTimeStepSeconds=5
+
+
+    while [ "$retryTimeSeconds" -gt 0 ]; do
+        res=$(kubectl get jobs -n $namespace -l $labelSelector \
+        -o jsonpath='{.items[*].status.conditions[?(@.type=="Complete")].status}' | grep "True")
+        # There is a job that finished
+        if [[ $res ]]; then
+            return 0
         fi
-        ((cnt=cnt-1)) || return 1
-        sleep 1
+        # It did not finished so we reduce the remaining time and wait for next retry cycle
+        echo "Waiting for job '${@:2}' to be completed, will retry in $retryTimeStepSeconds seconds ... "
+        retryTimeSeconds=retryTimeSeconds-$retryTimeStepSeconds
+        sleep $retryTimeStepSeconds
     done
 
-}
-k8s_wait_for_pod_ready() {
-    namespace=${1:?}
-    labelSelector=${2:?}
-    k8s_wait_for_pod $namespace $labelSelector Running
-}
+    echo "Job '${@:2}' did not complete"
 
-k8s_wait_for_pod_completed() {
-    namespace=${1:?}
-    labelSelector=${2:?}
-    k8s_wait_for_pod $namespace $labelSelector Completed
+    return 1
 }
 
 k8s_ensure_image() {
@@ -57,4 +56,17 @@ k8s_ensure_image() {
         echo "Failed to found $expectedPattern"
         return 1
     fi
+}
+
+# Waits for the rollout of all the deployments in a provided namespace 
+k8s_wait_for_deployments_rollout() {
+    namespace=${1:?}
+    # Check three times and return the latest result
+    for i in {1..3}; do
+        res=
+        kubectl get deployment -o name --namespace $namespace \
+            | xargs -n1 kubectl rollout status --namespace $namespace || res=$?
+    done
+
+    return $res
 }


### PR DESCRIPTION
We have noticed that the existing helpers used to wait for pods to be ready might not fulfill our requirements now that we have multiple replicas of every tier. 

I have changed that method to now rely on  `rollback status` which cover all replicas and also doing such check in all deployments in the namespace, not only the ones specifically set.

I have also slightly modified the job specific check to rely now in the job status flag instead of the pod Completed one.

it also fixed a bug in which the function did not seem to return when cnt was 0  

```
k8s_wait_for_pod() {
    ...
        ((cnt=cnt-1)) || return 1
        sleep 1
    done
}
```

I tried it in development:

Job that did not complete within the timeout window

```bash
$ k8s_wait_for_job_completed miguel apprepositories.kubeapps.com/repo-name=stable
Waiting for job 'apprepositories.kubeapps.com/repo-name=stable' to be completed, will retry in 5 seconds ... 
Waiting for job 'apprepositories.kubeapps.com/repo-name=stable' to be completed, will retry in 5 seconds ... 
Waiting for job 'apprepositories.kubeapps.com/repo-name=stable' to be completed, will retry in 5 seconds ... 
Job 'apprepositories.kubeapps.com/repo-name=stable' did not complete
```

Deployments that correctly finished

```bash
$ k8s_wait_for_deployments_rollout miguel
deployment "miguel-kubeapps" successfully rolled out
deployment "miguel-kubeapps-internal-apprepository-controller" successfully rolled out
deployment "miguel-kubeapps-internal-chartsvc" successfully rolled out
deployment "miguel-kubeapps-internal-dashboard" successfully rolled out
deployment "miguel-kubeapps-internal-tiller-proxy" successfully rolled out
deployment "miguel-kubeapps-mongodb" successfully rolled out
deployment "miguel-proxy-repo-nginx" successfully rolled out

```

Fixes https://github.com/kubeapps/kubeapps/issues/831