### PR TITLE
Add builds for GKE 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,14 +36,7 @@ workflows:
       - build_dashboard:
           <<: *build_always
       - GKE_1_9_MASTER:
-          <<: *build_on_master
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
-      - GKE_1_10_MASTER:
-          <<: *build_on_master
+          <<: *build_always
           requires:
             - test_go
             - test_dashboard
@@ -56,7 +49,28 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
+      - GKE_1_10_MASTER:
+          <<: *build_always
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
       - GKE_1_10_LATEST_RELEASE:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - GKE_1_11_MASTER:
+          <<: *build_always
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - GKE_1_11_LATEST_RELEASE:
           <<: *build_on_master
           requires:
             - test_go
@@ -67,24 +81,29 @@ workflows:
           <<: *build_on_master
           requires:
             - GKE_1_9_MASTER
-            - GKE_1_10_MASTER
             - GKE_1_9_LATEST_RELEASE
+            - GKE_1_10_MASTER
             - GKE_1_10_LATEST_RELEASE
+            - GKE_1_11_MASTER
+            - GKE_1_11_LATEST_RELEASE
       - push_images:
           <<: *build_always
           requires:
             - GKE_1_9_MASTER
-            - GKE_1_10_MASTER
             - GKE_1_9_LATEST_RELEASE
+            - GKE_1_10_MASTER
             - GKE_1_10_LATEST_RELEASE
+            - GKE_1_11_MASTER
+            - GKE_1_11_LATEST_RELEASE
       - release:
           <<: *build_on_tag
           requires:
             - GKE_1_9_MASTER
-            - GKE_1_10_MASTER
             - GKE_1_9_LATEST_RELEASE
+            - GKE_1_10_MASTER
             - GKE_1_10_LATEST_RELEASE
-      
+            - GKE_1_11_MASTER
+            - GKE_1_11_LATEST_RELEASE
 
 ## Definitions
 install_gcloud_sdk: &install_gcloud_sdk
@@ -110,6 +129,8 @@ exports: &exports
     # Apart from using a DEV_TAG we use a different image ID to avoid polluting the tag
     # history of the production tag
     echo "export IMG_MODIFIER=-ci" >> $BASH_ENV
+    # Kubectl version, we use the same for all the builds since typically it's backwards compatible
+    echo "export KUBECTL_VERSION=v1.12.0" >> $BASH_ENV
 build_images: &build_images
   steps:
     - setup_remote_docker
@@ -122,7 +143,7 @@ build_images: &build_images
         fi
         for IMAGE in "${IMG_ARRAY[@]}"; do
           make IMG_MODIFIER="$IMG_MODIFIER" IMAGE_TAG="${DEV_TAG}" $makeArgs ${IMAGE}
-          if [[ -z "${CIRCLE_PULL_REQUEST}" && -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
+          if [[ -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
             docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
             docker push ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
           fi
@@ -131,16 +152,16 @@ gke_test: &gke_test
   docker:
     - image: circleci/golang:1.11
   steps:
-    - checkout
     - run: |
-        source ./script/chart_sync_utils.sh
-
         # In case of GKE we will only want to build if it is
         # a build of a branch in the kubeapps repository
         if [[ -z "$GKE_ADMIN" ]]; then
           echo "Step aborted, we are not in the Kubeapps repository"
           circleci step halt
         fi
+    - checkout
+    - run: |
+        source ./script/chart_sync_utils.sh
 
         # Cancel job if this is a test stable release job but
         # the chart version has not been bumped
@@ -151,7 +172,10 @@ gke_test: &gke_test
     - <<: *exports
     - <<: *install_gcloud_sdk
     # Install kubectl
-    - run: gcloud components install kubectl
+    - run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+        chmod +x ./kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
     - setup_remote_docker
     - run: |
         gcloud -q config set project $GKE_PROJECT
@@ -233,11 +257,6 @@ jobs:
     environment:
       HELM_VERSION: v2.11.0
       GKE_BRANCH: 1.9
-  GKE_1_10_MASTER:
-    <<: *gke_test
-    environment:
-      HELM_VERSION: v2.11.0
-      GKE_BRANCH: 1.10
   GKE_1_9_LATEST_RELEASE:
     <<: *gke_test
     environment:
@@ -245,11 +264,27 @@ jobs:
       GKE_BRANCH: 1.9
       # We want to also test the chart with the current release of the images
       TEST_LATEST_RELEASE: 1
+  GKE_1_10_MASTER:
+    <<: *gke_test
+    environment:
+      HELM_VERSION: v2.11.0
+      GKE_BRANCH: 1.10
   GKE_1_10_LATEST_RELEASE:
     <<: *gke_test
     environment:
       HELM_VERSION: v2.11.0
       GKE_BRANCH: 1.10
+      TEST_LATEST_RELEASE: 1
+  GKE_1_11_MASTER:
+    <<: *gke_test
+    environment:
+      HELM_VERSION: v2.11.0
+      GKE_BRANCH: 1.11
+  GKE_1_11_LATEST_RELEASE:
+    <<: *gke_test
+    environment:
+      HELM_VERSION: v2.11.0
+      GKE_BRANCH: 1.11
       TEST_LATEST_RELEASE: 1
   sync_chart:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,42 +35,44 @@ workflows:
           <<: *build_always
       - build_dashboard:
           <<: *build_always
-      - GKE_1_9:
+      # E2E tests with the images just built
+      - GKE_1_9_LATEST:
           <<: *build_always
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_9_LATEST_RELEASE:
+      # E2E tests with the latest images released
+      - GKE_1_9_RELEASED:
           <<: *build_on_master
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_10:
+      - GKE_1_10_LATEST:
           <<: *build_always
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_10_LATEST_RELEASE:
+      - GKE_1_10_RELEASED:
           <<: *build_on_master
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_11:
+      - GKE_1_11_LATEST:
           <<: *build_always
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_11_LATEST_RELEASE:
+      - GKE_1_11_RELEASED:
           <<: *build_on_master
           requires:
             - test_go
@@ -80,30 +82,30 @@ workflows:
       - sync_chart:
           <<: *build_on_master
           requires:
-            - GKE_1_9
-            - GKE_1_9_LATEST_RELEASE
-            - GKE_1_10
-            - GKE_1_10_LATEST_RELEASE
-            - GKE_1_11
-            - GKE_1_11_LATEST_RELEASE
+            - GKE_1_9_LATEST
+            - GKE_1_9_RELEASED
+            - GKE_1_10_LATEST
+            - GKE_1_10_RELEASED
+            - GKE_1_11_LATEST
+            - GKE_1_11_RELEASED
       - push_images:
           <<: *build_always
           requires:
-            - GKE_1_9
-            - GKE_1_9_LATEST_RELEASE
-            - GKE_1_10
-            - GKE_1_10_LATEST_RELEASE
-            - GKE_1_11
-            - GKE_1_11_LATEST_RELEASE
+            - GKE_1_9_LATEST
+            - GKE_1_9_RELEASED
+            - GKE_1_10_LATEST
+            - GKE_1_10_RELEASED
+            - GKE_1_11_LATEST
+            - GKE_1_11_RELEASED
       - release:
           <<: *build_on_tag
           requires:
-            - GKE_1_9
-            - GKE_1_9_LATEST_RELEASE
-            - GKE_1_10
-            - GKE_1_10_LATEST_RELEASE
-            - GKE_1_11
-            - GKE_1_11_LATEST_RELEASE
+            - GKE_1_9_LATEST
+            - GKE_1_9_RELEASED
+            - GKE_1_10_LATEST
+            - GKE_1_10_RELEASED
+            - GKE_1_11_LATEST
+            - GKE_1_11_RELEASED
 
 ## Definitions
 install_gcloud_sdk: &install_gcloud_sdk
@@ -129,8 +131,8 @@ exports: &exports
     # Apart from using a DEV_TAG we use a different image ID to avoid polluting the tag
     # history of the production tag
     echo "export IMG_MODIFIER=-ci" >> $BASH_ENV
-    # Kubectl version, we use the same for all the builds since typically it's backwards compatible
-    echo "export KUBECTL_VERSION=v1.12.0" >> $BASH_ENV
+    # Helm version (should be +2.10)
+    echo "export HELM_VERSION=v2.11.0" >> $BASH_ENV
 build_images: &build_images
   steps:
     - setup_remote_docker
@@ -252,39 +254,34 @@ jobs:
     steps:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
-  GKE_1_9:
+  GKE_1_9_LATEST:
     <<: *gke_test
     environment:
-      HELM_VERSION: v2.11.0
-      GKE_BRANCH: 1.9
-  GKE_1_9_LATEST_RELEASE:
+      # Note: It's important to quote versions to avoid treating them as decimal numbers
+      GKE_BRANCH: "1.9"
+  GKE_1_9_RELEASED:
     <<: *gke_test
     environment:
-      HELM_VERSION: v2.11.0
-      GKE_BRANCH: 1.9
+      GKE_BRANCH: "1.9"
       # We want to also test the chart with the current release of the images
       TEST_LATEST_RELEASE: 1
-  GKE_1_10:
+  GKE_1_10_LATEST:
     <<: *gke_test
     environment:
-      HELM_VERSION: v2.11.0
       GKE_BRANCH: "1.10"
-  GKE_1_10_LATEST_RELEASE:
+  GKE_1_10_RELEASED:
     <<: *gke_test
     environment:
-      HELM_VERSION: v2.11.0
       GKE_BRANCH: "1.10"
       TEST_LATEST_RELEASE: 1
-  GKE_1_11:
+  GKE_1_11_LATEST:
     <<: *gke_test
     environment:
-      HELM_VERSION: v2.11.0
-      GKE_BRANCH: 1.11
-  GKE_1_11_LATEST_RELEASE:
+      GKE_BRANCH: "1.11"
+  GKE_1_11_RELEASED:
     <<: *gke_test
     environment:
-      HELM_VERSION: v2.11.0
-      GKE_BRANCH: 1.11
+      GKE_BRANCH: "1.11"
       TEST_LATEST_RELEASE: 1
   sync_chart:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,44 +35,42 @@ workflows:
           <<: *build_always
       - build_dashboard:
           <<: *build_always
-      # E2E tests with the images just built
-      - GKE_1_9_LATEST:
-          <<: *build_always
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
-      # E2E tests with the latest images released
-      - GKE_1_9_RELEASED:
+      - GKE_1_9_MASTER:
           <<: *build_on_master
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_10_LATEST:
-          <<: *build_always
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
-      - GKE_1_10_RELEASED:
+      - GKE_1_9_LATEST_RELEASE:
           <<: *build_on_master
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_11_LATEST:
-          <<: *build_always
+      - GKE_1_10_MASTER:
+          <<: *build_on_master
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_11_RELEASED:
+      - GKE_1_10_LATEST_RELEASE:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - GKE_1_11_MASTER:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - GKE_1_11_LATEST_RELEASE:
           <<: *build_on_master
           requires:
             - test_go
@@ -82,30 +80,30 @@ workflows:
       - sync_chart:
           <<: *build_on_master
           requires:
-            - GKE_1_9_LATEST
-            - GKE_1_9_RELEASED
-            - GKE_1_10_LATEST
-            - GKE_1_10_RELEASED
-            - GKE_1_11_LATEST
-            - GKE_1_11_RELEASED
+            - GKE_1_9_MASTER
+            - GKE_1_9_LATEST_RELEASE
+            - GKE_1_10_MASTER
+            - GKE_1_10_LATEST_RELEASE
+            - GKE_1_11_MASTER
+            - GKE_1_11_LATEST_RELEASE
       - push_images:
           <<: *build_always
           requires:
-            - GKE_1_9_LATEST
-            - GKE_1_9_RELEASED
-            - GKE_1_10_LATEST
-            - GKE_1_10_RELEASED
-            - GKE_1_11_LATEST
-            - GKE_1_11_RELEASED
+            - GKE_1_9_MASTER
+            - GKE_1_9_LATEST_RELEASE
+            - GKE_1_10_MASTER
+            - GKE_1_10_LATEST_RELEASE
+            - GKE_1_11_MASTER
+            - GKE_1_11_LATEST_RELEASE
       - release:
           <<: *build_on_tag
           requires:
-            - GKE_1_9_LATEST
-            - GKE_1_9_RELEASED
-            - GKE_1_10_LATEST
-            - GKE_1_10_RELEASED
-            - GKE_1_11_LATEST
-            - GKE_1_11_RELEASED
+            - GKE_1_9_MASTER
+            - GKE_1_9_LATEST_RELEASE
+            - GKE_1_10_MASTER
+            - GKE_1_10_LATEST_RELEASE
+            - GKE_1_11_MASTER
+            - GKE_1_11_LATEST_RELEASE
 
 ## Definitions
 install_gcloud_sdk: &install_gcloud_sdk
@@ -145,7 +143,7 @@ build_images: &build_images
         fi
         for IMAGE in "${IMG_ARRAY[@]}"; do
           make IMG_MODIFIER="$IMG_MODIFIER" IMAGE_TAG="${DEV_TAG}" $makeArgs ${IMAGE}
-          if [[ -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
+          if [[ -z "${CIRCLE_PULL_REQUEST}" && -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
             docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
             docker push ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
           fi
@@ -154,16 +152,16 @@ gke_test: &gke_test
   docker:
     - image: circleci/golang:1.11
   steps:
+    - checkout
     - run: |
+        source ./script/chart_sync_utils.sh
+
         # In case of GKE we will only want to build if it is
         # a build of a branch in the kubeapps repository
         if [[ -z "$GKE_ADMIN" ]]; then
           echo "Step aborted, we are not in the Kubeapps repository"
           circleci step halt
         fi
-    - checkout
-    - run: |
-        source ./script/chart_sync_utils.sh
 
         # Cancel job if this is a test stable release job but
         # the chart version has not been bumped
@@ -227,9 +225,8 @@ jobs:
   test_chart_render:
     docker:
       - image: circleci/golang:1.11
-    environment:
-      HELM_VERSION: v2.11.0
     steps:
+      - <<: *exports
       - checkout
       - <<: *install_helm_cli
       - run: helm init --client-only
@@ -254,31 +251,31 @@ jobs:
     steps:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
-  GKE_1_9_LATEST:
+  GKE_1_9_MASTER:
     <<: *gke_test
     environment:
       # Note: It's important to quote versions to avoid treating them as decimal numbers
       GKE_BRANCH: "1.9"
-  GKE_1_9_RELEASED:
+  GKE_1_9_LATEST_RELEASE:
     <<: *gke_test
     environment:
       GKE_BRANCH: "1.9"
       # We want to also test the chart with the current release of the images
       TEST_LATEST_RELEASE: 1
-  GKE_1_10_LATEST:
+  GKE_1_10_MASTER:
     <<: *gke_test
     environment:
       GKE_BRANCH: "1.10"
-  GKE_1_10_RELEASED:
+  GKE_1_10_LATEST_RELEASE:
     <<: *gke_test
     environment:
       GKE_BRANCH: "1.10"
       TEST_LATEST_RELEASE: 1
-  GKE_1_11_LATEST:
+  GKE_1_11_MASTER:
     <<: *gke_test
     environment:
       GKE_BRANCH: "1.11"
-  GKE_1_11_RELEASED:
+  GKE_1_11_LATEST_RELEASE:
     <<: *gke_test
     environment:
       GKE_BRANCH: "1.11"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ workflows:
           <<: *build_always
       - build_dashboard:
           <<: *build_always
-      - GKE_1_9_MASTER:
+      - GKE_1_9:
           <<: *build_always
           requires:
             - test_go
@@ -49,7 +49,7 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_10_MASTER:
+      - GKE_1_10:
           <<: *build_always
           requires:
             - test_go
@@ -63,7 +63,7 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_11_MASTER:
+      - GKE_1_11:
           <<: *build_always
           requires:
             - test_go
@@ -80,29 +80,29 @@ workflows:
       - sync_chart:
           <<: *build_on_master
           requires:
-            - GKE_1_9_MASTER
+            - GKE_1_9
             - GKE_1_9_LATEST_RELEASE
-            - GKE_1_10_MASTER
+            - GKE_1_10
             - GKE_1_10_LATEST_RELEASE
-            - GKE_1_11_MASTER
+            - GKE_1_11
             - GKE_1_11_LATEST_RELEASE
       - push_images:
           <<: *build_always
           requires:
-            - GKE_1_9_MASTER
+            - GKE_1_9
             - GKE_1_9_LATEST_RELEASE
-            - GKE_1_10_MASTER
+            - GKE_1_10
             - GKE_1_10_LATEST_RELEASE
-            - GKE_1_11_MASTER
+            - GKE_1_11
             - GKE_1_11_LATEST_RELEASE
       - release:
           <<: *build_on_tag
           requires:
-            - GKE_1_9_MASTER
+            - GKE_1_9
             - GKE_1_9_LATEST_RELEASE
-            - GKE_1_10_MASTER
+            - GKE_1_10
             - GKE_1_10_LATEST_RELEASE
-            - GKE_1_11_MASTER
+            - GKE_1_11
             - GKE_1_11_LATEST_RELEASE
 
 ## Definitions
@@ -252,7 +252,7 @@ jobs:
     steps:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
-  GKE_1_9_MASTER:
+  GKE_1_9:
     <<: *gke_test
     environment:
       HELM_VERSION: v2.11.0
@@ -264,18 +264,18 @@ jobs:
       GKE_BRANCH: 1.9
       # We want to also test the chart with the current release of the images
       TEST_LATEST_RELEASE: 1
-  GKE_1_10_MASTER:
+  GKE_1_10:
     <<: *gke_test
     environment:
       HELM_VERSION: v2.11.0
-      GKE_BRANCH: 1.10
+      GKE_BRANCH: "1.10"
   GKE_1_10_LATEST_RELEASE:
     <<: *gke_test
     environment:
       HELM_VERSION: v2.11.0
-      GKE_BRANCH: 1.10
+      GKE_BRANCH: "1.10"
       TEST_LATEST_RELEASE: 1
-  GKE_1_11_MASTER:
+  GKE_1_11:
     <<: *gke_test
     environment:
       HELM_VERSION: v2.11.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,9 +173,9 @@ gke_test: &gke_test
         fi
     - <<: *exports
     - <<: *install_gcloud_sdk
-    # Install kubectl
+    # Install kubectl (v1.12.0)
     - run: |
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl
         chmod +x ./kubectl
         sudo mv ./kubectl /usr/local/bin/kubectl
     - setup_remote_docker

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -27,6 +27,9 @@ source $ROOT_DIR/script/libtest.sh
 echo "IMAGE TAG TO BE TESTED: $DEV_TAG"
 echo "IMAGE_REPO_SUFFIX: $IMG_MODIFIER"
 
+# Print cluster version
+kubectl version
+
 # Install Tiller with TLS support
 helm init \
   --tiller-tls \

--- a/script/start-gke-env.sh
+++ b/script/start-gke-env.sh
@@ -10,9 +10,6 @@ if ! gcloud container clusters list; then
     exit 1
 fi
 
-# Resolve latest version from a branch
-VERSION=$(gcloud container get-server-config --zone $GKE_ZONE --format='yaml(validMasterVersions)' 2> /dev/null | grep $BRANCH | awk '{print $2}' | head -n 1)
-
 # Check if the cluster is already running
 if [[ $(gcloud container clusters list --filter="name:${CLUSTER}") ]]; then
     if gcloud container clusters list --filter="name:${CLUSTER}" | grep "STOPPING"; then
@@ -27,8 +24,8 @@ if [[ $(gcloud container clusters list --filter="name:${CLUSTER}") ]]; then
     fi
 fi
 
-echo "Creating cluster $CLUSTER in $ZONE (v$VERSION)"
-gcloud container clusters create --cluster-version=$VERSION --zone $ZONE $CLUSTER --num-nodes 2 --machine-type=n1-standard-2
+echo "Creating cluster $CLUSTER in $ZONE (v$BRANCH)"
+gcloud container clusters create --cluster-version=${BRANCH} --zone $ZONE $CLUSTER --num-nodes 2 --machine-type=n1-standard-2
 echo "Waiting for the cluster to respond..."
 cnt=20
 until kubectl get pods > /dev/null 2>&1; do


### PR DESCRIPTION
Fixes #822 
Fixes #834 

Changes:
 - Add builds for GKE 1.11
 - Pin `kubectl` version to `v1.12.0`
 - Fixes issue for the 1.10 branch that was picking the wrong version (see https://github.com/kubeapps/kubeapps/issues/822#issuecomment-440330246)
 ~~- Enabled GKE builds for any build in the repository `kubeapps/kubeapps` so we can easily tests PRs like this one.~~
