### PR TITLE
Show chart descriptions

### DIFF
--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -6,7 +6,7 @@ import { IAppOverview } from "../../shared/types";
 import InfoCard from "../InfoCard";
 import AppListItem from "./AppListItem";
 
-it("renders a app item", () => {
+it("renders an app item", () => {
   const wrapper = shallow(
     <AppListItem
       app={
@@ -21,8 +21,18 @@ it("renders a app item", () => {
     />,
   );
   const card = wrapper.find(InfoCard).shallow();
-  expect(card.find(Link).props().title).toBe("foo");
-  expect(card.find(Link).props().to).toBe("/apps/ns/default/foo");
+  expect(
+    card
+      .find(Link)
+      .at(0)
+      .props().title,
+  ).toBe("foo");
+  expect(
+    card
+      .find(Link)
+      .at(0)
+      .props().to,
+  ).toBe("/apps/ns/default/foo");
   expect(card.find(".type-color-light-blue").text()).toBe("myapp v1.0.0");
   expect(card.find(".deployed").exists()).toBe(true);
   expect(card.find(".ListItem__content__info_tag-1").text()).toBe("default");

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -55,7 +55,10 @@ describe("renderization", () => {
     const chartState = {
       isFetching: false,
       selected: {} as IChartState["selected"],
-      items: [{ id: "foo", attributes: {} } as IChart, { id: "bar", attributes: {} } as IChart],
+      items: [
+        { id: "foo", attributes: { description: "" } } as IChart,
+        { id: "bar", attributes: { description: "" } } as IChart,
+      ],
     } as IChartState;
 
     it("should render the list of charts", () => {

--- a/dashboard/src/components/Catalog/CatalogItem.scss
+++ b/dashboard/src/components/Catalog/CatalogItem.scss
@@ -22,8 +22,4 @@
   padding-top: 5px;
   padding-bottom: 5px;
   font-size: 14px;
-  &-full {
-    display: block;
-    height: 100%;
-  }
 }

--- a/dashboard/src/components/Catalog/CatalogItem.scss
+++ b/dashboard/src/components/Catalog/CatalogItem.scss
@@ -27,7 +27,3 @@
     height: 100%;
   }
 }
-
-.ListItem__content__description_link {
-  font-size: 14px;
-}

--- a/dashboard/src/components/Catalog/CatalogItem.scss
+++ b/dashboard/src/components/Catalog/CatalogItem.scss
@@ -15,3 +15,19 @@
     color: #fff;
   }
 }
+
+.ListItem__content__description {
+  overflow: hidden;
+  height: 80px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  font-size: 14px;
+  &-full {
+    display: block;
+    height: 100%;
+  }
+}
+
+.ListItem__content__description_link {
+  font-size: 14px;
+}

--- a/dashboard/src/components/Catalog/CatalogItem.test.tsx
+++ b/dashboard/src/components/Catalog/CatalogItem.test.tsx
@@ -1,4 +1,5 @@
 import { shallow } from "enzyme";
+import context from "jest-plugin-context";
 import * as React from "react";
 
 import { IChart, IRepo } from "../../shared/types";
@@ -34,7 +35,7 @@ it("should render an item", () => {
 });
 
 it("should use the default placeholder for the icon if it doesn't exist", () => {
-  const chartWithoutIcon = { ...defaultChart };
+  const chartWithoutIcon = Object.assign({}, defaultChart);
   chartWithoutIcon.attributes.icon = undefined;
   const wrapper = shallow(<CatalogItem chart={chartWithoutIcon} />);
   // Importing an image returns "undefined"
@@ -48,7 +49,7 @@ it("should use the default placeholder for the icon if it doesn't exist", () => 
 });
 
 it("should place a dash if the version is not avaliable", () => {
-  const chartWithoutVersion = { ...defaultChart };
+  const chartWithoutVersion = Object.assign({}, defaultChart);
   chartWithoutVersion.relationships.latestChartVersion.data.app_version = "";
   const wrapper = shallow(<CatalogItem chart={chartWithoutVersion} />);
   expect(
@@ -58,4 +59,62 @@ it("should place a dash if the version is not avaliable", () => {
       .find(".type-color-light-blue")
       .text(),
   ).toBe("-");
+});
+
+it("show the chart description", () => {
+  const chartWithDescription = Object.assign({}, defaultChart);
+  chartWithDescription.attributes.description = "This is a description";
+  const wrapper = shallow(<CatalogItem chart={chartWithDescription} />);
+  expect(
+    wrapper
+      .find(InfoCard)
+      .shallow()
+      .find(".ListItem__content__description")
+      .text(),
+  ).toBe(chartWithDescription.attributes.description);
+});
+
+context("when the description is too long", () => {
+  it("trims the description", () => {
+    const chartWithDescription = Object.assign({}, defaultChart);
+    chartWithDescription.attributes.description =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ultrices velit leo, quis pharetra mi vestibulum quis.";
+    const wrapper = shallow(<CatalogItem chart={chartWithDescription} />);
+    expect(
+      wrapper
+        .find(InfoCard)
+        .shallow()
+        .find(".ListItem__content__description")
+        .text(),
+    ).toContain("Show more");
+  });
+
+  it("toggles the short/long version", () => {
+    const chartWithDescription = Object.assign({}, defaultChart);
+    chartWithDescription.attributes.description =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ultrices velit leo, quis pharetra mi vestibulum quis.";
+    const wrapper = shallow(<CatalogItem chart={chartWithDescription} />);
+
+    let link = wrapper
+      .find(InfoCard)
+      .shallow()
+      .find("a");
+    expect(link).toExist();
+
+    link.simulate("click");
+    wrapper.update();
+
+    link = wrapper
+      .find(InfoCard)
+      .shallow()
+      .find("a");
+    expect(link.text()).toBe(" Hide");
+    expect(
+      wrapper
+        .find(InfoCard)
+        .shallow()
+        .find(".ListItem__content__description")
+        .text(),
+    ).toBe(`${chartWithDescription.attributes.description} Hide`);
+  });
 });

--- a/dashboard/src/components/Catalog/CatalogItem.test.tsx
+++ b/dashboard/src/components/Catalog/CatalogItem.test.tsx
@@ -1,5 +1,6 @@
 import { shallow } from "enzyme";
 import context from "jest-plugin-context";
+import * as _ from "lodash";
 import * as React from "react";
 
 import { IChart, IRepo } from "../../shared/types";
@@ -35,7 +36,7 @@ it("should render an item", () => {
 });
 
 it("should use the default placeholder for the icon if it doesn't exist", () => {
-  const chartWithoutIcon = Object.assign({}, defaultChart);
+  const chartWithoutIcon = _.cloneDeep(defaultChart);
   chartWithoutIcon.attributes.icon = undefined;
   const wrapper = shallow(<CatalogItem chart={chartWithoutIcon} />);
   // Importing an image returns "undefined"
@@ -49,7 +50,7 @@ it("should use the default placeholder for the icon if it doesn't exist", () => 
 });
 
 it("should place a dash if the version is not avaliable", () => {
-  const chartWithoutVersion = Object.assign({}, defaultChart);
+  const chartWithoutVersion = _.cloneDeep(defaultChart);
   chartWithoutVersion.relationships.latestChartVersion.data.app_version = "";
   const wrapper = shallow(<CatalogItem chart={chartWithoutVersion} />);
   expect(
@@ -62,7 +63,7 @@ it("should place a dash if the version is not avaliable", () => {
 });
 
 it("show the chart description", () => {
-  const chartWithDescription = Object.assign({}, defaultChart);
+  const chartWithDescription = _.cloneDeep(defaultChart);
   chartWithDescription.attributes.description = "This is a description";
   const wrapper = shallow(<CatalogItem chart={chartWithDescription} />);
   expect(
@@ -76,7 +77,7 @@ it("show the chart description", () => {
 
 context("when the description is too long", () => {
   it("trims the description", () => {
-    const chartWithDescription = Object.assign({}, defaultChart);
+    const chartWithDescription = _.cloneDeep(defaultChart);
     chartWithDescription.attributes.description =
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ultrices velit leo, quis pharetra mi vestibulum quis.";
     const wrapper = shallow(<CatalogItem chart={chartWithDescription} />);

--- a/dashboard/src/components/Catalog/CatalogItem.test.tsx
+++ b/dashboard/src/components/Catalog/CatalogItem.test.tsx
@@ -86,35 +86,6 @@ context("when the description is too long", () => {
         .shallow()
         .find(".ListItem__content__description")
         .text(),
-    ).toContain("Show more");
-  });
-
-  it("toggles the short/long version", () => {
-    const chartWithDescription = Object.assign({}, defaultChart);
-    chartWithDescription.attributes.description =
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ultrices velit leo, quis pharetra mi vestibulum quis.";
-    const wrapper = shallow(<CatalogItem chart={chartWithDescription} />);
-
-    let link = wrapper
-      .find(InfoCard)
-      .shallow()
-      .find("a");
-    expect(link).toExist();
-
-    link.simulate("click");
-    wrapper.update();
-
-    link = wrapper
-      .find(InfoCard)
-      .shallow()
-      .find("a");
-    expect(link.text()).toBe(" Hide");
-    expect(
-      wrapper
-        .find(InfoCard)
-        .shallow()
-        .find(".ListItem__content__description")
-        .text(),
-    ).toBe(`${chartWithDescription.attributes.description} Hide`);
+    ).toMatch(/\.\.\.$/);
   });
 });

--- a/dashboard/src/components/Catalog/CatalogItem.tsx
+++ b/dashboard/src/components/Catalog/CatalogItem.tsx
@@ -36,7 +36,7 @@ class CatalogItem extends React.Component<ICatalogItemProps, ICatalogItemState> 
     const description = (
       <div
         className={`ListItem__content__description
-          ${this.state.fullDescription && "ListItem__content__description-full"}`}
+          ${this.state.fullDescription ? "ListItem__content__description-full" : ""}`}
       >
         {this.state.fullDescription
           ? chart.attributes.description

--- a/dashboard/src/components/Catalog/CatalogItem.tsx
+++ b/dashboard/src/components/Catalog/CatalogItem.tsx
@@ -11,7 +11,18 @@ interface ICatalogItemProps {
   chart: IChart;
 }
 
-class CatalogItem extends React.Component<ICatalogItemProps> {
+// 3 lines description max
+const MAX_DESC_LENGTH = 90;
+
+interface ICatalogItemState {
+  fullDescription: boolean;
+}
+
+class CatalogItem extends React.Component<ICatalogItemProps, ICatalogItemState> {
+  public state: ICatalogItemState = {
+    fullDescription: false,
+  };
+
   public render() {
     const { chart } = this.props;
     const { icon, name, repo } = chart.attributes;
@@ -22,6 +33,22 @@ class CatalogItem extends React.Component<ICatalogItemProps> {
         {repo.name}
       </Link>
     );
+    const description = (
+      <div
+        className={`ListItem__content__description
+          ${this.state.fullDescription && "ListItem__content__description-full"}`}
+      >
+        {this.state.fullDescription
+          ? chart.attributes.description
+          : this.trimDescription(chart.attributes.description)}
+        {chart.attributes.description.length > MAX_DESC_LENGTH && (
+          <a onClick={this.toggleFullDescription}>
+            {" "}
+            {this.state.fullDescription ? "Hide" : "Show more"}
+          </a>
+        )}
+      </div>
+    );
     return (
       <InfoCard
         key={`${repo}/${name}`}
@@ -29,10 +56,23 @@ class CatalogItem extends React.Component<ICatalogItemProps> {
         link={`/charts/${chart.id}`}
         info={latestAppVersion || "-"}
         icon={iconSrc}
+        description={description}
         tag1Content={repoTag}
         tag1Class={repo.name}
       />
     );
+  }
+
+  private toggleFullDescription = () => {
+    this.setState({ fullDescription: !this.state.fullDescription });
+  };
+
+  private trimDescription(desc: string): string {
+    if (desc.length > MAX_DESC_LENGTH) {
+      // Trim to the last word under the max length
+      return desc.substr(0, desc.lastIndexOf(" ", MAX_DESC_LENGTH)).concat("... ");
+    }
+    return desc;
   }
 }
 

--- a/dashboard/src/components/Catalog/CatalogItem.tsx
+++ b/dashboard/src/components/Catalog/CatalogItem.tsx
@@ -14,66 +14,41 @@ interface ICatalogItemProps {
 // 3 lines description max
 const MAX_DESC_LENGTH = 90;
 
-interface ICatalogItemState {
-  fullDescription: boolean;
+function trimDescription(desc: string): string {
+  if (desc.length > MAX_DESC_LENGTH) {
+    // Trim to the last word under the max length
+    return desc.substr(0, desc.lastIndexOf(" ", MAX_DESC_LENGTH)).concat("...");
+  }
+  return desc;
 }
 
-class CatalogItem extends React.Component<ICatalogItemProps, ICatalogItemState> {
-  public state: ICatalogItemState = {
-    fullDescription: false,
-  };
-
-  public render() {
-    const { chart } = this.props;
-    const { icon, name, repo } = chart.attributes;
-    const iconSrc = icon ? `/api/chartsvc/${icon}` : placeholder;
-    const latestAppVersion = chart.relationships.latestChartVersion.data.app_version;
-    const repoTag = (
-      <Link className="ListItem__content__info_tag_link" to={`/catalog/${repo.name}`}>
-        {repo.name}
-      </Link>
-    );
-    const description = (
-      <div
-        className={`ListItem__content__description
-          ${this.state.fullDescription ? "ListItem__content__description-full" : ""}`}
-      >
-        {this.state.fullDescription
-          ? chart.attributes.description
-          : this.trimDescription(chart.attributes.description)}
-        {chart.attributes.description.length > MAX_DESC_LENGTH && (
-          <a onClick={this.toggleFullDescription}>
-            {" "}
-            {this.state.fullDescription ? "Hide" : "Show more"}
-          </a>
-        )}
-      </div>
-    );
-    return (
-      <InfoCard
-        key={`${repo}/${name}`}
-        title={name}
-        link={`/charts/${chart.id}`}
-        info={latestAppVersion || "-"}
-        icon={iconSrc}
-        description={description}
-        tag1Content={repoTag}
-        tag1Class={repo.name}
-      />
-    );
-  }
-
-  private toggleFullDescription = () => {
-    this.setState({ fullDescription: !this.state.fullDescription });
-  };
-
-  private trimDescription(desc: string): string {
-    if (desc.length > MAX_DESC_LENGTH) {
-      // Trim to the last word under the max length
-      return desc.substr(0, desc.lastIndexOf(" ", MAX_DESC_LENGTH)).concat("... ");
-    }
-    return desc;
-  }
-}
+const CatalogItem: React.SFC<ICatalogItemProps> = props => {
+  const { chart } = props;
+  const { icon, name, repo } = chart.attributes;
+  const iconSrc = icon ? `/api/chartsvc/${icon}` : placeholder;
+  const latestAppVersion = chart.relationships.latestChartVersion.data.app_version;
+  const repoTag = (
+    <Link className="ListItem__content__info_tag_link" to={`/catalog/${repo.name}`}>
+      {repo.name}
+    </Link>
+  );
+  const description = (
+    <div className="ListItem__content__description">
+      {trimDescription(chart.attributes.description)}
+    </div>
+  );
+  return (
+    <InfoCard
+      key={`${repo}/${name}`}
+      title={name}
+      link={`/charts/${chart.id}`}
+      info={latestAppVersion || "-"}
+      icon={iconSrc}
+      description={description}
+      tag1Content={repoTag}
+      tag1Class={repo.name}
+    />
+  );
+};
 
 export default CatalogItem;

--- a/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
@@ -23,7 +23,9 @@ exports[`renderization when charts available should render the list of charts 1`
       <CatalogItem
         chart={
           Object {
-            "attributes": Object {},
+            "attributes": Object {
+              "description": "",
+            },
             "id": "foo",
           }
         }
@@ -32,7 +34,9 @@ exports[`renderization when charts available should render the list of charts 1`
       <CatalogItem
         chart={
           Object {
-            "attributes": Object {},
+            "attributes": Object {
+              "description": "",
+            },
             "id": "bar",
           }
         }

--- a/dashboard/src/components/Catalog/__snapshots__/CatalogItem.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/CatalogItem.test.tsx.snap
@@ -2,6 +2,14 @@
 
 exports[`should render an item 1`] = `
 <InfoCard
+  description={
+    <div
+      className="ListItem__content__description
+          false"
+    >
+      
+    </div>
+  }
   icon="/api/chartsvc/icon.png"
   info="1.0.0"
   key="[object Object]/foo"

--- a/dashboard/src/components/Catalog/__snapshots__/CatalogItem.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/CatalogItem.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`should render an item 1`] = `
   description={
     <div
       className="ListItem__content__description
-          false"
+          "
     >
       
     </div>

--- a/dashboard/src/components/Catalog/__snapshots__/CatalogItem.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/CatalogItem.test.tsx.snap
@@ -4,8 +4,7 @@ exports[`should render an item 1`] = `
 <InfoCard
   description={
     <div
-      className="ListItem__content__description
-          "
+      className="ListItem__content__description"
     >
       
     </div>

--- a/dashboard/src/components/InfoCard/InfoCard.test.tsx
+++ b/dashboard/src/components/InfoCard/InfoCard.test.tsx
@@ -32,7 +32,10 @@ it("should generate a dummy link if it's not provided", () => {
       tag2Content="running"
     />,
   );
-  expect(wrapper.find(Link).props()).toMatchObject({ to: "#" });
+
+  const links = wrapper.find(Link);
+  expect(links.length).toBe(2);
+  links.forEach(l => expect(l.props()).toMatchObject({ to: "#" }));
 });
 
 it("should avoid tags if they are not defined", () => {
@@ -63,4 +66,15 @@ it("should parse JSX elements in the tags", () => {
   const tag2Elem = wrapper.find(".tag2");
   expect(tag2Elem).toExist();
   expect(tag2Elem.text()).toBe("tag2");
+});
+
+it("should parse a description as text", () => {
+  const wrapper = shallow(<InfoCard title="foo" info="foobar" description="a description" />);
+  expect(wrapper.find(".ListItem__content").text()).toContain("a description");
+});
+
+it("should parse a description as JSX.Element", () => {
+  const desc = <div className="description">This is a description</div>;
+  const wrapper = shallow(<InfoCard title="foo" info="foobar" description={desc} />);
+  expect(wrapper.find(".description").text()).toBe("This is a description");
 });

--- a/dashboard/src/components/InfoCard/InfoCard.tsx
+++ b/dashboard/src/components/InfoCard/InfoCard.tsx
@@ -10,6 +10,7 @@ export interface IServiceInstanceCardProps {
   info: string;
   link?: string;
   icon?: string;
+  description?: string | JSX.Element;
   tag1Class?: string;
   tag1Content?: string | JSX.Element;
   tag2Class?: string;
@@ -17,39 +18,42 @@ export interface IServiceInstanceCardProps {
 }
 
 const InfoCard: React.SFC<IServiceInstanceCardProps> = props => {
-  const { title, link, info, tag1Content, tag1Class, tag2Content, tag2Class } = props;
+  const { title, link, info, description, tag1Content, tag1Class, tag2Content, tag2Class } = props;
   const icon = props.icon ? props.icon : placeholder;
   return (
     <Card responsive={true} className="ListItem">
       <Link to={link || "#"} title={title}>
         <CardIcon icon={icon} />
-        <CardContent>
-          <div className="ListItem__content">
+      </Link>
+      <CardContent>
+        <div className="ListItem__content">
+          <Link to={link || "#"} title={title}>
             <h3 className="ListItem__content__title type-big">{title}</h3>
-            <div className="ListItem__content__info">
-              <p className="margin-reset type-small padding-t-tiny type-color-light-blue">{info}</p>
-              <div>
-                {tag1Content && (
-                  <span
-                    className={`ListItem__content__info_tag ListItem__content__info_tag-1 type-small type-color-white padding-t-tiny padding-h-normal ${tag1Class ||
-                      ""}`}
-                  >
-                    {tag1Content}
-                  </span>
-                )}
-                {tag2Content && (
-                  <span
-                    className={`ListItem__content__info_tag ListItem__content__info_tag-2 type-small type-color-white padding-t-tiny padding-h-normal margin-b-normal ${tag2Class ||
-                      ""}`}
-                  >
-                    {tag2Content}
-                  </span>
-                )}
-              </div>
+          </Link>
+          {description}
+          <div className="ListItem__content__info">
+            <p className="margin-reset type-small padding-t-tiny type-color-light-blue">{info}</p>
+            <div>
+              {tag1Content && (
+                <span
+                  className={`ListItem__content__info_tag ListItem__content__info_tag-1 type-small type-color-white padding-t-tiny padding-h-normal ${tag1Class ||
+                    ""}`}
+                >
+                  {tag1Content}
+                </span>
+              )}
+              {tag2Content && (
+                <span
+                  className={`ListItem__content__info_tag ListItem__content__info_tag-2 type-small type-color-white padding-t-tiny padding-h-normal margin-b-normal ${tag2Class ||
+                    ""}`}
+                >
+                  {tag2Content}
+                </span>
+              )}
             </div>
           </div>
-        </CardContent>
-      </Link>
+        </div>
+      </CardContent>
       {props.children}
     </Card>
   );

--- a/dashboard/src/components/InfoCard/__snapshots__/InfoCard.test.tsx.snap
+++ b/dashboard/src/components/InfoCard/__snapshots__/InfoCard.test.tsx.snap
@@ -13,38 +13,44 @@ exports[`should render a Card 1`] = `
     <CardIcon
       icon="an-icon.png"
     />
-    <CardContent>
-      <div
-        className="ListItem__content"
+  </Link>
+  <CardContent>
+    <div
+      className="ListItem__content"
+    >
+      <Link
+        replace={false}
+        title="foo"
+        to="/a/link/somewhere"
       >
         <h3
           className="ListItem__content__title type-big"
         >
           foo
         </h3>
-        <div
-          className="ListItem__content__info"
+      </Link>
+      <div
+        className="ListItem__content__info"
+      >
+        <p
+          className="margin-reset type-small padding-t-tiny type-color-light-blue"
         >
-          <p
-            className="margin-reset type-small padding-t-tiny type-color-light-blue"
+          foobar
+        </p>
+        <div>
+          <span
+            className="ListItem__content__info_tag ListItem__content__info_tag-1 type-small type-color-white padding-t-tiny padding-h-normal blue"
           >
-            foobar
-          </p>
-          <div>
-            <span
-              className="ListItem__content__info_tag ListItem__content__info_tag-1 type-small type-color-white padding-t-tiny padding-h-normal blue"
-            >
-              database
-            </span>
-            <span
-              className="ListItem__content__info_tag ListItem__content__info_tag-2 type-small type-color-white padding-t-tiny padding-h-normal margin-b-normal red"
-            >
-              running
-            </span>
-          </div>
+            database
+          </span>
+          <span
+            className="ListItem__content__info_tag ListItem__content__info_tag-2 type-small type-color-white padding-t-tiny padding-h-normal margin-b-normal red"
+          >
+            running
+          </span>
         </div>
       </div>
-    </CardContent>
-  </Link>
+    </div>
+  </CardContent>
 </Card>
 `;


### PR DESCRIPTION
Fixes #793 

This PR adds the chart descriptions to the Catalog view. Since descriptions can be quite long, descriptions over 90 characters are trimmed. Users can still see the full description clicking on "Show more". This is the justification of why I chose to do it that way:

 - The most common thing to trim text is using the CSS property `text-overflow: ellipsis`. Unfortunately that only works for text with just one line. One line in this case is not enough since it will never show a meaningful message.
 - There are several options to trim texts of more than one line (three lines usually gives a good description) as explained in this [post](http://hackingui.com/front-end/a-pure-css-solution-for-multiline-text-truncation/). The most common way of doing that is with a CSS class that defines `display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;`. Unfortunately again, that only works when the text has a fixed width. In our case, the width is responsive so we need to discard that option.
 - After evaluating the different options, it seems that the best approach is to trim the text using Javascript code. The minimum width a card can get is around ~200px. We need to calculate the amount of characters to show having in mind that if the card shrinks, some text may be hidden. Taking that into account I chose to use 90 characters as maximum so the view behaves properly with any size.
 - ~~To allow users to get the full meaningful description, I added a "Show more" button that displays the whole description of a chart.~~

<img width="1270" alt="screenshot 2018-12-14 at 10 23 33" src="https://user-images.githubusercontent.com/4025665/49994971-33d60080-ff8b-11e8-92c2-645f4065bd9b.png">

