### PR TITLE
Fix SecretTable for empty secrets

### DIFF
--- a/dashboard/src/components/AppView/SecretsTable/SecretItem.test.tsx
+++ b/dashboard/src/components/AppView/SecretsTable/SecretItem.test.tsx
@@ -10,7 +10,7 @@ const secret = {
   type: "Opaque",
   metadata: {
     namespace: "ns",
-    name: "deployment-one",
+    name: "secret-one",
     annotations: "",
     creationTimestamp: "",
     selfLink: "",
@@ -35,4 +35,11 @@ it("displays a secret when clicking on the icon", () => {
   icon.simulate("click");
   expect(wrapper.state()).toMatchObject({ showSecret: { foo: true } });
   expect(wrapper.text()).toContain("foo:bar");
+});
+
+it("displays a message if the secret is empty", () => {
+  const emptySecret = Object.assign({}, secret);
+  delete emptySecret.data;
+  const wrapper = shallow(<SecretItem secret={emptySecret} />);
+  expect(wrapper.text()).toContain("The secret is empty");
 });

--- a/dashboard/src/components/AppView/SecretsTable/SecretItem.tsx
+++ b/dashboard/src/components/AppView/SecretsTable/SecretItem.tsx
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import * as React from "react";
 import { Eye, EyeOff } from "react-feather";
 
@@ -16,16 +17,22 @@ class SecretItem extends React.Component<ISecretItemProps, ISecretItemState> {
   public constructor(props: ISecretItemProps) {
     super(props);
     const showSecret = {};
-    Object.keys(this.props.secret.data).forEach(k => (showSecret[k] = false));
+    if (this.props.secret.data) {
+      Object.keys(this.props.secret.data).forEach(k => (showSecret[k] = false));
+    }
     this.state = { showSecret };
   }
 
   public render() {
     const { secret } = this.props;
     const secretEntries: JSX.Element[] = [];
-    Object.keys(secret.data).forEach(k => {
-      secretEntries.push(this.renderSecretEntry(k));
-    });
+    if (!_.isEmpty(this.props.secret.data)) {
+      Object.keys(secret.data).forEach(k => {
+        secretEntries.push(this.renderSecretEntry(k));
+      });
+    } else {
+      secretEntries.push(<span key="empty">The secret is empty</span>);
+    }
     return (
       <tr className="flex">
         <td className="col-2">{secret.metadata.name}</td>

--- a/dashboard/src/components/AppView/SecretsTable/__snapshots__/SecretItem.test.tsx.snap
+++ b/dashboard/src/components/AppView/SecretsTable/__snapshots__/SecretItem.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`renders a secret (hidden by default) 1`] = `
   <td
     className="col-2"
   >
-    deployment-one
+    secret-one
   </td>
   <td
     className="col-2"


### PR DESCRIPTION
I noticed that if a secret is empty (it doesn't contain `data`) the AppView crashes.