### PR TITLE
Refactor automatic release name test

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -102,8 +102,19 @@ it("renders the full DeploymentForm", () => {
 
 it("renders a release name by default", () => {
   const versions = [{ id: "foo", attributes: { version: "1.2.3" } }] as IChartVersion[];
-  const wrapper = shallow(
+  let wrapper = shallow(
     <DeploymentForm {...defaultProps} selected={{ versions, version: versions[0] }} />,
   );
-  expect(wrapper.state("releaseName")).toBeTruthy();
+  const name1 = wrapper.state("releaseName") as string;
+  expect(name1).toBeTruthy();
+  expect(name1.length).toBeGreaterThan(1);
+
+  // When reloading the name should change
+  wrapper = shallow(
+    <DeploymentForm {...defaultProps} selected={{ versions, version: versions[0] }} />,
+  );
+  const name2 = wrapper.state("releaseName") as string;
+  expect(name2).toBeTruthy();
+  expect(name2.length).toBeGreaterThan(1);
+  expect(name2).not.toEqual(name1);
 });


### PR DESCRIPTION
Ref: 
https://github.com/kubeapps/kubeapps/pull/877#discussion_r241444613

Ensure that the release name changes between loads. cc/ @migmartri 
