### PR TITLE
Fix config.json

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -22,6 +22,6 @@ data:
     }
   config.json: |-
     {
-      "namespace": "{{ .Release.Namespace }}"
+      "namespace": "{{ .Release.Namespace }}",
       "appVersion": "{{ .Chart.AppVersion }}"
     }


### PR DESCRIPTION
Apps fail to deploy due to a syntax error in the config file in the chart.