### PR TITLE
Improve Other Resources rendering

### DIFF
--- a/dashboard/src/components/AppView/OtherResourcesTable/OtherResourcesTable.tsx
+++ b/dashboard/src/components/AppView/OtherResourcesTable/OtherResourcesTable.tsx
@@ -24,12 +24,21 @@ class OtherResourcesTable extends React.Component<IAppDetailsProps> {
     if (otherResources.length > 0) {
       otherResourcesSection = (
         <table>
+          <thead>
+            <tr>
+              <th>KIND</th>
+              <th>NAMESPACE</th>
+              <th>NAME</th>
+            </tr>
+          </thead>
           <tbody>
             {otherResources.map((r: IResource) => {
               return (
                 <tr key={`otherResources/${r.kind}/${r.metadata.name}`}>
                   <td>{r.kind}</td>
-                  <td>{r.metadata.namespace}</td>
+                  <td>
+                    {r.metadata.namespace || <i style={{ color: "lightgray" }}>Not Namespaced</i>}
+                  </td>
                   <td>{r.metadata.name}</td>
                 </tr>
               );

--- a/dashboard/src/components/AppView/OtherResourcesTable/__snapshots__/OtherResourcesTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/OtherResourcesTable/__snapshots__/OtherResourcesTable.test.tsx.snap
@@ -6,6 +6,19 @@ exports[`renders other resources details 1`] = `
     Other Resources
   </h6>
   <table>
+    <thead>
+      <tr>
+        <th>
+          KIND
+        </th>
+        <th>
+          NAMESPACE
+        </th>
+        <th>
+          NAME
+        </th>
+      </tr>
+    </thead>
     <tbody>
       <tr
         key="otherResources/Secret/foo"
@@ -13,7 +26,17 @@ exports[`renders other resources details 1`] = `
         <td>
           Secret
         </td>
-        <td />
+        <td>
+          <i
+            style={
+              Object {
+                "color": "lightgray",
+              }
+            }
+          >
+            Not Namespaced
+          </i>
+        </td>
         <td>
           foo
         </td>
@@ -24,7 +47,17 @@ exports[`renders other resources details 1`] = `
         <td>
           PersistentVolume
         </td>
-        <td />
+        <td>
+          <i
+            style={
+              Object {
+                "color": "lightgray",
+              }
+            }
+          >
+            Not Namespaced
+          </i>
+        </td>
         <td>
           foo
         </td>


### PR DESCRIPTION
Split from  #893

> I have also noticed that the table for other resources didn't have a header and that when the resource was not namespaces the field was blank. I've changed that as well to show more info:

<img width="794" alt="screenshot 2018-12-19 at 12 25 34" src="https://user-images.githubusercontent.com/4025665/50218529-8dc03700-038c-11e9-909c-866ee1f5b683.png">