### PR TITLE
Fix chart-repo image reference

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -99,9 +99,9 @@ apprepository:
   # Image used to perform chart repository syncs
   syncImage:
     registry: quay.io
-    repository: helmpack/chart-repo
     # TODO: Update tag when a new release is available
-    tag: "@sha256:bf4b31604ec35e8317079546f6e06b2f045958feff5903e2705b76bf3fcbee4b"
+    repository: "helmpack/chart-repo@sha256"
+    tag: bf4b31604ec35e8317079546f6e06b2f045958feff5903e2705b76bf3fcbee4b
   initialRepos:
   - name: stable
     url: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
Fix master e2e tests.

The template function is concatenating tags always with `:`. This produced a wrong image reference for the chart-repo temporary tag (`chart-repo:@sha256:...`). Applied a workaround to produce a valid image reference.

Note that this should be changed when a new chart-repo tag is released.