### PR TITLE
Update chartsvc and chart-repo to v1.2.0

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -101,7 +101,7 @@ apprepository:
     registry: quay.io
     # TODO: Update tag when a new release is available
     repository: helmpack/chart-repo
-    tag: latest
+    tag: v1.2.0
   initialRepos:
   - name: stable
     url: https://kubernetes-charts.storage.googleapis.com
@@ -169,7 +169,7 @@ chartsvc:
   image:
     registry: quay.io
     repository: helmpack/chartsvc
-    tag: v1.0.2
+    tag: v1.2.0
   service:
     port: 8080
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -100,8 +100,8 @@ apprepository:
   syncImage:
     registry: quay.io
     # TODO: Update tag when a new release is available
-    repository: "helmpack/chart-repo@sha256"
-    tag: bf4b31604ec35e8317079546f6e06b2f045958feff5903e2705b76bf3fcbee4b
+    repository: helmpack/chart-repo
+    tag: latest
   initialRepos:
   - name: stable
     url: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
The current chart-repo image cannot be pulled since `latest` was rebuilt yesterday. Apparently it's not possible to use the `sha256` of an old image (that behavior is different from the Docker Hub). I am changing the tag to use `latest` until there is a new release.

Note that Quay.io is under an incident: http://status.quay.io/incidents/72jyq4322h85 so I am not sure if the issue (not able to pull an old sha256) is actually caused by that incident.