### PR TITLE
Remove version prefix

### DIFF
--- a/dashboard/src/components/Footer/Footer.test.tsx
+++ b/dashboard/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,16 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+
+import Footer from "./Footer";
+
+it("renders version and link to release", () => {
+  const version = "v1.5.5-T500";
+  const linkURI = `https://github.com/kubeapps/kubeapps/releases/tag/${version}`;
+
+  const wrapper = shallow(<Footer appVersion={version} />);
+
+  const link = wrapper.find("p.version-link a").first();
+  expect(link.text()).toBe(version);
+  expect(link.props().href).toBe(linkURI);
+  expect(link).toMatchSnapshot();
+});

--- a/dashboard/src/components/Footer/Footer.tsx
+++ b/dashboard/src/components/Footer/Footer.tsx
@@ -9,6 +9,10 @@ interface IFooterProps {
 }
 
 const Footer: React.SFC<IFooterProps> = props => {
+  const linkColor = {
+    color: "#FFF",
+  };
+
   return (
     <footer className="osFooter bg-dark type-color-reverse-anchor-reset">
       <div className="container padding-h-big padding-v-bigger">
@@ -19,7 +23,11 @@ const Footer: React.SFC<IFooterProps> = props => {
             </h4>
             <p className="type-color-white type-small margin-reset">
               Made with <Heart className="icon icon-small" /> by Bitnami and{" "}
-              <a href="https://github.com/kubeapps/kubeapps/graphs/contributors" target="_blank">
+              <a
+                href="https://github.com/kubeapps/kubeapps/graphs/contributors"
+                style={linkColor}
+                target="_blank"
+              >
                 contributors
               </a>
               .
@@ -56,7 +64,15 @@ const Footer: React.SFC<IFooterProps> = props => {
                 />
               </svg>
             </a>
-            <p className="type-color-white type-small margin-small">v{props.appVersion}</p>
+            <p className="type-color-white type-small margin-small version-link">
+              <a
+                href={`https://github.com/kubeapps/kubeapps/releases/tag/${props.appVersion}`}
+                style={linkColor}
+                target="_blank"
+              >
+                {props.appVersion}
+              </a>
+            </p>
           </div>
         </div>
       </div>

--- a/dashboard/src/components/Footer/Footer.tsx
+++ b/dashboard/src/components/Footer/Footer.tsx
@@ -9,10 +9,6 @@ interface IFooterProps {
 }
 
 const Footer: React.SFC<IFooterProps> = props => {
-  const linkColor = {
-    color: "#FFF",
-  };
-
   return (
     <footer className="osFooter bg-dark type-color-reverse-anchor-reset">
       <div className="container padding-h-big padding-v-bigger">
@@ -21,11 +17,11 @@ const Footer: React.SFC<IFooterProps> = props => {
             <h4 className="inverse margin-reset">
               <img src={logo} alt="Kubeapps logo" className="osFooter__logo" />
             </h4>
-            <p className="type-color-white type-small margin-reset">
+            <p className="type-small margin-reset">
               Made with <Heart className="icon icon-small" /> by Bitnami and{" "}
               <a
                 href="https://github.com/kubeapps/kubeapps/graphs/contributors"
-                style={linkColor}
+                className="type-color-white"
                 target="_blank"
               >
                 contributors
@@ -64,10 +60,10 @@ const Footer: React.SFC<IFooterProps> = props => {
                 />
               </svg>
             </a>
-            <p className="type-color-white type-small margin-small version-link">
+            <p className="type-small margin-small version-link">
               <a
                 href={`https://github.com/kubeapps/kubeapps/releases/tag/${props.appVersion}`}
-                style={linkColor}
+                className="type-color-white"
                 target="_blank"
               >
                 {props.appVersion}

--- a/dashboard/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/dashboard/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders version and link to release 1`] = `
+<a
+  href="https://github.com/kubeapps/kubeapps/releases/tag/v1.5.5-T500"
+  style={
+    Object {
+      "color": "#FFF",
+    }
+  }
+  target="_blank"
+>
+  v1.5.5-T500
+</a>
+`;

--- a/dashboard/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/dashboard/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -2,12 +2,8 @@
 
 exports[`renders version and link to release 1`] = `
 <a
+  className="type-color-white"
   href="https://github.com/kubeapps/kubeapps/releases/tag/v1.5.5-T500"
-  style={
-    Object {
-      "color": "#FFF",
-    }
-  }
   target="_blank"
 >
   v1.5.5-T500


### PR DESCRIPTION
Removes `v` prefix and adds link to the release page.

![selection_801](https://user-images.githubusercontent.com/24523/50529495-22701680-0aaa-11e9-934c-364842609eb3.png)

Fixes https://github.com/kubeapps/kubeapps/issues/905