### PR TITLE
Move ingress rewrite to dashboard Nginx

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 1.2.1
+version: 1.2.2
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -132,15 +132,3 @@ Create name for the tiller-proxy based on the fullname
 {{ template "kubeapps.fullname" . }}-internal-tiller-proxy
 {{- end -}}
 
-{{/*
-Nginx rewrite rules that will add trailing slash to the provided custom ingress paths
-Trailing / is required for the react app to work
-*/}}
-{{- define "kubeapps.ingressRewrites" -}}
-{{ range .Values.ingress.hosts -}}
-{{- if (.path) and ne .path "/" -}}
-      rewrite ^({{ .path }})$ $1/ permanent;
-{{- end -}}
-{{- end }}
-{{- end -}}
-

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -17,6 +17,14 @@ data:
       gzip_static  on;
 
       location / {
+        # Redirects are required to be relative otherwise the internal hostname will be exposed
+        absolute_redirect off;
+
+        # Trailing / is required in the path for the React app to be loaded correctly
+        # The rewrite rule adds a trailing "/" to any path that does not contain "." neither "/".
+        # i.e kubeapps => kubeapps/
+        rewrite ^([^.]*[^/])$ $1/ permanent;
+
         # Support for ingress prefixes maintaining compatibility with the default /
         # 1 - Exactly two fragment URLs for files existing inside of the public/ dir
         # i.e /[prefix]/config.json => /config.json

--- a/chart/kubeapps/templates/ingress.yaml
+++ b/chart/kubeapps/templates/ingress.yaml
@@ -9,11 +9,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    {{- $rewrites := include "kubeapps.ingressRewrites" . -}}
-    {{- if ne $rewrites ""}}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{ template "kubeapps.ingressRewrites" $ }}
-    {{- end -}}
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}


### PR DESCRIPTION
Based on this discussion https://github.com/kubeapps/kubeapps/pull/897#pullrequestreview-186802634 I've managed to extract the redirection logic to the Nginx configuration inside the dashboard container as well as made it generic. This is good since now, the redirect does not depend now on the specifics of the Ingress controller as well as the deployment mechanism (Helm chart).

In my previous tests the solution did not work because the redirection was including the internal port (8080)

NOTE: see location header in the following examples.

```bash
$ curl -I -H 'Cache-Control: no-cache' https://miguel-kubeapps-dev.k.dev.bitnami.net/kubeapps
HTTP/2 301 
server: nginx/1.15.6
date: Wed, 02 Jan 2019 21:16:01 GMT
content-type: text/html
content-length: 185
location: http://miguel-kubeapps-dev.k.dev.bitnami.net:8080/kubeapps/
```

I tried disabling the port via the directive `port_in_redirect off;` but that made the internal server_name to be shown. Adding also `server_name_in_redirect` did not help either.

```bash
$ curl -I -H 'Cache-Control: no-cache' https://miguel-kubeapps-dev.k.dev.bitnami.net/kubeapps
HTTP/2 301
server: nginx/1.15.6
date: Wed, 02 Jan 2019 21:18:43 GMT
content-type: text/html
content-length: 185
location: http://miguel-kubeapps-internal-dashboard/kubeapps/
```

Setting the redirects relative does the trick.
```bash
$ curl -I -H 'Cache-Control: no-cache' https://miguel-kubeapps-dev.k.dev.bitnami.net/kubeapps
HTTP/2 301 
server: nginx/1.15.6
date: Wed, 02 Jan 2019 21:14:43 GMT
content-type: text/html
content-length: 185
location: /kubeapps/
```

Refs https://github.com/kubeapps/kubeapps/issues/402