### PR TITLE
Remove Namespace column from other resources

### DIFF
--- a/dashboard/src/components/AppView/OtherResourcesTable/OtherResourcesTable.tsx
+++ b/dashboard/src/components/AppView/OtherResourcesTable/OtherResourcesTable.tsx
@@ -27,7 +27,6 @@ class OtherResourcesTable extends React.Component<IAppDetailsProps> {
           <thead>
             <tr>
               <th>KIND</th>
-              <th>NAMESPACE</th>
               <th>NAME</th>
             </tr>
           </thead>
@@ -36,9 +35,6 @@ class OtherResourcesTable extends React.Component<IAppDetailsProps> {
               return (
                 <tr key={`otherResources/${r.kind}/${r.metadata.name}`}>
                   <td>{r.kind}</td>
-                  <td>
-                    {r.metadata.namespace || <i style={{ color: "lightgray" }}>Not Namespaced</i>}
-                  </td>
                   <td>{r.metadata.name}</td>
                 </tr>
               );

--- a/dashboard/src/components/AppView/OtherResourcesTable/__snapshots__/OtherResourcesTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/OtherResourcesTable/__snapshots__/OtherResourcesTable.test.tsx.snap
@@ -12,9 +12,6 @@ exports[`renders other resources details 1`] = `
           KIND
         </th>
         <th>
-          NAMESPACE
-        </th>
-        <th>
           NAME
         </th>
       </tr>
@@ -27,17 +24,6 @@ exports[`renders other resources details 1`] = `
           Secret
         </td>
         <td>
-          <i
-            style={
-              Object {
-                "color": "lightgray",
-              }
-            }
-          >
-            Not Namespaced
-          </i>
-        </td>
-        <td>
           foo
         </td>
       </tr>
@@ -46,17 +32,6 @@ exports[`renders other resources details 1`] = `
       >
         <td>
           PersistentVolume
-        </td>
-        <td>
-          <i
-            style={
-              Object {
-                "color": "lightgray",
-              }
-            }
-          >
-            Not Namespaced
-          </i>
         </td>
         <td>
           foo


### PR DESCRIPTION
Fixes #906 

The manifest doesn't always contain the namespace of the resources it contains since, by default, it resolves to the namespace in which the application is deployed. We don't have a mechanism to differ between namespaced and non-namespaced components so we'd need to remove that column.