### PR TITLE
Adds placeholder-style loading to the ServiceItems

### DIFF
--- a/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
+++ b/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`when apps available matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <div>
         <CardGrid>
@@ -95,6 +96,7 @@ exports[`when error present matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <ErrorSelector
         action="list"
@@ -130,6 +132,7 @@ exports[`when error present renders a generic error message 1`] = `
   <main>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <ErrorSelector
         action="list"
@@ -196,6 +199,7 @@ exports[`when fetched but not apps available matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <MessageAlertPage
         header="Supercharge your Kubernetes cluster"
@@ -267,6 +271,7 @@ exports[`while fetching apps loading spinner matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={false}
+      type={0}
     >
       <div />
     </LoadingWrapper>
@@ -328,6 +333,7 @@ exports[`while fetching apps matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={false}
+      type={0}
     >
       <div />
     </LoadingWrapper>

--- a/dashboard/src/components/AppUpgrade/__snapshots__/AppUpgrade.test.tsx.snap
+++ b/dashboard/src/components/AppUpgrade/__snapshots__/AppUpgrade.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`loading spinner matches the snapshot 1`] = `
 <LoadingWrapper
   loaded={false}
+  type={0}
 />
 `;
 

--- a/dashboard/src/components/AppView/AccessURLTable/__snapshots__/AccessURLTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/AccessURLTable/__snapshots__/AccessURLTable.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`when fetching ingresses or services loading spinner matches the snapsho
   <LoadingWrapper
     loaded={false}
     size="small"
+    type={0}
   >
     <table>
       <thead>
@@ -37,6 +38,7 @@ exports[`when fetching ingresses or services loading spinner matches the snapsho
   <LoadingWrapper
     loaded={false}
     size="small"
+    type={0}
   >
     <p>
       The current application does not expose a public URL.
@@ -53,6 +55,7 @@ exports[`when the app contain ingresses should show the table with available ing
   <LoadingWrapper
     loaded={true}
     size="small"
+    type={0}
   >
     <table>
       <thead>
@@ -96,6 +99,7 @@ exports[`when the app contain services and ingresses should show the table with 
   <LoadingWrapper
     loaded={true}
     size="small"
+    type={0}
   >
     <table>
       <thead>
@@ -152,6 +156,7 @@ exports[`when the app contain services should show the table if any service is a
   <LoadingWrapper
     loaded={true}
     size="small"
+    type={0}
   >
     <table>
       <thead>

--- a/dashboard/src/components/AppView/DeploymentsTable/__snapshots__/DeploymentsTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/DeploymentsTable/__snapshots__/DeploymentsTable.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders a deployment ready 1`] = `
   <LoadingWrapper
     loaded={true}
     size="small"
+    type={0}
   >
     <table>
       <thead>
@@ -53,6 +54,7 @@ exports[`when fetching deployments loading spinner matches the snapshot 1`] = `
   <LoadingWrapper
     loaded={false}
     size="small"
+    type={0}
   >
     <table>
       <thead>

--- a/dashboard/src/components/AppView/SecretsTable/__snapshots__/SecretsTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/SecretsTable/__snapshots__/SecretsTable.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders a table with a secret 1`] = `
   <LoadingWrapper
     loaded={true}
     size="small"
+    type={0}
   >
     <table>
       <thead>
@@ -57,6 +58,7 @@ exports[`when fetching secrets loading spinner matches the snapshot 1`] = `
   <LoadingWrapper
     loaded={false}
     size="small"
+    type={0}
   >
     <table>
       <thead>

--- a/dashboard/src/components/AppView/ServicesTable/ServiceItem.tsx
+++ b/dashboard/src/components/AppView/ServicesTable/ServiceItem.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { AlertTriangle } from "react-feather";
 
-import LoadingWrapper from "../../../components/LoadingWrapper";
+import LoadingWrapper, { LoaderType } from "../../../components/LoadingWrapper";
 import { IKubeItem, IResource, IServiceSpec, IServiceStatus } from "../../../shared/types";
 
 interface IServiceItemProps {
@@ -29,7 +29,7 @@ class ServiceItem extends React.Component<IServiceItemProps> {
     if (service === undefined || service.isFetching) {
       return (
         <td colSpan={4}>
-          <LoadingWrapper size="inline-small" />
+          <LoadingWrapper type={LoaderType.Placeholder} />
         </td>
       );
     }

--- a/dashboard/src/components/AppView/ServicesTable/__snapshots__/ServiceItem.test.tsx.snap
+++ b/dashboard/src/components/AppView/ServicesTable/__snapshots__/ServiceItem.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`when fetching services loading spinner matches the snapshot 1`] = `
   >
     <LoadingWrapper
       loaded={false}
-      size="inline-small"
+      type={1}
     />
   </td>
 </tr>
@@ -22,7 +22,7 @@ exports[`when fetching services loading spinner matches the snapshot 2`] = `
   >
     <LoadingWrapper
       loaded={false}
-      size="inline-small"
+      type={1}
     />
   </td>
 </tr>

--- a/dashboard/src/components/AppView/__snapshots__/AppControls.test.tsx.snap
+++ b/dashboard/src/components/AppView/__snapshots__/AppControls.test.tsx.snap
@@ -3,11 +3,13 @@
 exports[`when name or namespace do not exist loading spinner matches the snapshot 1`] = `
 <LoadingWrapper
   loaded={false}
+  type={0}
 />
 `;
 
 exports[`when name or namespace do not exist loading spinner matches the snapshot 2`] = `
 <LoadingWrapper
   loaded={false}
+  type={0}
 />
 `;

--- a/dashboard/src/components/AppView/__snapshots__/AppView.test.tsx.snap
+++ b/dashboard/src/components/AppView/__snapshots__/AppView.test.tsx.snap
@@ -3,5 +3,6 @@
 exports[`AppViewComponent when app info is null loading spinner matches the snapshot 1`] = `
 <LoadingWrapper
   loaded={false}
+  type={0}
 />
 `;

--- a/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`renderization when charts available should render the list of charts 1`
   </PageHeader>
   <LoadingWrapper
     loaded={true}
+    type={0}
   >
     <CardGrid>
       <CatalogItem
@@ -65,6 +66,7 @@ exports[`renderization when fetching apps loading spinner matches the snapshot 1
   </PageHeader>
   <LoadingWrapper
     loaded={false}
+    type={0}
   >
     <CardGrid />
   </LoadingWrapper>

--- a/dashboard/src/components/ChartView/__snapshots__/ChartReadme.test.tsx.snap
+++ b/dashboard/src/components/ChartView/__snapshots__/ChartReadme.test.tsx.snap
@@ -3,5 +3,6 @@
 exports[`when readme is not present loading spinner matches the snapshot 1`] = `
 <LoadingWrapper
   loaded={false}
+  type={0}
 />
 `;

--- a/dashboard/src/components/ChartView/__snapshots__/ChartView.test.tsx.snap
+++ b/dashboard/src/components/ChartView/__snapshots__/ChartView.test.tsx.snap
@@ -3,11 +3,13 @@
 exports[`when fetching is false but no chart is available loading spinner matches the snapshot 1`] = `
 <LoadingWrapper
   loaded={false}
+  type={0}
 />
 `;
 
 exports[`when fetching is true and chart is available loading spinner matches the snapshot 1`] = `
 <LoadingWrapper
   loaded={false}
+  type={0}
 />
 `;

--- a/dashboard/src/components/Config/ServiceBrokerList/__snapshots__/ServiceBrokerList.test.tsx.snap
+++ b/dashboard/src/components/Config/ServiceBrokerList/__snapshots__/ServiceBrokerList.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`if the service broker is not installed shows a warning message 1`] = `
   </PageHeader>
   <LoadingWrapper
     loaded={true}
+    type={0}
   >
     <ServiceCatalogNotInstalledAlert />
   </LoadingWrapper>
@@ -28,6 +29,7 @@ exports[`when all the brokers are loaded shows a forbiden (fetch) error if it ex
   </PageHeader>
   <LoadingWrapper
     loaded={true}
+    type={0}
   >
     <main>
       <ErrorSelector
@@ -125,6 +127,7 @@ exports[`when all the brokers are loaded shows a forbiden (resync) error if it e
     </PageHeader>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <main>
         <ErrorSelector
@@ -350,6 +353,7 @@ exports[`when all the brokers are loaded shows a warning to install no service b
     </PageHeader>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <main>
         <ServiceBrokersNotFoundAlert>
@@ -443,6 +447,7 @@ exports[`when all the brokers are loaded when there are no errors, renders the b
   </PageHeader>
   <LoadingWrapper
     loaded={true}
+    type={0}
   >
     <main>
       <CardGrid
@@ -483,6 +488,7 @@ exports[`while fetching brokers loading spinner matches the snapshot 1`] = `
   </PageHeader>
   <LoadingWrapper
     loaded={false}
+    type={0}
   >
     <main>
       <ServiceBrokersNotFoundAlert />
@@ -502,6 +508,7 @@ exports[`while fetching brokers matches the snapshot 1`] = `
   </PageHeader>
   <LoadingWrapper
     loaded={false}
+    type={0}
   >
     <main>
       <ServiceBrokersNotFoundAlert />

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -109,7 +109,7 @@ it("renders the full DeploymentForm", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
- it("renders a release name by default, relying in Monickers output", () => {
+it("renders a release name by default, relying in Monickers output", () => {
   const versions = [{ id: "foo", attributes: { version: "1.2.3" } }] as IChartVersion[];
   monikerChooseMock.mockImplementationOnce(() => "foo").mockImplementationOnce(() => "bar");
 

--- a/dashboard/src/components/DeploymentForm/__snapshots__/DeploymentForm.test.tsx.snap
+++ b/dashboard/src/components/DeploymentForm/__snapshots__/DeploymentForm.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`loading spinner matches the snapshot 1`] = `
 <LoadingWrapper
   loaded={false}
+  type={0}
 />
 `;
 

--- a/dashboard/src/components/LoadingWrapper/LoadingPlaceholder/LoadingPlaceholder.scss
+++ b/dashboard/src/components/LoadingWrapper/LoadingPlaceholder/LoadingPlaceholder.scss
@@ -1,0 +1,25 @@
+.LoadingPlaceholder {
+  height: 1em;
+  background-color: #f1f1f1;
+  position: relative;
+  &:after {
+    content: "";
+    position: absolute;
+    width: 100%;
+    height: 1em;
+    background: linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0),
+      rgba(255, 255, 255, 25%),
+      rgba(0, 0, 0, 0)
+    );
+    transform: translateX(-30%);
+    animation: loading 1.5s infinite;
+  }
+}
+
+@keyframes loading {
+  100% {
+    transform: translateX(100%);
+  }
+}

--- a/dashboard/src/components/LoadingWrapper/LoadingPlaceholder/LoadingPlaceholder.tsx
+++ b/dashboard/src/components/LoadingWrapper/LoadingPlaceholder/LoadingPlaceholder.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+import "./LoadingPlaceholder.css";
+
+// Renders a placeholder loader style
+// Based on https://kyusuf.com/post/fake-it-til-you-make-it-css/
+const LoadingPlaceholder: React.SFC = props => {
+  return <div className="LoadingPlaceholder" />;
+};
+
+export default LoadingPlaceholder;

--- a/dashboard/src/components/LoadingWrapper/LoadingPlaceholder/index.ts
+++ b/dashboard/src/components/LoadingWrapper/LoadingPlaceholder/index.ts
@@ -1,0 +1,3 @@
+import LoadingPlaceholder from "./LoadingPlaceholder";
+
+export default LoadingPlaceholder;

--- a/dashboard/src/components/LoadingWrapper/LoadingWrapper.test.tsx
+++ b/dashboard/src/components/LoadingWrapper/LoadingWrapper.test.tsx
@@ -1,7 +1,8 @@
 import { shallow } from "enzyme";
 import * as React from "react";
-import LoadingWrapper from ".";
+import LoadingWrapper, { LoaderType } from ".";
 import LoadingSpinner from "../LoadingSpinner";
+import LoadingPlaceholder from "./LoadingPlaceholder";
 
 let props = {} as any;
 
@@ -58,5 +59,13 @@ describe("when loaded is true", () => {
   it("renders it wrapped component", () => {
     const wrapper = renderComponent(props);
     expect(wrapper.find(ChildrenComponent)).toExist();
+  });
+});
+
+describe("loader types", () => {
+  it("renders the LoadingPlaceholder type when specified", () => {
+    const wrapper = renderComponent({ type: LoaderType.Placeholder });
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(LoadingPlaceholder)).toExist();
   });
 });

--- a/dashboard/src/components/LoadingWrapper/LoadingWrapper.tsx
+++ b/dashboard/src/components/LoadingWrapper/LoadingWrapper.tsx
@@ -1,7 +1,15 @@
 import * as React from "react";
+
 import LoadingSpinner from "../LoadingSpinner";
+import LoadingPlaceholder from "./LoadingPlaceholder";
+
+export enum LoaderType {
+  Spinner,
+  Placeholder,
+}
 
 export interface ILoadingWrapperProps {
+  type?: LoaderType;
   loaded?: boolean;
   size?: string;
 }
@@ -10,11 +18,22 @@ export interface ILoadingWrapperProps {
 // Currently, I am having issues transforming it via const LoadingWrapper: React.SFC<ILoadingWrapperProps>
 class LoadingWrapper extends React.Component<ILoadingWrapperProps> {
   public static defaultProps: ILoadingWrapperProps = {
+    type: LoaderType.Spinner,
     loaded: false,
   };
 
   public render() {
-    return this.props.loaded ? this.props.children : <LoadingSpinner size={this.props.size} />;
+    return this.props.loaded ? this.props.children : this.renderLoader();
+  }
+
+  private renderLoader() {
+    switch (this.props.type) {
+      case LoaderType.Spinner:
+        return <LoadingSpinner size={this.props.size} />;
+      case LoaderType.Placeholder:
+        return <LoadingPlaceholder />;
+    }
+    return;
   }
 }
 

--- a/dashboard/src/components/LoadingWrapper/__snapshots__/LoadingWrapper.test.tsx.snap
+++ b/dashboard/src/components/LoadingWrapper/__snapshots__/LoadingWrapper.test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`loader types renders the LoadingPlaceholder type when specified 1`] = `<LoadingPlaceholder />`;
+
 exports[`when loaded is false matches the snapshot 1`] = `<LoaderSpinner />`;
 
 exports[`when loaded is true matches the snapshot 1`] = `<ChildrenComponent />`;

--- a/dashboard/src/components/LoadingWrapper/index.ts
+++ b/dashboard/src/components/LoadingWrapper/index.ts
@@ -1,3 +1,3 @@
-import LoadingWrapper, { ILoadingWrapperProps } from "./LoadingWrapper";
-export { ILoadingWrapperProps };
+import LoadingWrapper, { ILoadingWrapperProps, LoaderType } from "./LoadingWrapper";
+export { ILoadingWrapperProps, LoaderType };
 export default LoadingWrapper;

--- a/dashboard/src/components/ServiceClassList/__snapshots__/ServiceClassList.test.tsx.snap
+++ b/dashboard/src/components/ServiceClassList/__snapshots__/ServiceClassList.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`should show a warning message if there are no classes available 1`] = `
   <main>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <p>
         Types of services available from all brokers
@@ -47,6 +48,7 @@ exports[`when there are classes available should show a Card item per class 1`] 
   <main>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <p>
         Types of services available from all brokers
@@ -120,6 +122,7 @@ exports[`while fetching classes loading spinner matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={false}
+      type={0}
     >
       <p>
         Types of services available from all brokers
@@ -157,6 +160,7 @@ exports[`while fetching classes matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={false}
+      type={0}
     >
       <p>
         Types of services available from all brokers

--- a/dashboard/src/components/ServiceClassView/__snapshots__/ServiceClassView.test.tsx.snap
+++ b/dashboard/src/components/ServiceClassView/__snapshots__/ServiceClassView.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`when all the components are loaded when an service class is available s
   <main>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <div
         className="class-view"
@@ -97,6 +98,7 @@ exports[`while fetching components loading spinner matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={false}
+      type={0}
     >
       <div
         className="class-view"
@@ -142,6 +144,7 @@ exports[`while fetching components matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={false}
+      type={0}
     >
       <div
         className="class-view"

--- a/dashboard/src/components/ServiceInstanceList/__snapshots__/ServiceInstanceList.test.tsx.snap
+++ b/dashboard/src/components/ServiceInstanceList/__snapshots__/ServiceInstanceList.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`when all the components are loaded shows a card list with the different
   </MessageAlertPage>
   <LoadingWrapper
     loaded={true}
+    type={0}
   >
     <main>
       <ServiceInstanceCardList
@@ -129,6 +130,7 @@ exports[`when all the components are loaded shows a forbiden error if it exists 
   </MessageAlertPage>
   <LoadingWrapper
     loaded={true}
+    type={0}
   >
     <main>
       <ErrorSelector
@@ -225,6 +227,7 @@ exports[`when all the components are loaded shows a warning to install no servic
   </MessageAlertPage>
   <LoadingWrapper
     loaded={true}
+    type={0}
   >
     <main>
       <ServiceBrokersNotFoundAlert />
@@ -288,6 +291,7 @@ exports[`when all the components are loaded shows a warning to install the Servi
   </MessageAlertPage>
   <LoadingWrapper
     loaded={true}
+    type={0}
   >
     <main>
       <ServiceCatalogNotInstalledAlert />
@@ -351,6 +355,7 @@ exports[`when all the components are loaded shows information of how to deploy a
   </MessageAlertPage>
   <LoadingWrapper
     loaded={true}
+    type={0}
   >
     <main>
       <MessageAlertPage
@@ -438,6 +443,7 @@ exports[`while fetching components loading spinner matches the snapshot 1`] = `
   </MessageAlertPage>
   <LoadingWrapper
     loaded={false}
+    type={0}
   >
     <main>
       <ServiceBrokersNotFoundAlert />
@@ -501,6 +507,7 @@ exports[`while fetching components matches the snapshot 1`] = `
   </MessageAlertPage>
   <LoadingWrapper
     loaded={false}
+    type={0}
   >
     <main>
       <ServiceBrokersNotFoundAlert />

--- a/dashboard/src/components/ServiceInstanceView/__snapshots__/ServiceInstanceView.test.tsx.snap
+++ b/dashboard/src/components/ServiceInstanceView/__snapshots__/ServiceInstanceView.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`when all the components are loaded shows a deprovision error if it exis
   <main>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <div
         className="container"
@@ -83,6 +84,7 @@ exports[`when all the components are loaded shows a fetch error if it exists 1`]
   <main>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <div
         className="container"
@@ -351,6 +353,7 @@ exports[`when all the components are loaded when an instance is available should
     <main>
       <LoadingWrapper
         loaded={true}
+        type={0}
       >
         <div
           className="container"
@@ -1286,6 +1289,7 @@ exports[`when all the components are loaded when an instance is available should
   <main>
     <LoadingWrapper
       loaded={true}
+      type={0}
     >
       <div
         className="container"
@@ -1531,6 +1535,7 @@ exports[`while fetching components loading spinner matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={false}
+      type={0}
     >
       <div
         className="container"
@@ -1547,6 +1552,7 @@ exports[`while fetching components matches the snapshot 1`] = `
   <main>
     <LoadingWrapper
       loaded={false}
+      type={0}
     >
       <div
         className="container"

--- a/dashboard/src/components/UpgradeForm/__snapshots__/UpgradeForm.test.tsx.snap
+++ b/dashboard/src/components/UpgradeForm/__snapshots__/UpgradeForm.test.tsx.snap
@@ -3,11 +3,13 @@
 exports[`render when no version selected loading spinner matches the snapshot 1`] = `
 <LoadingWrapper
   loaded={false}
+  type={0}
 />
 `;
 
 exports[`render when versions but deploying loading spinner matches the snapshot 1`] = `
 <LoadingWrapper
   loaded={false}
+  type={0}
 />
 `;


### PR DESCRIPTION
The placeholder style loading is used in some webapps to show that text
content is loading. This is a better fit for the ServiceTables compared
to the LoadingSpinner.

The implementation adds a new `type` prop to the LoadingWrapper
component, which is used to determine which type of loader to render.
This could easily be extended to different types of loaders in the
future.