### PR TITLE
Fix User-Agent header for Tiller-proxy

### DIFF
--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -45,7 +45,6 @@ var (
 	settings    environment.EnvSettings
 	proxy       *tillerProxy.Proxy
 	kubeClient  kubernetes.Interface
-	netClient   *clientWithDefaultUserAgent
 	disableAuth bool
 	listLimit   int
 
@@ -120,7 +119,7 @@ func main() {
 	}
 
 	proxy = tillerProxy.NewProxy(kubeClient, helmClient)
-	chartutils := chartUtils.NewChart(kubeClient, helmChartUtil.LoadArchive)
+	chartutils := chartUtils.NewChart(kubeClient, helmChartUtil.LoadArchive, userAgent())
 
 	r := mux.NewRouter()
 

--- a/cmd/tiller-proxy/version.go
+++ b/cmd/tiller-proxy/version.go
@@ -18,19 +18,12 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 )
 
 var (
 	version          = "devel"
 	userAgentComment string
 )
-
-// clientWithDefaultUserAgent implements chart.HTTPClient interface
-// and includes an override of the Do method which injects an User-Agent
-type clientWithDefaultUserAgent struct {
-	http.Client
-}
 
 // Returns the user agent to be used during calls to the chart repositories
 // Examples:
@@ -44,10 +37,4 @@ func userAgent() string {
 		ua = fmt.Sprintf("%s (%s)", ua, userAgentComment)
 	}
 	return ua
-}
-
-func (c *clientWithDefaultUserAgent) Do(req *http.Request) (*http.Response, error) {
-	req.Header.Set("User-Agent", userAgent())
-
-	return c.Client.Do(req)
 }

--- a/cmd/tiller-proxy/version_test.go
+++ b/cmd/tiller-proxy/version_test.go
@@ -17,9 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/arschles/assert"
@@ -66,22 +63,4 @@ func Test_userAgent(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, userAgent(), "expected user agent")
 		})
 	}
-}
-
-func Test_clientWithDefaultUserAgentOverride(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "tiller-proxy/devel", req.Header.Get("User-Agent"), "expected user agent")
-	}))
-	// Close the server when test finishes
-	defer server.Close()
-
-	serverURL, _ := url.Parse(server.URL)
-
-	netClient = &clientWithDefaultUserAgent{}
-	_, err := netClient.Do(&http.Request{
-		URL:    serverURL,
-		Header: map[string][]string{},
-	})
-
-	assert.NoErr(t, err)
 }

--- a/pkg/chart/fake/chart.go
+++ b/pkg/chart/fake/chart.go
@@ -43,6 +43,6 @@ func (f *FakeChart) GetChart(details *chartUtils.Details, netClient chartUtils.H
 	}, nil
 }
 
-func (f *FakeChart) InitNetClient(customCA *chartUtils.CustomCA) (*http.Client, error) {
+func (f *FakeChart) InitNetClient(customCA *chartUtils.CustomCA) (chartUtils.HTTPClient, error) {
 	return &http.Client{}, nil
 }


### PR DESCRIPTION
Since v1.1.0 the `netClient` is created in the `chartUtils` pkg instead of the main one. This caused that the User-Agent that we were setting in the main package was not being used.