### PR TITLE
Bump nginx image version for security vulns

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,5 +7,5 @@ RUN yarn install --frozen-lockfile
 COPY . /app
 RUN yarn run build
 
-FROM bitnami/nginx:1.14.0-r27
+FROM bitnami/nginx:1.14.2-r61
 COPY --from=build /app/build /app


### PR DESCRIPTION
It appears the older image contains some security vulnerabilities that have been fixed in more recent Debian versions. This PR bumps the nginx image used in the dashboard to upgrade the underlying Debian OS.