### PR TITLE
Disable builds for GKE 1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,20 +35,6 @@ workflows:
           <<: *build_always
       - build_dashboard:
           <<: *build_always
-      - GKE_1_10_MASTER:
-          <<: *build_on_master
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
-      - GKE_1_10_LATEST_RELEASE:
-          <<: *build_on_master
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
       - GKE_1_11_MASTER:
           <<: *build_on_master
           requires:
@@ -66,22 +52,16 @@ workflows:
       - sync_chart:
           <<: *build_on_master
           requires:
-            - GKE_1_10_MASTER
-            - GKE_1_10_LATEST_RELEASE
             - GKE_1_11_MASTER
             - GKE_1_11_LATEST_RELEASE
       - push_images:
           <<: *build_always
           requires:
-            - GKE_1_10_MASTER
-            - GKE_1_10_LATEST_RELEASE
             - GKE_1_11_MASTER
             - GKE_1_11_LATEST_RELEASE
       - release:
           <<: *build_on_tag
           requires:
-            - GKE_1_10_MASTER
-            - GKE_1_10_LATEST_RELEASE
             - GKE_1_11_MASTER
             - GKE_1_11_LATEST_RELEASE
 
@@ -231,15 +211,6 @@ jobs:
     steps:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
-  GKE_1_10_MASTER:
-    <<: *gke_test
-    environment:
-      GKE_BRANCH: "1.10"
-  GKE_1_10_LATEST_RELEASE:
-    <<: *gke_test
-    environment:
-      GKE_BRANCH: "1.10"
-      TEST_LATEST_RELEASE: 1
   GKE_1_11_MASTER:
     <<: *gke_test
     environment:


### PR DESCRIPTION
Closes #972

GKE 1.10 has been deprecated. Release notes: https://cloud.google.com/kubernetes-engine/release-notes