### PR TITLE
Use bitnami images before updating bitnami chart

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 1.5.0
+version: 1.5.1
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -98,9 +98,9 @@ apprepository:
     tag: latest
   # Image used to perform chart repository syncs
   syncImage:
-    registry: quay.io
-    repository: helmpack/chart-repo
-    tag: v1.4.0
+    registry: docker.io
+    repository: bitnami/kubeapps-chart-repo
+    tag: 1.4.0
   initialRepos:
   - name: stable
     url: https://kubernetes-charts.storage.googleapis.com
@@ -175,9 +175,9 @@ tillerProxy:
 chartsvc:
   replicaCount: 2
   image:
-    registry: quay.io
-    repository: helmpack/chartsvc
-    tag: v1.4.0
+    registry: docker.io
+    repository: bitnami/kubeapps-chartsvc
+    tag: 1.4.0
   service:
     port: 8080
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -58,6 +58,13 @@ updateRepo() {
     rm "${targetChartPath}/Chart.yaml.bk"
     # DANGER: This replaces any tag marked as latest in the values.yaml
     sed -i.bk 's/tag: latest/tag: '"${targetTag}"'/g' "${targetChartPath}/values.yaml"
+    # Replace quay.io images for docker.io
+    sed -i.bk 's/registry: quay.io/registry: docker.io/g' "${targetChartPath}/values.yaml"
+    # Remove v prefix from tags
+    sed -i.bk 's/tag: v\(.*\)/tag: \1/g' "${targetChartPath}/values.yaml"
+    # Use bitnami images
+    sed -i.bk 's/repository: helmpack\/\(.*\)/repository: bitnami\/kubeapps-\1/g' "${targetChartPath}/values.yaml"
+    sed -i.bk 's/repository: kubeapps\/\(.*\)/repository: bitnami\/kubeapps-\1/g' "${targetChartPath}/values.yaml"
     rm "${targetChartPath}/values.yaml.bk"
 }
 

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -57,13 +57,9 @@ updateRepo() {
     sed -i.bk 's/appVersion: DEVEL/appVersion: '"${targetTag}"'/g' "${chartYaml}"
     rm "${targetChartPath}/Chart.yaml.bk"
     # DANGER: This replaces any tag marked as latest in the values.yaml
-    sed -i.bk 's/tag: latest/tag: '"${targetTag}"'/g' "${targetChartPath}/values.yaml"
-    # Replace quay.io images for docker.io
-    sed -i.bk 's/registry: quay.io/registry: docker.io/g' "${targetChartPath}/values.yaml"
-    # Remove v prefix from tags
-    sed -i.bk 's/tag: v\(.*\)/tag: \1/g' "${targetChartPath}/values.yaml"
+    local tagWithoutV=$(echo $targetTag | tr -d v)
+    sed -i.bk 's/tag: latest/tag: '"${tagWithoutV}"'/g' "${targetChartPath}/values.yaml"
     # Use bitnami images
-    sed -i.bk 's/repository: helmpack\/\(.*\)/repository: bitnami\/kubeapps-\1/g' "${targetChartPath}/values.yaml"
     sed -i.bk 's/repository: kubeapps\/\(.*\)/repository: bitnami\/kubeapps-\1/g' "${targetChartPath}/values.yaml"
     rm "${targetChartPath}/values.yaml.bk"
 }


### PR DESCRIPTION
It's now a requirement to use bitnami images wherever is possible for charts published at https://github.com/bitnami/charts.

Note that bitnami images are mirrored versions from the ones we are currently using but their tags doesn't contain the prefix `v`: `v1.3.0 -> 1.3.0`. They are hosted in the docker hub and have the prefix `kubeapps-<name of the image>`.

This is an example of changes performed from the dev version of the chart in this repository to the one that will be submitted to the bitnami repository:

```patch
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -94,13 +94,13 @@ apprepository:
   replicaCount: 1
   image:
     registry: docker.io
-    repository: kubeapps/apprepository-controller
-    tag: latest
+    repository: bitnami/kubeapps-apprepository-controller
+    tag: 1.3.0
   # Image used to perform chart repository syncs
   syncImage:
-    registry: quay.io
-    repository: helmpack/chart-repo
-    tag: v1.4.0
+    registry: docker.io
+    repository: bitnami/kubeapps-chart-repo
+    tag: 1.4.0
   initialRepos:
   - name: stable
     url: https://kubernetes-charts.storage.googleapis.com
@@ -149,8 +149,8 @@ tillerProxy:
   replicaCount: 2
   image:
     registry: docker.io
-    repository: kubeapps/tiller-proxy
-    tag: latest
+    repository: bitnami/kubeapps-tiller-proxy
+    tag: 1.3.0
   service:
     port: 8080
   host: tiller-deploy.kube-system:44134
@@ -175,9 +175,9 @@ tillerProxy:
 chartsvc:
   replicaCount: 2
   image:
-    registry: quay.io
-    repository: helmpack/chartsvc
-    tag: v1.4.0
+    registry: docker.io
+    repository: bitnami/kubeapps-chartsvc
+    tag: 1.4.0
   service:
     port: 8080
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
@@ -211,8 +211,8 @@ dashboard:
   replicaCount: 2
   image:
     registry: docker.io
-    repository: kubeapps/dashboard
-    tag: latest
+    repository: bitnami/kubeapps-dashboard
+    tag: 1.3.0
   service:
     port: 8080
   livenessProbe:
```

I have manually tested the changes and I didn't found any issue with the mirrored images.