### PR TITLE
Refactor upgrade flow

### DIFF
--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -75,11 +75,12 @@ describe("fetches applications", () => {
       const expectedActions = [
         { type: getType(actions.apps.listApps), payload: false },
         { type: getType(actions.apps.receiveAppList), payload: appsResponse },
+        { type: getType(actions.apps.requestApps) },
         {
           type: getType(actions.apps.receiveAppUpdateInfo),
           payload: {
             releaseName: "foobar",
-            updateInfo: { latestVersion: "1.1.0", repository: { name: "bar" } },
+            updateInfo: { upToDate: false, latestVersion: "1.1.0", repository: { name: "bar" } },
           },
         },
       ];
@@ -87,7 +88,7 @@ describe("fetches applications", () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
 
-    it("does not populate updateInfo if there are no new versions", async () => {
+    it("set up upToDate=true if the application is up to date", async () => {
       const appsResponse = [
         {
           releaseName: "foobar",
@@ -105,11 +106,12 @@ describe("fetches applications", () => {
       const expectedActions = [
         { type: getType(actions.apps.listApps), payload: false },
         { type: getType(actions.apps.receiveAppList), payload: appsResponse },
+        { type: getType(actions.apps.requestApps) },
         {
           type: getType(actions.apps.receiveAppUpdateInfo),
           payload: {
             releaseName: "foobar",
-            updateInfo: { latestVersion: "", repository: { name: "", url: "" } },
+            updateInfo: { upToDate: true, latestVersion: "1.0.0", repository: { name: "bar" } },
           },
         },
       ];

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -75,7 +75,7 @@ describe("fetches applications", () => {
       const expectedActions = [
         { type: getType(actions.apps.listApps), payload: false },
         { type: getType(actions.apps.receiveAppList), payload: appsResponse },
-        { type: getType(actions.apps.requestApps) },
+        { type: getType(actions.apps.requestAppUpdateInfo) },
         {
           type: getType(actions.apps.receiveAppUpdateInfo),
           payload: {
@@ -106,7 +106,7 @@ describe("fetches applications", () => {
       const expectedActions = [
         { type: getType(actions.apps.listApps), payload: false },
         { type: getType(actions.apps.receiveAppList), payload: appsResponse },
-        { type: getType(actions.apps.requestApps) },
+        { type: getType(actions.apps.requestAppUpdateInfo) },
         {
           type: getType(actions.apps.receiveAppUpdateInfo),
           payload: {

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -28,6 +28,8 @@ export const receiveAppList = createAction("RECEIVE_APP_LIST", resolve => {
   return (apps: IAppOverview[]) => resolve(apps);
 });
 
+export const requestAppUpdateInfo = createAction("REQUEST_APP_UPDATE_INFO");
+
 export const receiveAppUpdateInfo = createAction("RECEIVE_APP_UPDATE_INFO", resolve => {
   return (payload: { releaseName: string; updateInfo: IChartUpdateInfo }) => resolve(payload);
 });
@@ -49,6 +51,7 @@ const allActions = [
   requestApps,
   receiveApps,
   receiveAppList,
+  requestAppUpdateInfo,
   receiveAppUpdateInfo,
   errorApps,
   errorDeleteApp,
@@ -81,7 +84,7 @@ function getAppUpdateInfo(
   appVersion: string,
 ): ThunkAction<Promise<void>, IStoreState, null, AppsAction> {
   return async dispatch => {
-    dispatch(requestApps());
+    dispatch(requestAppUpdateInfo());
     try {
       const chartsInfo = await Chart.listWithFilters(chartName, currentVersion, appVersion);
       let updateInfo: IChartUpdateInfo = {

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -93,22 +93,19 @@ function getAppUpdateInfo(
         latestVersion: "",
       };
       if (chartsInfo.length > 0) {
-        // Initialize updateInfo with the first chart found
+        const sortedCharts = chartsInfo.sort((a, b) =>
+          semver.compare(
+            a.relationships.latestChartVersion.data.version,
+            b.relationships.latestChartVersion.data.version,
+          ),
+        );
+        const latestVersion = sortedCharts[0].relationships.latestChartVersion.data.version;
+        // Initialize updateInfo with the latest chart found
         updateInfo = {
-          upToDate: true,
-          latestVersion: chartsInfo[0].relationships.latestChartVersion.data.version,
-          repository: chartsInfo[0].attributes.repo,
+          upToDate: semver.gte(currentVersion, latestVersion),
+          latestVersion,
+          repository: sortedCharts[0].attributes.repo,
         };
-        chartsInfo.forEach(c => {
-          const chartLatestVersion = c.relationships.latestChartVersion.data.version;
-          if (semver.gt(chartLatestVersion, updateInfo.latestVersion)) {
-            updateInfo.latestVersion = chartLatestVersion;
-            updateInfo.repository = c.attributes.repo;
-          }
-          if (semver.gt(chartLatestVersion, currentVersion)) {
-            updateInfo.upToDate = false;
-          }
-        });
       }
       dispatch(receiveAppUpdateInfo({ releaseName, updateInfo }));
     } catch (e) {

--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -49,7 +49,11 @@ it("should set a banner if there are updates available", () => {
           status: "DEPLOYED",
           version: "1.0.0",
           chart: "myapp",
-          updateInfo: { latestVersion: "1.1.0", repository: { name: "", url: "" } },
+          updateInfo: {
+            upToDate: false,
+            latestVersion: "1.1.0",
+            repository: { name: "", url: "" },
+          },
         } as IAppOverview
       }
     />,

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -14,7 +14,7 @@ class AppListItem extends React.Component<IAppListItemProps> {
     const { app } = this.props;
     const icon = app.icon ? app.icon : placeholder;
     const banner =
-      app.updateInfo && app.updateInfo.latestVersion
+      app.updateInfo && !app.updateInfo.upToDate
         ? `v${app.updateInfo.latestVersion} available`
         : undefined;
     return (

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.test.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.test.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 import { hapi } from "shared/hapi/release";
 import itBehavesLike from "../../shared/specs";
-import { ForbiddenError, IAppRepository, IChartState } from "../../shared/types";
+import { ForbiddenError, IAppRepository, IChartState, IRelease } from "../../shared/types";
 import { ErrorSelector, PermissionsErrorAlert } from "../ErrorAlert";
 import ErrorPageHeader from "../ErrorAlert/ErrorAlertHeader";
 import UpgradeForm from "../UpgradeForm";
@@ -13,12 +13,13 @@ import AppUpgrade from "./AppUpgrade";
 
 const defaultProps = {
   app: {} as hapi.release.Release,
+  isFetching: false,
   checkChart: jest.fn(),
   clearRepo: jest.fn(),
   error: undefined,
   fetchChartVersions: jest.fn(),
   fetchRepositories: jest.fn(),
-  getApp: jest.fn(),
+  getAppWithUpdateInfo: jest.fn(),
   getChartValues: jest.fn(),
   getChartVersion: jest.fn(),
   kubeappsNamespace: "kubeapps",
@@ -33,7 +34,10 @@ const defaultProps = {
   version: "1.0.0",
 };
 
-itBehavesLike("aLoadingComponent", { component: AppUpgrade, props: defaultProps });
+itBehavesLike("aLoadingComponent", {
+  component: AppUpgrade,
+  props: { ...defaultProps, isFetching: true },
+});
 
 it("renders the repo selection form if not introduced", () => {
   const wrapper = shallow(
@@ -48,7 +52,7 @@ it("renders the repo selection form if not introduced", () => {
             },
           },
           name: "foo",
-        } as hapi.release.Release
+        } as IRelease
       }
       repos={[
         {
@@ -150,7 +154,40 @@ it("renders the upgrade form when the repo is available", () => {
             },
           },
           name: "foo",
-        } as hapi.release.Release
+        } as IRelease
+      }
+      repos={[repo]}
+      repo={repo}
+    />,
+  );
+  expect(wrapper.find(UpgradeForm)).toExist();
+  expect(wrapper.find(ErrorSelector)).not.toExist();
+  expect(wrapper.find(SelectRepoForm)).not.toExist();
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("skips the repo selection form if the app contains upgrade info", () => {
+  const repo = {
+    metadata: { name: "stable" },
+  } as IAppRepository;
+  const wrapper = shallow(
+    <AppUpgrade
+      {...defaultProps}
+      app={
+        {
+          chart: {
+            metadata: {
+              name: "bar",
+              version: "1.0.0",
+            },
+          },
+          name: "foo",
+          updateInfo: {
+            upToDate: true,
+            latestVersion: "",
+            repository: { name: "stable", url: "" },
+          },
+        } as IRelease
       }
       repos={[repo]}
       repo={repo}

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -1,15 +1,21 @@
 import * as React from "react";
 
 import { RouterAction } from "connected-react-router";
-import { hapi } from "../../shared/hapi/release";
-import { IAppRepository, IChartState, IChartVersion, IRBACRole } from "../../shared/types";
+import {
+  IAppRepository,
+  IChartState,
+  IChartVersion,
+  IRBACRole,
+  IRelease,
+} from "../../shared/types";
 import { ErrorSelector } from "../ErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
 import UpgradeForm from "../UpgradeForm";
 import SelectRepoForm from "../UpgradeForm/SelectRepoForm";
 
 interface IAppUpgradeProps {
-  app: hapi.release.Release;
+  app: IRelease;
+  isFetching: boolean;
   error: Error | undefined;
   repoError: Error | undefined;
   kubeappsNamespace: string;
@@ -28,7 +34,7 @@ interface IAppUpgradeProps {
   clearRepo: () => void;
   checkChart: (repo: string, chartName: string) => void;
   fetchChartVersions: (id: string) => Promise<IChartVersion[]>;
-  getApp: (releaseName: string, namespace: string) => void;
+  getAppWithUpdateInfo: (releaseName: string, namespace: string) => void;
   getChartVersion: (id: string, chartVersion: string) => void;
   getChartValues: (id: string, chartVersion: string) => void;
   push: (location: string) => RouterAction;
@@ -41,13 +47,17 @@ interface IAppUpgradeState {
 
 class AppUpgrade extends React.Component<IAppUpgradeProps, IAppUpgradeState> {
   public componentDidMount() {
-    const { releaseName, getApp, namespace, fetchRepositories } = this.props;
-    getApp(releaseName, namespace);
+    const { releaseName, getAppWithUpdateInfo, namespace, fetchRepositories } = this.props;
+    getAppWithUpdateInfo(releaseName, namespace);
     fetchRepositories();
   }
 
   public render() {
-    const { app, repos, error, namespace, releaseName, repoError } = this.props;
+    const { app, repos, error, namespace, releaseName, repoError, isFetching } = this.props;
+    let { repo } = this.props;
+    if (isFetching) {
+      return <LoadingWrapper />;
+    }
     if (
       !repos ||
       repos.length === 0 ||
@@ -77,11 +87,31 @@ class AppUpgrade extends React.Component<IAppUpgradeProps, IAppUpgradeState> {
             resource="App Repositories"
           />
         );
+      } else if (repos.length === 0) {
+        return (
+          <ErrorSelector
+            error={new Error("Unable to any repo to upgrade from")}
+            resource={releaseName}
+          />
+        );
       } else {
-        return <LoadingWrapper />;
+        return (
+          <ErrorSelector
+            error={new Error("Unable to obtain the required information to upgrade")}
+            resource={releaseName}
+          />
+        );
       }
     }
-    if (!this.props.repo.metadata) {
+    if (app.updateInfo) {
+      const repoWithLatest = repos.find(
+        r => r.metadata.name === (app.updateInfo && app.updateInfo.repository.name),
+      );
+      if (repoWithLatest) {
+        repo = repoWithLatest;
+      }
+    }
+    if (!repo.metadata) {
       return (
         <div>
           <SelectRepoForm
@@ -99,7 +129,7 @@ class AppUpgrade extends React.Component<IAppUpgradeProps, IAppUpgradeState> {
           appCurrentVersion={app.chart.metadata.version}
           appCurrentValues={(app.config && app.config.raw) || ""}
           chartName={app.chart.metadata.name}
-          repo={this.props.repo.metadata.name}
+          repo={repo.metadata.name}
         />
       </div>
     );

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -103,6 +103,8 @@ class AppUpgrade extends React.Component<IAppUpgradeProps, IAppUpgradeState> {
         );
       }
     }
+    // If there is update info about the app we can automatically chose the repository
+    // with the latest version
     if (app.updateInfo) {
       const repoWithLatest = repos.find(
         r => r.metadata.name === (app.updateInfo && app.updateInfo.repository.name),

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { RouterAction } from "connected-react-router";
+import { Link } from "react-router-dom";
 import {
   IAppRepository,
   IChartState,
@@ -8,7 +9,7 @@ import {
   IRBACRole,
   IRelease,
 } from "../../shared/types";
-import { ErrorSelector } from "../ErrorAlert";
+import { ErrorSelector, MessageAlert } from "../ErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
 import UpgradeForm from "../UpgradeForm";
 import SelectRepoForm from "../UpgradeForm/SelectRepoForm";
@@ -89,9 +90,15 @@ class AppUpgrade extends React.Component<IAppUpgradeProps, IAppUpgradeState> {
         );
       } else if (repos.length === 0) {
         return (
-          <ErrorSelector
-            error={new Error("Unable to any repo to upgrade from")}
-            resource={releaseName}
+          <MessageAlert
+            level={"warning"}
+            children={
+              <div>
+                <h5>Chart repositories not found.</h5>
+                Manage your Helm chart repositories in Kubeapps by visiting the{" "}
+                <Link to={"/config/repos"}>App repositories configuration</Link> page.
+              </div>
+            }
           />
         );
       } else {

--- a/dashboard/src/components/AppUpgrade/__snapshots__/AppUpgrade.test.tsx.snap
+++ b/dashboard/src/components/AppUpgrade/__snapshots__/AppUpgrade.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`renders the repo selection form if not introduced 1`] = `
         ],
       }
     }
-    getApp={
+    getAppWithUpdateInfo={
       [MockFunction] {
         "calls": Array [
           Array [
@@ -54,6 +54,7 @@ exports[`renders the repo selection form if not introduced 1`] = `
     }
     getChartValues={[MockFunction]}
     getChartVersion={[MockFunction]}
+    isFetching={false}
     kubeappsNamespace="kubeapps"
     namespace="default"
     push={[MockFunction]}
@@ -108,7 +109,7 @@ exports[`renders the upgrade form when the repo is available 1`] = `
         ],
       }
     }
-    getApp={
+    getAppWithUpdateInfo={
       [MockFunction] {
         "calls": Array [
           Array [
@@ -144,6 +145,111 @@ exports[`renders the upgrade form when the repo is available 1`] = `
     }
     getChartValues={[MockFunction]}
     getChartVersion={[MockFunction]}
+    isFetching={false}
+    kubeappsNamespace="kubeapps"
+    namespace="default"
+    push={[MockFunction]}
+    releaseName="foo"
+    repo="stable"
+    repos={
+      Array [
+        Object {
+          "metadata": Object {
+            "name": "stable",
+          },
+        },
+      ]
+    }
+    selected={Object {}}
+    upgradeApp={[MockFunction]}
+    version="1.0.0"
+  />
+</div>
+`;
+
+exports[`skips the repo selection form if the app contains upgrade info 1`] = `
+<div>
+  <UpgradeForm
+    app={
+      Object {
+        "chart": Object {
+          "metadata": Object {
+            "name": "bar",
+            "version": "1.0.0",
+          },
+        },
+        "name": "foo",
+        "updateInfo": Object {
+          "latestVersion": "",
+          "repository": Object {
+            "name": "stable",
+            "url": "",
+          },
+          "upToDate": true,
+        },
+      }
+    }
+    appCurrentValues=""
+    appCurrentVersion="1.0.0"
+    chartName="bar"
+    checkChart={[MockFunction]}
+    clearRepo={[MockFunction]}
+    fetchChartVersions={[MockFunction]}
+    fetchRepositories={
+      [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+      }
+    }
+    getAppWithUpdateInfo={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "foo",
+            "default",
+          ],
+          Array [
+            "foo",
+            "default",
+          ],
+          Array [
+            "foo",
+            "default",
+          ],
+          Array [
+            "foo",
+            "default",
+          ],
+          Array [
+            "foo",
+            "default",
+          ],
+          Array [
+            "foo",
+            "default",
+          ],
+          Array [
+            "foo",
+            "default",
+          ],
+          Array [
+            "foo",
+            "default",
+          ],
+        ],
+      }
+    }
+    getChartValues={[MockFunction]}
+    getChartVersion={[MockFunction]}
+    isFetching={false}
     kubeappsNamespace="kubeapps"
     namespace="default"
     push={[MockFunction]}

--- a/dashboard/src/components/AppUpgrade/__snapshots__/AppUpgrade.test.tsx.snap
+++ b/dashboard/src/components/AppUpgrade/__snapshots__/AppUpgrade.test.tsx.snap
@@ -29,22 +29,12 @@ exports[`renders the repo selection form if not introduced 1`] = `
       [MockFunction] {
         "calls": Array [
           Array [],
-          Array [],
-          Array [],
         ],
       }
     }
     getAppWithUpdateInfo={
       [MockFunction] {
         "calls": Array [
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
           Array [
             "foo",
             "default",
@@ -100,42 +90,12 @@ exports[`renders the upgrade form when the repo is available 1`] = `
       [MockFunction] {
         "calls": Array [
           Array [],
-          Array [],
-          Array [],
-          Array [],
-          Array [],
-          Array [],
-          Array [],
         ],
       }
     }
     getAppWithUpdateInfo={
       [MockFunction] {
         "calls": Array [
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
           Array [
             "foo",
             "default",
@@ -199,47 +159,12 @@ exports[`skips the repo selection form if the app contains upgrade info 1`] = `
       [MockFunction] {
         "calls": Array [
           Array [],
-          Array [],
-          Array [],
-          Array [],
-          Array [],
-          Array [],
-          Array [],
-          Array [],
         ],
       }
     }
     getAppWithUpdateInfo={
       [MockFunction] {
         "calls": Array [
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
-          Array [
-            "foo",
-            "default",
-          ],
           Array [
             "foo",
             "default",

--- a/dashboard/src/components/AppView/AppControls/AppControls.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/AppControls.test.tsx
@@ -157,3 +157,21 @@ context("when there is a new version available", () => {
     expect(wrapper.find(UpgradeButton).prop("updateVersion")).toBe("1.0.0");
   });
 });
+
+context("when the application is up to date", () => {
+  it("should not forward the latest version", () => {
+    const name = "foo";
+    const namespace = "bar";
+    const app = {
+      name,
+      namespace,
+      updateInfo: {
+        upToDate: true,
+        latestVersion: "1.0.0",
+      },
+    } as IRelease;
+    const wrapper = shallow(<AppControls app={app} deleteApp={jest.fn()} push={jest.fn()} />);
+
+    expect(wrapper.find(UpgradeButton).prop("updateVersion")).toBe(undefined);
+  });
+});

--- a/dashboard/src/components/AppView/AppControls/AppControls.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/AppControls.test.tsx
@@ -7,7 +7,9 @@ import { hapi } from "../../../shared/hapi/release";
 import itBehavesLike from "../../../shared/specs";
 import ConfirmDialog from "../../ConfirmDialog";
 
+import { IRelease } from "shared/types";
 import AppControls from "./AppControls";
+import UpgradeButton from "./UpgradeButton";
 
 it("calls delete function when clicking the button", done => {
   const name = "foo";
@@ -135,5 +137,23 @@ context("when the application has been already deleted", () => {
     const buttons = wrapper.find("button");
     expect(buttons.length).toBe(1);
     expect(buttons.text()).toBe("Purge");
+  });
+});
+
+context("when there is a new version available", () => {
+  it("should forward the latest version", () => {
+    const name = "foo";
+    const namespace = "bar";
+    const app = {
+      name,
+      namespace,
+      updateInfo: {
+        upToDate: false,
+        latestVersion: "1.0.0",
+      },
+    } as IRelease;
+    const wrapper = shallow(<AppControls app={app} deleteApp={jest.fn()} push={jest.fn()} />);
+
+    expect(wrapper.find(UpgradeButton).prop("updateVersion")).toBe("1.0.0");
   });
 });

--- a/dashboard/src/components/AppView/AppControls/AppControls.tsx
+++ b/dashboard/src/components/AppView/AppControls/AppControls.tsx
@@ -45,7 +45,9 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
         {/* If the app has been deleted hide the upgrade button */}
         {!deleted && (
           <UpgradeButton
-            updateVersion={app.updateInfo && app.updateInfo.latestVersion}
+            updateVersion={
+              app.updateInfo && !app.updateInfo.upToDate ? app.updateInfo.latestVersion : undefined
+            }
             releaseName={name}
             releaseNamespace={namespace}
             push={push}

--- a/dashboard/src/components/AppView/ChartInfo.test.tsx
+++ b/dashboard/src/components/AppView/ChartInfo.test.tsx
@@ -29,14 +29,14 @@ it("renders a app item", () => {
 
 context("when information about updates is available", () => {
   it("renders an up to date message if there are no updates", () => {
-    const appWithoutUpdates = { ...defaultProps.app, updateInfo: {} } as IRelease;
+    const appWithoutUpdates = { ...defaultProps.app, updateInfo: { upToDate: true } } as IRelease;
     const wrapper = shallow(<ChartInfo {...defaultProps} app={appWithoutUpdates} />);
     expect(wrapper.html()).toContain("Up to date");
   });
   it("renders an new version found message if the latest version is newer", () => {
     const appWithUpdates = {
       ...defaultProps.app,
-      updateInfo: { latestVersion: "1.0.0" },
+      updateInfo: { upToDate: false, latestVersion: "1.0.0" },
     } as IRelease;
     const wrapper = shallow(<ChartInfo {...defaultProps} app={appWithUpdates} />);
     expect(

--- a/dashboard/src/components/AppView/ChartInfo.tsx
+++ b/dashboard/src/components/AppView/ChartInfo.tsx
@@ -51,7 +51,7 @@ class ChartInfo extends React.Component<IChartInfoProps> {
     // If update is not set yet we cannot know if there is
     // an update available or not
     if (app.updateInfo) {
-      if (!app.updateInfo.latestVersion) {
+      if (app.updateInfo.upToDate) {
         return (
           <span>
             -{" "}
@@ -61,7 +61,6 @@ class ChartInfo extends React.Component<IChartInfoProps> {
         );
       } else {
         return (
-          // TODO: It should already include the repo found when clicking
           <Link to={`/apps/ns/${app.namespace}/upgrade/${app.name}`}>
             <span>
               -{" "}

--- a/dashboard/src/containers/AppUpgradeContainer/AppUpgradeContainer.tsx
+++ b/dashboard/src/containers/AppUpgradeContainer/AppUpgradeContainer.tsx
@@ -23,6 +23,7 @@ function mapStateToProps(
 ) {
   return {
     app: apps.selected,
+    isFetching: apps.isFetching || repos.isFetching,
     error: apps.error || charts.selected.error,
     kubeappsNamespace: config.namespace,
     namespace: params.namespace,
@@ -41,7 +42,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     clearRepo: () => dispatch(actions.repos.clearRepo()),
     fetchChartVersions: (id: string) => dispatch(actions.charts.fetchChartVersions(id)),
     fetchRepositories: () => dispatch(actions.repos.fetchRepos()),
-    getApp: (releaseName: string, ns: string) => dispatch(actions.apps.getApp(releaseName, ns)),
+    getAppWithUpdateInfo: (releaseName: string, ns: string) =>
+      dispatch(actions.apps.getAppWithUpdateInfo(releaseName, ns)),
     getChartValues: (id: string, version: string) =>
       dispatch(actions.charts.getChartValues(id, version)),
     getChartVersion: (id: string, version: string) =>

--- a/dashboard/src/reducers/apps.ts
+++ b/dashboard/src/reducers/apps.ts
@@ -30,6 +30,8 @@ const appsReducer = (
       return { ...state, isFetching: true, listingAll: action.payload };
     case getType(actions.apps.receiveAppList):
       return { ...state, isFetching: false, listOverview: action.payload };
+    case getType(actions.apps.requestAppUpdateInfo):
+      return { ...state, isFetching: true };
     case getType(actions.apps.receiveAppUpdateInfo):
       let listOverview;
       if (state.listOverview) {

--- a/dashboard/src/reducers/apps.ts
+++ b/dashboard/src/reducers/apps.ts
@@ -51,6 +51,7 @@ const appsReducer = (
       }
       return {
         ...state,
+        isFetching: false,
         listOverview: listOverview || state.listOverview,
         selected: selected || state.selected,
       };

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -84,6 +84,7 @@ export interface IChartState {
 }
 
 export interface IChartUpdateInfo {
+  upToDate: boolean;
   latestVersion: string;
   repository: IRepo;
 }


### PR DESCRIPTION
Fixes #969 

The goal of this PR is to avoid the issue described in #969. Now, when clicking in the "Upgrade" button, we check if the application has `updateInfo`. In that case we skip the `SelectRepoForm` and we automatically choose the repo with the latest version.