### PR TITLE
docs: update prerequisites

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -28,7 +28,7 @@ It also packages the [Bitnami MongoDB chart](https://github.com/helm/charts/tree
 
 - Kubernetes 1.8+ (tested with Azure Kubernetes Service, Google Kubernetes Engine, minikube and Docker for Desktop Kubernetes)
 - Helm 2.10.0+
-- Administrative access to the cluster to create and update RBAC ClusterRoles
+- Administrative access to the cluster to create Custom Resource Definitions (CRDs)
 
 ## Installing the Chart
 


### PR DESCRIPTION
- remove prereq for RBAC ClusterRoles as this is no longer necessary
- add prereq for creating CRDs

Technically the CRD prereq can be worked around by creating it out-of-band of the chart, but it then still requires that someone has that permission to be able to install it.

see #992