### PR TITLE
Reload OIDC token when needed

### DIFF
--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -107,7 +107,8 @@ describe("OIDC authentication", () => {
         type: getType(actions.auth.setAuthenticated),
       },
       {
-        type: getType(actions.auth.unsetSessionExpired),
+        payload: { sessionExpired: false },
+        type: getType(actions.auth.setSessionExpired),
       },
     ];
 
@@ -120,6 +121,7 @@ describe("OIDC authentication", () => {
     Auth.usingOIDCToken = jest.fn(() => true);
     const expectedActions = [
       {
+        payload: { sessionExpired: true },
         type: getType(actions.auth.setSessionExpired),
       },
       {

--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -13,6 +13,7 @@ let store: any;
 
 beforeEach(() => {
   const state: IAuthState = {
+    sessionExpired: false,
     authenticated: false,
     authenticating: false,
     oidcAuthenticated: false,

--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -106,6 +106,9 @@ describe("OIDC authentication", () => {
         payload: { authenticated: true, oidc: true },
         type: getType(actions.auth.setAuthenticated),
       },
+      {
+        type: getType(actions.auth.unsetSessionExpired),
+      },
     ];
 
     return store.dispatch(actions.auth.tryToAuthenticateWithOIDC()).then(() => {
@@ -113,10 +116,11 @@ describe("OIDC authentication", () => {
     });
   });
 
-  it("logouts expiring the session ", () => {
+  it("expires the session and logs out ", () => {
+    Auth.usingOIDCToken = jest.fn(() => true);
     const expectedActions = [
       {
-        type: getType(actions.auth.setExpiredSession),
+        type: getType(actions.auth.setSessionExpired),
       },
       {
         payload: { authenticated: false, oidc: false },
@@ -124,7 +128,7 @@ describe("OIDC authentication", () => {
       },
     ];
 
-    return store.dispatch(actions.auth.logout()).then(() => {
+    return store.dispatch(actions.auth.expireSession()).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -112,4 +112,20 @@ describe("OIDC authentication", () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
+
+  it("logouts expiring the session ", () => {
+    const expectedActions = [
+      {
+        type: getType(actions.auth.setExpiredSession),
+      },
+      {
+        payload: { authenticated: false, oidc: false },
+        type: getType(actions.auth.setAuthenticated),
+      },
+    ];
+
+    return store.dispatch(actions.auth.logout()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
 });

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -34,9 +34,7 @@ export function authenticate(
   };
 }
 
-export function logout(
-  needRefresh?: boolean,
-): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
+export function logout(): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
   return async dispatch => {
     Auth.unsetAuthToken();
     dispatch(setAuthenticated(false, false));

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -14,16 +14,11 @@ export const authenticationError = createAction("AUTHENTICATION_ERROR", resolve 
   return (errorMsg: string) => resolve(errorMsg);
 });
 
-export const setSessionExpired = createAction("SET_AUTHENTICATION_SESSION_EXPIRED");
-export const unsetSessionExpired = createAction("UNSET_AUTHENTICATION_SESSION_EXPIRED");
+export const setSessionExpired = createAction("SET_AUTHENTICATION_SESSION_EXPIRED", resolve => {
+  return (sessionExpired: boolean) => resolve({ sessionExpired });
+});
 
-const allActions = [
-  setAuthenticated,
-  authenticating,
-  authenticationError,
-  setSessionExpired,
-  unsetSessionExpired,
-];
+const allActions = [setAuthenticated, authenticating, authenticationError, setSessionExpired];
 
 export type AuthAction = ActionType<typeof allActions[number]>;
 
@@ -38,7 +33,7 @@ export function authenticate(
       Auth.setAuthToken(token, oidc);
       dispatch(setAuthenticated(true, oidc));
       if (oidc) {
-        dispatch(unsetSessionExpired());
+        dispatch(setSessionExpired(false));
       }
     } catch (e) {
       dispatch(authenticationError(e.toString()));
@@ -56,7 +51,7 @@ export function logout(): ThunkAction<Promise<void>, IStoreState, null, AuthActi
 export function expireSession(): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
   return async dispatch => {
     if (Auth.usingOIDCToken()) {
-      dispatch(setSessionExpired());
+      dispatch(setSessionExpired(true));
     }
     dispatch(logout());
   };

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -14,7 +14,9 @@ export const authenticationError = createAction("AUTHENTICATION_ERROR", resolve 
   return (errorMsg: string) => resolve(errorMsg);
 });
 
-const allActions = [setAuthenticated, authenticating, authenticationError];
+export const setExpiredSession = createAction("AUTHENTICATION_EXPIRED");
+
+const allActions = [setAuthenticated, authenticating, authenticationError, setExpiredSession];
 
 export type AuthAction = ActionType<typeof allActions[number]>;
 
@@ -37,6 +39,8 @@ export function authenticate(
 export function logout(): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
   return async dispatch => {
     Auth.unsetAuthToken();
+    // Expire the session if we are using OIDC tokens
+    dispatch(setExpiredSession());
     dispatch(setAuthenticated(false, false));
   };
 }

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -34,7 +34,9 @@ export function authenticate(
   };
 }
 
-export function logout(): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
+export function logout(
+  needRefresh?: boolean,
+): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
   return async dispatch => {
     Auth.unsetAuthToken();
     dispatch(setAuthenticated(false, false));

--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -1,33 +1,28 @@
-import axios from "axios";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { getType } from "typesafe-actions";
+import { axios } from "../shared/Auth";
 
 import actions from ".";
 import { NotFoundError } from "../shared/types";
 
 const mockStore = configureMockStore([thunk]);
-jest.mock("axios");
-const axiosGetMock = axios.get as jest.Mock;
 
+let axiosGetMock = jest.fn();
 let store: any;
-let fetchMock: jest.Mock;
 let response: any;
 
 beforeEach(() => {
   store = mockStore();
-  fetchMock = jest.fn(() => {
+  axiosGetMock.mockImplementation(() => {
     return {
-      ok: true,
-      json: () => {
-        return { data: response };
+      status: 200,
+      data: {
+        data: response,
       },
     };
   });
-  window.fetch = fetchMock;
-  axiosGetMock.mockImplementation(() => {
-    return { data: response };
-  });
+  axios.get = axiosGetMock;
 });
 
 afterEach(() => {
@@ -43,7 +38,7 @@ describe("fetchCharts", () => {
     ];
     await store.dispatch(actions.charts.fetchCharts("foo"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(fetchMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo");
+    expect(axiosGetMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo");
   });
 
   it("returns a 404 error", async () => {
@@ -51,16 +46,14 @@ describe("fetchCharts", () => {
       { type: getType(actions.charts.requestCharts) },
       { type: getType(actions.charts.errorChart), payload: new NotFoundError("not found") },
     ];
-    fetchMock = jest.fn(() => {
+    axiosGetMock = jest.fn(() => {
       return {
         ok: false,
         status: 404,
-        json: () => {
-          return { data: "not found" };
-        },
+        data: "not found",
       };
     });
-    window.fetch = fetchMock;
+    axios.get = axiosGetMock;
     await store.dispatch(actions.charts.fetchCharts("foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -70,16 +63,14 @@ describe("fetchCharts", () => {
       { type: getType(actions.charts.requestCharts) },
       { type: getType(actions.charts.errorChart), payload: new Error("something went wrong") },
     ];
-    fetchMock = jest.fn(() => {
+    axiosGetMock = jest.fn(() => {
       return {
         ok: false,
         status: 500,
-        json: () => {
-          return { data: "something went wrong" };
-        },
+        data: "something went wrong",
       };
     });
-    window.fetch = fetchMock;
+    axios.get = axiosGetMock;
     await store.dispatch(actions.charts.fetchCharts("foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -94,7 +85,7 @@ describe("fetchChartVersions", () => {
     ];
     await store.dispatch(actions.charts.fetchChartVersions("foo"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(fetchMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo/versions");
+    expect(axiosGetMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo/versions");
   });
 });
 
@@ -107,7 +98,7 @@ describe("getChartVersion", () => {
     ];
     await store.dispatch(actions.charts.getChartVersion("foo", "1.0.0"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(fetchMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo/versions/1.0.0");
+    expect(axiosGetMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo/versions/1.0.0");
   });
 });
 
@@ -121,7 +112,7 @@ describe("fetchChartVersionsAndSelectVersion", () => {
     ];
     await store.dispatch(actions.charts.fetchChartVersionsAndSelectVersion("foo", "1.0.0"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(fetchMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo/versions");
+    expect(axiosGetMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo/versions");
   });
 
   it("returns a not found error", async () => {
@@ -130,18 +121,16 @@ describe("fetchChartVersionsAndSelectVersion", () => {
       { type: getType(actions.charts.requestCharts) },
       { type: getType(actions.charts.errorChart), payload: new NotFoundError("not found") },
     ];
-    fetchMock = jest.fn(() => {
+    axiosGetMock = jest.fn(() => {
       return {
         ok: false,
         status: 404,
-        json: () => {
-          return { data: "not found" };
-        },
+        data: "not found",
       };
     });
-    window.fetch = fetchMock;
+    axios.get = axiosGetMock;
     await store.dispatch(actions.charts.fetchChartVersionsAndSelectVersion("foo", "1.0.0"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(fetchMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo/versions");
+    expect(axiosGetMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo/versions");
   });
 });

--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -1,7 +1,7 @@
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { getType } from "typesafe-actions";
-import { axios } from "../shared/Auth";
+import { axios } from "../shared/AxiosInstance";
 
 import actions from ".";
 import { NotFoundError } from "../shared/types";

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -56,6 +56,7 @@ export type ChartsAction = ActionType<typeof allActions[number]>;
 async function httpGet(dispatch: Dispatch, targetURL: string): Promise<any> {
   try {
     const response = await axios.get(targetURL);
+    // If non-2XX response (not ok)
     if (response.status < 200 || response.status > 299) {
       const error = response.data || response.statusText;
       if (response.status === 404) {

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -56,7 +56,7 @@ export type ChartsAction = ActionType<typeof allActions[number]>;
 async function httpGet(dispatch: Dispatch, targetURL: string): Promise<any> {
   try {
     const response = await axios.get(targetURL);
-    if (response.status !== 200) {
+    if (response.status < 200 || response.status > 299) {
       const error = response.data || response.statusText;
       if (response.status === 404) {
         dispatch(errorChart(new NotFoundError(error)));

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -55,8 +55,7 @@ export type ChartsAction = ActionType<typeof allActions[number]>;
 
 async function httpGet(dispatch: Dispatch, targetURL: string): Promise<any> {
   try {
-    const response: any = await axios.get(targetURL);
-    // const json = await response.json();
+    const response = await axios.get(targetURL);
     if (response.status !== 200) {
       const error = response.data || response.statusText;
       if (response.status === 404) {

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -2,7 +2,7 @@ import { Dispatch } from "redux";
 import { ThunkAction } from "redux-thunk";
 import { ActionType, createAction } from "typesafe-actions";
 
-import { axios } from "../shared/Auth";
+import { axios } from "../shared/AxiosInstance";
 import Chart from "../shared/Chart";
 import { IChart, IChartVersion, IStoreState, NotFoundError } from "../shared/types";
 import * as url from "../shared/url";

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -2,6 +2,7 @@ import { Dispatch } from "redux";
 import { ThunkAction } from "redux-thunk";
 import { ActionType, createAction } from "typesafe-actions";
 
+import { axios } from "../shared/Auth";
 import Chart from "../shared/Chart";
 import { IChart, IChartVersion, IStoreState, NotFoundError } from "../shared/types";
 import * as url from "../shared/url";
@@ -54,17 +55,17 @@ export type ChartsAction = ActionType<typeof allActions[number]>;
 
 async function httpGet(dispatch: Dispatch, targetURL: string): Promise<any> {
   try {
-    const response = await fetch(targetURL);
-    const json = await response.json();
-    if (!response.ok) {
-      const error = json.data || response.statusText;
+    const response: any = await axios.get(targetURL);
+    // const json = await response.json();
+    if (response.status !== 200) {
+      const error = response.data || response.statusText;
       if (response.status === 404) {
         dispatch(errorChart(new NotFoundError(error)));
       } else {
         dispatch(errorChart(new Error(error)));
       }
     } else {
-      return json.data;
+      return response.data.data;
     }
   } catch (e) {
     dispatch(errorChart(e));

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -4,6 +4,7 @@ import thunk from "redux-thunk";
 import { getType } from "typesafe-actions";
 import actions from ".";
 import { AppRepository } from "../shared/AppRepository";
+import { axios } from "../shared/Auth";
 import Secret from "../shared/Secret";
 import { IAppRepository, NotFoundError } from "../shared/types";
 
@@ -12,6 +13,7 @@ const mockStore = configureMockStore([thunk]);
 
 let store: any;
 const appRepo = { spec: { resyncRequests: 10000 } };
+axios.get = jest.fn();
 
 beforeEach(() => {
   store = mockStore({ config: { namespace: "my-namespace" } });
@@ -28,6 +30,8 @@ beforeEach(() => {
   });
   Secret.create = jest.fn();
 });
+
+afterEach(jest.resetAllMocks);
 
 // Regular action creators
 interface ITestCase {
@@ -347,10 +351,6 @@ describe("installRepo", () => {
 });
 
 describe("checkChart", () => {
-  window.fetch = jest.fn().mockImplementationOnce(() => {
-    return { ok: true };
-  });
-
   it("dispatches requestRepo and receivedRepo if no error", async () => {
     const expectedActions = [
       {
@@ -367,8 +367,8 @@ describe("checkChart", () => {
   });
 
   it("dispatches requestRepo and errorChart if error fetching", async () => {
-    window.fetch = jest.fn().mockImplementationOnce(() => {
-      return { ok: false };
+    axios.get = jest.fn(() => {
+      throw new Error();
     });
 
     const expectedActions = [

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -4,7 +4,7 @@ import thunk from "redux-thunk";
 import { getType } from "typesafe-actions";
 import actions from ".";
 import { AppRepository } from "../shared/AppRepository";
-import { axios } from "../shared/Auth";
+import { axios } from "../shared/AxiosInstance";
 import Secret from "../shared/Secret";
 import { IAppRepository, NotFoundError } from "../shared/types";
 

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -1,6 +1,7 @@
 import { ThunkAction } from "redux-thunk";
 import { ActionType, createAction } from "typesafe-actions";
 import { AppRepository } from "../shared/AppRepository";
+import { axios } from "../shared/Auth";
 import Secret from "../shared/Secret";
 import * as url from "../shared/url";
 import { errorChart } from "./charts";
@@ -193,10 +194,10 @@ export function checkChart(
     } = getState();
     dispatch(requestRepo());
     const appRepository = await AppRepository.get(repo, namespace);
-    const res = await fetch(url.api.charts.listVersions(`${repo}/${chartName}`));
-    if (res.ok) {
+    try {
+      await axios.get(url.api.charts.listVersions(`${repo}/${chartName}`));
       dispatch(receiveRepo(appRepository));
-    } else {
+    } catch (e) {
       dispatch(
         errorChart(new NotFoundError(`Chart ${chartName} not found in the repository ${repo}.`)),
       );

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -1,7 +1,7 @@
 import { ThunkAction } from "redux-thunk";
 import { ActionType, createAction } from "typesafe-actions";
 import { AppRepository } from "../shared/AppRepository";
-import { axios } from "../shared/Auth";
+import { axios } from "../shared/AxiosInstance";
 import Secret from "../shared/Secret";
 import * as url from "../shared/url";
 import { errorChart } from "./charts";

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.test.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.test.tsx
@@ -56,3 +56,12 @@ it("renders the given component when authenticated", () => {
   const wrapper2 = shallow(<RenderMethod {...emptyRouteComponentProps} />);
   expect(wrapper2.find(MockComponent).exists()).toBe(true);
 });
+
+it("renders modal to reload the page if the session is expired", () => {
+  const wrapper = shallow(
+    <PrivateRoute sessionExpired={true} authenticated={false} {...emptyRouteComponentProps} />,
+  );
+  const renderization: JSX.Element = wrapper.prop("render")();
+  expect(renderization.type.toString()).toContain("Modal");
+  expect(renderization.props.isOpen).toBe(true);
+});

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.test.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.test.tsx
@@ -26,6 +26,7 @@ class MockComponent extends React.Component {}
 it("redirects to the /login route if not authenticated", () => {
   const wrapper = shallow(
     <PrivateRoute
+      sessionExpired={false}
       authenticated={false}
       path="/test"
       component={MockComponent}
@@ -44,6 +45,7 @@ it("redirects to the /login route if not authenticated", () => {
 it("renders the given component when authenticated", () => {
   const wrapper = shallow(
     <PrivateRoute
+      sessionExpired={false}
       authenticated={true}
       path="/test"
       component={MockComponent}

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
@@ -37,8 +37,7 @@ class PrivateRoute extends React.Component<IPrivateRouteProps> {
         >
           <div>
             <div className="margin-b-normal">
-              Your session has expired or there is a different network issue, please reload the
-              page.
+              Your session has expired or the connection has been lost, please reload the page.
             </div>
             <div className="flex text-c">
               <button className="button" onClick={this.reload}>

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
@@ -37,7 +37,8 @@ class PrivateRoute extends React.Component<IPrivateRouteProps> {
         >
           <div>
             <div className="margin-b-normal">
-              Your session has expired, please reload to refresh your credentials.
+              Your session has expired or there is a different network issue, please reload the
+              page.
             </div>
             <div className="flex text-c">
               <button className="button" onClick={this.reload}>

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
@@ -1,37 +1,26 @@
 import * as React from "react";
 import * as Modal from "react-modal";
 import { Redirect, Route, RouteComponentProps, RouteProps } from "react-router";
-import { Auth } from "../../shared/Auth";
 
 type IRouteComponentPropsAndRouteProps = RouteProps & RouteComponentProps<any>;
 
 interface IPrivateRouteProps extends IRouteComponentPropsAndRouteProps {
   authenticated: boolean;
+  sessionExpired: boolean;
 }
 
-interface IPrivateRouteState {
-  previouslyAuthenticated: boolean;
-}
-
-class PrivateRoute extends React.Component<IPrivateRouteProps, IPrivateRouteState> {
-  public state: IPrivateRouteState = {
-    previouslyAuthenticated: false,
-  };
-
+class PrivateRoute extends React.Component<IPrivateRouteProps> {
   public render() {
     const { authenticated, component: Component, ...rest } = this.props;
     return <Route {...rest} render={this.renderRouteIfAuthenticated} />;
   }
 
   public renderRouteIfAuthenticated = (props: RouteComponentProps<any>) => {
-    const { authenticated, component: Component } = this.props;
+    const { sessionExpired, authenticated, component: Component } = this.props;
     if (authenticated && Component) {
-      if (!this.state.previouslyAuthenticated) {
-        this.setState({ previouslyAuthenticated: true });
-      }
       return <Component {...props} />;
     }
-    if (!authenticated && this.state.previouslyAuthenticated && Auth.usingOIDCToken()) {
+    if (sessionExpired) {
       return (
         <Modal
           style={{

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
@@ -37,7 +37,7 @@ class PrivateRoute extends React.Component<IPrivateRouteProps> {
         >
           <div>
             <div className="margin-b-normal">
-              Your session has expired, please reload to refresh your credentials
+              Your session has expired, please reload to refresh your credentials.
             </div>
             <div className="flex text-c">
               <button className="button" onClick={this.reload}>

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
+import * as Modal from "react-modal";
 import { Redirect, Route, RouteComponentProps, RouteProps } from "react-router";
+import { Auth } from "shared/Auth";
 
 type IRouteComponentPropsAndRouteProps = RouteProps & RouteComponentProps<any>;
 
@@ -7,7 +9,15 @@ interface IPrivateRouteProps extends IRouteComponentPropsAndRouteProps {
   authenticated: boolean;
 }
 
-class PrivateRoute extends React.Component<IPrivateRouteProps> {
+interface IPrivateRouteState {
+  previouslyAuthenticated: boolean;
+}
+
+class PrivateRoute extends React.Component<IPrivateRouteProps, IPrivateRouteState> {
+  public state: IPrivateRouteState = {
+    previouslyAuthenticated: false,
+  };
+
   public render() {
     const { authenticated, component: Component, ...rest } = this.props;
     return <Route {...rest} render={this.renderRouteIfAuthenticated} />;
@@ -15,12 +25,46 @@ class PrivateRoute extends React.Component<IPrivateRouteProps> {
 
   public renderRouteIfAuthenticated = (props: RouteComponentProps<any>) => {
     const { authenticated, component: Component } = this.props;
-    return authenticated && Component ? (
-      <Component {...props} />
-    ) : (
-      <Redirect to={{ pathname: "/login", state: { from: props.location } }} />
-    );
+    if (authenticated && Component) {
+      if (!this.state.previouslyAuthenticated) {
+        this.setState({ previouslyAuthenticated: true });
+      }
+      return <Component {...props} />;
+    }
+    if (!authenticated && this.state.previouslyAuthenticated && Auth.usingOIDCToken()) {
+      return (
+        <Modal
+          style={{
+            content: {
+              bottom: "auto",
+              left: "50%",
+              marginRight: "-50%",
+              right: "auto",
+              top: "50%",
+              transform: "translate(-50%, -50%)",
+            },
+          }}
+          isOpen={true}
+        >
+          <div>
+            <div className="margin-b-normal">
+              Your session has expired, please reload to refresh your credentials
+            </div>
+            <div className="flex text-c">
+              <button className="button" onClick={this.reload}>
+                Reload
+              </button>
+            </div>
+          </div>
+        </Modal>
+      );
+    }
+    return <Redirect to={{ pathname: "/login", state: { from: props.location } }} />;
   };
+
+  private reload() {
+    window.location.reload();
+  }
 }
 
 export default PrivateRoute;

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Modal from "react-modal";
 import { Redirect, Route, RouteComponentProps, RouteProps } from "react-router";
-import { Auth } from "shared/Auth";
+import { Auth } from "../../shared/Auth";
 
 type IRouteComponentPropsAndRouteProps = RouteProps & RouteComponentProps<any>;
 

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.test.tsx
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.test.tsx
@@ -15,6 +15,7 @@ const emptyLocation = {
 
 const makeStore = (authenticated: boolean, oidcAuthenticated: boolean) => {
   const state: IAuthState = {
+    sessionExpired: false,
     authenticated,
     oidcAuthenticated,
     authenticating: false,

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -9,12 +9,14 @@ import LoginForm from "./LoginFormContainer";
 const mockStore = configureMockStore([thunk]);
 
 const makeStore = (
+  sessionExpired: boolean,
   authenticated: boolean,
   authenticating: boolean,
   oidcAuthenticated: boolean,
   authenticationError: string,
 ) => {
   const state: IAuthState = {
+    sessionExpired,
     authenticated,
     authenticating,
     oidcAuthenticated,
@@ -32,7 +34,7 @@ const emptyLocation: Location = {
 
 describe("LoginFormContainer props", () => {
   it("maps authentication redux states to props", () => {
-    const store = makeStore(true, true, true, "It's a trap");
+    const store = makeStore(true, true, true, true, "It's a trap");
     const wrapper = shallow(<LoginForm store={store} location={emptyLocation} />);
     const form = wrapper.find("LoginForm");
     expect(form).toHaveProp({

--- a/dashboard/src/containers/PrivateRouteContainer/PrivateRouteContainer.ts
+++ b/dashboard/src/containers/PrivateRouteContainer/PrivateRouteContainer.ts
@@ -4,8 +4,11 @@ import { withRouter } from "react-router";
 import PrivateRoute from "../../components/PrivateRoute";
 import { IStoreState } from "../../shared/types";
 
-function mapStateToProps({ auth: { authenticated, oidcAuthenticated } }: IStoreState) {
+function mapStateToProps({
+  auth: { authenticated, oidcAuthenticated, sessionExpired },
+}: IStoreState) {
   return {
+    sessionExpired,
     authenticated,
     oidcAuthenticated,
   };

--- a/dashboard/src/index.tsx
+++ b/dashboard/src/index.tsx
@@ -1,16 +1,19 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as Modal from "react-modal";
-import * as Axios from "shared/AxiosInstance";
-import * as Auth from "./shared/Auth";
+import { addAuthHeaders, addErrorHandling, axios, axiosWithAuth } from "shared/AxiosInstance";
 
 import Root from "./containers/Root";
 import "./index.css";
 import store from "./store";
 // import registerServiceWorker from "./registerServiceWorker";
 
-Axios.createAxiosInterceptors(Axios.axios, store);
-Axios.createAxiosInterceptorsWithAuth(Auth.axios, store);
+// Now that the store has been initialized, initialize axios instances
+// One axios instance will be used for services that requires auth (those that use the K8s API)
+// and the other for services that don't (like the chartsvc)
+addErrorHandling(axios, store);
+addErrorHandling(axiosWithAuth, store);
+addAuthHeaders(axiosWithAuth);
 
 ReactDOM.render(<Root />, document.getElementById("root") as HTMLElement);
 

--- a/dashboard/src/index.tsx
+++ b/dashboard/src/index.tsx
@@ -1,15 +1,16 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as Modal from "react-modal";
-import { createAxiosInterceptors } from "shared/AxiosInstance";
-import { axios } from "./shared/Auth";
+import * as Axios from "shared/AxiosInstance";
+import * as Auth from "./shared/Auth";
 
 import Root from "./containers/Root";
 import "./index.css";
 import store from "./store";
 // import registerServiceWorker from "./registerServiceWorker";
 
-createAxiosInterceptors(axios, store);
+Axios.createAxiosInterceptors(Axios.axios, store);
+Axios.createAxiosInterceptorsWithAuth(Auth.axios, store);
 
 ReactDOM.render(<Root />, document.getElementById("root") as HTMLElement);
 

--- a/dashboard/src/reducers/auth.test.ts
+++ b/dashboard/src/reducers/auth.test.ts
@@ -10,7 +10,8 @@ describe("authReducer", () => {
     authenticating: getType(actions.auth.authenticating),
     authenticationError: getType(actions.auth.authenticationError),
     setAuthenticated: getType(actions.auth.setAuthenticated),
-    setExpiredSession: getType(actions.auth.setExpiredSession),
+    setSessionExpired: getType(actions.auth.setSessionExpired),
+    unsetSessionExpired: getType(actions.auth.unsetSessionExpired),
   };
 
   beforeEach(() => {
@@ -93,15 +94,14 @@ describe("authReducer", () => {
             oidcAuthenticated: false,
           },
           {
-            type: actionTypes.setAuthenticated as any,
-            payload: { authenticated: true, oidc: true },
+            type: actionTypes.unsetSessionExpired as any,
           },
         ),
       ).toEqual({
         sessionExpired: false,
-        authenticating: false,
-        authenticated: true,
-        oidcAuthenticated: true,
+        authenticating: true,
+        authenticated: false,
+        oidcAuthenticated: false,
       });
     });
 
@@ -115,7 +115,7 @@ describe("authReducer", () => {
             oidcAuthenticated: true,
           },
           {
-            type: actionTypes.setExpiredSession as any,
+            type: actionTypes.setSessionExpired as any,
           },
         ),
       ).toEqual({
@@ -123,27 +123,6 @@ describe("authReducer", () => {
         authenticating: false,
         authenticated: false,
         oidcAuthenticated: true,
-      });
-    });
-
-    it("ignores session expired if not oidcAuthenticated", () => {
-      expect(
-        authReducer(
-          {
-            sessionExpired: false,
-            authenticating: false,
-            authenticated: false,
-            oidcAuthenticated: false,
-          },
-          {
-            type: actionTypes.setExpiredSession as any,
-          },
-        ),
-      ).toEqual({
-        sessionExpired: false,
-        authenticating: false,
-        authenticated: false,
-        oidcAuthenticated: false,
       });
     });
   });

--- a/dashboard/src/reducers/auth.test.ts
+++ b/dashboard/src/reducers/auth.test.ts
@@ -11,7 +11,6 @@ describe("authReducer", () => {
     authenticationError: getType(actions.auth.authenticationError),
     setAuthenticated: getType(actions.auth.setAuthenticated),
     setSessionExpired: getType(actions.auth.setSessionExpired),
-    unsetSessionExpired: getType(actions.auth.unsetSessionExpired),
   };
 
   beforeEach(() => {
@@ -94,7 +93,8 @@ describe("authReducer", () => {
             oidcAuthenticated: false,
           },
           {
-            type: actionTypes.unsetSessionExpired as any,
+            type: actionTypes.setSessionExpired as any,
+            payload: { sessionExpired: false },
           },
         ),
       ).toEqual({
@@ -115,6 +115,7 @@ describe("authReducer", () => {
             oidcAuthenticated: true,
           },
           {
+            payload: { sessionExpired: true },
             type: actionTypes.setSessionExpired as any,
           },
         ),

--- a/dashboard/src/reducers/auth.test.ts
+++ b/dashboard/src/reducers/auth.test.ts
@@ -14,6 +14,7 @@ describe("authReducer", () => {
 
   beforeEach(() => {
     initialState = {
+      sessionExpired: false,
       authenticated: false,
       authenticating: false,
       oidcAuthenticated: false,
@@ -50,18 +51,12 @@ describe("authReducer", () => {
       ).toEqual({ ...initialState, authenticating: true, authenticated: false });
     });
 
-    it(`resets authenticated, authenticating and sets error if type ${
-      actionTypes.authenticationError
-    }`, () => {
+    it(`sets error if type ${actionTypes.authenticationError}`, () => {
       expect(
-        authReducer(
-          {
-            authenticating: true,
-            authenticated: true,
-            oidcAuthenticated: true,
-          },
-          { type: actionTypes.authenticationError as any, payload: errMessage },
-        ),
+        authReducer(initialState, {
+          type: actionTypes.authenticationError as any,
+          payload: errMessage,
+        }),
       ).toEqual({ ...initialState, authenticationError: errMessage });
     });
 
@@ -69,6 +64,7 @@ describe("authReducer", () => {
       expect(
         authReducer(
           {
+            sessionExpired: false,
             authenticating: true,
             authenticated: false,
             oidcAuthenticated: false,
@@ -79,6 +75,7 @@ describe("authReducer", () => {
           },
         ),
       ).toEqual({
+        sessionExpired: false,
         authenticating: false,
         authenticated: true,
         oidcAuthenticated: true,

--- a/dashboard/src/reducers/auth.test.ts
+++ b/dashboard/src/reducers/auth.test.ts
@@ -10,6 +10,7 @@ describe("authReducer", () => {
     authenticating: getType(actions.auth.authenticating),
     authenticationError: getType(actions.auth.authenticationError),
     setAuthenticated: getType(actions.auth.setAuthenticated),
+    setExpiredSession: getType(actions.auth.setExpiredSession),
   };
 
   beforeEach(() => {
@@ -79,6 +80,70 @@ describe("authReducer", () => {
         authenticating: false,
         authenticated: true,
         oidcAuthenticated: true,
+      });
+    });
+
+    it("unsets session expired", () => {
+      expect(
+        authReducer(
+          {
+            sessionExpired: true,
+            authenticating: true,
+            authenticated: false,
+            oidcAuthenticated: false,
+          },
+          {
+            type: actionTypes.setAuthenticated as any,
+            payload: { authenticated: true, oidc: true },
+          },
+        ),
+      ).toEqual({
+        sessionExpired: false,
+        authenticating: false,
+        authenticated: true,
+        oidcAuthenticated: true,
+      });
+    });
+
+    it("sets session expired", () => {
+      expect(
+        authReducer(
+          {
+            sessionExpired: false,
+            authenticating: false,
+            authenticated: false,
+            oidcAuthenticated: true,
+          },
+          {
+            type: actionTypes.setExpiredSession as any,
+          },
+        ),
+      ).toEqual({
+        sessionExpired: true,
+        authenticating: false,
+        authenticated: false,
+        oidcAuthenticated: true,
+      });
+    });
+
+    it("ignores session expired if not oidcAuthenticated", () => {
+      expect(
+        authReducer(
+          {
+            sessionExpired: false,
+            authenticating: false,
+            authenticated: false,
+            oidcAuthenticated: false,
+          },
+          {
+            type: actionTypes.setExpiredSession as any,
+          },
+        ),
+      ).toEqual({
+        sessionExpired: false,
+        authenticating: false,
+        authenticated: false,
+        oidcAuthenticated: false,
       });
     });
   });

--- a/dashboard/src/reducers/auth.ts
+++ b/dashboard/src/reducers/auth.ts
@@ -37,12 +37,7 @@ const authReducer = (state: IAuthState = initialState, action: AuthAction): IAut
     case getType(actions.auth.setSessionExpired):
       return {
         ...state,
-        sessionExpired: true,
-      };
-    case getType(actions.auth.unsetSessionExpired):
-      return {
-        ...state,
-        sessionExpired: false,
+        sessionExpired: action.payload.sessionExpired,
       };
     default:
   }

--- a/dashboard/src/reducers/auth.ts
+++ b/dashboard/src/reducers/auth.ts
@@ -26,8 +26,6 @@ const authReducer = (state: IAuthState = initialState, action: AuthAction): IAut
         authenticated: action.payload.authenticated,
         oidcAuthenticated: action.payload.oidc,
         authenticating: false,
-        // If authenticated the session is no longer expired
-        sessionExpired: action.payload.authenticated ? false : state.sessionExpired,
       };
     case getType(actions.auth.authenticating):
       return { ...state, authenticated: false, authenticating: true };
@@ -36,11 +34,15 @@ const authReducer = (state: IAuthState = initialState, action: AuthAction): IAut
         ...state,
         authenticationError: action.payload,
       };
-    case getType(actions.auth.setExpiredSession):
+    case getType(actions.auth.setSessionExpired):
       return {
         ...state,
-        // The session can only expire if we are using OIDC tokens
-        sessionExpired: state.oidcAuthenticated ? true : state.sessionExpired,
+        sessionExpired: true,
+      };
+    case getType(actions.auth.unsetSessionExpired):
+      return {
+        ...state,
+        sessionExpired: false,
       };
     default:
   }

--- a/dashboard/src/reducers/auth.ts
+++ b/dashboard/src/reducers/auth.ts
@@ -4,6 +4,7 @@ import actions from "../actions";
 import { AuthAction } from "../actions/auth";
 
 export interface IAuthState {
+  sessionExpired: boolean;
   authenticated: boolean;
   authenticating: boolean;
   oidcAuthenticated: boolean;
@@ -11,6 +12,7 @@ export interface IAuthState {
 }
 
 const initialState: IAuthState = {
+  sessionExpired: false,
   authenticated: !(localStorage.getItem("kubeapps_auth_token") === null),
   authenticating: false,
   oidcAuthenticated: localStorage.getItem("kubeapps_auth_token_oidc") === "true",
@@ -24,16 +26,21 @@ const authReducer = (state: IAuthState = initialState, action: AuthAction): IAut
         authenticated: action.payload.authenticated,
         oidcAuthenticated: action.payload.oidc,
         authenticating: false,
+        // If authenticated the session is no longer expired
+        sessionExpired: action.payload.authenticated ? false : state.sessionExpired,
       };
     case getType(actions.auth.authenticating):
       return { ...state, authenticated: false, authenticating: true };
     case getType(actions.auth.authenticationError):
       return {
         ...state,
-        authenticated: false,
-        authenticating: false,
-        oidcAuthenticated: false,
         authenticationError: action.payload,
+      };
+    case getType(actions.auth.setExpiredSession):
+      return {
+        ...state,
+        // The session can only expire if we are using OIDC tokens
+        sessionExpired: state.oidcAuthenticated ? true : state.sessionExpired,
       };
     default:
   }

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -1,14 +1,14 @@
 import * as moxios from "moxios";
 import { App, TILLER_PROXY_ROOT_URL } from "./App";
-import { axios } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { IAppOverview } from "./types";
 
 describe("App", () => {
   beforeEach(() => {
-    moxios.install(axios);
+    moxios.install(axiosWithAuth);
   });
   afterEach(() => {
-    moxios.uninstall(axios);
+    moxios.uninstall(axiosWithAuth);
   });
   describe("getResourceURL", () => {
     [

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -1,5 +1,5 @@
 import { AppRepository } from "./AppRepository";
-import { axios } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { hapi } from "./hapi/release";
 import { IAppOverview, IChartVersion } from "./types";
 
@@ -32,7 +32,7 @@ export class App {
     const repo = await AppRepository.get(chartAttrs.repo.name, kubeappsNamespace);
     const auth = repo.spec.auth;
     const endpoint = App.getResourceURL(namespace);
-    const { data } = await axios.post(endpoint, {
+    const { data } = await axiosWithAuth.post(endpoint, {
       auth,
       chartName: chartAttrs.name,
       releaseName,
@@ -54,7 +54,7 @@ export class App {
     const repo = await AppRepository.get(chartAttrs.repo.name, kubeappsNamespace);
     const auth = repo.spec.auth;
     const endpoint = App.getResourceURL(namespace, releaseName);
-    const { data } = await axios.put(endpoint, {
+    const { data } = await axiosWithAuth.put(endpoint, {
       auth,
       chartName: chartAttrs.name,
       releaseName,
@@ -70,7 +70,9 @@ export class App {
     if (purge) {
       purgeQuery = "purge=true";
     }
-    const { data } = await axios.delete(App.getResourceURL(namespace, releaseName, purgeQuery));
+    const { data } = await axiosWithAuth.delete(
+      App.getResourceURL(namespace, releaseName, purgeQuery),
+    );
     return data;
   }
 
@@ -79,14 +81,14 @@ export class App {
     if (allStatuses) {
       query = "statuses=all";
     }
-    const { data } = await axios.get<{ data: IAppOverview[] }>(
+    const { data } = await axiosWithAuth.get<{ data: IAppOverview[] }>(
       App.getResourceURL(namespace, undefined, query),
     );
     return data.data;
   }
 
   public static async getRelease(namespace: string, name: string) {
-    const { data } = await axios.get<{ data: hapi.release.Release }>(
+    const { data } = await axiosWithAuth.get<{ data: hapi.release.Release }>(
       this.getResourceURL(namespace, name),
     );
     return data.data;

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -1,36 +1,41 @@
-import { axios } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { IAppRepository, IAppRepositoryList } from "./types";
 
 export class AppRepository {
   public static async list(namespace: string) {
-    const { data } = await axios.get<IAppRepositoryList>(AppRepository.getResourceLink(namespace));
+    const { data } = await axiosWithAuth.get<IAppRepositoryList>(
+      AppRepository.getResourceLink(namespace),
+    );
     return data;
   }
 
   public static async get(name: string, namespace: string) {
-    const { data } = await axios.get(AppRepository.getSelfLink(name, namespace));
+    const { data } = await axiosWithAuth.get(AppRepository.getSelfLink(name, namespace));
     return data;
   }
 
   public static async update(name: string, namespace: string, newApp: IAppRepository) {
-    const { data } = await axios.put(AppRepository.getSelfLink(name, namespace), newApp);
+    const { data } = await axiosWithAuth.put(AppRepository.getSelfLink(name, namespace), newApp);
     return data;
   }
 
   public static async delete(name: string, namespace: string) {
-    const { data } = await axios.delete(AppRepository.getSelfLink(name, namespace));
+    const { data } = await axiosWithAuth.delete(AppRepository.getSelfLink(name, namespace));
     return data;
   }
 
   public static async create(name: string, namespace: string, url: string, auth: any) {
-    const { data } = await axios.post<IAppRepository>(AppRepository.getResourceLink(namespace), {
-      apiVersion: "kubeapps.com/v1alpha1",
-      kind: "AppRepository",
-      metadata: {
-        name,
+    const { data } = await axiosWithAuth.post<IAppRepository>(
+      AppRepository.getResourceLink(namespace),
+      {
+        apiVersion: "kubeapps.com/v1alpha1",
+        kind: "AppRepository",
+        metadata: {
+          name,
+        },
+        spec: { auth, type: "helm", url },
       },
-      spec: { auth, type: "helm", url },
-    });
+    );
     return data;
   }
 

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -16,6 +16,11 @@ export class Auth {
     return localStorage.removeItem(AuthTokenKey);
   }
 
+  public static usingOIDCToken() {
+    const oidc = localStorage.getItem(AuthTokenOIDCKey);
+    return oidc === "true" ? true : false;
+  }
+
   public static wsProtocols() {
     const token = this.getAuthToken();
     if (!token) {

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -65,5 +65,3 @@ export class Auth {
     return null;
   }
 }
-
-export const axios = Axios.create();

--- a/dashboard/src/shared/AxiosInstance.test.ts
+++ b/dashboard/src/shared/AxiosInstance.test.ts
@@ -2,7 +2,7 @@ import * as moxios from "moxios";
 import { IAuthState } from "reducers/auth";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
-import { createAxiosInterceptors } from "../shared/AxiosInstance";
+import { createAxiosInterceptorsWithAuth } from "../shared/AxiosInstance";
 import { Auth, axios } from "./Auth";
 import {
   ConflictError,
@@ -21,6 +21,7 @@ describe("createAxiosInterceptor", () => {
 
   beforeAll(() => {
     const state: IAuthState = {
+      sessionExpired: false,
       authenticated: false,
       authenticating: false,
       oidcAuthenticated: false,
@@ -40,7 +41,7 @@ describe("createAxiosInterceptor", () => {
       return authToken;
     });
 
-    createAxiosInterceptors(axios, store);
+    createAxiosInterceptorsWithAuth(axios, store);
   });
 
   beforeEach(() => {
@@ -122,11 +123,14 @@ describe("createAxiosInterceptor", () => {
     }
   });
 
-  it("dispatches auth error and logout if 401", async () => {
+  it("dispatches auth error if 401", async () => {
     const expectedActions = [
       {
         payload: "Boom!",
         type: "AUTHENTICATION_ERROR",
+      },
+      {
+        type: "AUTHENTICATION_EXPIRED",
       },
       {
         payload: { authenticated: false, oidc: false },

--- a/dashboard/src/shared/AxiosInstance.test.ts
+++ b/dashboard/src/shared/AxiosInstance.test.ts
@@ -2,8 +2,8 @@ import * as moxios from "moxios";
 import { IAuthState } from "reducers/auth";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
-import { createAxiosInterceptorsWithAuth } from "../shared/AxiosInstance";
-import { Auth, axios } from "./Auth";
+import { addAuthHeaders, addErrorHandling, axios } from "../shared/AxiosInstance";
+import { Auth } from "./Auth";
 import {
   ConflictError,
   ForbiddenError,
@@ -41,7 +41,8 @@ describe("createAxiosInterceptorWithAuth", () => {
       return authToken;
     });
 
-    createAxiosInterceptorsWithAuth(axios, store);
+    addErrorHandling(axios, store);
+    addAuthHeaders(axios);
   });
 
   beforeEach(() => {
@@ -128,9 +129,6 @@ describe("createAxiosInterceptorWithAuth", () => {
       {
         payload: "Boom!",
         type: "AUTHENTICATION_ERROR",
-      },
-      {
-        type: "AUTHENTICATION_EXPIRED",
       },
       {
         payload: { authenticated: false, oidc: false },

--- a/dashboard/src/shared/AxiosInstance.test.ts
+++ b/dashboard/src/shared/AxiosInstance.test.ts
@@ -12,7 +12,7 @@ import {
   UnprocessableEntity,
 } from "./types";
 
-describe("createAxiosInterceptor", () => {
+describe("createAxiosInterceptorWithAuth", () => {
   const mockStore = configureMockStore([thunk]);
   const testPath = "/internet-is-in-a-box";
   const authToken = "search-google-in-google";

--- a/dashboard/src/shared/Chart.ts
+++ b/dashboard/src/shared/Chart.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { axios } from "./AxiosInstance";
 import { IChart } from "./types";
 
 export default class Chart {

--- a/dashboard/src/shared/ClusterServiceClass.ts
+++ b/dashboard/src/shared/ClusterServiceClass.ts
@@ -1,4 +1,4 @@
-import { axios } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { ServiceCatalog } from "./ServiceCatalog";
 
 export interface IClusterServiceClass {
@@ -34,7 +34,7 @@ export interface IClusterServiceClass {
 export class ClusterServiceClass {
   public static async get(namespace?: string, name?: string): Promise<IClusterServiceClass> {
     const url = this.getLink(namespace, name);
-    const { data } = await axios.get<IClusterServiceClass>(url);
+    const { data } = await axiosWithAuth.get<IClusterServiceClass>(url);
     return data;
   }
 

--- a/dashboard/src/shared/Kube.test.ts
+++ b/dashboard/src/shared/Kube.test.ts
@@ -1,13 +1,13 @@
 import * as moxios from "moxios";
-import { axios } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { APIBase, Kube, WebSocketAPIBase } from "./Kube";
 
 describe("App", () => {
   beforeEach(() => {
-    moxios.install(axios);
+    moxios.install(axiosWithAuth);
   });
   afterEach(() => {
-    moxios.uninstall(axios);
+    moxios.uninstall(axiosWithAuth);
   });
   describe("getResourceURL", () => {
     [

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -1,4 +1,5 @@
-import { Auth, axios } from "./Auth";
+import { Auth } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { IResource } from "./types";
 
 export const APIBase = "api/kube";
@@ -70,7 +71,7 @@ export class Kube {
     name?: string,
     query?: string,
   ) {
-    const { data } = await axios.get<IResource>(
+    const { data } = await axiosWithAuth.get<IResource>(
       this.getResourceURL(apiVersion, resource, namespace, name, query),
     );
     return data;

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -1,10 +1,10 @@
-import { axios } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 
 import { IK8sList, IResource } from "./types";
 
 export default class Namespace {
   public static async list() {
-    const { data } = await axios.get<IK8sList<IResource, {}>>(`${Namespace.APIEndpoint}`);
+    const { data } = await axiosWithAuth.get<IK8sList<IResource, {}>>(`${Namespace.APIEndpoint}`);
     return data;
   }
 

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -1,4 +1,4 @@
-import { axios } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { definedNamespaces } from "./Namespace";
 import { IOwnerReference, ISecret } from "./types";
 
@@ -10,7 +10,7 @@ export default class Secret {
     namespace: string = definedNamespaces.default,
   ) {
     const url = Secret.getLink(namespace);
-    const { data } = await axios.post<ISecret>(url, {
+    const { data } = await axiosWithAuth.post<ISecret>(url, {
       apiVersion: "v1",
       data: secrets,
       kind: "Secret",
@@ -25,18 +25,18 @@ export default class Secret {
 
   public static async delete(name: string, namespace: string = definedNamespaces.default) {
     const url = this.getLink(namespace, name);
-    return axios.delete(url);
+    return axiosWithAuth.delete(url);
   }
 
   public static async get(name: string, namespace: string = definedNamespaces.default) {
     const url = this.getLink(namespace, name);
-    const { data } = await axios.get<ISecret>(url);
+    const { data } = await axiosWithAuth.get<ISecret>(url);
     return data;
   }
 
   public static async list(namespace: string = definedNamespaces.default) {
     const url = Secret.getLink(namespace);
-    const { data } = await axios.get<ISecret>(url);
+    const { data } = await axiosWithAuth.get<ISecret>(url);
     return data;
   }
 

--- a/dashboard/src/shared/ServiceBinding.ts
+++ b/dashboard/src/shared/ServiceBinding.ts
@@ -1,4 +1,4 @@
-import { axios } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { definedNamespaces } from "./Namespace";
 import { ICondition, ServiceCatalog } from "./ServiceCatalog";
 
@@ -55,7 +55,7 @@ export class ServiceBinding {
     parameters: {},
   ) {
     const url = ServiceBinding.getLink(namespace);
-    const { data } = await axios.post<IServiceBinding>(url, {
+    const { data } = await axiosWithAuth.post<IServiceBinding>(url, {
       metadata: {
         name: bindingName,
       },
@@ -71,12 +71,12 @@ export class ServiceBinding {
 
   public static async delete(name: string, namespace: string) {
     const url = this.getLink(namespace, name);
-    return axios.delete(url);
+    return axiosWithAuth.delete(url);
   }
 
   public static async get(namespace: string, name: string) {
     const url = this.getLink(namespace, name);
-    const { data } = await axios.get<IServiceBinding>(url);
+    const { data } = await axiosWithAuth.get<IServiceBinding>(url);
     return data;
   }
 
@@ -87,7 +87,7 @@ export class ServiceBinding {
       bindings.map(binding => {
         const { secretName } = binding.spec;
         const ns = binding.metadata.namespace;
-        return axios
+        return axiosWithAuth
           .get<IK8sApiSecretResponse>(this.secretEndpoint(ns) + secretName)
           .then(response => {
             return { binding, secret: response.data };

--- a/dashboard/src/shared/ServiceCatalog.ts
+++ b/dashboard/src/shared/ServiceCatalog.ts
@@ -1,6 +1,6 @@
 import { JSONSchema6 } from "json-schema";
 import * as urls from "../shared/url";
-import { axios } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { IClusterServiceClass } from "./ClusterServiceClass";
 import { IServiceInstance } from "./ServiceInstance";
 import { IK8sList, IStatus } from "./types";
@@ -19,12 +19,12 @@ export class ServiceCatalog {
   }
 
   public static async deprovisionInstance(instance: IServiceInstance) {
-    const { data } = await axios.delete("api/kube" + instance.metadata.selfLink);
+    const { data } = await axiosWithAuth.delete("api/kube" + instance.metadata.selfLink);
     return data;
   }
 
   public static async syncBroker(broker: IServiceBroker) {
-    const { data } = await axios.patch<IStatus>(
+    const { data } = await axiosWithAuth.patch<IStatus>(
       urls.api.clusterservicebrokers.sync(broker),
       {
         spec: {
@@ -41,7 +41,7 @@ export class ServiceCatalog {
 
   public static async isCatalogInstalled(): Promise<boolean> {
     try {
-      const { status } = await axios.get(this.endpoint);
+      const { status } = await axiosWithAuth.get(this.endpoint);
       return status === 200;
     } catch (err) {
       return false;
@@ -49,7 +49,7 @@ export class ServiceCatalog {
   }
 
   public static async getItems<T>(resource: string, namespace?: string): Promise<T[]> {
-    const response = await axios.get<IK8sList<T, {}>>(
+    const response = await axiosWithAuth.get<IK8sList<T, {}>>(
       this.endpoint + (namespace ? `/namespaces/${namespace}` : "") + `/${resource}`,
     );
     const json = response.data;

--- a/dashboard/src/shared/ServiceInstance.ts
+++ b/dashboard/src/shared/ServiceInstance.ts
@@ -1,4 +1,4 @@
-import { axios } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { ICondition, ServiceCatalog } from "./ServiceCatalog";
 import { IStatus } from "./types";
 
@@ -35,7 +35,7 @@ export class ServiceInstance {
     planName: string,
     parameters: {},
   ) {
-    const { data } = await axios.post<IStatus>(this.getLink(namespace), {
+    const { data } = await axiosWithAuth.post<IStatus>(this.getLink(namespace), {
       apiVersion: "servicecatalog.k8s.io/v1beta1",
       kind: "ServiceInstance",
       metadata: {
@@ -52,7 +52,7 @@ export class ServiceInstance {
 
   public static async get(namespace?: string, name?: string): Promise<IServiceInstance> {
     const url = this.getLink(namespace, name);
-    const { data } = await axios.get<IServiceInstance>(url);
+    const { data } = await axiosWithAuth.get<IServiceInstance>(url);
     return data;
   }
 


### PR DESCRIPTION
Fix #974 

With this PR we catch errors potentially thrown because the OIDC token is no longer valid. In that case we show a modal for the users  to notice that the application needs to reload. I used the Modal to avoid the user seing the application reloading without apparent reason.

![opengl-rotating-triangle](https://user-images.githubusercontent.com/4025665/54551210-eb751700-49ad-11e9-850d-addbf39656a2.gif)

Note that we are only checking request made by axios so to avoid issues I have replaced the current `fetch` calls with `axios.get` (so this PR also fixes #606).