### PR TITLE
Enable end-to-end tests for pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,65 +25,67 @@ workflows:
   version: 2
   kubeapps:
     jobs:
-      - test_go:
+      - test_e2e:
           <<: *build_always
-      - test_dashboard:
-          <<: *build_always
-      - test_chart_render:
-          <<: *build_always
-      - build_go_images:
-          <<: *build_always
-      - build_dashboard:
-          <<: *build_always
-      - GKE_1_11_MASTER:
-          <<: *build_on_master
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
-      - GKE_1_11_LATEST_RELEASE:
-          <<: *build_on_master
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
-      - GKE_1_12_MASTER:
-          <<: *build_on_master
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
-      - GKE_1_12_LATEST_RELEASE:
-          <<: *build_on_master
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
-      - sync_chart:
-          <<: *build_on_master
-          requires:
-            - GKE_1_11_MASTER
-            - GKE_1_11_LATEST_RELEASE
-            - GKE_1_12_MASTER
-            - GKE_1_12_LATEST_RELEASE
-      - push_images:
-          <<: *build_always
-          requires:
-            - GKE_1_11_MASTER
-            - GKE_1_11_LATEST_RELEASE
-            - GKE_1_12_MASTER
-            - GKE_1_12_LATEST_RELEASE
-      - release:
-          <<: *build_on_tag
-          requires:
-            - GKE_1_11_MASTER
-            - GKE_1_11_LATEST_RELEASE
-            - GKE_1_12_MASTER
-            - GKE_1_12_LATEST_RELEASE
+      # - test_go:
+      #     <<: *build_always
+      # - test_dashboard:
+      #     <<: *build_always
+      # - test_chart_render:
+      #     <<: *build_always
+      # - build_go_images:
+      #     <<: *build_always
+      # - build_dashboard:
+      #     <<: *build_always
+      # - GKE_1_11_MASTER:
+      #     <<: *build_on_master
+      #     requires:
+      #       - test_go
+      #       - test_dashboard
+      #       - build_go_images
+      #       - build_dashboard
+      # - GKE_1_11_LATEST_RELEASE:
+      #     <<: *build_on_master
+      #     requires:
+      #       - test_go
+      #       - test_dashboard
+      #       - build_go_images
+      #       - build_dashboard
+      # - GKE_1_12_MASTER:
+      #     <<: *build_on_master
+      #     requires:
+      #       - test_go
+      #       - test_dashboard
+      #       - build_go_images
+      #       - build_dashboard
+      # - GKE_1_12_LATEST_RELEASE:
+      #     <<: *build_on_master
+      #     requires:
+      #       - test_go
+      #       - test_dashboard
+      #       - build_go_images
+      #       - build_dashboard
+      # - sync_chart:
+      #     <<: *build_on_master
+      #     requires:
+      #       - GKE_1_11_MASTER
+      #       - GKE_1_11_LATEST_RELEASE
+      #       - GKE_1_12_MASTER
+      #       - GKE_1_12_LATEST_RELEASE
+      # - push_images:
+      #     <<: *build_always
+      #     requires:
+      #       - GKE_1_11_MASTER
+      #       - GKE_1_11_LATEST_RELEASE
+      #       - GKE_1_12_MASTER
+      #       - GKE_1_12_LATEST_RELEASE
+      # - release:
+      #     <<: *build_on_tag
+      #     requires:
+      #       - GKE_1_11_MASTER
+      #       - GKE_1_11_LATEST_RELEASE
+      #       - GKE_1_12_MASTER
+      #       - GKE_1_12_LATEST_RELEASE
 
 ## Definitions
 install_gcloud_sdk: &install_gcloud_sdk
@@ -190,6 +192,17 @@ jobs:
       CGO_ENABLED: "0"
     docker:
       - image: circleci/golang:1.11
+    steps:
+      - checkout
+      - <<: *exports
+      - run: make test
+  test_e2e:
+    working_directory: /go/src/github.com/kubeapps/kubeapps
+    machine: true
+    environment:
+      CGO_ENABLED: "0"
+    # docker:
+    #   - image: circleci/golang:1.11
     steps:
       - checkout
       - <<: *exports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,20 +247,15 @@ jobs:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
   local_e2e_tests:
-    working_directory: /home/circleci/.go_workspace/src/github.com/kubeapps/kubeapps
     machine: true
-    environment:
-      GOPATH: /home/circleci/.go_workspace
     steps:
       - checkout
       - <<: *exports
-      # By default Go 1.9 is installed, we need 1.11 to use kind
+      # Install kind
       - run: |
-          sudo rm -rf /usr/local/go/*
-          sudo chown $(whoami) /usr/local/go
-          curl -LO https://dl.google.com/go/go1.11.9.linux-amd64.tar.gz
-          tar -C /usr/local -xzf go1.11.9.linux-amd64.tar.gz
-      - run: go get -u sigs.k8s.io/kind
+          curl -LO https://github.com/kubernetes-sigs/kind/releases/download/0.2.1/kind-linux-amd64
+          chmod +x kind-linux-amd64
+          sudo mv kind-linux-amd64 /usr/local/bin/kind
       - run: kind create cluster
       - run: echo "export KUBECONFIG=$(kind get kubeconfig-path --name=kind)" >> $BASH_ENV
       - <<: *install_kubectl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,14 +192,6 @@ gke_test: &gke_test
     # Install helm
     - <<: *install_helm_cli
     - <<: *run_e2e_tests
-    - run: |
-        # If we want to test the latest version instead we override the image to be used
-        if [[ -n "$TEST_LATEST_RELEASE" ]]; then
-          source ./script/chart_sync_utils.sh
-          DEV_TAG=$(latestReleaseTag)
-          IMG_MODIFIER=""
-        fi
-        ./script/e2e-test.sh $DEV_TAG $IMG_MODIFIER
     - run:
         name: Cleanup GKE Cluster
         command: gcloud container clusters delete --async --zone $GKE_ZONE $ESCAPED_GKE_CLUSTER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
           tar -C /usr/local -xzf go1.11.9.linux-amd64.tar.gz
       - run: go get -u sigs.k8s.io/kind
       - run: kind create cluster
-      - run: export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+      - run: echo "export KUBECONFIG=$(kind get kubeconfig-path --name=kind)" >> $BASH_ENV
       - <<: *install_kubectl
       - <<: *install_helm_cli
       - <<: *run_e2e_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,20 @@ build_images: &build_images
             docker push ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
           fi
         done
+install_kubectl: &install_kubectl
+  run: |
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl
+    chmod +x ./kubectl
+    sudo mv ./kubectl /usr/local/bin/kubectl
+run_e2e_tests: &run_e2e_tests
+  run: |
+    # If we want to test the latest version instead we override the image to be used
+    if [[ -n "$TEST_LATEST_RELEASE" ]]; then
+      source ./script/chart_sync_utils.sh
+      DEV_TAG=$(latestReleaseTag)
+      IMG_MODIFIER=""
+    fi
+    ./script/e2e-test.sh $DEV_TAG $IMG_MODIFIER
 gke_test: &gke_test
   docker:
     - image: circleci/golang:1.11
@@ -184,20 +198,6 @@ gke_test: &gke_test
         name: Cleanup GKE Cluster
         command: gcloud container clusters delete --async --zone $GKE_ZONE $ESCAPED_GKE_CLUSTER
         when: always
-install_kubectl: &install_kubectl
-  run: |
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl
-    chmod +x ./kubectl
-    sudo mv ./kubectl /usr/local/bin/kubectl
-run_e2e_tests: &run_e2e_tests
-  run: |
-    # If we want to test the latest version instead we override the image to be used
-    if [[ -n "$TEST_LATEST_RELEASE" ]]; then
-      source ./script/chart_sync_utils.sh
-      DEV_TAG=$(latestReleaseTag)
-      IMG_MODIFIER=""
-    fi
-    ./script/e2e-test.sh $DEV_TAG $IMG_MODIFIER
 ###
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,18 +25,23 @@ workflows:
   version: 2
   kubeapps:
     jobs:
+      - test_go:
+          <<: *build_always
+      - test_dashboard:
+          <<: *build_always
+      - test_chart_render:
+          <<: *build_always
+      - build_go_images:
+          <<: *build_always
+      - build_dashboard:
+          <<: *build_always
       - test_e2e:
           <<: *build_always
-      # - test_go:
-      #     <<: *build_always
-      # - test_dashboard:
-      #     <<: *build_always
-      # - test_chart_render:
-      #     <<: *build_always
-      # - build_go_images:
-      #     <<: *build_always
-      # - build_dashboard:
-      #     <<: *build_always
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
       # - GKE_1_11_MASTER:
       #     <<: *build_on_master
       #     requires:
@@ -153,11 +158,6 @@ gke_test: &gke_test
         fi
     - <<: *exports
     - <<: *install_gcloud_sdk
-    # Install kubectl (v1.12.0)
-    - run: |
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl
-        chmod +x ./kubectl
-        sudo mv ./kubectl /usr/local/bin/kubectl
     - setup_remote_docker
     - run: |
         gcloud -q config set project $GKE_PROJECT
@@ -171,6 +171,7 @@ gke_test: &gke_test
     - run: ./script/start-gke-env.sh $ESCAPED_GKE_CLUSTER $GKE_ZONE $GKE_BRANCH $GKE_ADMIN > /dev/null
     # Install helm
     - <<: *install_helm_cli
+    - <<: *run_e2e_tests
     - run: |
         # If we want to test the latest version instead we override the image to be used
         if [[ -n "$TEST_LATEST_RELEASE" ]]; then
@@ -183,6 +184,20 @@ gke_test: &gke_test
         name: Cleanup GKE Cluster
         command: gcloud container clusters delete --async --zone $GKE_ZONE $ESCAPED_GKE_CLUSTER
         when: always
+install_kubectl: &install_kubectl
+  run: |
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl
+    chmod +x ./kubectl
+    sudo mv ./kubectl /usr/local/bin/kubectl
+run_e2e_tests: &run_e2e_tests
+  run: |
+    # If we want to test the latest version instead we override the image to be used
+    if [[ -n "$TEST_LATEST_RELEASE" ]]; then
+      source ./script/chart_sync_utils.sh
+      DEV_TAG=$(latestReleaseTag)
+      IMG_MODIFIER=""
+    fi
+    ./script/e2e-test.sh $DEV_TAG $IMG_MODIFIER
 ###
 
 jobs:
@@ -192,18 +207,6 @@ jobs:
       CGO_ENABLED: "0"
     docker:
       - image: circleci/golang:1.11
-    steps:
-      - checkout
-      - <<: *exports
-      - run: make test
-  test_e2e:
-    working_directory: /home/circleci/.go_workspace/src/github.com/kubeapps/kubeapps
-    machine: true
-    environment:
-      CGO_ENABLED: "0"
-      GOPATH: /home/circleci/.go_workspace
-    # docker:
-    #   - image: circleci/golang:1.11
     steps:
       - checkout
       - <<: *exports
@@ -245,6 +248,25 @@ jobs:
     steps:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
+  test_e2e:
+    working_directory: /home/circleci/.go_workspace/src/github.com/kubeapps/kubeapps
+    machine: true
+    environment:
+      GOPATH: /home/circleci/.go_workspace
+    steps:
+      - checkout
+      - <<: *exports
+      - run: |
+          sudo rm -rf /usr/local/go/*
+          sudo chown $(whoami) /usr/local/go
+          curl -LO https://dl.google.com/go/go1.11.9.linux-amd64.tar.gz
+          tar -C /usr/local -xzf go1.11.9.linux-amd64.tar.gz
+      - run: go get -u sigs.k8s.io/kind
+      - run: kind create cluster
+      - run: export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+      - <<: *install_kubectl
+      - <<: *install_helm_cli
+      - <<: *run_e2e_tests
   GKE_1_11_MASTER:
     <<: *gke_test
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,62 +35,62 @@ workflows:
           <<: *build_always
       - build_dashboard:
           <<: *build_always
-      - test_e2e:
+      - local_e2e_tests:
           <<: *build_always
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      # - GKE_1_11_MASTER:
-      #     <<: *build_on_master
-      #     requires:
-      #       - test_go
-      #       - test_dashboard
-      #       - build_go_images
-      #       - build_dashboard
-      # - GKE_1_11_LATEST_RELEASE:
-      #     <<: *build_on_master
-      #     requires:
-      #       - test_go
-      #       - test_dashboard
-      #       - build_go_images
-      #       - build_dashboard
-      # - GKE_1_12_MASTER:
-      #     <<: *build_on_master
-      #     requires:
-      #       - test_go
-      #       - test_dashboard
-      #       - build_go_images
-      #       - build_dashboard
-      # - GKE_1_12_LATEST_RELEASE:
-      #     <<: *build_on_master
-      #     requires:
-      #       - test_go
-      #       - test_dashboard
-      #       - build_go_images
-      #       - build_dashboard
-      # - sync_chart:
-      #     <<: *build_on_master
-      #     requires:
-      #       - GKE_1_11_MASTER
-      #       - GKE_1_11_LATEST_RELEASE
-      #       - GKE_1_12_MASTER
-      #       - GKE_1_12_LATEST_RELEASE
-      # - push_images:
-      #     <<: *build_always
-      #     requires:
-      #       - GKE_1_11_MASTER
-      #       - GKE_1_11_LATEST_RELEASE
-      #       - GKE_1_12_MASTER
-      #       - GKE_1_12_LATEST_RELEASE
-      # - release:
-      #     <<: *build_on_tag
-      #     requires:
-      #       - GKE_1_11_MASTER
-      #       - GKE_1_11_LATEST_RELEASE
-      #       - GKE_1_12_MASTER
-      #       - GKE_1_12_LATEST_RELEASE
+      - GKE_1_11_MASTER:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - GKE_1_11_LATEST_RELEASE:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - GKE_1_12_MASTER:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - GKE_1_12_LATEST_RELEASE:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - sync_chart:
+          <<: *build_on_master
+          requires:
+            - GKE_1_11_MASTER
+            - GKE_1_11_LATEST_RELEASE
+            - GKE_1_12_MASTER
+            - GKE_1_12_LATEST_RELEASE
+      - push_images:
+          <<: *build_always
+          requires:
+            - GKE_1_11_MASTER
+            - GKE_1_11_LATEST_RELEASE
+            - GKE_1_12_MASTER
+            - GKE_1_12_LATEST_RELEASE
+      - release:
+          <<: *build_on_tag
+          requires:
+            - GKE_1_11_MASTER
+            - GKE_1_11_LATEST_RELEASE
+            - GKE_1_12_MASTER
+            - GKE_1_12_LATEST_RELEASE
 
 ## Definitions
 install_gcloud_sdk: &install_gcloud_sdk
@@ -248,14 +248,16 @@ jobs:
     steps:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
-  test_e2e:
+  local_e2e_tests:
     working_directory: /home/circleci/.go_workspace/src/github.com/kubeapps/kubeapps
     machine: true
     environment:
       GOPATH: /home/circleci/.go_workspace
+      IMAGES: "kubeapps/apprepository-controller kubeapps/tiller-proxy kubeapps/dashboard"
     steps:
       - checkout
       - <<: *exports
+      # By default Go 1.9 is installed, we need 1.11 to use kind
       - run: |
           sudo rm -rf /usr/local/go/*
           sudo chown $(whoami) /usr/local/go
@@ -266,6 +268,18 @@ jobs:
       - run: echo "export KUBECONFIG=$(kind get kubeconfig-path --name=kind)" >> $BASH_ENV
       - <<: *install_kubectl
       - <<: *install_helm_cli
+      - run: |
+          read -ra IMG_ARRAY <<< "$IMAGES"
+          if [[ -n "${CIRCLE_TAG}" ]]; then
+           makeArgs="VERSION=${CIRCLE_TAG}"
+          fi
+          for IMAGE in "${IMG_ARRAY[@]}"; do
+            make IMG_MODIFIER="$IMG_MODIFIER" IMAGE_TAG="${DEV_TAG}" $makeArgs ${IMAGE}
+            if [[ -z "${CIRCLE_PULL_REQUEST}" && -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
+              docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+              docker push ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
+            fi
+          done
       - <<: *run_e2e_tests
   GKE_1_11_MASTER:
     <<: *gke_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ jobs:
       # Load images from other jobs
       - attach_workspace:
           at: /tmp/images
-      - run: kind load image-archive /tmp/images/*
+      - run: for image in /tmp/images/*; do kind load image-archive "$image"; done
       - <<: *run_e2e_tests
   GKE_1_11_MASTER:
     <<: *gke_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ build_images: &build_images
     - persist_to_workspace:
         root: images
         paths:
-          - *
+          - "*"
 install_kubectl: &install_kubectl
   run: |
     curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,17 +124,23 @@ build_images: &build_images
     - checkout
     - <<: *exports
     - run: |
+        mkdir -p images/
         read -ra IMG_ARRAY <<< "$IMAGES"
         if [[ -n "${CIRCLE_TAG}" ]]; then
           makeArgs="VERSION=${CIRCLE_TAG}"
         fi
         for IMAGE in "${IMG_ARRAY[@]}"; do
-          make IMG_MODIFIER="$IMG_MODIFIER" IMAGE_TAG="${DEV_TAG}" $makeArgs ${IMAGE}
+          make IMG_MODIFIER="$IMG_MODIFIER" IMAGE_TAG="${DEV_TAG}" $makeArgs kubeapps/${IMAGE}
           if [[ -z "${CIRCLE_PULL_REQUEST}" && -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
             docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-            docker push ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
+            docker push kubeapps/${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
           fi
+          docker save kubeapps/${IMAGE}${IMG_MODIFIER}:${DEV_TAG} > images/${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
         done
+    - persist_to_workspace:
+        root: images
+        paths:
+          - *
 install_kubectl: &install_kubectl
   run: |
     curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl
@@ -234,13 +240,13 @@ jobs:
     working_directory: /go/src/github.com/kubeapps/kubeapps
     environment:
       GOPATH: /home/circleci/.go_workspace
-      IMAGES: "kubeapps/apprepository-controller kubeapps/tiller-proxy"
+      IMAGES: "apprepository-controller tiller-proxy"
     <<: *build_images
   build_dashboard:
     docker:
       - image: circleci/golang:1.11
     environment:
-      IMAGES: "kubeapps/dashboard"
+      IMAGES: "dashboard"
     <<: *build_images
   release:
     docker:
@@ -253,7 +259,6 @@ jobs:
     machine: true
     environment:
       GOPATH: /home/circleci/.go_workspace
-      IMAGES: "kubeapps/apprepository-controller kubeapps/tiller-proxy kubeapps/dashboard"
     steps:
       - checkout
       - <<: *exports
@@ -268,18 +273,10 @@ jobs:
       - run: echo "export KUBECONFIG=$(kind get kubeconfig-path --name=kind)" >> $BASH_ENV
       - <<: *install_kubectl
       - <<: *install_helm_cli
-      - run: |
-          read -ra IMG_ARRAY <<< "$IMAGES"
-          if [[ -n "${CIRCLE_TAG}" ]]; then
-           makeArgs="VERSION=${CIRCLE_TAG}"
-          fi
-          for IMAGE in "${IMG_ARRAY[@]}"; do
-            make IMG_MODIFIER="$IMG_MODIFIER" IMAGE_TAG="${DEV_TAG}" $makeArgs ${IMAGE}
-            if [[ -z "${CIRCLE_PULL_REQUEST}" && -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
-              docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-              docker push ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
-            fi
-          done
+      # Load images from other jobs
+      - attach_workspace:
+          at: /tmp/images
+      - run: kind load image-archive /tmp/images/*
       - <<: *run_e2e_tests
   GKE_1_11_MASTER:
     <<: *gke_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,10 +197,11 @@ jobs:
       - <<: *exports
       - run: make test
   test_e2e:
-    working_directory: /go/src/github.com/kubeapps/kubeapps
+    working_directory: /home/circleci/.go_workspace/src/github.com/kubeapps/kubeapps
     machine: true
     environment:
       CGO_ENABLED: "0"
+      GOPATH: /home/circleci/.go_workspace
     # docker:
     #   - image: circleci/golang:1.11
     steps:

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -31,7 +31,10 @@ echo "IMAGE_REPO_SUFFIX: $IMG_MODIFIER"
 kubectl version
 
 # Install Tiller with TLS support
+kubectl -n kube-system create sa tiller
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
 helm init \
+  --service-account tiller \
   --tiller-tls \
   --tiller-tls-cert ${CERTS_DIR}/tiller.cert.pem \
   --tiller-tls-key ${CERTS_DIR}/tiller.key.pem \


### PR DESCRIPTION
This PR adds a new job that run our end-to-end tests (helm tests) that's run in a local Kubernetes cluster using [kind](https://github.com/kubernetes-sigs/kind). This enable us to use our end-to-end tests with untrusted code (PRs).