### PR TITLE
updates nginx dependency to bitnami/nginx:1.16

### DIFF
--- a/chart/kubeapps/templates/dashboard-deployment.yaml
+++ b/chart/kubeapps/templates/dashboard-deployment.yaml
@@ -31,7 +31,7 @@ spec:
 {{ toYaml .Values.dashboard.readinessProbe | indent 10 }}
         volumeMounts:
         - name: vhost
-          mountPath: /opt/bitnami/nginx/conf/vhosts
+          mountPath: /opt/bitnami/nginx/conf/server_blocks
         - name: config
           mountPath: /app/config.json
           subPath: config.json

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -31,7 +31,7 @@ spec:
 {{ toYaml .Values.frontend.readinessProbe | indent 10 }}
         volumeMounts:
         - name: vhost
-          mountPath: /opt/bitnami/nginx/conf/vhosts
+          mountPath: /opt/bitnami/nginx/conf/server_blocks
         ports:
         - name: http
           containerPort: 8080

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -61,7 +61,7 @@ frontend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.14.0-r27
+    tag: 1.16.0-r3
   service:
     port: 80
     type: ClusterIP
@@ -286,7 +286,7 @@ testImage:
   # Image used for the tests. The only requirement is to include curl
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.14.0-r27
+  tag: 1.16.0-r3
 
 # Auth Proxy for OIDC support
 # ref: https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,5 +7,5 @@ RUN yarn install --frozen-lockfile
 COPY . /app
 RUN yarn run build
 
-FROM bitnami/nginx:1.14.2-r61
+FROM bitnami/nginx:1.16.0-r3
 COPY --from=build /app/build /app


### PR DESCRIPTION
This version changes the mount path for vhosts to
`/opt/bitnami/nginx/conf/server_blocks`.

Note I am not updating the chart version here, as this requires a new build of the dashboard image. When we release a new version, the chart can be updated and published.

fixes #1015 