### PR TITLE
only update listOverview if release present when processing updateInfo

### DIFF
--- a/dashboard/src/reducers/apps.test.ts
+++ b/dashboard/src/reducers/apps.test.ts
@@ -3,13 +3,14 @@ import actions from "../actions";
 import { IAppState } from "../shared/types";
 import appsReducer from "./apps";
 
-describe("authReducer", () => {
+describe("appsReducer", () => {
   let initialState: IAppState;
 
   const actionTypes = {
     listApps: getType(actions.apps.listApps),
     receiveAppList: getType(actions.apps.receiveAppList),
     requestApps: getType(actions.apps.requestApps),
+    receiveAppUpdateInfo: getType(actions.apps.receiveAppUpdateInfo),
   };
 
   beforeEach(() => {
@@ -42,6 +43,132 @@ describe("authReducer", () => {
         type: actionTypes.listApps as any,
       });
       expect(state).toEqual({ ...initialState, isFetching: true, listingAll: false });
+    });
+
+    describe("receieveAppUpdateInfo", () => {
+      const testListOverview = [
+        { releaseName: "test1" },
+        { releaseName: "test2" },
+        { releaseName: "test3" },
+      ];
+      const testUpdateInfo = {
+        upToDate: false,
+        latestVersion: "1.0.0",
+        repository: { name: "myrepo", url: "myrepo.com" },
+      };
+
+      it("updates the listOverview entry with the updateInfo if it exists", () => {
+        let state = {
+          ...initialState,
+          listOverview: testListOverview,
+        } as IAppState;
+
+        state = appsReducer(state, {
+          payload: {
+            releaseName: "test2",
+            updateInfo: testUpdateInfo,
+          },
+          type: actionTypes.receiveAppUpdateInfo,
+        });
+
+        expect(state.listOverview![1].updateInfo).toEqual(testUpdateInfo);
+      });
+
+      it("doesn't change listOverview if the entry doesn't exist", () => {
+        let state = {
+          ...initialState,
+          listOverview: testListOverview,
+        } as IAppState;
+
+        state = appsReducer(state, {
+          payload: {
+            releaseName: "test4",
+            updateInfo: testUpdateInfo,
+          },
+          type: actionTypes.receiveAppUpdateInfo,
+        });
+
+        expect(state.listOverview).toBe(testListOverview);
+      });
+
+      it("doesn't change listOverview if it is undefined", () => {
+        const state = appsReducer(initialState, {
+          payload: {
+            releaseName: "test4",
+            updateInfo: testUpdateInfo,
+          },
+          type: actionTypes.receiveAppUpdateInfo,
+        });
+
+        expect(state.listOverview).toBeUndefined();
+      });
+
+      it("sets updateInfo for selected if release name matches", () => {
+        let state = {
+          ...initialState,
+          selected: {
+            name: "test",
+          },
+        } as IAppState;
+
+        state = appsReducer(state, {
+          payload: {
+            releaseName: "test",
+            updateInfo: testUpdateInfo,
+          },
+          type: actionTypes.receiveAppUpdateInfo,
+        });
+
+        expect(state.selected!.updateInfo).toEqual(testUpdateInfo);
+      });
+
+      it("doesn't set updateInfo for selected if release name does not match", () => {
+        let state = {
+          ...initialState,
+          selected: {
+            name: "test",
+          },
+        } as IAppState;
+
+        state = appsReducer(state, {
+          payload: {
+            releaseName: "nottest",
+            updateInfo: testUpdateInfo,
+          },
+          type: actionTypes.receiveAppUpdateInfo,
+        });
+
+        expect(state.selected!.updateInfo).toBeUndefined();
+      });
+
+      it("doesn't set updateInfo for selected if selected is undefined", () => {
+        const state = appsReducer(initialState, {
+          payload: {
+            releaseName: "test",
+            updateInfo: testUpdateInfo,
+          },
+          type: actionTypes.receiveAppUpdateInfo,
+        });
+
+        expect(state.selected).toBeUndefined();
+      });
+
+      it("sets isFetching to false", () => {
+        let state = {
+          ...initialState,
+          isFetching: true,
+        } as IAppState;
+
+        state = appsReducer(state, {
+          payload: {
+            releaseName: "test",
+            updateInfo: testUpdateInfo,
+          },
+          type: actionTypes.receiveAppUpdateInfo,
+        });
+
+        expect(state.isFetching).toBe(false);
+      });
     });
   });
 });

--- a/dashboard/src/reducers/apps.test.ts
+++ b/dashboard/src/reducers/apps.test.ts
@@ -104,11 +104,10 @@ describe("appsReducer", () => {
       });
 
       it("sets updateInfo for selected if release name matches", () => {
+        const selected = { name: "test" };
         let state = {
           ...initialState,
-          selected: {
-            name: "test",
-          },
+          selected,
         } as IAppState;
 
         state = appsReducer(state, {
@@ -119,15 +118,14 @@ describe("appsReducer", () => {
           type: actionTypes.receiveAppUpdateInfo,
         });
 
-        expect(state.selected!.updateInfo).toEqual(testUpdateInfo);
+        expect(state.selected).toEqual({ ...selected, updateInfo: testUpdateInfo });
       });
 
-      it("doesn't set updateInfo for selected if release name does not match", () => {
+      it("doesn't change selected if release name does not match", () => {
+        const selected = { name: "test" };
         let state = {
           ...initialState,
-          selected: {
-            name: "test",
-          },
+          selected,
         } as IAppState;
 
         state = appsReducer(state, {
@@ -138,7 +136,7 @@ describe("appsReducer", () => {
           type: actionTypes.receiveAppUpdateInfo,
         });
 
-        expect(state.selected!.updateInfo).toBeUndefined();
+        expect(state.selected).toBe(selected);
       });
 
       it("doesn't set updateInfo for selected if selected is undefined", () => {

--- a/dashboard/src/reducers/apps.ts
+++ b/dashboard/src/reducers/apps.ts
@@ -39,12 +39,16 @@ const appsReducer = (
         const appOverviewIndex = state.listOverview.findIndex(
           a => a.releaseName === action.payload.releaseName,
         );
-        // Replace item in listOverview array
-        listOverview = [
-          ...state.listOverview.slice(0, appOverviewIndex),
-          { ...state.listOverview[appOverviewIndex], updateInfo: action.payload.updateInfo },
-          ...state.listOverview.slice(appOverviewIndex + 1),
-        ];
+        // If the release exists in the listOverview, update the updateInfo
+        // field. If it doesn't exist, we don't do anything, it will get fetched
+        // when loading the app list
+        if (appOverviewIndex >= 0) {
+          listOverview = [
+            ...state.listOverview.slice(0, appOverviewIndex),
+            { ...state.listOverview[appOverviewIndex], updateInfo: action.payload.updateInfo },
+            ...state.listOverview.slice(appOverviewIndex + 1),
+          ];
+        }
       }
       let selected;
       if (state.selected && state.selected.name === action.payload.releaseName) {


### PR DESCRIPTION
We weren't checking if we were actually able to find the release name in
the `listOverview`, if it wasn't there (which is usually the case after
installing a chart as you get directed to the app page not the app list)
then `appOverviewIndex` would be `-1` and we won't be slicing the array
correctly.

This patch checks that we actually found the release in the
`listOverview` before updating the entry. If we don't find it, we don't
need to do anything, as it will get fetched and set in the
`listOverview` when visiting the AppList page.

fixes #1019 