### PR TITLE
[Dashboard] Treat anything with items as a list in AppView

### DIFF
--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -311,4 +311,24 @@ describe("AppViewComponent", () => {
       otherResources: [obj],
     });
   });
+
+  it("renders a list of roles", () => {
+    const obj = { kind: "ClusterRole", metadata: { name: "foo" } };
+    const list = {
+      kind: "RoleList",
+      items: [obj, resources.deployment],
+    };
+    const manifest = generateYamlManifest([resources.service, list]);
+
+    const wrapper = shallow(<AppViewComponent {...validProps} />);
+    validProps.app.manifest = manifest;
+    // setProps again so we trigger componentWillReceiveProps
+    wrapper.setProps(validProps);
+
+    expect(wrapper.state()).toMatchObject({
+      deployRefs: [new ResourceRef(resources.deployment, appRelease.namespace)],
+      serviceRefs: [new ResourceRef(resources.service, appRelease.namespace)],
+      otherResources: [obj],
+    });
+  });
 });

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -215,34 +215,38 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
       secretRefs: [],
     };
     resources.forEach(i => {
-      const item = i as IResource;
-      const resource = { isFetching: true, item };
-      switch (i.kind) {
-        case "Deployment":
-          result.deployRefs.push(new ResourceRef(resource.item, releaseNamespace));
-          break;
-        case "Service":
-          result.serviceRefs.push(new ResourceRef(resource.item, releaseNamespace));
-          break;
-        case "Ingress":
-          result.ingressRefs.push(new ResourceRef(resource.item, releaseNamespace));
-          break;
-        case "Secret":
-          result.secretRefs.push(new ResourceRef(resource.item, releaseNamespace));
-          break;
-        case "List":
-          // A List can contain an arbitrary set of resources so we treat them as an
-          // additional manifest. We merge the current result with the resources of
-          // the List, concatenating items from both.
-          _.assignWith(
-            result,
-            this.parseResources((i as IK8sList<IResource, {}>).items, releaseNamespace),
-            // Merge the list with the current result
-            (prev, newArray) => prev.concat(newArray),
-          );
-          break;
-        default:
-          result.otherResources.push(item);
+      // The item may be a list
+      const itemList = i as IK8sList<IResource, {}>;
+      if (itemList.items) {
+        // If the resource  has a list of items, treat them as a list
+        // A List can contain an arbitrary set of resources so we treat them as an
+        // additional manifest. We merge the current result with the resources of
+        // the List, concatenating items from both.
+        _.assignWith(
+          result,
+          this.parseResources((i as IK8sList<IResource, {}>).items, releaseNamespace),
+          // Merge the list with the current result
+          (prev, newArray) => prev.concat(newArray),
+        );
+      } else {
+        const item = i as IResource;
+        const resource = { isFetching: true, item };
+        switch (i.kind) {
+          case "Deployment":
+            result.deployRefs.push(new ResourceRef(resource.item, releaseNamespace));
+            break;
+          case "Service":
+            result.serviceRefs.push(new ResourceRef(resource.item, releaseNamespace));
+            break;
+          case "Ingress":
+            result.ingressRefs.push(new ResourceRef(resource.item, releaseNamespace));
+            break;
+          case "Secret":
+            result.secretRefs.push(new ResourceRef(resource.item, releaseNamespace));
+            break;
+          default:
+            result.otherResources.push(item);
+        }
       }
     });
     return result;


### PR DESCRIPTION
Fixes #1026
Closes #1025

There are other type of lists apart than `List` (like `RoleBindingList`).