### PR TITLE
Disable default securityContext for MongoDB

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 1.7.1
+version: 1.7.2
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -254,6 +254,8 @@ mongodb:
     enabled: false
   # MongoDB credentials are handled by kubeapps to facilitate upgrades
   existingSecret: kubeapps-mongodb
+  securityContext:
+    enabled: false
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
   resources:
     limits:


### PR DESCRIPTION
Disable the default securityContext configuration for MongoDB since the image is already running as root and setting the securityContext causes some issues like #1043 or #1017