### PR TITLE
Application status message

### DIFF
--- a/dashboard/src/components/ApplicationStatus/ApplicationStatus.scss
+++ b/dashboard/src/components/ApplicationStatus/ApplicationStatus.scss
@@ -12,6 +12,11 @@
   background-color: #1598cb;
 }
 
+.ApplicationStatus--error {
+  color: #fff;
+  background-color: #de0606;
+}
+
 .ApplicationStatus--pending {
   background-color: #fdba12;
 }

--- a/dashboard/src/components/ApplicationStatus/ApplicationStatus.test.tsx
+++ b/dashboard/src/components/ApplicationStatus/ApplicationStatus.test.tsx
@@ -53,6 +53,23 @@ it("renders a deleting status", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it("renders a failed status", () => {
+  const deployments = [
+    {
+      isFetching: false,
+    },
+  ];
+  const wrapper = shallow(
+    <ApplicationStatus
+      {...defaultProps}
+      deployments={deployments}
+      info={{ status: { code: 4 } }}
+    />,
+  );
+  expect(wrapper.text()).toContain("Failed");
+  expect(wrapper).toMatchSnapshot();
+});
+
 describe("isFetching", () => {
   const tests: Array<{
     title: string;

--- a/dashboard/src/components/ApplicationStatus/ApplicationStatus.test.tsx
+++ b/dashboard/src/components/ApplicationStatus/ApplicationStatus.test.tsx
@@ -167,41 +167,7 @@ describe("isFetching", () => {
           daemonsets={t.daemonsets}
         />,
       );
-      expect(wrapper.text()).toContain(t.deployed ? "Deployed" : "Deploying");
+      expect(wrapper.text()).toContain(t.deployed ? "Ready" : "Not Ready");
     });
   });
-});
-
-it("renders a deploying status", () => {
-  const deployments = [
-    {
-      isFetching: false,
-      item: {
-        status: {
-          replicas: 1,
-          availableReplicas: 0,
-        },
-      } as IResource,
-    },
-  ];
-  const wrapper = shallow(<ApplicationStatus {...defaultProps} deployments={deployments} />);
-  expect(wrapper.text()).toContain("Deploying");
-  expect(wrapper).toMatchSnapshot();
-});
-
-it("renders a deployed status", () => {
-  const deployments = [
-    {
-      isFetching: false,
-      item: {
-        status: {
-          replicas: 1,
-          availableReplicas: 1,
-        },
-      } as IResource,
-    },
-  ];
-  const wrapper = shallow(<ApplicationStatus {...defaultProps} deployments={deployments} />);
-  expect(wrapper.text()).toContain("Deployed");
-  expect(wrapper).toMatchSnapshot();
 });

--- a/dashboard/src/components/ApplicationStatus/ApplicationStatus.tsx
+++ b/dashboard/src/components/ApplicationStatus/ApplicationStatus.tsx
@@ -39,6 +39,13 @@ class ApplicationStatus extends React.Component<IApplicationStatusProps> {
     if (this.props.info && this.props.info.deleted) {
       return this.renderDeletedStatus();
     }
+    if (this.props.info && this.props.info.status) {
+      // If the status code is different than "Deployed", display that status
+      const helmStatus = this.codeToString(this.props.info.status);
+      if (helmStatus !== "Deployed") {
+        return this.helmStatusError(helmStatus);
+      }
+    }
     return this.isReady() ? this.renderSuccessStatus() : this.renderPendingStatus();
   }
 
@@ -46,6 +53,34 @@ class ApplicationStatus extends React.Component<IApplicationStatusProps> {
     return (
       <span className="ApplicationStatus ApplicationStatus--success">
         <Check className="icon padding-t-tiny" /> Ready
+      </span>
+    );
+  }
+
+  private codeToString(status: hapi.release.IStatus | null | undefined) {
+    // Codes from https://github.com/helm/helm/blob/268695813ba957821e53a784ac849aa3ca7f70a3/_proto/hapi/release/status.proto
+    const codes = {
+      0: "Unknown",
+      1: "Deployed",
+      2: "Deleted",
+      3: "Superseded",
+      4: "Failed",
+      5: "Deleting",
+      6: "Pending Install",
+      7: "Pending Upgrade",
+      8: "Pending Rollback",
+    };
+    if (status && status.code) {
+      return codes[status.code];
+    }
+    return codes[0];
+  }
+
+  private helmStatusError(status: string) {
+    return (
+      <span className="ApplicationStatus ApplicationStatus--error">
+        <AlertTriangle className="icon" style={{ bottom: "-0.425em", left: "-0.3em" }} />
+        {status}
       </span>
     );
   }

--- a/dashboard/src/components/ApplicationStatus/ApplicationStatus.tsx
+++ b/dashboard/src/components/ApplicationStatus/ApplicationStatus.tsx
@@ -45,7 +45,7 @@ class ApplicationStatus extends React.Component<IApplicationStatusProps> {
   private renderSuccessStatus() {
     return (
       <span className="ApplicationStatus ApplicationStatus--success">
-        <Check className="icon padding-t-tiny" /> Deployed
+        <Check className="icon padding-t-tiny" /> Ready
       </span>
     );
   }
@@ -53,7 +53,7 @@ class ApplicationStatus extends React.Component<IApplicationStatusProps> {
   private renderPendingStatus() {
     return (
       <span className="ApplicationStatus ApplicationStatus--pending">
-        <Compass className="icon padding-t-tiny" /> Deploying
+        <Compass className="icon padding-t-tiny" /> Not Ready
       </span>
     );
   }

--- a/dashboard/src/components/ApplicationStatus/__snapshots__/ApplicationStatus.test.tsx.snap
+++ b/dashboard/src/components/ApplicationStatus/__snapshots__/ApplicationStatus.test.tsx.snap
@@ -18,6 +18,25 @@ exports[`renders a deleting status 1`] = `
 </span>
 `;
 
+exports[`renders a failed status 1`] = `
+<span
+  className="ApplicationStatus ApplicationStatus--error"
+>
+  <AlertTriangle
+    className="icon"
+    color="currentColor"
+    size="24"
+    style={
+      Object {
+        "bottom": "-0.425em",
+        "left": "-0.3em",
+      }
+    }
+  />
+  Failed
+</span>
+`;
+
 exports[`renders a loading status 1`] = `
 <span
   className="ApplicationStatus"

--- a/dashboard/src/components/ApplicationStatus/__snapshots__/ApplicationStatus.test.tsx.snap
+++ b/dashboard/src/components/ApplicationStatus/__snapshots__/ApplicationStatus.test.tsx.snap
@@ -18,28 +18,6 @@ exports[`renders a deleting status 1`] = `
 </span>
 `;
 
-exports[`renders a deployed status 1`] = `
-<span
-  className="ApplicationStatus ApplicationStatus--success"
->
-  <Check
-    className="icon padding-t-tiny"
-  />
-   Deployed
-</span>
-`;
-
-exports[`renders a deploying status 1`] = `
-<span
-  className="ApplicationStatus ApplicationStatus--pending"
->
-  <Compass
-    className="icon padding-t-tiny"
-  />
-   Deploying
-</span>
-`;
-
 exports[`renders a loading status 1`] = `
 <span
   className="ApplicationStatus"


### PR DESCRIPTION
Closes #439 

Implementation discussed at https://docs.google.com/document/d/1eWvabsnY5tfhGVyV3cDbh_YPrAsnmrn06nWUXjXzke4/

If the Helm status is different than "DEPLOYED" show that status.

Substitute the message `Deploying/Deployed` to avoid confusion with the Helm status.

![Screenshot from 2019-06-05 14-42-20](https://user-images.githubusercontent.com/4025665/58993214-b6ed4c00-87a1-11e9-8f8e-5493ccc3bd22.png)
![Screenshot from 2019-06-05 14-41-26](https://user-images.githubusercontent.com/4025665/58993215-b6ed4c00-87a1-11e9-877c-19ded4b00e2f.png)
![Screenshot from 2019-06-05 14-34-45](https://user-images.githubusercontent.com/4025665/58993216-b6ed4c00-87a1-11e9-96cb-13cf101f191b.png)
