### PR TITLE
Use global security context for apprepositories-sync job

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 1.7.3
+version: 1.7.4
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/apprepositories.yaml
+++ b/chart/kubeapps/templates/apprepositories.yaml
@@ -1,4 +1,3 @@
-{{- $root := . -}}
 {{- range .Values.apprepository.initialRepos }}
 apiVersion: kubeapps.com/v1alpha1
 kind: AppRepository
@@ -26,11 +25,11 @@ metadata:
 spec:
   type: helm
   url: {{ .url }}
-  {{- if $root.Values.securityContext.enabled }}
+  {{- if $.Values.securityContext.enabled }}
   syncJobPodTemplate:
     spec:
       securityContext:
-        runAsUser: {{ $root.Values.securityContext.runAsUser }}
+        runAsUser: {{ $.Values.securityContext.runAsUser }}
   {{- end }}
   {{- if or .caCert .authorizationHeader }}
   auth:

--- a/chart/kubeapps/templates/apprepositories.yaml
+++ b/chart/kubeapps/templates/apprepositories.yaml
@@ -1,3 +1,4 @@
+{{- $root := . -}}
 {{- range .Values.apprepository.initialRepos }}
 apiVersion: kubeapps.com/v1alpha1
 kind: AppRepository
@@ -25,6 +26,12 @@ metadata:
 spec:
   type: helm
   url: {{ .url }}
+  {{- if $root.Values.securityContext.enabled }}
+  syncJobPodTemplate:
+    spec:
+      securityContext:
+        runAsUser: {{ $root.Values.securityContext.runAsUser }}
+  {{- end }}
   {{- if or .caCert .authorizationHeader }}
   auth:
     {{- if .caCert }}


### PR DESCRIPTION
Currently, the apprepositories-sync job does not use the global securityContext defined in the values.yaml. If Kubeapps is being deployed on a cluster where this security context is required, apprepositories have to be configured individually, or else the sync job will fail.

This PR checks the value of securityContext, and will ensure the apprepository-sync job will run as the correct user.