### PR TITLE
Fix memory usage for tiller-proxy

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -167,7 +167,7 @@ tillerProxy:
   resources:
     limits:
       cpu: 250m
-      memory: 128Mi
+      memory: 256Mi
     requests:
       cpu: 25m
       memory: 32Mi

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -242,3 +242,18 @@ func TestGetChartWithCustomUserAgent(t *testing.T) {
 		t.Errorf("It should return a Chart")
 	}
 }
+
+func TestGetIndexFromCache(t *testing.T) {
+	repoURL := "https://test.com"
+	data := []byte("foo")
+	index, sha := getIndexFromCache(repoURL, data)
+	if index != nil {
+		t.Error("Index should be empty since it's not in the cache yet")
+	}
+	fakeIndex := &repo.IndexFile{}
+	storeIndexInCache(repoURL, fakeIndex, sha)
+	index, _ = getIndexFromCache(repoURL, data)
+	if index != fakeIndex {
+		t.Error("It should return the stored index")
+	}
+}


### PR DESCRIPTION
Fix #1052 

Cache the result of unmarshaling the `index.yaml` file of a repository.

Increase the memory limit for Tiller-proxy.