### PR TITLE
Update mongodb chart version in deps

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 1.7.5
+version: 2.0.0
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/requirements.lock
+++ b/chart/kubeapps/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 4.9.0
+  version: 6.0.0
 digest: sha256:415440e73af7d4b02a10a15f28bb2fc095cbdffdc2e1676d76e0f0eaa1632d50
-generated: 2018-11-14T11:54:24.338893216Z
+generated: "2019-07-04T06:45:43.970255988Z"


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

A new MongoDB version was released (https://github.com/helm/charts/pull/15229) fixing an issue in some k8s cluster when IPv6 was disabled in the host, i.e https://github.com/kubeapps/kubeapps/issues/577.

This version also contains other changes in the chart (from MongoDB chart 5.0.0): https://github.com/helm/charts/tree/master/stable/mongodb#to-500

And also the `bitnami/mongodb` image was moved [from nami to bash](https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#3613-debian-9-r15-3613-ol-7-r15-4010-debian-9-r23-4010-ol-7-r24-4113-debian-9-r22-4113-ol-7-r23-or-later).