### PR TITLE
Avoid using rolling tag

### DIFF
--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -58,7 +58,7 @@ updateRepo() {
     rm "${targetChartPath}/Chart.yaml.bk"
     # DANGER: This replaces any tag marked as latest in the values.yaml
     local tagWithoutV=$(echo $targetTag | tr -d v)
-    sed -i.bk 's/tag: latest/tag: '"${tagWithoutV}"'/g' "${targetChartPath}/values.yaml"
+    sed -i.bk 's/tag: latest/tag: '"${tagWithoutV}"'-r0/g' "${targetChartPath}/values.yaml"
     # Use bitnami images
     sed -i.bk 's/repository: kubeapps\/\(.*\)/repository: bitnami\/kubeapps-\1/g' "${targetChartPath}/values.yaml"
     rm "${targetChartPath}/values.yaml.bk"


### PR DESCRIPTION
Fixes #1077 

Use the first revision when doing a release. We cannot use `debian-9` since some images (tiller-proxy, apprepository-controller) use `scratch` as their base image.