### PR TITLE
Update chart repo

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -104,7 +104,7 @@ apprepository:
   syncImage:
     registry: docker.io
     repository: bitnami/kubeapps-chart-repo
-    tag: 1.8.1-r0
+    tag: 1.8.2-r0
   initialReposProxy:
     enabled: false
 #    http_proxy: "http://yourproxy:3128"
@@ -186,7 +186,7 @@ chartsvc:
   image:
     registry: docker.io
     repository: bitnami/kubeapps-chartsvc
-    tag: 1.8.1-r0
+    tag: 1.8.2-r0
   service:
     port: 8080
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -104,7 +104,7 @@ apprepository:
   syncImage:
     registry: docker.io
     repository: bitnami/kubeapps-chart-repo
-    tag: 1.8.0-r0
+    tag: 1.8.1-r0
   initialReposProxy:
     enabled: false
 #    http_proxy: "http://yourproxy:3128"
@@ -186,7 +186,7 @@ chartsvc:
   image:
     registry: docker.io
     repository: bitnami/kubeapps-chartsvc
-    tag: 1.8.0-r0
+    tag: 1.8.1-r0
   service:
     port: 8080
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -389,7 +389,7 @@ func newCronJob(apprepo *apprepov1alpha1.AppRepository) *batchv1beta1.CronJob {
 			},
 		},
 		Spec: batchv1beta1.CronJobSpec{
-			Schedule: "* * * * *",
+			Schedule: "*/10 * * * *",
 			// Set to replace as short-circuit in k8s <1.12
 			// TODO re-evaluate ConcurrentPolicy when 1.12+ is mainstream (i.e 1.14)
 			// https://github.com/kubernetes/kubernetes/issues/54870

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -389,8 +389,7 @@ func newCronJob(apprepo *apprepov1alpha1.AppRepository) *batchv1beta1.CronJob {
 			},
 		},
 		Spec: batchv1beta1.CronJobSpec{
-			// TODO: make schedule customisable
-			Schedule: "0 * * * *",
+			Schedule: "* * * * *",
 			// Set to replace as short-circuit in k8s <1.12
 			// TODO re-evaluate ConcurrentPolicy when 1.12+ is mainstream (i.e 1.14)
 			// https://github.com/kubernetes/kubernetes/issues/54870

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -389,6 +389,7 @@ func newCronJob(apprepo *apprepov1alpha1.AppRepository) *batchv1beta1.CronJob {
 			},
 		},
 		Spec: batchv1beta1.CronJobSpec{
+			// TODO: make schedule customisable
 			Schedule: "*/10 * * * *",
 			// Set to replace as short-circuit in k8s <1.12
 			// TODO re-evaluate ConcurrentPolicy when 1.12+ is mainstream (i.e 1.14)

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -56,7 +56,7 @@ func Test_newCronJob(t *testing.T) {
 					},
 				},
 				Spec: batchv1beta1.CronJobSpec{
-					Schedule:          "0 * * * *",
+					Schedule:          "* * * * *",
 					ConcurrencyPolicy: "Replace",
 					JobTemplate: batchv1beta1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
@@ -136,7 +136,7 @@ func Test_newCronJob(t *testing.T) {
 					},
 				},
 				Spec: batchv1beta1.CronJobSpec{
-					Schedule:          "0 * * * *",
+					Schedule:          "* * * * *",
 					ConcurrencyPolicy: "Replace",
 					JobTemplate: batchv1beta1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -56,7 +56,7 @@ func Test_newCronJob(t *testing.T) {
 					},
 				},
 				Spec: batchv1beta1.CronJobSpec{
-					Schedule:          "* * * * *",
+					Schedule:          "*/10 * * * *",
 					ConcurrencyPolicy: "Replace",
 					JobTemplate: batchv1beta1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
@@ -136,7 +136,7 @@ func Test_newCronJob(t *testing.T) {
 					},
 				},
 				Spec: batchv1beta1.CronJobSpec{
-					Schedule:          "* * * * *",
+					Schedule:          "*/10 * * * *",
 					ConcurrencyPolicy: "Replace",
 					JobTemplate: batchv1beta1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{


### PR DESCRIPTION
Closes #1070
Closes #617

Updates the `chart-repo` image to the latest version. This allows us to execute as often as wanted. 

As an example, the `stable` repository takes ~35s to do a full sync while with the new changes it takes just about a second.