### PR TITLE
[Doc] Append a new line after the account secret

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -37,7 +37,7 @@ To retrieve the token,
 ### On Linux/macOS:
 
 ```bash
-kubectl get secret $(kubectl get serviceaccount kubeapps-operator -o jsonpath='{.secrets[].name}') -o jsonpath='{.data.token}' | base64 --decode
+kubectl get secret $(kubectl get serviceaccount kubeapps-operator -o jsonpath='{.secrets[].name}') -o jsonpath='{.data.token}' | base64 --decode && echo
 ```
 
 ### On Windows:


### PR DESCRIPTION
The command `kubectl get secret ... | base 64 --decode` in getting-started.md
will print the secret text together with the bash shell prompt in one single line.
Sometimes users might carelessly copy the secret text with the bash shell prompt.