### PR TITLE
Add dashboard/.devcontainer/ with setup for containerized developing and testing

### DIFF
--- a/dashboard/.devcontainer/Dockerfile
+++ b/dashboard/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+# Creates a node-8 debian image with telepresence installed and relevant tooling.
+FROM bitnami/node:8-debian-9
+
+RUN apt-get update -y \
+  # See Debian instructions at https://www.telepresence.io/reference/install#ubuntu-1604-or-later
+  && curl -sO https://packagecloud.io/install/repositories/datawireio/telepresence/script.deb.sh \
+  && env os=ubuntu dist=xenial bash script.deb.sh \
+  && apt-get install -y --no-install-recommends telepresence \
+  && rm script.deb.sh \
+  # Not sure why iptables and sudo are not pulled in as deps of telepresence, perhaps due to the above
+  # hack of pretending to be ubuntu (and telepresence not expecting to run in a docker container).
+  && apt-get install -y iptables sudo \
+  # kubectl
+  && curl -sSL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+  && chmod +x /usr/local/bin/kubectl \
+  # Typescript deps
+  && npm install -g tslint typescript \
+  # Cleanup
+  && apt-get autoremove -y \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PORT 3000
+
+COPY rootfs/ /
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["yarn", "start"]

--- a/dashboard/.devcontainer/README.md
+++ b/dashboard/.devcontainer/README.md
@@ -1,0 +1,40 @@
+## Running the dev server in a container
+To run the dev server in a container without telepresence or similar, run
+
+```
+docker-compose up
+```
+and then open a browser at http://localhost:3000/
+
+## Running the test runner
+You can run the frontend tests in a separate shell: 
+
+```
+docker-compose run dev-dashboard yarn test
+```
+
+## Running the dashboard via telepresence in-cluster
+To instead run the local dev server via a telepresence shell, you can:
+```
+docker-compose run dev-dashboard bash
+/telepresence-shell.sh
+```
+This will drop you into a telepresence shell, from which you can then `yarn start`. You can customise your KubeApps namespace and deployment with the env vars defined in the `docker-compose.yml`.
+
+NOTE: I was unable so far to get telepresence working 100% correctly. The shell starts, but with the warnings:
+
+```
+T: Mounting remote volumes failed, they will be unavailable in this session. If you are running on Windows 
+T: Subystem for Linux then see https://github.com/datawire/telepresence/issues/115, otherwise please report a 
+T: bug, attaching telepresence.log to the bug report: https://github.com/datawire/telepresence/issues/new
+
+T: Mount error was: fuse: mount failed: Permission denied
+```
+This is an issue running `fuse` / `sshfs` in a container, it seems. Need to check the HOWTO for Telepresence in containers mentioned in [175](https://github.com/telepresenceio/telepresence/issues/175)
+
+Similarly, `yarn start` exits 1 without much more info when run from the telepresence shell. Not sure if it is related.
+
+## Opening the container in VSCode
+To open the dev container running in VSCode, assuming you have the [Remote Development Extension pack](https://code.visualstudio.com/docs/remote/remote-overview) installed, you can use the `Remote-Containers: Open Folder in Container` command to open the `kubeapps/dashboard` folder and VSCode will automatically start the container and attach itself, as well as stop the container when you close the remote session.
+
+You can then use terminal windows within VSCode to run `yarn start` or `yarn test` or `/telepresence-shell.sh` as above.

--- a/dashboard/.devcontainer/devcontainer.json
+++ b/dashboard/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+// See https://aka.ms/vscode-remote/devcontainer.json for format details.
+{
+	"name": "KubeApps - Node.js 8, TypeScript and telepresence",
+	"dockerComposeFile": ["docker-compose.yml", "docker-compose.vscode.yml"],
+	"service": "dev-dashboard",
+	"extensions": [
+		"ms-vscode.vscode-typescript-tslint-plugin"
+	],
+	"workspaceFolder": "/app"
+}

--- a/dashboard/.devcontainer/docker-compose.vscode.yml
+++ b/dashboard/.devcontainer/docker-compose.vscode.yml
@@ -1,0 +1,10 @@
+version: '3.7'
+
+services:
+  dev-dashboard:
+    # Apparently VSCode overrides the default command if you specify a Dockerfile
+    # or docker image, but it doesn't appear to if you specify a docker-compose.
+    # So instead, ensure it's overridden when opening with VSCode so that the
+    # dev server can be started and stopped or alternativelry the telepresence console
+    # can be started.
+    command: /bin/sh -c "while sleep 1000; do :; done"

--- a/dashboard/.devcontainer/docker-compose.yml
+++ b/dashboard/.devcontainer/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+services:
+  dev-dashboard:
+    build:
+      context: .
+    volumes:
+      - type: bind
+        source: "${HOME}${USERPROFILE}/.kube"
+        target: "/root/.kube"
+      - type: bind
+        source: ".."
+        target: "/app"
+    # /dev/fuse is required by telepresence (sshfs)
+    devices:
+      - "/dev/fuse"
+    # NET_ADMiin and NET_BIND_SERVICE are required by telepresence (iptables), and /dev/fuse is
+    # required by telepresences file mounts (as is MKNOD)
+    cap_add:
+      # - NET_ADMIN
+      # - NET_BIND_SERVICE
+      # - MKNOD
+      - ALL
+    ports:
+      - "3000:3000"
+    environment:
+      - SKIP_YARN_DEP_CHECK
+      - KUBEAPPS_NAMESPACE=${KUBEAPPS_NAMESPACE:-kubeapps}
+      - KUBEAPPS_DASHBOARD_DEPLOYMENT=${KUBEAPPS_DASHBOARD_DEPLOYLMENT:-kubeapps-internal-dashboard}

--- a/dashboard/.devcontainer/rootfs/entrypoint.sh
+++ b/dashboard/.devcontainer/rootfs/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+export PATH="/app/node_modules/.bin:$PATH"
+
+echo "Node Version:  $(node -v)"
+
+if ! [ -v SKIP_YARN_DEP_CHECK ]; then
+  echo "Checking dependencies..."
+  if ! yarn check > /dev/null 2>&1; then
+    echo "Updating dependencies..."
+    yarn install
+  else
+    echo "All dependencies are up to date"
+  fi
+fi
+
+exec "$@"

--- a/dashboard/.devcontainer/rootfs/telepresence-shell.sh
+++ b/dashboard/.devcontainer/rootfs/telepresence-shell.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+telepresence \
+  --namespace "${KUBEAPPS_NAMESPACE:-kubeapps}" \
+  --method inject-tcp \
+  --swap-deployment "${KUBEAPPS_DASHBOARD_DEPLOYMENT:-kubeapps-internal-dashboard}" \
+  --expose 3000:8080 --run-shell

--- a/docs/developer/dashboard.md
+++ b/docs/developer/dashboard.md
@@ -81,3 +81,9 @@ yarn run test
 
 > **NOTE**: macOS users may need to install watchman (https://facebook.github.io/watchman/).
 
+Alternatively, execute the following command within the dashboard directory to start the test runner without watching for changes:
+
+```bash
+yarn run test --watchAll=false
+```
+


### PR DESCRIPTION
Not necessarily for merging, but just to ask some questions and get a bit of feedback as to whether I should bother continuing (to get telepresence via the docker container working).

Background: I took a look at setting up for developing on KubeApps (dashboard in particular) it seemed to require quite a lot of manual setup and installation of things I didn't really want to install locally. At the same time, I'd recently been playing with VSCode's new support for remote/container development, so wanted to provide something which works by default with the normal tools (`docker-compose`) but can also be extended simply to integrate with any editor such as VSCode. This is the result.

The contents should be pretty self-explanatory, and the included `dashboard/.devcontainer/README.md` hopefully summarises the functionality (I've not advertised this functionality in the main README for now).

I'm keen to know if people are using telepresence for doing local development? Not sure yet but I assume it's necessary/encouraged because as an easy way to give the dashboard all the backend data it needs to run locally? I guess this requires each dev having their own kubeapps deployment in a cluster (or perhaps it's light enough to run via minikube? Haven't tried). Are there other options that people use or have thought about?

To be clear: this isn't a priority for me or something I'll push for, I just wanted to record what I found in my first experience setting up the dev env, before it feels normal :)

Also: I notice that just normal git interactions requires nodejs? If telepresence isn't necessary for (my own personal) local development, I might simplify this removing it but adding git client support in the container to support the nodejs hooks. Or I'll just install nodejs :) (or use dockerdev).