### PR TITLE
Tiller proxy - use proxy settings from environment

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -312,6 +312,7 @@ func (c *Chart) InitNetClient(customCA *CustomCA) (HTTPClient, error) {
 		client: &http.Client{
 			Timeout: time.Second * defaultTimeoutSeconds,
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{
 					RootCAs: caCertPool,
 				},


### PR DESCRIPTION
The purpose of this PR is to fix #696 .
The net client built by func InitNetClient in  https://github.com/kubeapps/kubeapps/blob/master/pkg/chart/chart.go, used by tiller-proxy to download repositories index and charts now uses proxy settings defined by http_proxy/https_proxy/no_proxy env vars.