### PR TITLE
Set authenticating to false on authError (fixes #1092)

### DIFF
--- a/dashboard/src/reducers/auth.test.ts
+++ b/dashboard/src/reducers/auth.test.ts
@@ -61,6 +61,15 @@ describe("authReducer", () => {
       ).toEqual({ ...initialState, authenticationError: errMessage });
     });
 
+    it(`sets authenticating to false if type ${actionTypes.authenticationError}`, () => {
+      expect(
+        authReducer(
+          { ...initialState, authenticating: true },
+          { type: actionTypes.authenticationError as any, payload: errMessage },
+        ),
+      ).toEqual({ ...initialState, authenticationError: errMessage });
+    });
+
     it("sets authenticated and oidcAuthenticated", () => {
       expect(
         authReducer(

--- a/dashboard/src/reducers/auth.ts
+++ b/dashboard/src/reducers/auth.ts
@@ -33,6 +33,7 @@ const authReducer = (state: IAuthState = initialState, action: AuthAction): IAut
       return {
         ...state,
         authenticationError: action.payload,
+        authenticating: false,
       };
     case getType(actions.auth.setSessionExpired):
       return {


### PR DESCRIPTION
Fixes #1092. See the issue for the problem description.

The cause turned out to be that when the login form is submitted with an invalid token, the state is updated to `authenticating: true`, but is not reset when handling the `authenticationError`. This code hadn't changed in a while so I assume it's been that way for a long time, but what did change more recently was the `render()` function of the login form, which had a guard added in 407cae2b5 which:
```
   public render() {
+    if (this.props.authenticating) {
+      return <LoadingWrapper />;
+    }
```

The change makes sense, we just need to update to ensure we don't leave the state `authenticating`.