### PR TITLE
State not set to authenticated when validateToken fails with non-401 error

### DIFF
--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -32,6 +32,11 @@ describe("Auth", () => {
         response: { status: 500, data: "Server exception" },
         expectedError: new Error("500: Server exception"),
       },
+      {
+        name: "should succeed for a 403 response",
+        response: { status: 403, data: "Not Allowed" },
+        expectedError: null,
+      },
     ].forEach(testCase => {
       it(testCase.name, async () => {
         const mock = jest.fn(() => {
@@ -40,13 +45,12 @@ describe("Auth", () => {
         Axios.get = mock;
         // TODO(absoludity): tried using `expect(fn()).rejects.toThrow()` but it seems we need
         // to upgrade jest for `toThrow()` to work with async.
-        let err;
+        let err = null;
         try {
           await Auth.validateToken("foo");
         } catch (e) {
           err = e;
         } finally {
-          expect(err).not.toBe(undefined);
           expect(err).toEqual(testCase.expectedError);
         }
       });

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -50,7 +50,14 @@ export class Auth {
       if (res.status === 401) {
         throw new Error("invalid token");
       }
-      throw new Error(`${res.status}: ${res.data}`);
+      // A 403 authorization error only occurs if the token resulted in
+      // successful authentication. We don't make any assumptions over RBAC
+      // for the root "/" nonResourceURL or other required authz permissions
+      // until operations on those resources are attempted (though we may
+      // want to revisit this in the future).
+      if (res.status !== 403) {
+        throw new Error(`${res.status}: ${res.data}`);
+      }
     }
   }
 

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -1,6 +1,7 @@
 import Axios, { AxiosResponse } from "axios";
 const AuthTokenKey = "kubeapps_auth_token";
 const AuthTokenOIDCKey = "kubeapps_auth_token_oidc";
+import { APIBase } from "./Kube";
 
 export class Auth {
   public static getAuthToken() {
@@ -43,12 +44,13 @@ export class Auth {
   // Throws an error if the token is invalid
   public static async validateToken(token: string) {
     try {
-      await Axios.get("api/kube/", { headers: { Authorization: `Bearer ${token}` } });
+      await Axios.get(APIBase + "/", { headers: { Authorization: `Bearer ${token}` } });
     } catch (e) {
       const res = e.response as AxiosResponse;
       if (res.status === 401) {
         throw new Error("invalid token");
       }
+      throw new Error(`${res.status}: ${res.data}`);
     }
   }
 


### PR DESCRIPTION
This is just something I noticed while investigating #1009: if `validateToken()` receives an error response other than `401`, we silently ignore it and set the user as `authenticated: true`. This is most easily seen in the dev environment (below) but would be the case if the k8s api responded with a 502 or whatever, I assume?

Here's what you see locally in the dev env without the telepresence setup after entering any token (and `validateToken()` results in a 404):
![authenticatd-not-authenticated](https://user-images.githubusercontent.com/497518/62188601-3ec19200-b3b0-11e9-8940-fef484780e42.png)
Note that the redux state shows `authenticated: true`.

With this PR `validateToken()` always throws an error for an error response when validating the authz to the k8s api, so that (with the separate #1009), the user sees an error message:
![authenticated-error](https://user-images.githubusercontent.com/497518/62188777-c3acab80-b3b0-11e9-8cf3-9ae927210a19.png)
Note the redux state shows `authenticated: false`.

We could probably improve the default error displayed if we use custom `Error` types (though I haven't yet checked the error handling outside of this call-site).