### PR TITLE
Use Kube.APIBase consistently

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -18,6 +18,7 @@ src/**/*.css
 .env.test.local
 .env.production.local
 .vscode
+.devcontainer
 .idea
 
 npm-debug.log*

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -1,4 +1,5 @@
 import { axiosWithAuth } from "./AxiosInstance";
+import { APIBase } from "./Kube";
 import { IAppRepository, IAppRepositoryList } from "./types";
 
 export class AppRepository {
@@ -39,7 +40,7 @@ export class AppRepository {
     return data;
   }
 
-  private static APIBase: string = "api/kube";
+  private static APIBase: string = APIBase;
   private static APIEndpoint: string = `${AppRepository.APIBase}/apis/kubeapps.com/v1alpha1`;
   private static getResourceLink(namespace?: string): string {
     return `${AppRepository.APIEndpoint}/${

--- a/dashboard/src/shared/ClusterServiceClass.ts
+++ b/dashboard/src/shared/ClusterServiceClass.ts
@@ -1,4 +1,5 @@
 import { axiosWithAuth } from "./AxiosInstance";
+import { APIBase } from "./Kube";
 import { ServiceCatalog } from "./ServiceCatalog";
 
 export interface IClusterServiceClass {
@@ -44,7 +45,7 @@ export class ClusterServiceClass {
   }
 
   private static getLink(namespace?: string, name?: string): string {
-    return `api/kube/apis/servicecatalog.k8s.io/v1beta1${
+    return `${APIBase}/apis/servicecatalog.k8s.io/v1beta1${
       namespace ? `/namespaces/${namespace}` : ""
     }/clusterserviceclasses${name ? `/${name}` : ""}`;
   }

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -1,4 +1,5 @@
 import { axiosWithAuth } from "./AxiosInstance";
+import { APIBase } from "./Kube";
 
 import { IK8sList, IResource } from "./types";
 
@@ -8,7 +9,7 @@ export default class Namespace {
     return data;
   }
 
-  private static APIBase: string = "api/kube";
+  private static APIBase: string = APIBase;
   private static APIEndpoint: string = `${Namespace.APIBase}/api/v1/namespaces`;
 }
 

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -1,4 +1,5 @@
 import { axiosWithAuth } from "./AxiosInstance";
+import { APIBase } from "./Kube";
 import { definedNamespaces } from "./Namespace";
 import { IOwnerReference, ISecret } from "./types";
 
@@ -41,6 +42,6 @@ export default class Secret {
   }
 
   private static getLink(namespace: string, name?: string): string {
-    return `api/kube/api/v1/namespaces/${namespace}/secrets${name ? `/${name}` : ""}`;
+    return `${APIBase}/api/v1/namespaces/${namespace}/secrets${name ? `/${name}` : ""}`;
   }
 }

--- a/dashboard/src/shared/ServiceBinding.ts
+++ b/dashboard/src/shared/ServiceBinding.ts
@@ -1,4 +1,5 @@
 import { axiosWithAuth } from "./AxiosInstance";
+import { APIBase } from "./Kube";
 import { definedNamespaces } from "./Namespace";
 import { ICondition, ServiceCatalog } from "./ServiceCatalog";
 
@@ -101,12 +102,12 @@ export class ServiceBinding {
   }
 
   private static getLink(namespace?: string, name?: string): string {
-    return `api/kube/apis/servicecatalog.k8s.io/v1beta1${
+    return `${APIBase}/apis/servicecatalog.k8s.io/v1beta1${
       namespace ? `/namespaces/${namespace}` : ""
     }/servicebindings${name ? `/${name}` : ""}`;
   }
 
   private static secretEndpoint(namespace: string = definedNamespaces.default): string {
-    return `api/kube/api/v1/namespaces/${namespace}/secrets/`;
+    return `${APIBase}/api/v1/namespaces/${namespace}/secrets/`;
   }
 }

--- a/dashboard/src/shared/ServiceCatalog.ts
+++ b/dashboard/src/shared/ServiceCatalog.ts
@@ -1,8 +1,8 @@
 import { JSONSchema6 } from "json-schema";
 import * as urls from "../shared/url";
 import { axiosWithAuth } from "./AxiosInstance";
-import { APIBase } from "./Kube";
 import { IClusterServiceClass } from "./ClusterServiceClass";
+import { APIBase } from "./Kube";
 import { IServiceInstance } from "./ServiceInstance";
 import { IK8sList, IStatus } from "./types";
 

--- a/dashboard/src/shared/ServiceCatalog.ts
+++ b/dashboard/src/shared/ServiceCatalog.ts
@@ -1,6 +1,7 @@
 import { JSONSchema6 } from "json-schema";
 import * as urls from "../shared/url";
 import { axiosWithAuth } from "./AxiosInstance";
+import { APIBase } from "./Kube";
 import { IClusterServiceClass } from "./ClusterServiceClass";
 import { IServiceInstance } from "./ServiceInstance";
 import { IK8sList, IStatus } from "./types";
@@ -19,7 +20,7 @@ export class ServiceCatalog {
   }
 
   public static async deprovisionInstance(instance: IServiceInstance) {
-    const { data } = await axiosWithAuth.delete("api/kube" + instance.metadata.selfLink);
+    const { data } = await axiosWithAuth.delete(`${APIBase}${instance.metadata.selfLink}`);
     return data;
   }
 
@@ -56,7 +57,7 @@ export class ServiceCatalog {
     return json.items;
   }
 
-  private static endpoint: string = "api/kube/apis/servicecatalog.k8s.io/v1beta1";
+  private static endpoint: string = `${APIBase}/apis/servicecatalog.k8s.io/v1beta1`;
 }
 export interface IK8sApiListResponse<T> {
   kind: string;

--- a/dashboard/src/shared/ServiceInstance.ts
+++ b/dashboard/src/shared/ServiceInstance.ts
@@ -1,4 +1,5 @@
 import { axiosWithAuth } from "./AxiosInstance";
+import { APIBase } from "./Kube";
 import { ICondition, ServiceCatalog } from "./ServiceCatalog";
 import { IStatus } from "./types";
 
@@ -65,7 +66,7 @@ export class ServiceInstance {
   }
 
   private static getLink(namespace?: string, name?: string): string {
-    return `api/kube/apis/servicecatalog.k8s.io/v1beta1${
+    return `${APIBase}/apis/servicecatalog.k8s.io/v1beta1${
       namespace ? `/namespaces/${namespace}` : ""
     }/serviceinstances${name ? `/${name}` : ""}`;
   }

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -1,3 +1,4 @@
+import { APIBase } from "./Kube";
 import { definedNamespaces } from "./Namespace";
 import { IServiceBroker } from "./ServiceCatalog";
 import { IChartVersion } from "./types";
@@ -13,7 +14,7 @@ export const app = {
 
 export const api = {
   apprepostories: {
-    base: "api/kube/apis/kubeapps.com/v1alpha1",
+    base: `${APIBase}/apis/kubeapps.com/v1alpha1`,
     create: (namespace = definedNamespaces.default) =>
       `${api.apprepostories.base}/namespaces/${namespace}/apprepositories`,
   },
@@ -32,13 +33,13 @@ export const api = {
   },
 
   serviceinstances: {
-    base: "api/kube/apis/servicecatalog.k8s.io/v1beta1",
+    base: `${APIBase}/apis/servicecatalog.k8s.io/v1beta1`,
     create: (namespace = definedNamespaces.default) =>
       `${api.serviceinstances.base}/namespaces/${namespace}/serviceinstances`,
   },
 
   clusterservicebrokers: {
-    base: "api/kube/apis/servicecatalog.k8s.io/v1beta1",
+    base: `${APIBase}/apis/servicecatalog.k8s.io/v1beta1`,
     sync: (broker: IServiceBroker) =>
       `${api.clusterservicebrokers.base}/clusterservicebrokers/${broker.metadata.name}`,
   },


### PR DESCRIPTION
The `shared/Kube` module exports the `APIBase` constant, but this was not being used in quite a bit of the application code.

The reason I bothered with this branch is a little convoluted: I want to be able to run the dashboard dev environment in a container, which works fine except I can't yet use `telepresence` within a container (due to fusefs issues).

That said, I don't need telepresence (or my own kubeapps running in k8s) to simply point the dashboard at a kubernetes host during development, I just need the dev server to proxy those requests.

All I should need is to add a [`src/setupProxy.[js|ts]`](https://facebook.github.io/create-react-app/docs/proxying-api-requests-in-development#configuring-the-proxy-manually). This would be perfect as it would not affect those using the telepresence setup (which proxies by the frontend nginx), it would only be used in dev by design, and it would allow me to proxy different `/api/*` requests as needed (supporting other proxied services like `tiller-proxy`). Alas our version of create-react-app (specifically react-scripts-ts) didn't support `setupProxy.js` at the time (you can see this in `./node_modules/react-scripts-ts/config/paths.js` where `setupTests.ts` is checked and exported but `setupProxy.[js/ts]` is not). These days `react-scripts-ts` is not used as the `--typescript` is an option to `create-react-app` itself.

But rather than shave the yak of updating/upgrading (though perhaps there's an easy way @Angelmmiguel knows?), I've found a work-around I can use right now, which is to just temporarily set the [`proxy` option in `package.json`](https://facebook.github.io/create-react-app/docs/proxying-api-requests-in-development) which is supported in `react-scripts-ts/scripts/start`, sending any unrecognised URLs through to the k8s api server I'm using. This method doesn't allow any chopping of prefixes, so I've set `APIBase = ""` temporarily. This works perfectly for the k8s requests (I won't be able to do this when I need two services proxied), is simple for me to do in the mean-time, and only requires this trivial fix of using `Kube.APIBase` consistently which probably should be done anyway :) (EDIT: it's not so useful in the end as dashboard requires both k8s api and tiller-proxy concurrently for most views)