### PR TITLE
Fix overflow for SecretType. Fixes #1109

### DIFF
--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/SecretItem/SecretContent.scss
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/SecretItem/SecretContent.scss
@@ -9,8 +9,12 @@
   margin: 0;
   min-width: 0;
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: anywhere;
   padding-left: 0.3em;
   padding-right: 0.3em;
   color: inherit;
+}
+
+.SecretType {
+  overflow-wrap: anywhere;
 }

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/SecretItem/SecretContent.scss
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/SecretItem/SecretContent.scss
@@ -9,12 +9,12 @@
   margin: 0;
   min-width: 0;
   white-space: pre-wrap;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   padding-left: 0.3em;
   padding-right: 0.3em;
   color: inherit;
 }
 
 .SecretType {
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
 }

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/SecretItem/SecretItem.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/SecretItem/SecretItem.tsx
@@ -23,7 +23,7 @@ const SecretItem: React.SFC<ISecretItemRow> = props => {
   return (
     <React.Fragment>
       <td className="col-3">{resource.metadata.name}</td>
-      <td className="col-2">{resource.type}</td>
+      <td className="col-2 SecretType">{resource.type}</td>
       {isEmpty(resource.data) ? (
         <td className="col-7">
           <span>This Secret is empty</span>

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/SecretItem/__snapshots__/SecretItem.test.tsx.snap
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/SecretItem/__snapshots__/SecretItem.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`renders a SecretItemDatum component for each Secret key 1`] = `
     foo
   </td>
   <td
-    className="col-2"
+    className="col-2 SecretType"
   >
     Opaque
   </td>
@@ -37,7 +37,7 @@ exports[`when there is an empty Secret displays a message 1`] = `
     foo
   </td>
   <td
-    className="col-2"
+    className="col-2 SecretType"
   >
     Opaque
   </td>


### PR DESCRIPTION
I've included screenshots and reasoning for the choice in a [comment on the issue](https://github.com/kubeapps/kubeapps/issues/1109#issuecomment-519317900).

While there, I updated an existing use of the nonstandard, unprefixed MS extension `word-wrap: break-word` to `overflow-wrap: break-word`, as I saw that [`word-wrap` is an alias for the standard `overflow-wrap` property in all browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap).