### PR TITLE
Use yaml.safeLoad for pod template.

### DIFF
--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -169,7 +169,7 @@ export const installRepo = (
       }
       let syncJobPodTemplateObj = {};
       if (syncJobPodTemplate.length) {
-        syncJobPodTemplateObj = yaml.load(syncJobPodTemplate);
+        syncJobPodTemplateObj = yaml.safeLoad(syncJobPodTemplate);
       }
       dispatch(addRepo());
       const apprepo = await AppRepository.create(


### PR DESCRIPTION
Related to #1085, `yaml.safeLoad` should be used rather than `yaml.load`. The included new test will fail (as it will load the unsafe yaml) `yaml.load`.