### PR TITLE
[tiller-proxy] Add endpoint for testing a release

### DIFF
--- a/cmd/tiller-proxy/README.md
+++ b/cmd/tiller-proxy/README.md
@@ -33,9 +33,11 @@ This proxy provides 6 different routes:
  - `GET` `/v1/releases`: List all the releases of the Tiller
  - `GET` `/v1/namespaces/{namespace}/releases`: List all the releases within a namespace
  - `POST` `/v1/namespaces/{namespace}/releases`: Create a new release
+ - `GET` `/v1/namespaces/{namespace}/releases/{release}/test`: Runs tests for the release
  - `GET` `/v1/namespaces/{namespace}/releases/{release}`: Get release info
  - `PUT` `/v1/namespaces/{namespace}/releases/{release}`: Update release info
  - `DELETE` `/v1/namespaces/{namespace}/releases/{release}`: Delete a release
+
 
 # Enabling authorization
 

--- a/cmd/tiller-proxy/README.md
+++ b/cmd/tiller-proxy/README.md
@@ -33,7 +33,6 @@ This proxy provides 6 different routes:
  - `GET` `/v1/releases`: List all the releases of the Tiller
  - `GET` `/v1/namespaces/{namespace}/releases`: List all the releases within a namespace
  - `POST` `/v1/namespaces/{namespace}/releases`: Create a new release
- - `GET` `/v1/namespaces/{namespace}/releases/{release}/test`: Runs tests for the release
  - `GET` `/v1/namespaces/{namespace}/releases/{release}`: Get release info
  - `PUT` `/v1/namespaces/{namespace}/releases/{release}`: Update release info
  - `DELETE` `/v1/namespaces/{namespace}/releases/{release}`: Delete a release

--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -223,6 +223,16 @@ func (h *TillerProxy) ListReleases(w http.ResponseWriter, req *http.Request, par
 	response.NewDataResponse(apps).Write(w)
 }
 
+// TestRelease in the namespace given as Param
+func (h *TillerProxy) TestRelease(w http.ResponseWriter, req *http.Request, params Params) {
+	testResult, err := h.ProxyClient.TestRelease(params["releaseName"], params["namespace"])
+	if err != nil {
+		response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
+		return
+	}
+	response.NewDataResponse(testResult).Write(w)
+}
+
 // GetRelease returns the release info
 func (h *TillerProxy) GetRelease(w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
 	rel, err := h.ProxyClient.GetRelease(params["releaseName"], params["namespace"])

--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -121,6 +121,8 @@ func (h *TillerProxy) OperateRelease(w http.ResponseWriter, req *http.Request, p
 		h.UpgradeRelease(w, req, params)
 	case "rollback":
 		h.RollbackRelease(w, req, params)
+	case "test":
+		h.TestRelease(w, req, params)
 	default:
 		// By default, for maintaining compatibility, we call upgrade
 		h.UpgradeRelease(w, req, params)
@@ -224,10 +226,26 @@ func (h *TillerProxy) ListReleases(w http.ResponseWriter, req *http.Request, par
 }
 
 // TestRelease in the namespace given as Param
-func (h *TillerProxy) TestRelease(w http.ResponseWriter, req *http.Request, params Params) {
+func (h *TillerProxy) TestRelease(w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
+
+	if !h.DisableAuth {
+		userAuth := req.Context().Value(auth.UserKey).(auth.Checker)
+		// helm tests only create pods so we only need to check that
+		manifest := "apiVersion: v1\nkind: Pod"
+		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "create", manifest)
+		if err != nil {
+			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+			return
+		}
+		if len(forbiddenActions) > 0 {
+			returnForbiddenActions(forbiddenActions, w)
+			return
+		}
+	}
+
 	testResult, err := h.ProxyClient.TestRelease(params["releaseName"], params["namespace"])
 	if err != nil {
-		response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return
 	}
 	response.NewDataResponse(testResult).Write(w)

--- a/cmd/tiller-proxy/internal/handler/handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/handler_test.go
@@ -407,6 +407,38 @@ func TestActions(t *testing.T) {
 			RemainingReleases: []release.Release{},
 			ResponseBody:      "",
 		},
+		{
+			// Scenario params
+			Description:      "Test a release successfully",
+			ExistingReleases: []release.Release{release.Release{Name: "kubeapps", Namespace: "kubeapps-ns"}},
+			DisableAuth:      true,
+			ForbiddenActions: []auth.Action{},
+			// Request params
+			RequestBody:  "",
+			RequestQuery: "",
+			Action:       "test",
+			Params:       map[string]string{"namespace": "kubeapps-ns", "releaseName": "kubeapps"},
+			// Expected result
+			StatusCode:        200,
+			RemainingReleases: []release.Release{release.Release{Name: "kubeapps", Namespace: "kubeapps-ns"}},
+			ResponseBody:      `{"data":{"UNKNOWN":["No Tests Found"]}}`,
+		},
+		{
+			// Scenario params
+			Description:      "Fail to test a release",
+			ExistingReleases: []release.Release{release.Release{Name: "kubeapps", Namespace: "kubeapps-ns"}},
+			DisableAuth:      true,
+			ForbiddenActions: []auth.Action{},
+			// Request params
+			RequestBody:  "",
+			RequestQuery: "",
+			Action:       "test",
+			Params:       map[string]string{"namespace": "default", "releaseName": "kubeapps"},
+			// Expected result
+			StatusCode:        404,
+			RemainingReleases: []release.Release{release.Release{Name: "kubeapps", Namespace: "kubeapps-ns"}},
+			ResponseBody:      `{"code":404,"message":"Unable to locate release: Release kubeapps not found"}`,
+		},
 	}
 	for _, test := range tests {
 		// Prepare environment

--- a/cmd/tiller-proxy/internal/handler/handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/handler_test.go
@@ -445,6 +445,8 @@ func TestActions(t *testing.T) {
 			handler.ListReleases(response, req, test.Params)
 		case "listall":
 			handler.ListAllReleases(response, req)
+		case "test":
+			handler.TestRelease(response, req, test.Params)
 		default:
 			t.Errorf("Unexpected action %s", test.Action)
 		}

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -207,6 +207,11 @@ func main() {
 		negroni.Wrap(http.StripPrefix(chartsvcPrefix, chartsvcProxy)),
 	))
 
+	apiv1.Methods("GET").Path("/namespaces/{namespace}/releases/{releaseName}/test").Handler(negroni.New(
+		authGate,
+		negroni.Wrap(handler.WithParams(h.TestRelease)),
+	))
+
 	n := negroni.Classic()
 	n.UseHandler(r)
 

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -207,11 +207,6 @@ func main() {
 		negroni.Wrap(http.StripPrefix(chartsvcPrefix, chartsvcProxy)),
 	))
 
-	apiv1.Methods("GET").Path("/namespaces/{namespace}/releases/{releaseName}/test").Handler(negroni.New(
-		authGate,
-		negroni.Wrap(handler.WithParams(h.TestRelease)),
-	))
-
 	n := negroni.Classic()
 	n.UseHandler(r)
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40
 	github.com/kubeapps/common v0.0.0-20190508164739-10b110436c1a
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
 	github.com/unrolled/render v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,7 +52,6 @@ github.com/arschles/assert v1.0.0/go.mod h1:m/u69zW43x0h8dTHcv3JJZljINyEYgBuf5fY
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -201,7 +200,6 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -216,7 +214,6 @@ github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200j
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
@@ -236,7 +233,6 @@ github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
-github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -259,7 +255,6 @@ github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v0.0.0-20190222133341-cfaf5686ec79/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.3.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
-github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
@@ -329,7 +324,6 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180320133207-05fbef0ca5da/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -340,12 +334,10 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
-github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -373,7 +365,6 @@ github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.2.1 h1:JnMpQc6ppsNgw9QPAGF6Dod479itz7lvlsMzzNayLOI=
 github.com/prometheus/client_golang v1.2.1/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNkDYzz3xecMgSW/F+U=
-github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
@@ -383,7 +374,6 @@ github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
-github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d h1:GoAlyOgbOEIFdaDqxJVlbOQ1DtGmZWs/Qau0hIlk+WQ=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190129233650-316cf8ccfec5/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -406,7 +396,6 @@ github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -415,7 +404,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
@@ -489,7 +477,6 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -513,7 +500,6 @@ golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934 h1:u/E0NqCIWRDAo9WCFo6Ko49njPFDLSd3z+X1HgWDMpE=
 golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -552,7 +538,6 @@ google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6 h1:UXl+Zk3jqqcbEVV7ace5lrt4YdA4tXiz3f/KbmD29Vo=
 google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
-google.golang.org/grpc v1.16.0 h1:dz5IJGuC2BB7qXR5AyHNwAUBhZscK2xVez7mznh72sY=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -563,7 +548,6 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -578,7 +562,6 @@ gopkg.in/square/go-jose.v1 v1.1.2/go.mod h1:QpYS+a4WhS+DTlyQIi6Ka7MS3SuR9a055rgX
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=

--- a/pkg/proxy/fake/proxy.go
+++ b/pkg/proxy/fake/proxy.go
@@ -97,7 +97,7 @@ func (f *FakeProxy) RollbackRelease(name, namespace string, revision int32) (*re
 
 func (f *FakeProxy) GetRelease(name, namespace string) (*release.Release, error) {
 	for _, r := range f.Releases {
-		if r.Name == name {
+		if r.Name == name && r.Namespace == namespace {
 			return &r, nil
 		}
 	}

--- a/pkg/proxy/fake/proxy.go
+++ b/pkg/proxy/fake/proxy.go
@@ -123,3 +123,17 @@ func (f *FakeProxy) DeleteRelease(name, namespace string, purge bool) error {
 	}
 	return fmt.Errorf("Release %s not found", name)
 }
+
+func (f *FakeProxy) TestRelease(name, namespace string) (*proxy.TestStatus, error) {
+
+	_, err := f.GetRelease(name, namespace)
+
+	if err != nil {
+		return nil, fmt.Errorf("Unable to locate release: %v", err)
+	}
+
+	m := make(map[string][]string)
+	m["UNKNOWN"] = []string{"No Tests Found"}
+
+	return &m, nil
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -343,6 +343,20 @@ func (p *Proxy) DeleteRelease(name, namespace string, purge bool) error {
 	return p.deleteRelease(name, namespace, purge)
 }
 
+// TestRelease runs tests for a release in a namespace
+func (p *Proxy) TestRelease(name, namespace string) (string, error) {
+	release, err := p.GetRelease(name, namespace)
+	if err != nil {
+		return "", fmt.Errorf("Unable to locate release: %v", err)
+	}
+	testResult, _ := p.helmClient.RunReleaseTest(release.GetName())
+	log.Println("Running Tests for ", name, " in namespace ", namespace)
+
+	val := <-testResult
+
+	return val.GetMsg(), nil
+}
+
 // extracted from https://github.com/helm/helm/blob/master/cmd/helm/helm.go#L227
 // prettyError unwraps or rewrites certain errors to make them more user-friendly.
 func prettyError(err error) error {
@@ -365,6 +379,7 @@ type TillerClient interface {
 	ResolveManifestFromRelease(releaseName string, revision int32) (string, error)
 	ListReleases(namespace string, releaseListLimit int, status string) ([]AppOverview, error)
 	CreateRelease(name, namespace, values string, ch *chart.Chart) (*release.Release, error)
+	TestRelease(relName, namespace string) (string, error)
 	UpdateRelease(name, namespace string, values string, ch *chart.Chart) (*release.Release, error)
 	RollbackRelease(name, namespace string, revision int32) (*release.Release, error)
 	GetRelease(name, namespace string) (*release.Release, error)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -363,6 +363,7 @@ func (p *Proxy) TestRelease(name, namespace string) (string, error) {
 
 		// Sieving response messages from Tiller into three categories
 		message := response.GetMsg()
+
 		parts := strings.Split(message, ": ")
 		switch parts[0] {
 		case "RUNNING":
@@ -371,10 +372,12 @@ func (p *Proxy) TestRelease(name, namespace string) (string, error) {
 			testStatus.Passed = append(testStatus.Passed, parts[1])
 		case "FAILED":
 			testStatus.Failed = append(testStatus.Failed, parts[1])
+		case "ERROR":
+			testStatus.Error = append(testStatus.Error, parts[1])
 		}
 	}
 	str, _ := json.Marshal(testStatus)
-	return string(str), nil
+	return string(str[:]), nil
 }
 
 // extracted from https://github.com/helm/helm/blob/master/cmd/helm/helm.go#L227
@@ -394,9 +397,17 @@ func prettyError(err error) error {
 
 // TestStatus represent information about tests for a release
 type TestStatus struct {
-	Run    []string `json:"run,omitempty"`
+	// List of run tests
+	Run []string `json:"run,omitempty"`
+
+	// List of tests that passed
 	Passed []string `json:"passed,omitempty"`
+
+	// List of tests that failed
 	Failed []string `json:"failed,omitempty"`
+
+	// List of tests that encountered an error
+	Error []string `json:"error,omitempty"`
 }
 
 // TillerClient for exposed funcs

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -353,15 +353,15 @@ func (p *Proxy) TestRelease(name, namespace string) (*TestStatus, error) {
 	}
 
 	// Request Tiller to run tests for the specified release
-	testResult, _ := p.helmClient.RunReleaseTest(release.GetName(), helm.ReleaseTestCleanup(true))
+	// error channel (second return value) is ignored for now since all relevant "errors"
+	// are channeled into "testReleaseResponseChannel"
+	testReleaseResponseChannel, _ := p.helmClient.RunReleaseTest(release.GetName(), helm.ReleaseTestCleanup(true))
 	log.Println("Running Tests for ", name, " in namespace ", namespace)
 
-	// Parsing messages from Tiller into Json, see TestStatus
+	// Parsing messages from Tiller, see TestStatus
 	testStatus := TestStatus{}
-	for response := range testResult {
-
+	for response := range testReleaseResponseChannel {
 		// Sieving response messages from Tiller into categories depdening on their status
-
 		status := response.GetStatus().String()
 		message := response.GetMsg()
 
@@ -387,8 +387,8 @@ func prettyError(err error) error {
 }
 
 // TestStatus is an alias for a mapping between a string to a list of strings
-// key is STATUS returned by Tiller
-// value is MESSAGE of status key
+// key is "status" returned by Tiller
+// value is "message" of status key
 type TestStatus = map[string][]string
 
 // TillerClient for exposed funcs

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -575,17 +575,17 @@ func TestTestRelease(t *testing.T) {
 		namespace string
 	}
 
-	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress", chart.Metadata{
-		Version: "1.0.0",
-		Icon:    "icon.png",
-		Name:    "wordpress",
-	}}
-
 	// create and populate scenarios to test against
 	scenarios := make(map[ScenarioParameter]ScenarioResult)
 	scenarios[ScenarioParameter{"foo", "my_ns"}] = ScenarioResult{&map[string][]string{}, nil}
 	scenarios[ScenarioParameter{"foo", "other_ns"}] = ScenarioResult{nil, errors.New("Unable to locate release: Release \"foo\" not found in namespace \"other_ns\"")}
 	scenarios[ScenarioParameter{"bar", "my_ns"}] = ScenarioResult{nil, errors.New("Unable to locate release: release: \"bar\" not found")}
+
+	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress", chart.Metadata{
+		Version: "1.0.0",
+		Icon:    "icon.png",
+		Name:    "wordpress",
+	}}
 
 	// instantiating a fake proxy
 	proxy := newFakeProxy([]AppOverview{app})

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package proxy
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -557,6 +558,53 @@ func TestHelmReleaseDeleted(t *testing.T) {
 	}
 	if len(rels.Releases) != 0 {
 		t.Errorf("Unexpected amount of releases %d, it should be empty", len(rels.Releases))
+	}
+}
+
+func TestTestRelease(t *testing.T) {
+
+	// Represents expected result from a test scenario
+	type ScenarioResult struct {
+		testStatus *TestStatus
+		err        error
+	}
+
+	// Represents parameters of a scenario
+	type ScenarioParameter struct {
+		appname   string
+		namespace string
+	}
+
+	app := AppOverview{"foo", "1.0.0", "my_ns", "icon.png", "DEPLOYED", "wordpress", chart.Metadata{
+		Version: "1.0.0",
+		Icon:    "icon.png",
+		Name:    "wordpress",
+	}}
+
+	// create and populate scenarios to test against
+	scenarios := make(map[ScenarioParameter]ScenarioResult)
+	scenarios[ScenarioParameter{"foo", "my_ns"}] = ScenarioResult{&map[string][]string{}, nil}
+	scenarios[ScenarioParameter{"foo", "other_ns"}] = ScenarioResult{nil, errors.New("Unable to locate release: Release \"foo\" not found in namespace \"other_ns\"")}
+	scenarios[ScenarioParameter{"bar", "my_ns"}] = ScenarioResult{nil, errors.New("Unable to locate release: release: \"bar\" not found")}
+
+	// instantiating a fake proxy
+	proxy := newFakeProxy([]AppOverview{app})
+
+	// iterate over scenarios, and ensure expected return values match our expectation
+	for scenarioParameter, scenarioResult := range scenarios {
+		testStatus, err := proxy.TestRelease(scenarioParameter.appname, scenarioParameter.namespace)
+
+		if !reflect.DeepEqual(err, scenarioResult.err) {
+			t.Error("Error with scenario", scenarioParameter)
+			t.Error("want:", scenarioResult.err)
+			t.Error("have:", err)
+		}
+
+		if !reflect.DeepEqual(testStatus, scenarioResult.testStatus) {
+			t.Error("Error with scenario", scenarioParameter)
+			t.Error("want:", scenarioResult.testStatus)
+			t.Error("have:", testStatus)
+		}
 	}
 }
 


### PR DESCRIPTION
Change proposed in #1106 

New endpoint added to tiller-proxy
`GET /namespaces/{namespace}/releases/{releaseName}/test`


### Expected Behaviour:
+ Release exists, tests are defined and passed 
```json
{
  "data": {
    "RUNNING": [
      "RUNNING: kubeapps-chartsvc-test",
      "RUNNING: kubeapps-dashboard-test",
      "RUNNING: kubeapps-tiller-proxy-test"
    ],
    "SUCCESS": [
      "PASSED: kubeapps-chartsvc-test",
      "PASSED: kubeapps-dashboard-test",
      "PASSED: kubeapps-tiller-proxy-test"
    ]
  }
}
```
+ Release doesn't exist
```json
{
  "code": 404,
  "message": "Unable to locate release: release: \"kubeapps2\" not found"
}

```
+ Release exists, no tests are defined
```json
{
  "data": {
    "UNKNOWN": [
      "No Tests Found"
    ]
  }
}
```
+ Release exists, tests fail to complete
```json
{
  "data": {
    "FAILURE": [
      "ERROR: pods \"kubeapps-chartsvc-test\" already exists",
      "ERROR: pods \"kubeapps-dashboard-test\" already exists",
      "ERROR: pods \"kubeapps-tiller-proxy-test\" already exists"
    ],
    "RUNNING": [
      "RUNNING: kubeapps-chartsvc-test",
      "RUNNING: kubeapps-dashboard-test",
      "RUNNING: kubeapps-tiller-proxy-test"
    ]
  }
}
```
### Sensible Defaults
The tests are cleaned up after running, to make it easier to re-run them.
To reap the full power of `helm test` command, I propose adding ability to send options in the request body as a future improvement.

### Tests
Tests are added for the components changed, mainly
+ proxy_test.go
+ handler_test.go

### No Frontend
This PR only adds functionality to the tiller-proxy component, to use the new endpoint in the frontend, a GUI component is needed to control and visualize the results.