### PR TITLE
Add tests for InitNetClient. Refactor to pass chart details

### DIFF
--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -127,7 +127,7 @@ func getChart(req *http.Request, cu chartUtils.Resolver) (*chartUtils.Details, *
 	if err != nil {
 		return nil, nil, err
 	}
-	netClient, err := cu.InitNetClient(chartDetails.Auth.CustomCA)
+	netClient, err := cu.InitNetClient(chartDetails)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -17,6 +17,7 @@ package chart
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/arschles/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/repo"
@@ -242,6 +244,149 @@ func TestParseDetails(t *testing.T) {
 	}
 }
 
+// fakeLoadChart implements LoadChart interface.
+func fakeLoadChart(in io.Reader) (*chart.Chart, error) {
+	return &chart.Chart{}, nil
+}
+
+const pem_cert = `
+-----BEGIN CERTIFICATE-----
+MIIDETCCAfkCFEY03BjOJGqOuIMoBewOEDORMewfMA0GCSqGSIb3DQEBCwUAMEUx
+CzAJBgNVBAYTAkRFMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRl
+cm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTkwODE5MDQxNzU5WhcNMTkxMDA4MDQx
+NzU5WjBFMQswCQYDVQQGEwJERTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UE
+CgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEAzA+X6HcScuHxqxCc5gs68weW8i72qMjvcWvBG064SvpTuNDK
+ECEGvug6f8SFJjpA+hWjlqR5+UPMdfjMKPUEg1CI8JZm6lyNiB54iY50qvhv+qQg
+1STdAWNTzvqUXUMGIImzeXFnErxlq8WwwLGwPNT4eFxF8V8fzIhR8sqQKFLOqvpS
+7sCQwF5QOhziGfS+zParDLFsBoXQpWyDKqxb/yBSPwqijKkuW7kF4jGfPHD0Re3+
+rspXiq8+jWSwSJIPSIbya8DQqrMwFeLCAxABidPnlrwS0UUion557ylaBK6Cv0UB
+MojA4SMfjm5xRdzrOcoE8EcabxqoQD5rCIBgFQIDAQABMA0GCSqGSIb3DQEBCwUA
+A4IBAQCped08LTojPejkPqmp1edZa9rWWrCMviY5cvqb6t3P3erse+jVcBi9NOYz
+8ewtDbR0JWYvSW6p3+/nwyDG4oVfG5TiooAZHYHmgg4x9+5h90xsnmgLhIsyopPc
+Rltj86tRCl1YiuRpkWrOfRBGdYfkGEG4ihJzLHWRMCd1SmMwnmLliBctD7IeqBKw
+UKt8wcroO8/sj/Xd1/LCtNZ79/FdQFa4l3HnzhOJOrlQyh4gyK05EKdg6vv3un17
+l6NEPfiXd7dZvsWi9uY/PGBhu9EY/bdvuIOWDNNK262azk1A56HINpMrYBUcfti1
+YrvYQHgOtHsqCB/hFHWfZp1lg2Sx
+-----END CERTIFICATE-----
+`
+
+func TestInitNetClient(t *testing.T) {
+	// TODO(mnelson): currently the InitNetClient swallows any error during
+	// call to SystemCertPool, silently creating an empty cert pool. If that
+	// path is taken on the test system, this test will fail. Find out why.
+	systemCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	testCases := []struct {
+		name             string
+		details          *Details
+		customCAData     string
+		errorExpected    bool
+		numCertsExpected int
+	}{
+		{
+			name: "default cert pool without auth",
+			details: &Details{
+				Auth: Auth{},
+			},
+			numCertsExpected: len(systemCertPool.Subjects()),
+		},
+		{
+			name: "cert added when present in auth",
+			details: &Details{
+				Auth: Auth{
+					CustomCA: &CustomCA{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{"custom-secret-name"},
+							"custom-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			customCAData:     pem_cert,
+			numCertsExpected: len(systemCertPool.Subjects()) + 1,
+		},
+		{
+			name: "errors if custom CA cannot be found in secret",
+			details: &Details{
+				Auth: Auth{
+					CustomCA: &CustomCA{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{"custom-secret-name"},
+							"some-other-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			customCAData:  pem_cert,
+			errorExpected: true,
+		},
+		{
+			name: "errors if custom CA cannot be parsed",
+			details: &Details{
+				Auth: Auth{
+					CustomCA: &CustomCA{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{"custom-secret-name"},
+							"custom-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			customCAData:  "not valid data",
+			errorExpected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		// Create the client with the test case data.
+		kubeClient := fake.NewSimpleClientset(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "custom-secret-name",
+			},
+			Data: map[string][]byte{
+				"custom-secret-key": []byte(tc.customCAData),
+			},
+		})
+		chUtils := Chart{
+			kubeClient: kubeClient,
+			load:       fakeLoadChart,
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			httpClient, err := chUtils.InitNetClient(tc.details)
+
+			if err != nil {
+				if tc.errorExpected {
+					return
+				}
+				t.Fatalf("%+v", err)
+			}
+
+			clientWithUserAgent, ok := httpClient.(*clientWithDefaultUserAgent)
+			if !ok {
+				t.Fatalf("unable to assert expected type")
+			}
+			client, ok := clientWithUserAgent.client.(*http.Client)
+			if !ok {
+				t.Fatalf("unable to assert expected type")
+			}
+			transport, ok := client.Transport.(*http.Transport)
+			certPool := transport.TLSClientConfig.RootCAs
+
+			if got, want := len(certPool.Subjects()), tc.numCertsExpected; got != want {
+				t.Errorf("got: %d, want: %d", got, want)
+			}
+		})
+	}
+}
+
 // Fake server for repositories and charts
 type fakeHTTPClient struct {
 	repoURLs  []string
@@ -274,10 +419,6 @@ func (f *fakeHTTPClient) Do(h *http.Request) (*http.Response, error) {
 	}
 	// Unexpected path
 	return &http.Response{StatusCode: 404}, fmt.Errorf("Unexpected path")
-}
-
-func fakeLoadChart(in io.Reader) (*chart.Chart, error) {
-	return &chart.Chart{}, nil
 }
 
 func newHTTPClient(charts []Details, userAgent string) HTTPClient {

--- a/pkg/chart/fake/chart.go
+++ b/pkg/chart/fake/chart.go
@@ -43,6 +43,6 @@ func (f *FakeChart) GetChart(details *chartUtils.Details, netClient chartUtils.H
 	}, nil
 }
 
-func (f *FakeChart) InitNetClient(customCA *chartUtils.CustomCA) (chartUtils.HTTPClient, error) {
+func (f *FakeChart) InitNetClient(details *chartUtils.Details) (chartUtils.HTTPClient, error) {
 	return &http.Client{}, nil
 }


### PR DESCRIPTION
This is the next small installment for #1110 .

I'm planning to have `InitNetClient` fetching the `AppRepository` custom resource, when present in the request, but wasn't confident to change it before adding tests. So this PR just tests the existing functionality, with a tiny refactor to pass the `ChartDetails` into the call (as this will include the auth object for the current `Details.Auth.CustomCA` secret ref, as well as the `Details.AppRepository.ResourceName` which I'll pull from k8s and parse in a later PR).

I have one other small prep branch next, before I'll add the fetch of the custom resource in `InitNetClient`.
