### PR TITLE
Handle error when specified CA cert secret is not present.

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -309,7 +309,7 @@ func (c *Chart) InitNetClient(details *Details) (HTTPClient, error) {
 		namespace := os.Getenv("POD_NAMESPACE")
 		caCertSecret, err := c.kubeClient.CoreV1().Secrets(namespace).Get(customCA.SecretKeyRef.Name, metav1.GetOptions{})
 		if err != nil {
-			log.Fatalf("Unable to read the given CA cert: %v", err)
+			return nil, fmt.Errorf("unable to read secret %q: %v", customCA.SecretKeyRef.Name, err)
 		}
 
 		// Append our cert to the system pool

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -311,6 +311,22 @@ func TestInitNetClient(t *testing.T) {
 			numCertsExpected: len(systemCertPool.Subjects()) + 1,
 		},
 		{
+			name: "errors if secret for custom CA cannot be found",
+			details: &Details{
+				Auth: Auth{
+					CustomCA: &CustomCA{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{"other-secret-name"},
+							"custom-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			customCAData:  pem_cert,
+			errorExpected: true,
+		},
+		{
 			name: "errors if custom CA cannot be found in secret",
 			details: &Details{
 				Auth: Auth{


### PR DESCRIPTION
As mentioned on #1124, we should not be causing tiller-proxy to exit if it can't fetch a user-supplied secret.

There was another question I had, which I'll add inline.