### PR TITLE
Move fetching of Auth secret to client initialization (matching customCA)

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -308,8 +308,11 @@ func (c *Chart) InitNetClient(details *Details) (HTTPClient, error) {
 
 	// If additionalCA is set, load it
 	customCA := details.Auth.CustomCA
+	namespace := os.Getenv("POD_NAMESPACE")
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
 	if customCA != nil {
-		namespace := os.Getenv("POD_NAMESPACE")
 		caCertSecret, err := c.kubeClient.CoreV1().Secrets(namespace).Get(customCA.SecretKeyRef.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("unable to read secret %q: %v", customCA.SecretKeyRef.Name, err)
@@ -327,13 +330,6 @@ func (c *Chart) InitNetClient(details *Details) (HTTPClient, error) {
 
 	defaultHeaders := http.Header{"User-Agent": []string{c.userAgent}}
 	if details.Auth.Header != nil {
-		namespace := os.Getenv("POD_NAMESPACE")
-		// TODO: Check with Andres: why are we relying on the defaultNamespace here for
-		// Auth, but not above for the customCA? Should both or neither?
-		// if namespace == "" {
-		// 	namespace = defaultNamespace
-		// }
-
 		secret, err := c.kubeClient.Core().Secrets(namespace).Get(details.Auth.Header.SecretKeyRef.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -313,22 +313,6 @@ func TestInitNetClient(t *testing.T) {
 			numCertsExpected: len(systemCertPool.Subjects()) + 1,
 		},
 		{
-			name: "authorization header added when present in auth",
-			details: &Details{
-				Auth: Auth{
-					Header: &AuthHeader{
-						SecretKeyRef: corev1.SecretKeySelector{
-							corev1.LocalObjectReference{"custom-secret-name"},
-							"custom-secret-key",
-							nil,
-						},
-					},
-				},
-			},
-			secretData:       authHeaderSecret,
-			numCertsExpected: len(systemCertPool.Subjects()),
-		},
-		{
 			name: "errors if secret for custom CA cannot be found",
 			details: &Details{
 				Auth: Auth{
@@ -373,7 +357,39 @@ func TestInitNetClient(t *testing.T) {
 					},
 				},
 			},
-			secretData:    "not valid data",
+			secretData:    "not a valid cert",
+			errorExpected: true,
+		},
+		{
+			name: "authorization header added when present in auth",
+			details: &Details{
+				Auth: Auth{
+					Header: &AuthHeader{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{"custom-secret-name"},
+							"custom-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			secretData:       authHeaderSecret,
+			numCertsExpected: len(systemCertPool.Subjects()),
+		},
+		{
+			name: "errors if auth secret cannot be found",
+			details: &Details{
+				Auth: Auth{
+					Header: &AuthHeader{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{"other-secret-name"},
+							"custom-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			secretData:    authHeaderSecret,
 			errorExpected: true,
 		},
 	}

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -398,7 +398,8 @@ func TestInitNetClient(t *testing.T) {
 		// Create the client with the test case data.
 		kubeClient := fake.NewSimpleClientset(&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "custom-secret-name",
+				Name:      "custom-secret-name",
+				Namespace: metav1.NamespaceSystem,
 			},
 			Data: map[string][]byte{
 				"custom-secret-key": []byte(tc.secretData),


### PR DESCRIPTION
Follow on from #1128 , this moves the fetching of the Auth secret to the client initialization function, to match what we already do for the customCA and also allow me to do the same (in the next PR) when fetching the `AppRepository` to get the auth details.

Ref #1110 