### PR TITLE
Refactor Modals style

### DIFF
--- a/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackButton.tsx
+++ b/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackButton.tsx
@@ -51,16 +51,7 @@ class RollbackButton extends React.Component<IRollbackButtonProps> {
     return (
       <React.Fragment>
         <Modal
-          style={{
-            content: {
-              bottom: "auto",
-              left: "50%",
-              marginRight: "-50%",
-              right: "auto",
-              top: "50%",
-              transform: "translate(-50%, -50%)",
-            },
-          }}
+          className="centered-modal"
           isOpen={this.state.modalIsOpen}
           onRequestClose={this.closeModal}
           contentLabel="Modal"

--- a/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackDialog.tsx
+++ b/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackDialog.tsx
@@ -37,13 +37,15 @@ class RollbackDialog extends React.Component<IRollbackDialogProps, IRollbackDial
         <label>
           Select the revision to which you want to rollback (current: {this.props.currentRevision})
         </label>
-        <select className="margin-t-normal" onChange={this.selectRevision}>
-          {options.map(o => (
-            <option key={o} value={o}>
-              {o}
-            </option>
-          ))}
-        </select>
+        <div>
+          <select className="margin-t-normal" onChange={this.selectRevision}>
+            {options.map(o => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+        </div>
         <div className="margin-t-normal button-row">
           <button className="button" type="button" onClick={this.props.closeModal}>
             Cancel

--- a/dashboard/src/components/AppView/AppControls/RollbackButton/__snapshots__/RollbackDialog.test.tsx.snap
+++ b/dashboard/src/components/AppView/AppControls/RollbackButton/__snapshots__/RollbackDialog.test.tsx.snap
@@ -7,17 +7,19 @@ exports[`should render the form if it is not loading 1`] = `
     2
     )
   </label>
-  <select
-    className="margin-t-normal"
-    onChange={[Function]}
-  >
-    <option
-      key="1"
-      value={1}
+  <div>
+    <select
+      className="margin-t-normal"
+      onChange={[Function]}
     >
-      1
-    </option>
-  </select>
+      <option
+        key="1"
+        value={1}
+      >
+        1
+      </option>
+    </select>
+  </div>
   <div
     className="margin-t-normal button-row"
   >

--- a/dashboard/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/dashboard/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -26,16 +26,7 @@ class ConfirmDialog extends React.Component<IConfirmDialogProps, IConfirmDialogS
     return (
       <div className="ConfirmDialog">
         <Modal
-          style={{
-            content: {
-              bottom: "auto",
-              left: "50%",
-              marginRight: "-50%",
-              right: "auto",
-              top: "50%",
-              transform: "translate(-50%, -50%)",
-            },
-          }}
+          className="centered-modal"
           isOpen={this.props.modalIsOpen}
           onRequestClose={this.closeModal}
           contentLabel="Modal"

--- a/dashboard/src/components/ConfirmDialog/__snapshots__/ConfirmDialog.test.tsx.snap
+++ b/dashboard/src/components/ConfirmDialog/__snapshots__/ConfirmDialog.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`when loading is true loading spinner matches the snapshot 1`] = `
   <Modal
     ariaHideApp={true}
     bodyOpenClassName="ReactModal__Body--open"
+    className="centered-modal"
     closeTimeoutMS={0}
     contentLabel="Modal"
     isOpen={false}
@@ -18,18 +19,6 @@ exports[`when loading is true loading spinner matches the snapshot 1`] = `
     shouldCloseOnOverlayClick={true}
     shouldFocusAfterRender={true}
     shouldReturnFocusAfterClose={true}
-    style={
-      Object {
-        "content": Object {
-          "bottom": "auto",
-          "left": "50%",
-          "marginRight": "-50%",
-          "right": "auto",
-          "top": "50%",
-          "transform": "translate(-50%, -50%)",
-        },
-      }
-    }
   >
     <div
       className="row confirm-dialog-loading-info"

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
@@ -22,19 +22,7 @@ class PrivateRoute extends React.Component<IPrivateRouteProps> {
     }
     if (sessionExpired) {
       return (
-        <Modal
-          style={{
-            content: {
-              bottom: "auto",
-              left: "50%",
-              marginRight: "-50%",
-              right: "auto",
-              top: "50%",
-              transform: "translate(-50%, -50%)",
-            },
-          }}
-          isOpen={true}
-        >
+        <Modal className="centered-modal" isOpen={true}>
           <div>
             <div className="margin-b-normal">
               Your session has expired or the connection has been lost, please reload the page.

--- a/dashboard/src/components/ServiceClassView/ProvisionButton.tsx
+++ b/dashboard/src/components/ServiceClassView/ProvisionButton.tsx
@@ -41,17 +41,6 @@ const RequiredRBACRoles: IRBACRole[] = [
   },
 ];
 
-const smallModalStyle = {
-  content: {
-    bottom: "auto",
-    left: "50%",
-    marginRight: "-50%",
-    right: "auto",
-    top: "50%",
-    transform: "translate(-50%, -50%)",
-  },
-};
-
 class ProvisionButton extends React.Component<IProvisionButtonProps, IProvisionButtonState> {
   public state: IProvisionButtonState = {
     displayNameForm: true,
@@ -89,7 +78,7 @@ class ProvisionButton extends React.Component<IProvisionButtonProps, IProvisionB
           isOpen={this.state.modalIsOpen}
           onRequestClose={this.closeModal}
           contentLabel="Modal"
-          style={this.state.displayNameForm ? smallModalStyle : {}}
+          className={this.state.displayNameForm ? "centered-modal" : ""}
         >
           {error && (
             <ErrorSelector

--- a/dashboard/src/components/ServiceClassView/__snapshots__/ProvisionButton.test.tsx.snap
+++ b/dashboard/src/components/ServiceClassView/__snapshots__/ProvisionButton.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`when the modal is open shows an error if is present 1`] = `
   <Modal
     ariaHideApp={true}
     bodyOpenClassName="ReactModal__Body--open"
+    className="centered-modal"
     closeTimeoutMS={0}
     contentLabel="Modal"
     isOpen={true}
@@ -25,18 +26,6 @@ exports[`when the modal is open shows an error if is present 1`] = `
     shouldCloseOnOverlayClick={true}
     shouldFocusAfterRender={true}
     shouldReturnFocusAfterClose={true}
-    style={
-      Object {
-        "content": Object {
-          "bottom": "auto",
-          "left": "50%",
-          "marginRight": "-50%",
-          "right": "auto",
-          "top": "50%",
-          "transform": "translate(-50%, -50%)",
-        },
-      }
-    }
   >
     <ErrorSelector
       action="provision"

--- a/dashboard/src/components/ServiceInstanceView/__snapshots__/ServiceInstanceView.test.tsx.snap
+++ b/dashboard/src/components/ServiceInstanceView/__snapshots__/ServiceInstanceView.test.tsx.snap
@@ -567,6 +567,7 @@ exports[`when all the components are loaded when an instance is available should
                           <Modal
                             ariaHideApp={true}
                             bodyOpenClassName="ReactModal__Body--open"
+                            className="centered-modal"
                             closeTimeoutMS={0}
                             contentLabel="Modal"
                             isOpen={false}
@@ -578,18 +579,6 @@ exports[`when all the components are loaded when an instance is available should
                             shouldCloseOnOverlayClick={true}
                             shouldFocusAfterRender={true}
                             shouldReturnFocusAfterClose={true}
-                            style={
-                              Object {
-                                "content": Object {
-                                  "bottom": "auto",
-                                  "left": "50%",
-                                  "marginRight": "-50%",
-                                  "right": "auto",
-                                  "top": "50%",
-                                  "transform": "translate(-50%, -50%)",
-                                },
-                              }
-                            }
                           >
                             <Portal
                               containerInfo={
@@ -601,6 +590,7 @@ exports[`when all the components are loaded when an instance is available should
                               <ModalPortal
                                 ariaHideApp={true}
                                 bodyOpenClassName="ReactModal__Body--open"
+                                className="centered-modal"
                                 closeTimeoutMS={0}
                                 contentLabel="Modal"
                                 defaultStyles={
@@ -640,14 +630,8 @@ exports[`when all the components are loaded when an instance is available should
                                 shouldReturnFocusAfterClose={true}
                                 style={
                                   Object {
-                                    "content": Object {
-                                      "bottom": "auto",
-                                      "left": "50%",
-                                      "marginRight": "-50%",
-                                      "right": "auto",
-                                      "top": "50%",
-                                      "transform": "translate(-50%, -50%)",
-                                    },
+                                    "content": Object {},
+                                    "overlay": Object {},
                                   }
                                 }
                               />

--- a/dashboard/src/index.scss
+++ b/dashboard/src/index.scss
@@ -21,3 +21,19 @@ see: https://github.com/bitnami/hex/issues/216 */
 .alert .button {
   text-decoration: none;
 }
+
+.centered-modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  right: auto;
+  bottom: auto;
+  border: 1px solid rgb(204, 204, 204);
+  background: rgb(255, 255, 255);
+  overflow: auto;
+  border-radius: 4px;
+  outline: none;
+  padding: 20px;
+  margin-right: -50%;
+  transform: translate(-50%, -50%);
+}


### PR DESCRIPTION
Fixes #1123

Avoid to use inline style every time we use a Modal (in the case we want a small, centered Modal).

I have moved the resulting CSS to the index file so the class `centered-modal` can be used anywhere.

I have also slightly modified the `RollbackButton` modal, see inline.