### PR TITLE
Don't ignore system cert error

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -297,10 +297,14 @@ func (c *clientWithDefaultUserAgent) Do(req *http.Request) (*http.Response, erro
 // InitNetClient returns an HTTP client based on the chart details loading a
 // custom CA if provided (as a secret)
 func (c *Chart) InitNetClient(details *Details) (HTTPClient, error) {
-	// Get the SystemCertPool, continue with an empty pool on error
-	caCertPool, _ := x509.SystemCertPool()
-	if caCertPool == nil {
-		caCertPool = x509.NewCertPool()
+	caCertPool := x509.NewCertPool()
+	// Get the SystemCertPool unless the env var is explicitly set.
+	if _, ok := os.LookupEnv("TILLER_PROXY_ALLOW_EMPTY_CERT_POOL"); !ok {
+		var err error
+		caCertPool, err = x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If additionalCA is set, load it

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -297,14 +297,13 @@ func (c *clientWithDefaultUserAgent) Do(req *http.Request) (*http.Response, erro
 // InitNetClient returns an HTTP client based on the chart details loading a
 // custom CA if provided (as a secret)
 func (c *Chart) InitNetClient(details *Details) (HTTPClient, error) {
-	caCertPool := x509.NewCertPool()
-	// Get the SystemCertPool unless the env var is explicitly set.
-	if _, ok := os.LookupEnv("TILLER_PROXY_ALLOW_EMPTY_CERT_POOL"); !ok {
-		var err error
-		caCertPool, err = x509.SystemCertPool()
-		if err != nil {
+	// Require the SystemCertPool unless the env var is explicitly set.
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		if _, ok := os.LookupEnv("TILLER_PROXY_ALLOW_EMPTY_CERT_POOL"); !ok {
 			return nil, err
 		}
+		caCertPool = x509.NewCertPool()
 	}
 
 	// If additionalCA is set, load it

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -273,9 +273,6 @@ YrvYQHgOtHsqCB/hFHWfZp1lg2Sx
 `
 
 func TestInitNetClient(t *testing.T) {
-	// TODO(mnelson): currently the InitNetClient swallows any error during
-	// call to SystemCertPool, silently creating an empty cert pool. If that
-	// path is taken on the test system, this test will fail. Find out why.
 	systemCertPool, err := x509.SystemCertPool()
 	if err != nil {
 		t.Fatalf("%+v", err)
@@ -297,14 +294,6 @@ func TestInitNetClient(t *testing.T) {
 			numCertsExpected: len(systemCertPool.Subjects()),
 		},
 		{
-			name: "zero system certs if allowing empty system certs",
-			details: &Details{
-				Auth: Auth{},
-			},
-			enableEmptyCertPool: true,
-			numCertsExpected:    0,
-		},
-		{
 			name: "cert added when present in auth",
 			details: &Details{
 				Auth: Auth{
@@ -319,23 +308,6 @@ func TestInitNetClient(t *testing.T) {
 			},
 			customCAData:     pem_cert,
 			numCertsExpected: len(systemCertPool.Subjects()) + 1,
-		},
-		{
-			name: "cert added (and it is the only cert when no system certs) when present in auth",
-			details: &Details{
-				Auth: Auth{
-					CustomCA: &CustomCA{
-						SecretKeyRef: corev1.SecretKeySelector{
-							corev1.LocalObjectReference{"custom-secret-name"},
-							"custom-secret-key",
-							nil,
-						},
-					},
-				},
-			},
-			customCAData:        pem_cert,
-			enableEmptyCertPool: true,
-			numCertsExpected:    1,
 		},
 		{
 			name: "cert added when present in auth",

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -281,11 +282,12 @@ func TestInitNetClient(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name             string
-		details          *Details
-		customCAData     string
-		errorExpected    bool
-		numCertsExpected int
+		name                string
+		details             *Details
+		customCAData        string
+		errorExpected       bool
+		numCertsExpected    int
+		enableEmptyCertPool bool
 	}{
 		{
 			name: "default cert pool without auth",
@@ -293,6 +295,47 @@ func TestInitNetClient(t *testing.T) {
 				Auth: Auth{},
 			},
 			numCertsExpected: len(systemCertPool.Subjects()),
+		},
+		{
+			name: "zero system certs if allowing empty system certs",
+			details: &Details{
+				Auth: Auth{},
+			},
+			enableEmptyCertPool: true,
+			numCertsExpected:    0,
+		},
+		{
+			name: "cert added when present in auth",
+			details: &Details{
+				Auth: Auth{
+					CustomCA: &CustomCA{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{"custom-secret-name"},
+							"custom-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			customCAData:     pem_cert,
+			numCertsExpected: len(systemCertPool.Subjects()) + 1,
+		},
+		{
+			name: "cert added (and it is the only cert when no system certs) when present in auth",
+			details: &Details{
+				Auth: Auth{
+					CustomCA: &CustomCA{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{"custom-secret-name"},
+							"custom-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			customCAData:        pem_cert,
+			enableEmptyCertPool: true,
+			numCertsExpected:    1,
 		},
 		{
 			name: "cert added when present in auth",
@@ -376,6 +419,10 @@ func TestInitNetClient(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.enableEmptyCertPool {
+				os.Setenv("TILLER_PROXY_ALLOW_EMPTY_CERT_POOL", "true")
+				defer os.Unsetenv("TILLER_PROXY_ALLOW_EMPTY_CERT_POOL")
+			}
 			httpClient, err := chUtils.InitNetClient(tc.details)
 
 			if err != nil {

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -281,12 +280,11 @@ func TestInitNetClient(t *testing.T) {
 	const authHeaderSecret = "really-secret-stuff"
 
 	testCases := []struct {
-		name                string
-		details             *Details
-		secretData          string
-		errorExpected       bool
-		numCertsExpected    int
-		enableEmptyCertPool bool
+		name             string
+		details          *Details
+		secretData       string
+		errorExpected    bool
+		numCertsExpected int
 	}{
 		{
 			name: "default cert pool without auth",
@@ -294,22 +292,6 @@ func TestInitNetClient(t *testing.T) {
 				Auth: Auth{},
 			},
 			numCertsExpected: len(systemCertPool.Subjects()),
-		},
-		{
-			name: "cert added when present in auth",
-			details: &Details{
-				Auth: Auth{
-					CustomCA: &CustomCA{
-						SecretKeyRef: corev1.SecretKeySelector{
-							corev1.LocalObjectReference{"custom-secret-name"},
-							"custom-secret-key",
-							nil,
-						},
-					},
-				},
-			},
-			secretData:       pem_cert,
-			numCertsExpected: len(systemCertPool.Subjects()) + 1,
 		},
 		{
 			name: "cert added when present in auth",
@@ -426,10 +408,6 @@ func TestInitNetClient(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.enableEmptyCertPool {
-				os.Setenv("TILLER_PROXY_ALLOW_EMPTY_CERT_POOL", "true")
-				defer os.Unsetenv("TILLER_PROXY_ALLOW_EMPTY_CERT_POOL")
-			}
 			httpClient, err := chUtils.InitNetClient(tc.details)
 
 			if err != nil {


### PR DESCRIPTION
Following up on a comment https://github.com/kubeapps/kubeapps/pull/1125/files#r315253073 this ensures that we don't swallow an error unnecessarily when getting the system certs.

So that I don't break anyone's test environment, an empty pool of certs can be explicitly allowed if necessary.