### PR TITLE
Use dry-run to resolve manifest when rolling back

### DIFF
--- a/cmd/tiller-proxy/internal/handler/handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/handler_test.go
@@ -387,7 +387,7 @@ func TestActions(t *testing.T) {
 			DisableAuth:      false,
 			ForbiddenActions: []auth.Action{},
 			// Request params
-			RequestBody: `{"chartName": "foo", "releaseName": "foo",	"version": "1.0.0"}`,
+			RequestBody:  "",
 			RequestQuery: "?revision=1",
 			Action:       "rollback",
 			Params:       map[string]string{"namespace": "default", "releaseName": "foo"},
@@ -405,7 +405,7 @@ func TestActions(t *testing.T) {
 			DisableAuth:      true,
 			ForbiddenActions: []auth.Action{},
 			// Request params
-			RequestBody: `{"chartName": "foo", "releaseName": "foobar",	"version": "1.0.0"}`,
+			RequestBody:  "",
 			RequestQuery: "?revision=1",
 			Action:       "rollback",
 			Params:       map[string]string{"namespace": "default", "releaseName": "foobar"},
@@ -421,7 +421,7 @@ func TestActions(t *testing.T) {
 			DisableAuth:      true,
 			ForbiddenActions: []auth.Action{},
 			// Request params
-			RequestBody: `{"chartName": "foo", "releaseName": "foobar",	"version": "1.0.0"}`,
+			RequestBody:  "",
 			RequestQuery: "",
 			Action:       "rollback",
 			Params:       map[string]string{"namespace": "default", "releaseName": "foobar"},

--- a/pkg/proxy/fake/proxy.go
+++ b/pkg/proxy/fake/proxy.go
@@ -37,6 +37,10 @@ func (f *FakeProxy) ResolveManifest(namespace, values string, ch *chart.Chart) (
 	return "", nil
 }
 
+func (f *FakeProxy) ResolveManifestFromRelease(releaseName string, revision int32) (string, error) {
+	return "", nil
+}
+
 func (f *FakeProxy) ListReleases(namespace string, releaseListLimit int, status string) ([]proxy.AppOverview, error) {
 	res := []proxy.AppOverview{}
 	for _, r := range f.Releases {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -128,16 +128,15 @@ func (p *Proxy) ResolveManifest(namespace, values string, ch *chart.Chart) (stri
 // ResolveManifestFromRelease returns a manifest given the release name and revision
 func (p *Proxy) ResolveManifestFromRelease(releaseName string, revision int32) (string, error) {
 	// We use the release returned after running a dry-run to know the components of the release
-	resDry, err := p.helmClient.RollbackRelease(
+	res, err := p.helmClient.ReleaseContent(
 		releaseName,
-		helm.RollbackVersion(revision),
-		helm.RollbackDryRun(true),
+		helm.ContentReleaseVersion(revision),
 	)
 	if err != nil {
 		return "", err
 	}
 	// The manifest returned has some extra new lines at the beginning
-	return strings.TrimLeft(resDry.Release.Manifest, "\n"), nil
+	return strings.TrimLeft(res.Release.Manifest, "\n"), nil
 }
 
 // Apply the same filtering than helm CLI


### PR DESCRIPTION
Follow up #997

After the feedback from @absoludity I checked that it's actually not necessary to send the chart details to tiller-proxy in order to retrieve the chart manifest that a release has.

We can get the changes we are going to perform if we run the rollback with the dry-run option.

I tested this manually and it works but there is not anything useful to test here since we are depending on the result from tiller.