### PR TITLE
Remove code related to resolve chart when rolling back

### DIFF
--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -274,13 +274,7 @@ describe("upgradeApp", () => {
 });
 
 describe("rollbackApp", () => {
-  const provisionCMD = actions.apps.rollbackApp(
-    "my-version" as any,
-    "my-release",
-    1,
-    definedNamespaces.default,
-    "my-values",
-  );
+  const provisionCMD = actions.apps.rollbackApp("my-release", definedNamespaces.default, 1);
 
   it("success and re-request apps info", async () => {
     App.rollback = jest.fn().mockImplementationOnce(() => true);
@@ -293,14 +287,7 @@ describe("rollbackApp", () => {
       { type: getType(actions.apps.requestApps) },
     ];
     expect(store.getActions()).toEqual(expectedActions);
-    expect(App.rollback).toHaveBeenCalledWith(
-      "my-release",
-      definedNamespaces.default,
-      1,
-      "kubeapps-ns",
-      "my-version" as any,
-      "my-values",
-    );
+    expect(App.rollback).toHaveBeenCalledWith("my-release", definedNamespaces.default, 1);
   });
 
   it("dispatches an error", async () => {

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -259,18 +259,13 @@ export function upgradeApp(
 }
 
 export function rollbackApp(
-  chartVersion: IChartVersion,
   releaseName: string,
-  revision: number,
   namespace: string,
-  values: string,
+  revision: number,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppsAction> {
-  return async (dispatch, getState) => {
+  return async dispatch => {
     try {
-      const {
-        config: { namespace: kubeappsNamespace },
-      } = getState();
-      await App.rollback(releaseName, namespace, revision, kubeappsNamespace, chartVersion, values);
+      await App.rollback(releaseName, namespace, revision);
       dispatch(getAppWithUpdateInfo(releaseName, namespace));
       return true;
     } catch (e) {

--- a/dashboard/src/components/AppView/AppControls/AppControls.tsx
+++ b/dashboard/src/components/AppView/AppControls/AppControls.tsx
@@ -54,7 +54,11 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
             />
             {/* We only show the rollback button if there are versions to rollback */}
             {app.version > 1 && (
-              <RollbackButtonContainer releaseName={name} namespace={namespace} />
+              <RollbackButtonContainer
+                releaseName={name}
+                namespace={namespace}
+                revision={app.version}
+              />
             )}
           </React.Fragment>
         )}

--- a/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackButton.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackButton.test.tsx
@@ -1,36 +1,16 @@
-import { mount, shallow, ShallowWrapper } from "enzyme";
-import context from "jest-plugin-context";
+import { shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 import * as ReactModal from "react-modal";
-import { IAppRepository, IChartVersion, IRelease } from "shared/types";
 import RollbackButton from ".";
-import SelectRepoForm from "../../../../components/SelectRepoForm";
 import RollbackDialog from "./RollbackDialog";
 
 const defaultProps = {
-  app: {
-    chart: {
-      metadata: {
-        name: "foo",
-        version: "1.0.0",
-      },
-    },
-  } as IRelease,
+  releaseName: "foo",
+  namespace: "default",
+  revision: 2,
   rollbackApp: jest.fn(),
-  getChartVersion: jest.fn(),
   loading: false,
-  repos: [],
-  repo: {} as IAppRepository,
-  kubeappsNamespace: "kubeapps",
-  fetchRepositories: jest.fn(),
-  checkChart: jest.fn(),
 };
-
-it("stores the chart name and version in the state", () => {
-  const wrapper = shallow(<RollbackButton {...defaultProps} />);
-
-  expect(wrapper.state()).toMatchObject({ chartName: "foo", chartVersion: "1.0.0" });
-});
 
 function openModal(wrapper: ShallowWrapper) {
   ReactModal.setAppElement(document.createElement("div"));
@@ -38,127 +18,14 @@ function openModal(wrapper: ShallowWrapper) {
   wrapper.update();
 }
 
-context("when opening the Modal", () => {
-  context("when there is no info about the chart", () => {
-    it("should render the SelectRepoForm", () => {
-      const wrapper = shallow(<RollbackButton {...defaultProps} chartVersion={undefined} />);
-      openModal(wrapper);
+it("should perform the rollback", async () => {
+  const rollbackApp = jest.fn();
+  const wrapper = shallow(<RollbackButton {...defaultProps} rollbackApp={rollbackApp} />);
+  openModal(wrapper);
 
-      expect(wrapper.find(SelectRepoForm)).toExist();
-      expect(wrapper.find(RollbackDialog)).not.toExist();
-    });
-
-    it("should fetch the available repositories", () => {
-      const fetchRepositories = jest.fn();
-      const wrapper = shallow(
-        <RollbackButton
-          {...defaultProps}
-          chartVersion={undefined}
-          fetchRepositories={fetchRepositories}
-        />,
-      );
-      const button = wrapper.find(".button");
-      expect(button).toExist();
-      button.simulate("click");
-      expect(fetchRepositories).toBeCalled();
-    });
-
-    it("if the app has updateInfo, fetch the chart", () => {
-      const getChartVersion = jest.fn();
-      const app = {
-        chart: {
-          metadata: {
-            name: "bar",
-            version: "1.0.0",
-          },
-        },
-        updateInfo: {
-          repository: {
-            name: "foo",
-          },
-        },
-      } as IRelease;
-      const wrapper = mount(
-        <RollbackButton
-          {...defaultProps}
-          chartVersion={undefined}
-          getChartVersion={getChartVersion}
-          app={app}
-        />,
-      );
-
-      const button = wrapper.find(".button");
-      expect(button).toExist();
-      button.simulate("click");
-      expect(getChartVersion).toBeCalledWith("foo/bar", "1.0.0");
-    });
-
-    it("should retrieve a chart if there is no updateInfo through the SelectRepoForm", async () => {
-      const checkChart = jest.fn().mockReturnValueOnce(true);
-      const getChartVersion = jest.fn();
-      const wrapper = shallow(
-        <RollbackButton
-          {...defaultProps}
-          chartVersion={undefined}
-          checkChart={checkChart}
-          getChartVersion={getChartVersion}
-        />,
-      );
-      openModal(wrapper);
-      wrapper.setState({ chartVersion: "1.0.0" });
-
-      const form = wrapper.find(SelectRepoForm);
-      expect(form).toExist();
-      const checkChartWithinForm = form.prop("checkChart") as (
-        repo: string,
-        chartName: string,
-      ) => any;
-      await checkChartWithinForm("foo", "bar");
-      expect(checkChart).toBeCalled();
-      expect(getChartVersion).toBeCalledWith("foo/bar", "1.0.0");
-    });
-  });
-
-  context("when there is info about the chart", () => {
-    it("should render the RollbackDialog", () => {
-      const wrapper = shallow(
-        <RollbackButton {...defaultProps} chartVersion={{} as IChartVersion} />,
-      );
-      openModal(wrapper);
-
-      expect(wrapper.find(SelectRepoForm)).not.toExist();
-      expect(wrapper.find(RollbackDialog)).toExist();
-    });
-
-    it("should perform the rollback", async () => {
-      const rollbackApp = jest.fn();
-      const chart = { id: "foo" } as IChartVersion;
-      const app = {
-        name: "bar",
-        namespace: "default",
-        config: { raw: "this: that" },
-        chart: {
-          metadata: {
-            name: "foo",
-            version: "1.0.0",
-          },
-        },
-      } as IRelease;
-      const wrapper = shallow(
-        <RollbackButton
-          {...defaultProps}
-          rollbackApp={rollbackApp}
-          chartVersion={chart}
-          app={app}
-        />,
-      );
-      openModal(wrapper);
-
-      const dialog = wrapper.find(RollbackDialog);
-      expect(dialog).toExist();
-      const onConfirm = dialog.prop("onConfirm") as (revision: number) => Promise<any>;
-      await onConfirm(1);
-      expect(rollbackApp).toBeCalledWith(chart, app.name, 1, app.namespace, app.config!.raw);
-    });
-  });
+  const dialog = wrapper.find(RollbackDialog);
+  expect(dialog).toExist();
+  const onConfirm = dialog.prop("onConfirm") as (revision: number) => Promise<any>;
+  await onConfirm(1);
+  expect(rollbackApp).toBeCalledWith(defaultProps.releaseName, defaultProps.namespace, 1);
 });

--- a/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackButton.tsx
+++ b/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackButton.tsx
@@ -1,50 +1,25 @@
 import * as React from "react";
 import * as Modal from "react-modal";
-import { IAppRepository, IChartVersion, IRelease } from "shared/types";
-import SelectRepoForm from "../../../../components/SelectRepoForm";
 import RollbackDialog from "./RollbackDialog";
 
 interface IRollbackButtonProps {
-  app: IRelease;
-  rollbackApp: (
-    chartVersion: IChartVersion,
-    releaseName: string,
-    revision: number,
-    namespace: string,
-    values?: string,
-  ) => Promise<boolean>;
-  chartVersion?: IChartVersion;
-  getChartVersion: (id: string, version: string) => Promise<void>;
+  releaseName: string;
+  namespace: string;
+  revision: number;
+  rollbackApp: (releaseName: string, namespace: string, revision: number) => Promise<boolean>;
   loading: boolean;
-  repos: IAppRepository[];
-  repo: IAppRepository;
-  kubeappsNamespace: string;
-  fetchRepositories: () => void;
-  checkChart: (repo: string, chartName: string) => Promise<boolean>;
   error?: Error;
 }
 
 interface IRollbackButtonState {
   modalIsOpen: boolean;
   loading: boolean;
-  chartName: string;
-  chartVersion: string;
 }
 
 class RollbackButton extends React.Component<IRollbackButtonProps> {
   public state: IRollbackButtonState = {
     modalIsOpen: false,
     loading: false,
-    chartName:
-      (this.props.app.chart &&
-        this.props.app.chart.metadata &&
-        this.props.app.chart.metadata.name) ||
-      "",
-    chartVersion:
-      (this.props.app.chart &&
-        this.props.app.chart.metadata &&
-        this.props.app.chart.metadata.version) ||
-      "",
   };
 
   public render() {
@@ -56,24 +31,12 @@ class RollbackButton extends React.Component<IRollbackButtonProps> {
           onRequestClose={this.closeModal}
           contentLabel="Modal"
         >
-          {/* If we were not able to resolve the chart, ask for the repository */}
-          {this.props.chartVersion ? (
-            <RollbackDialog
-              onConfirm={this.handleRollback}
-              loading={this.state.loading}
-              closeModal={this.closeModal}
-              currentRevision={this.props.app.version}
-            />
-          ) : (
-            <SelectRepoForm
-              repos={this.props.repos}
-              repo={this.props.repo}
-              kubeappsNamespace={this.props.kubeappsNamespace}
-              checkChart={this.getChart}
-              error={this.props.error}
-              chartName={this.state.chartName}
-            />
-          )}
+          <RollbackDialog
+            onConfirm={this.handleRollback}
+            loading={this.state.loading}
+            closeModal={this.closeModal}
+            currentRevision={this.props.revision}
+          />
         </Modal>
         <button className="button" onClick={this.openModal}>
           Rollback
@@ -83,25 +46,6 @@ class RollbackButton extends React.Component<IRollbackButtonProps> {
   }
 
   public openModal = () => {
-    // Only when the rollback button is clicked do we ensure the required state is available, fetching
-    // the chart version or repositories, if the repo is not known.
-    const { repos, fetchRepositories, chartVersion, app, getChartVersion } = this.props;
-
-    if (!this.state.chartName || !this.state.chartVersion) {
-      // This should not be reached, unexpected error
-      throw new Error("The current app is missing its chart information");
-    }
-
-    if (!chartVersion && app.updateInfo) {
-      // If there is updateInfo we can retrieve the chart
-      const chartID = `${app.updateInfo.repository.name}/${this.state.chartName}`;
-      getChartVersion(chartID, this.state.chartVersion);
-    } else {
-      // In other case we need to ask for the repository so we fecth the available ones
-      if (repos.length === 0) {
-        fetchRepositories();
-      }
-    }
     this.setState({
       modalIsOpen: true,
     });
@@ -116,24 +60,14 @@ class RollbackButton extends React.Component<IRollbackButtonProps> {
   private handleRollback = async (revision: number) => {
     this.setState({ loading: true });
     const success = await this.props.rollbackApp(
-      this.props.chartVersion!, // Chart should be defined to reach this point
-      this.props.app.name,
+      this.props.releaseName,
+      this.props.namespace,
       revision,
-      this.props.app.namespace,
-      (this.props.app.config && this.props.app.config.raw) || "",
     );
     // If there is an error it's catched at AppView level
     if (success) {
       this.setState({ loading: false });
       this.closeModal();
-    }
-  };
-
-  private getChart = async (repo: string, chartName: string) => {
-    const exists = await this.props.checkChart(repo, chartName);
-    if (exists) {
-      const chartID = `${repo}/${chartName}`;
-      this.props.getChartVersion(chartID, this.state.chartVersion);
     }
   };
 }

--- a/dashboard/src/containers/RollbackButtonContainer/RollbackButtonContainer.tsx
+++ b/dashboard/src/containers/RollbackButtonContainer/RollbackButtonContainer.tsx
@@ -4,42 +4,27 @@ import { ThunkDispatch } from "redux-thunk";
 
 import actions from "../../actions";
 import RollbackButton from "../../components/AppView/AppControls/RollbackButton";
-import { IChartVersion, IStoreState } from "../../shared/types";
+import { IStoreState } from "../../shared/types";
 
 interface IButtonProps {
   namespace: string;
   releaseName: string;
+  revision: number;
 }
 
-function mapStateToProps({ apps, charts, repos, config }: IStoreState, props: IButtonProps) {
+function mapStateToProps({ apps }: IStoreState, props: IButtonProps) {
   return {
-    app: apps.selected!,
-    error: apps.error || repos.errors.fetch,
     namespace: props.namespace,
     releaseName: props.releaseName,
-    chartVersion: charts.selected.version,
-    loading: charts.isFetching || apps.isFetching || repos.isFetching,
-    repo: repos.repo,
-    repoError: repos.errors.fetch,
-    repos: repos.repos,
-    kubeappsNamespace: config.namespace,
+    revision: props.revision,
+    loading: apps.isFetching,
   };
 }
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    rollbackApp: (
-      chartVersion: IChartVersion,
-      releaseName: string,
-      revision: number,
-      namespace: string,
-      values: string,
-    ) => dispatch(actions.apps.rollbackApp(chartVersion, releaseName, revision, namespace, values)),
-    getChartVersion: (id: string, version: string) =>
-      dispatch(actions.charts.getChartVersion(id, version)),
-    checkChart: (repo: string, chartName: string) =>
-      dispatch(actions.repos.checkChart(repo, chartName)),
-    fetchRepositories: () => dispatch(actions.repos.fetchRepos()),
+    rollbackApp: (releaseName: string, namespace: string, revision: number) =>
+      dispatch(actions.apps.rollbackApp(releaseName, namespace, revision)),
   };
 }
 

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -1,8 +1,7 @@
 import * as moxios from "moxios";
 import { App, TILLER_PROXY_ROOT_URL } from "./App";
-import { AppRepository } from "./AppRepository";
 import { axiosWithAuth } from "./AxiosInstance";
-import { IAppOverview, IChartVersion } from "./types";
+import { IAppOverview } from "./types";
 
 describe("App", () => {
   beforeEach(() => {
@@ -109,23 +108,11 @@ describe("App", () => {
 
   describe("rollback", () => {
     it("should rollback an application", async () => {
-      AppRepository.get = jest.fn().mockReturnValue({ spec: { auth: {} } });
       axiosWithAuth.put = jest.fn().mockReturnValue({ data: "ok" });
-      const c = {
-        attributes: { version: "1.0.0" },
-        relationships: { chart: { data: { name: "foo", repo: { name: "bar", url: "test.com" } } } },
-      } as IChartVersion;
-      expect(await App.rollback("foo", "default", 1, "kubeapps", c, "foo: bar")).toBe("ok");
+      expect(await App.rollback("foo", "default", 1)).toBe("ok");
       expect(axiosWithAuth.put).toBeCalledWith(
         "api/tiller-deploy/v1/namespaces/default/releases/foo",
-        {
-          auth: {},
-          chartName: "foo",
-          releaseName: "foo",
-          repoUrl: "test.com",
-          values: "foo: bar",
-          version: "1.0.0",
-        },
+        {},
         { params: { action: "rollback", revision: 1 } },
       );
     });

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -65,28 +65,11 @@ export class App {
     return data;
   }
 
-  public static async rollback(
-    releaseName: string,
-    namespace: string,
-    revision: number,
-    kubeappsNamespace: string,
-    chartVersion: IChartVersion,
-    values: string,
-  ) {
-    const chartAttrs = chartVersion.relationships.chart.data;
-    const repo = await AppRepository.get(chartAttrs.repo.name, kubeappsNamespace);
-    const auth = repo.spec.auth;
+  public static async rollback(releaseName: string, namespace: string, revision: number) {
     const endpoint = App.getResourceURL(namespace, releaseName);
     const { data } = await axiosWithAuth.put(
       endpoint,
-      {
-        auth,
-        chartName: chartAttrs.name,
-        releaseName,
-        repoUrl: chartAttrs.repo.url,
-        values,
-        version: chartVersion.attributes.version,
-      },
+      {},
       {
         params: {
           action: "rollback",


### PR DESCRIPTION
Frontend changes related to #1133

Since we don't require to resolve the chart here, there is a lot of code we can delete.