### PR TITLE
Bump chart version

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 2.0.3
+version: 2.1.0
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png


### PR DESCRIPTION
The images `bitnami/kubeapps-dashboard:v1.5.0-r0` `bitnami/kubeapps-tiller-proxy:v1.5.0-r0` and `bitnami/kubeapps-apprepository-controller:v1.5.0-r0` are already available so we can release.

cc/ @absoludity 
