### PR TITLE
Client sends chart repo resource name rather than fetching auth data.

### DIFF
--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -29,11 +29,9 @@ export class App {
     values?: string,
   ) {
     const chartAttrs = chartVersion.relationships.chart.data;
-    const repo = await AppRepository.get(chartAttrs.repo.name, kubeappsNamespace);
-    const auth = repo.spec.auth;
     const endpoint = App.getResourceURL(namespace);
     const { data } = await axiosWithAuth.post(endpoint, {
-      auth,
+      appRepositoryResourceName: chartAttrs.repo.name,
       chartName: chartAttrs.name,
       releaseName,
       repoUrl: chartAttrs.repo.url,

--- a/docs/user/access-control.md
+++ b/docs/user/access-control.md
@@ -53,20 +53,14 @@ kubectl create -n default rolebinding example-view \
 #### Write access to Applications within a namespace
 
 In order to create, update and delete Applications in a namespace, apply the
-`edit` ClusterRole in the desired namespace and the `$KUBEAPPS_RELEASE_NAME-repositories-read`
-Role in the namespace Kubeapps is installed in. The `edit` ClusterRole should be
+`edit` ClusterRole in the desired namespace. The `edit` ClusterRole should be
 available in most Kubernetes distributions, you can find more information about
 that role
 [here](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles).
 
 ```
-export KUBEAPPS_NAMESPACE=kubeapps
-export KUBEAPPS_RELEASE_NAME=kubeapps
 kubectl create -n default rolebinding example-edit \
   --clusterrole=edit \
-  --serviceaccount default:example
-kubectl create -n $KUBEAPPS_NAMESPACE rolebinding example-kubeapps-repositories-read \
-  --role=$KUBEAPPS_RELEASE_NAME-repositories-read \
   --serviceaccount default:example
 ```
 

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -255,8 +255,8 @@ func (c *Chart) ParseDetails(data []byte) (*Details, error) {
 		return nil, fmt.Errorf("Unable to parse request body: %v", err)
 	}
 
-	if (details.RepoURL != "" || details.Auth.Header != nil || details.Auth.CustomCA != nil) && details.AppRepositoryResourceName != "" {
-		return nil, fmt.Errorf("repoUrl or auth specified together with appRepositoryResourceName")
+	if (details.Auth.Header != nil || details.Auth.CustomCA != nil) && details.AppRepositoryResourceName != "" {
+		return nil, fmt.Errorf("auth specified together with appRepositoryResourceName")
 	}
 	return details, nil
 }

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -159,18 +159,6 @@ func TestParseDetails(t *testing.T) {
 			},
 		},
 		{
-			name: "error returned if both resource and repo url specified",
-			data: `{
-	        	"repoUrl": "foo.com",
-				"appRepositoryResourceName": "my-chart-repo",
-	        	"chartName": "test",
-	        	"releaseName": "foo",
-	        	"version": "1.0.0",
-	        	"values": "foo: bar"
-			}`,
-			err: true,
-		},
-		{
 			name: "error returned if both resource and auth header specified",
 			data: `{
 				"appRepositoryResourceName": "my-chart-repo",


### PR DESCRIPTION
Updates the frontend to send the repository resource name (and relying on the recent tiller-proxy changes to fetch the custom repo resource to get the auth), rather than fetching the resource from the client.

This removes the need for users to have read access to the app repositories CRD to simply deploy a chart, as per #1110 .

Update the docs to say the same, after QAing locally.

I temporarily removed a restriction I'd added in tiller-proxy so that the frontend can still send the repoURL as part of the request. With this PR, the task is finished, but I've got a final cleanup to followup with that will:

  * updating tiller-proxy to store the repoUrl from the fetched app repository,
  * removing the repoURL option from the `Details` struct and from the frontend request.