### PR TITLE
App.upgrade sends app repo name

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -3,7 +3,7 @@ import * as Moniker from "moniker-native";
 import * as React from "react";
 import AceEditor from "react-ace";
 
-import { IChartState, IChartVersion, IRBACRole } from "../../shared/types";
+import { IChartState, IChartVersion } from "../../shared/types";
 import { ErrorSelector } from "../ErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
 
@@ -110,7 +110,6 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
             <ErrorSelector
               error={this.props.error}
               namespace={namespace}
-              defaultRequiredRBACRoles={{ create: this.requiredRBACRoles() }}
               action="create"
               resource={latestSubmittedReleaseName}
             />
@@ -202,17 +201,6 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   public handleValuesChange = (value: string) => {
     this.setState({ appValues: value, valuesModified: true });
   };
-
-  private requiredRBACRoles(): IRBACRole[] {
-    return [
-      {
-        apiGroup: "kubeapps.com",
-        namespace: this.props.kubeappsNamespace,
-        resource: "apprepositories",
-        verbs: ["get"],
-      },
-    ];
-  }
 }
 
 export default DeploymentForm;

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -126,7 +126,7 @@ describe("App", () => {
         },
       },
     } as IChartVersion;
-    it("creates an app in a namespace", async () => {
+    it("upgrades an app in a namespace", async () => {
       moxios.stubRequest(/.*/, { response: "ok", status: 200 });
       expect(await App.upgrade("absent-ant", "default", "kubeapps", testChartVersion)).toBe("ok");
       const request = moxios.requests.mostRecent();

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -102,13 +102,45 @@ describe("App", () => {
           appRepositoryResourceName: testChartVersion.relationships.chart.data.repo.name,
           chartName: testChartVersion.relationships.chart.data.name,
           releaseName: "absent-ant",
-          repoUrl: testChartVersion.relationships.chart.data.repo.url,
           version: testChartVersion.attributes.version,
         }),
       );
     });
   });
 
+  describe("upgrade", () => {
+    const expectedURL = `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases/absent-ant`;
+    const testChartVersion: IChartVersion = {
+      attributes: {
+        version: "1.2.3",
+      },
+      relationships: {
+        chart: {
+          data: {
+            name: "test",
+            repo: {
+              name: "testrepo",
+              url: "http://example.com/charts",
+            },
+          },
+        },
+      },
+    } as IChartVersion;
+    it("creates an app in a namespace", async () => {
+      moxios.stubRequest(/.*/, { response: "ok", status: 200 });
+      expect(await App.upgrade("absent-ant", "default", "kubeapps", testChartVersion)).toBe("ok");
+      const request = moxios.requests.mostRecent();
+      expect(request.url).toBe(expectedURL);
+      expect(request.config.data).toEqual(
+        JSON.stringify({
+          appRepositoryResourceName: testChartVersion.relationships.chart.data.repo.name,
+          chartName: testChartVersion.relationships.chart.data.name,
+          releaseName: "absent-ant",
+          version: testChartVersion.attributes.version,
+        }),
+      );
+    });
+  });
   describe("delete", () => {
     [
       {

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -1,4 +1,3 @@
-import { AppRepository } from "./AppRepository";
 import { axiosWithAuth } from "./AxiosInstance";
 import { hapi } from "./hapi/release";
 import { IAppOverview, IChartVersion } from "./types";
@@ -34,7 +33,6 @@ export class App {
       appRepositoryResourceName: chartAttrs.repo.name,
       chartName: chartAttrs.name,
       releaseName,
-      repoUrl: chartAttrs.repo.url,
       values,
       version: chartVersion.attributes.version,
     });
@@ -49,14 +47,11 @@ export class App {
     values?: string,
   ) {
     const chartAttrs = chartVersion.relationships.chart.data;
-    const repo = await AppRepository.get(chartAttrs.repo.name, kubeappsNamespace);
-    const auth = repo.spec.auth;
     const endpoint = App.getResourceURL(namespace, releaseName);
     const { data } = await axiosWithAuth.put(endpoint, {
-      auth,
+      appRepositoryResourceName: chartAttrs.repo.name,
       chartName: chartAttrs.name,
       releaseName,
-      repoUrl: chartAttrs.repo.url,
       values,
       version: chartVersion.attributes.version,
     });


### PR DESCRIPTION
Removes requiredRBAC role from DeploymentForm and updates the App.upgrade method to pass the app repo name, as per Andres' comment https://github.com/kubeapps/kubeapps/pull/1147#pullrequestreview-282873375

Also updates both create and upgrade to no longer send the repoURL (in #1150 tiller-proxy is updated to use the fetched app repo's repoURL instead).

Ref #1110