### PR TITLE
Use fixed tag for bitnami/kubeapps-dashboard image

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 2.1.1
+version: 2.1.2
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/requirements.lock
+++ b/chart/kubeapps/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 7.0.1
+  version: 7.2.7
 digest: sha256:415440e73af7d4b02a10a15f28bb2fc095cbdffdc2e1676d76e0f0eaa1632d50
-generated: "2019-08-01T12:14:01.340862919+02:00"
+generated: "2019-09-05T17:11:21.302113+02:00"

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -62,7 +62,7 @@ frontend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.16.0-r99
+    tag: 1.16.1-r25
   service:
     port: 80
     type: ClusterIP
@@ -221,8 +221,11 @@ dashboard:
   replicaCount: 2
   image:
     registry: docker.io
-    repository: kubeapps/dashboard
-    tag: latest
+    # Once issue #1156 is fixed we can continue using kubeapps repository instead of bitnami fixed tags
+    # repository: kubeapps/dashboard
+    # tag: latest
+    repository: bitnami/kubeapps-dashboard
+    tag: 1.5.0-debian-9-r14
   service:
     port: 8080
   livenessProbe:


### PR DESCRIPTION
This PR updates some image with CVEs.
It also changes the dashboard image from kubeapps/dashboard:latest to bitnami/kubeapps-dashboard:1.5.0-debian-9-r14 until #1156 is fixed.
