### PR TITLE
Customization for apprepository crontab.

### DIFF
--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         - --namespace={{ .Release.Namespace }}
         - --mongo-url={{ template "kubeapps.mongodb.fullname" . }}
         - --mongo-secret-name={{ .Values.mongodb.existingSecret }}
+        - --crontab={{ .Values.apprepository.crontab }}
         resources:
 {{ toYaml .Values.apprepository.resources | indent 12 }}
     {{- with .Values.apprepository.nodeSelector }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -97,7 +97,7 @@ frontend:
 apprepository:
   # Running a single controller replica to avoid sync job duplication
   replicaCount: 1
-  # Schedule for apprepository
+  # Schedule for syncing apprepositories
   crontab: "*/10 * * * *"
   image:
     registry: docker.io

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -97,6 +97,8 @@ frontend:
 apprepository:
   # Running a single controller replica to avoid sync job duplication
   replicaCount: 1
+  # Schedule for apprepository
+  crontab: "*/10 * * * *"
   image:
     registry: docker.io
     repository: kubeapps/apprepository-controller

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -389,8 +389,7 @@ func newCronJob(apprepo *apprepov1alpha1.AppRepository) *batchv1beta1.CronJob {
 			},
 		},
 		Spec: batchv1beta1.CronJobSpec{
-			// TODO: make schedule customisable
-			Schedule: "*/10 * * * *",
+			Schedule: crontab,
 			// Set to replace as short-circuit in k8s <1.12
 			// TODO re-evaluate ConcurrentPolicy when 1.12+ is mainstream (i.e 1.14)
 			// https://github.com/kubernetes/kubernetes/issues/54870

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -20,6 +20,7 @@ func Test_newCronJob(t *testing.T) {
 		apprepo          *apprepov1alpha1.AppRepository
 		expected         batchv1beta1.CronJob
 		userAgentComment string
+		crontab          string
 	}{
 		{
 			"my-charts",
@@ -96,9 +97,10 @@ func Test_newCronJob(t *testing.T) {
 				},
 			},
 			"",
+			"",
 		},
 		{
-			"my-charts with auth and userAgent comment",
+			"my-charts with auth, userAgent and crontab configuration",
 			&apprepov1alpha1.AppRepository{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "AppRepository",
@@ -136,7 +138,7 @@ func Test_newCronJob(t *testing.T) {
 					},
 				},
 				Spec: batchv1beta1.CronJobSpec{
-					Schedule:          "*/10 * * * *",
+					Schedule:          "*/20 * * * *",
 					ConcurrencyPolicy: "Replace",
 					JobTemplate: batchv1beta1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
@@ -182,6 +184,7 @@ func Test_newCronJob(t *testing.T) {
 				},
 			},
 			"kubeapps/v2.3",
+			"*/20 * * * *",
 		},
 	}
 
@@ -190,6 +193,10 @@ func Test_newCronJob(t *testing.T) {
 			if tt.userAgentComment != "" {
 				userAgentComment = tt.userAgentComment
 				defer func() { userAgentComment = "" }()
+			}
+			if tt.crontab != "" {
+				crontab = tt.crontab
+				defer func() { crontab = "" }()
 			}
 			result := newCronJob(tt.apprepo)
 			if diff := deep.Equal(tt.expected, *result); diff != nil {

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -37,6 +37,7 @@ var (
 	mongoURL         string
 	mongoSecretName  string
 	userAgentComment string
+	crontab          string
 )
 
 func main() {
@@ -81,4 +82,5 @@ func init() {
 	flag.StringVar(&mongoURL, "mongo-url", "localhost", "MongoDB URL (see https://godoc.org/labix.org/v2/mgo#Dial for format)")
 	flag.StringVar(&mongoSecretName, "mongo-secret-name", "mongodb", "Kubernetes secret name for MongoDB credentials")
 	flag.StringVar(&userAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
+	flag.StringVar(&crontab, "crontab", "*/10 * * * *", "CronTab to specify schedule")
 }


### PR DESCRIPTION
Hi,

first time contributing to this project, so please bear with me. I don't know whether this change is something you want. Any feedback welcome! I stumbled across this leftover `TODO` in the code regarding the cron schedule of the apprepository sync controller. I made the crontab modifiable and resolved the `TODO`.

Cheers,
Fabian

**This is the original commit message on PR submission:** 

Customization for apprepository crontab.

Apprepository controller now has a configurable crontab. Defaults to
"*/10 * * * *", as this was the hard-coded value before this change.

The cli parameter for the controller is '--crontab' and the
configuration property in the helm-chart is 'apprepository.crontab'.
