### PR TITLE
Use default namespace from auth state rather than 'default'.

### DIFF
--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -2,7 +2,7 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { getType } from "typesafe-actions";
 import Namespace from "../shared/Namespace";
-import { fetchNamespaces, receiveNamespaces, setNamespace } from "./namespace";
+import { errorNamespaces, fetchNamespaces, receiveNamespaces, setNamespace } from "./namespace";
 
 const mockStore = configureMockStore([thunk]);
 
@@ -61,9 +61,18 @@ describe("fetchNamespaces", () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
-  // TODO(miguel) Improve error handling in this case.
-  it("dispatches nothing if error", async () => {
+  it("dispatches errorNamespace if error listing namespaces", async () => {
+    const err = new Error("Bang!");
+    Namespace.list = jest.fn().mockImplementationOnce(() => Promise.reject(err));
+    const expectedActions = [
+      {
+        type: getType(errorNamespaces),
+        payload: { err, op: "list" },
+      },
+    ];
+
     await store.dispatch(fetchNamespaces());
-    expect(store.getActions().length).toEqual(0);
+
+    expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -13,7 +13,11 @@ export const receiveNamespaces = createAction("RECEIVE_NAMESPACES", resolve => {
   return (namespaces: string[]) => resolve(namespaces);
 });
 
-const allActions = [setNamespace, receiveNamespaces];
+export const errorNamespaces = createAction("ERROR_NAMESPACES", resolve => {
+  return (err: Error, op: "list") => resolve({ err, op });
+});
+
+const allActions = [setNamespace, receiveNamespaces, errorNamespaces];
 export type NamespaceAction = ActionType<typeof allActions[number]>;
 
 export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
@@ -23,7 +27,7 @@ export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null,
       const namespaceStrings = namespaces.items.map((n: IResource) => n.metadata.name);
       dispatch(receiveNamespaces(namespaceStrings));
     } catch (e) {
-      // TODO: handle namespace call error
+      dispatch(errorNamespaces(e, "list"));
       return;
     }
   };

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -10,9 +10,10 @@ const defaultProps = {
   fetchNamespaces: jest.fn(),
   logout: jest.fn(),
   namespace: {
-    current: "default",
-    namespaces: ["default"],
+    current: "",
+    namespaces: [],
   } as INamespaceState,
+  defaultNamespace: "kubeapps-user",
   pathname: "",
   push: jest.fn(),
   setNamespace: jest.fn(),
@@ -31,6 +32,20 @@ it("renders the header links and titles", () => {
     expect(item.children).toBe(expectedItems[index].children);
     expect(item.to).toBe(expectedItems[index].to);
   });
+});
+
+it("renders the namespace switcher", () => {
+  const wrapper = shallow(<Header {...defaultProps} />);
+
+  const namespaceSelector = wrapper.find("NamespaceSelector");
+
+  expect(namespaceSelector).toExist();
+  expect(namespaceSelector.props()).toEqual(
+    expect.objectContaining({
+      defaultNamespace: defaultProps.defaultNamespace,
+      namespace: defaultProps.namespace,
+    }),
+  );
 });
 
 it("disables the logout link when hideLogoutLink is set", () => {

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -17,6 +17,7 @@ interface IHeaderProps {
   fetchNamespaces: () => void;
   logout: () => void;
   namespace: INamespaceState;
+  defaultNamespace: string;
   pathname: string;
   push: (path: string) => void;
   setNamespace: (ns: string) => void;
@@ -64,7 +65,13 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   }
 
   public render() {
-    const { fetchNamespaces, namespace, authenticated: showNav, hideLogoutLink } = this.props;
+    const {
+      fetchNamespaces,
+      namespace,
+      defaultNamespace,
+      authenticated: showNav,
+      hideLogoutLink,
+    } = this.props;
     const header = `header ${this.state.mobileOpen ? "header-open" : ""}`;
     const submenu = `header__nav__submenu ${
       this.state.configOpen ? "header__nav__submenu-open" : ""
@@ -105,6 +112,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
               <div className="header__nav header__nav-config">
                 <NamespaceSelector
                   namespace={namespace}
+                  defaultNamespace={defaultNamespace}
                   onChange={this.handleNamespaceChange}
                   fetchNamespaces={fetchNamespaces}
                 />

--- a/dashboard/src/components/Header/NamespaceSelector.test.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.test.tsx
@@ -1,0 +1,74 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+
+import { INamespaceState } from "../../reducers/namespace";
+import NamespaceSelector from "./NamespaceSelector";
+
+const defaultProps = {
+  fetchNamespaces: jest.fn(),
+  namespace: {
+    current: "namespace-two",
+    namespaces: ["namespace-one", "namespace-two"],
+  } as INamespaceState,
+  defaultNamespace: "kubeapps-user",
+  onChange: jest.fn(),
+};
+
+it("renders the given namespaces with current selection", () => {
+  const wrapper = shallow(<NamespaceSelector {...defaultProps} />);
+  const select = wrapper.find(".NamespaceSelector__select").first();
+
+  const expectedValue = {
+    label: defaultProps.namespace.current,
+    value: defaultProps.namespace.current,
+  };
+  expect(select.props()).toEqual(
+    expect.objectContaining({
+      value: expectedValue,
+      options: [
+        { label: "All Namespaces", value: "_all" },
+        { label: "namespace-one", value: "namespace-one" },
+        { label: "namespace-two", value: "namespace-two" },
+      ],
+    }),
+  );
+});
+
+it("render with the default namespace selected if no current selection", () => {
+  const props = {
+    ...defaultProps,
+    namespace: {
+      ...defaultProps.namespace,
+      current: "",
+    },
+  };
+  const wrapper = shallow(<NamespaceSelector {...props} />);
+  const select = wrapper.find(".NamespaceSelector__select").first();
+
+  const expectedValue = {
+    label: defaultProps.defaultNamespace,
+    value: defaultProps.defaultNamespace,
+  };
+  expect(select.props().value).toEqual(expectedValue);
+});
+
+it("renders the default namespace option if no namespaces provided", () => {
+  const props = {
+    ...defaultProps,
+    namespace: {
+      current: "",
+      namespaces: [],
+    },
+  };
+  const wrapper = shallow(<NamespaceSelector {...props} />);
+  const select = wrapper.find(".NamespaceSelector__select").first();
+
+  expect(select.props()).toEqual(
+    expect.objectContaining({
+      options: [
+        { label: "All Namespaces", value: "_all" },
+        { label: defaultProps.defaultNamespace, value: defaultProps.defaultNamespace },
+      ],
+    }),
+  );
+});

--- a/dashboard/src/components/Header/NamespaceSelector.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.tsx
@@ -8,6 +8,7 @@ import "./NamespaceSelector.css";
 
 interface INamespaceSelectorProps {
   namespace: INamespaceState;
+  defaultNamespace: string;
   onChange: (ns: string) => any;
   fetchNamespaces: () => void;
 }
@@ -20,12 +21,17 @@ class NamespaceSelector extends React.Component<INamespaceSelectorProps> {
   public render() {
     const {
       namespace: { current, namespaces },
+      defaultNamespace,
     } = this.props;
-    const options = namespaces.map(n => ({ value: n, label: n }));
+    const options =
+      namespaces.length > 0
+        ? namespaces.map(n => ({ value: n, label: n }))
+        : [{ value: defaultNamespace, label: defaultNamespace }];
     const allOption = { value: definedNamespaces.all, label: "All Namespaces" };
     options.unshift(allOption);
+    const selected = current || defaultNamespace;
     const value =
-      current === definedNamespaces.all ? allOption : { value: current, label: current };
+      selected === definedNamespaces.all ? allOption : { value: selected, label: selected };
     return (
       <div className="NamespaceSelector margin-r-normal">
         <label className="NamespaceSelector__label type-tiny">NAMESPACE</label>

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -13,7 +13,7 @@ interface IState extends IStoreState {
 }
 
 function mapStateToProps({
-  auth: { authenticated, oidcAuthenticated },
+  auth: { authenticated, oidcAuthenticated, defaultNamespace },
   namespace,
   router: {
     location: { pathname },
@@ -22,6 +22,7 @@ function mapStateToProps({
   return {
     authenticated,
     namespace,
+    defaultNamespace,
     pathname,
     // If oidcAuthenticated it's not yet supported to logout
     // Some IdP like Keycloak allows to hit an endpoint to logout:

--- a/dashboard/src/containers/RoutesContainer/RoutesContainer.tsx
+++ b/dashboard/src/containers/RoutesContainer/RoutesContainer.tsx
@@ -4,8 +4,8 @@ import { withRouter } from "react-router";
 import { IStoreState } from "../../shared/types";
 import Routes from "./Routes";
 
-function mapStateToProps({ namespace }: IStoreState) {
-  return { namespace: namespace.current };
+function mapStateToProps({ auth, namespace }: IStoreState) {
+  return { namespace: namespace.current || auth.defaultNamespace };
 }
 
 export default withRouter(connect(mapStateToProps)(Routes));

--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -1,33 +1,54 @@
 import { LOCATION_CHANGE, RouterActionType } from "connected-react-router";
 import context from "jest-plugin-context";
+import { getType } from "typesafe-actions";
+
+import actions from "../actions";
 import namespaceReducer from "./namespace";
 
 describe("namespaceReducer", () => {
-  const location = {
-    hash: "",
-    search: "",
-    state: "",
+  const initialState = {
+    current: "initial-current",
+    namespaces: ["default", "initial-current"],
   };
-  const initialState = namespaceReducer(undefined, {} as any);
-
   context("when LOCATION CHANGE", () => {
-    it("changes the current stored namespace if it is in the URL", () => {
+    const location = {
+      hash: "",
+      search: "",
+      state: "",
+    };
+
+    describe("changes the current stored namespace if it is in the URL", () => {
       const testCases = [
         { path: "/ns/cyberdyne/apps", current: "cyberdyne" },
-        { path: "/cyberdyne/apps", current: "default" },
+        { path: "/cyberdyne/apps", current: "initial-current" },
         { path: "/ns/T-600/charts", current: "T-600" },
       ];
       testCases.forEach(tc => {
-        expect(
-          namespaceReducer(undefined, {
-            type: LOCATION_CHANGE,
-            payload: {
-              location: { ...location, pathname: tc.path },
-              action: "PUSH" as RouterActionType,
-            },
-          }),
-        ).toEqual({ ...initialState, current: tc.current });
+        it(tc.path, () =>
+          expect(
+            namespaceReducer(initialState, {
+              type: LOCATION_CHANGE,
+              payload: {
+                location: { ...location, pathname: tc.path },
+                action: "PUSH" as RouterActionType,
+              },
+            }),
+          ).toEqual({ ...initialState, current: tc.current }),
+        );
       });
+    });
+  });
+
+  context("when ERROR_NAMESPACE", () => {
+    const err = new Error("Bang!");
+
+    it("leaves namespaces intact and sets error", () => {
+      expect(
+        namespaceReducer(initialState, {
+          type: getType(actions.namespace.errorNamespaces),
+          payload: { err, op: "list" },
+        }),
+      ).toEqual({ ...initialState, error: err });
     });
   });
 });

--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -48,7 +48,7 @@ describe("namespaceReducer", () => {
           type: getType(actions.namespace.errorNamespaces),
           payload: { err, op: "list" },
         }),
-      ).toEqual({ ...initialState, error: err });
+      ).toEqual({ ...initialState, errorMsg: err.message });
     });
   });
 });

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -7,11 +7,12 @@ import { NamespaceAction } from "../actions/namespace";
 export interface INamespaceState {
   current: string;
   namespaces: string[];
+  error?: Error;
 }
 
 const initialState: INamespaceState = {
-  current: localStorage.getItem("kubeapps_namespace") || "default",
-  namespaces: ["default"],
+  current: "",
+  namespaces: [],
 };
 
 const namespaceReducer = (
@@ -23,6 +24,8 @@ const namespaceReducer = (
       return { ...state, namespaces: action.payload };
     case getType(actions.namespace.setNamespace):
       return { ...state, current: action.payload };
+    case getType(actions.namespace.errorNamespaces):
+      return { ...state, error: action.payload.err };
     case LOCATION_CHANGE:
       const pathname = action.payload.location.pathname;
       // looks for /ns/:namespace in URL

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -7,7 +7,7 @@ import { NamespaceAction } from "../actions/namespace";
 export interface INamespaceState {
   current: string;
   namespaces: string[];
-  error?: Error;
+  errorMsg?: string;
 }
 
 const initialState: INamespaceState = {
@@ -25,7 +25,7 @@ const namespaceReducer = (
     case getType(actions.namespace.setNamespace):
       return { ...state, current: action.payload };
     case getType(actions.namespace.errorNamespaces):
-      return { ...state, error: action.payload.err };
+      return { ...state, errorMsg: action.payload.err.message };
     case LOCATION_CHANGE:
       const pathname = action.payload.location.pathname;
       // looks for /ns/:namespace in URL


### PR DESCRIPTION
Follows on from #1167 to fix #1162 .

Conceptually this just removes any `default` option for the header/namespace selector, replacing it with the `state.auth.defaultNamespace` set in the previous branch. When testing I had some issues because the redirect from the root route was using `state.namespaces.current` which is no longer necessary set - eg., when first logging in after a refresh.

Also includes a drive-by to no longer ignore errors when fetching namespaces (at least storing the error in the state).

I'll follow-up with one or two small drive-by's that I noticed (one is that we retain state when logging out, for namespaces etc.)