### PR TITLE
Clear namespaces on logout

### DIFF
--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -130,6 +130,9 @@ describe("OIDC authentication", () => {
         payload: { authenticated: false, oidc: false, defaultNamespace: "" },
         type: getType(actions.auth.setAuthenticated),
       },
+      {
+        type: getType(actions.namespace.clearNamespaces),
+      },
     ];
 
     return store.dispatch(actions.auth.expireSession()).then(() => {

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -3,6 +3,7 @@ import { ActionType, createAction } from "typesafe-actions";
 
 import { Auth } from "../shared/Auth";
 import { IStoreState } from "../shared/types";
+import { clearNamespaces, NamespaceAction } from "./namespace";
 
 export const setAuthenticated = createAction("SET_AUTHENTICATED", resolve => {
   return (authenticated: boolean, oidc: boolean, defaultNamespace: string) =>
@@ -42,10 +43,16 @@ export function authenticate(
   };
 }
 
-export function logout(): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
+export function logout(): ThunkAction<
+  Promise<void>,
+  IStoreState,
+  null,
+  AuthAction | NamespaceAction
+> {
   return async dispatch => {
     Auth.unsetAuthToken();
     dispatch(setAuthenticated(false, false, ""));
+    dispatch(clearNamespaces());
   };
 }
 

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -17,7 +17,11 @@ export const errorNamespaces = createAction("ERROR_NAMESPACES", resolve => {
   return (err: Error, op: "list") => resolve({ err, op });
 });
 
-const allActions = [setNamespace, receiveNamespaces, errorNamespaces];
+export const clearNamespaces = createAction("CLEAR_NAMESPACES", resolve => {
+  return () => resolve();
+});
+
+const allActions = [setNamespace, receiveNamespaces, errorNamespaces, clearNamespaces];
 export type NamespaceAction = ActionType<typeof allActions[number]>;
 
 export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -17,9 +17,7 @@ export const errorNamespaces = createAction("ERROR_NAMESPACES", resolve => {
   return (err: Error, op: "list") => resolve({ err, op });
 });
 
-export const clearNamespaces = createAction("CLEAR_NAMESPACES", resolve => {
-  return () => resolve();
-});
+export const clearNamespaces = createAction("CLEAR_NAMESPACES");
 
 const allActions = [setNamespace, receiveNamespaces, errorNamespaces, clearNamespaces];
 export type NamespaceAction = ActionType<typeof allActions[number]>;

--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -51,4 +51,19 @@ describe("namespaceReducer", () => {
       ).toEqual({ ...initialState, errorMsg: err.message });
     });
   });
+
+  context("when CLEAR_NAMESPACES", () => {
+    const clearedState = {
+      current: "",
+      namespaces: [],
+    };
+
+    it("clears any namespaces state", () => {
+      expect(
+        namespaceReducer(initialState, {
+          type: getType(actions.namespace.clearNamespaces),
+        }),
+      ).toEqual(clearedState);
+    });
+  });
 });

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -26,6 +26,8 @@ const namespaceReducer = (
       return { ...state, current: action.payload };
     case getType(actions.namespace.errorNamespaces):
       return { ...state, errorMsg: action.payload.err.message };
+    case getType(actions.namespace.clearNamespaces):
+      return { ...initialState };
     case LOCATION_CHANGE:
       const pathname = action.payload.location.pathname;
       // looks for /ns/:namespace in URL

--- a/dashboard/src/shared/AxiosInstance.test.ts
+++ b/dashboard/src/shared/AxiosInstance.test.ts
@@ -136,6 +136,9 @@ describe("createAxiosInterceptorWithAuth", () => {
         payload: { authenticated: false, oidc: false, defaultNamespace: "" },
         type: "SET_AUTHENTICATED",
       },
+      {
+        type: "CLEAR_NAMESPACES",
+      },
     ];
 
     moxios.stubRequest(testPath, {

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -10,7 +10,7 @@ export default class Namespace {
   }
 
   private static APIBase: string = APIBase;
-  private static APIEndpoint: string = `${Namespace.APIBase}/api/v1/namespaces`;
+  private static APIEndpoint: string = `${Namespace.APIBase}/api/v1/namespaces/`;
 }
 
 // Set of namespaces used accross the applications as default and "all ns" placeholders


### PR DESCRIPTION
Just two tiny clean-ups I'd noted in some earlier work.

First, ensure that we clear the namespaces in the client state when logging out: I kept finding that I would re-authenticate with a token for a user with access to only a single namespace, but find the UI still presented all namespaces, until I refreshed.

Second, avoid 302 permanent redirects when checking namespaces api endpoint.