### PR TITLE
Add tests for values.yaml state in DeploymentForm

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -6,7 +6,7 @@ import itBehavesLike from "../../shared/specs";
 import { IChartState, IChartVersion, NotFoundError, UnprocessableEntity } from "../../shared/types";
 import { ErrorSelector } from "../ErrorAlert";
 import ErrorPageHeader from "../ErrorAlert/ErrorAlertHeader";
-import DeploymentForm from "./DeploymentForm";
+import DeploymentForm, { IDeploymentFormProps, IDeploymentFormState } from "./DeploymentForm";
 
 const defaultProps = {
   kubeappsNamespace: "kubeapps",
@@ -126,4 +126,81 @@ it("renders a release name by default, relying in Monickers output", () => {
   );
   const name2 = wrapper.state("releaseName") as string;
   expect(name2).toBe("bar");
+});
+
+describe("stores modified values locally", () => {
+  const initialValues = "some yaml text";
+  const chartVersion = {
+    id: "foo",
+    attributes: { version: "1.0", app_version: "1.0", created: "1" },
+    relationships: {
+      chart: {
+        data: {
+          name: "chart",
+          description: "chart-description",
+          keywords: [],
+          maintainers: [],
+          repo: {
+            name: "repo",
+            url: "http://example.com",
+          },
+          sources: [],
+        },
+      },
+    },
+  };
+  const props: IDeploymentFormProps = {
+    ...defaultProps,
+    selected: {
+      ...defaultProps.selected,
+      versions: [chartVersion],
+      version: chartVersion,
+      values: initialValues,
+    },
+  };
+
+  it("initializes the local values from props when props set", () => {
+    const wrapper = shallow(<DeploymentForm {...props} />);
+
+    wrapper.setProps(props);
+
+    const localState: IDeploymentFormState = wrapper.instance().state as IDeploymentFormState;
+    expect(localState.appValues).toEqual(initialValues);
+  });
+
+  it("updates initial values from props if not modified", () => {
+    const wrapper = shallow(<DeploymentForm {...props} />);
+
+    const updatedValuesFromProps = "some other yaml";
+    wrapper.setProps({
+      ...props,
+      selected: {
+        ...props.selected,
+        values: updatedValuesFromProps,
+      },
+    });
+
+    const localState: IDeploymentFormState = wrapper.instance().state as IDeploymentFormState;
+    expect(localState.appValues).toEqual(updatedValuesFromProps);
+  });
+
+  it("does not update values from props if they have been modified in local state", () => {
+    const wrapper = shallow(<DeploymentForm {...props} />);
+    const modifiedValues = "user-modified values.yaml";
+    const form: DeploymentForm = wrapper.instance() as DeploymentForm;
+    form.handleValuesChange(modifiedValues);
+
+    const updatedValuesFromProps = "some other yaml";
+    wrapper.setProps({
+      ...props,
+      selected: {
+        ...props.selected,
+        values: updatedValuesFromProps,
+      },
+    });
+
+    const localState: IDeploymentFormState = wrapper.instance().state as IDeploymentFormState;
+    expect(localState.appValues).not.toEqual(updatedValuesFromProps);
+    expect(localState.appValues).toEqual(modifiedValues);
+  });
 });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -10,7 +10,7 @@ import LoadingWrapper from "../LoadingWrapper";
 import "brace/mode/yaml";
 import "brace/theme/xcode";
 
-interface IDeploymentFormProps {
+export interface IDeploymentFormProps {
   kubeappsNamespace: string;
   chartID: string;
   chartVersion: string;
@@ -29,7 +29,7 @@ interface IDeploymentFormProps {
   namespace: string;
 }
 
-interface IDeploymentFormState {
+export interface IDeploymentFormState {
   isDeploying: boolean;
   // deployment options
   releaseName: string;

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -39,6 +39,7 @@ export interface IDeploymentFormState {
   latestSubmittedReleaseName: string;
   namespace: string;
   appValues?: string;
+  valuesModified: boolean;
 }
 
 class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFormState> {
@@ -48,6 +49,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
     namespace: this.props.namespace,
     releaseName: Moniker.choose(),
     latestSubmittedReleaseName: "",
+    valuesModified: false,
   };
 
   public componentDidMount() {
@@ -82,8 +84,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
       return;
     }
 
-    const valuesModified = selected.values !== this.state.appValues;
-    if (!this.state.appValues || !valuesModified) {
+    if (!this.state.valuesModified) {
       if (version) {
         this.setState({ appValues: nextProps.selected.values });
       }
@@ -198,7 +199,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   };
 
   public handleValuesChange = (value: string) => {
-    this.setState({ appValues: value });
+    this.setState({ appValues: value, valuesModified: true });
   };
 }
 

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -39,7 +39,6 @@ export interface IDeploymentFormState {
   latestSubmittedReleaseName: string;
   namespace: string;
   appValues?: string;
-  valuesModified: boolean;
 }
 
 class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFormState> {
@@ -49,7 +48,6 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
     namespace: this.props.namespace,
     releaseName: Moniker.choose(),
     latestSubmittedReleaseName: "",
-    valuesModified: false,
   };
 
   public componentDidMount() {
@@ -84,7 +82,8 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
       return;
     }
 
-    if (!this.state.valuesModified) {
+    const valuesModified = selected.values !== this.state.appValues;
+    if (!this.state.appValues || !valuesModified) {
       if (version) {
         this.setState({ appValues: nextProps.selected.values });
       }
@@ -199,7 +198,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   };
 
   public handleValuesChange = (value: string) => {
-    this.setState({ appValues: value, valuesModified: true });
+    this.setState({ appValues: value });
   };
 }
 


### PR DESCRIPTION
I was wanting to better understand how the state is currently managed for values.yaml in charts.

Seems that we have global state in redux for the selected chart version, which we copy into the form's local state which the user can modify - which is fine, but while there, I noticed some redundant state, so added tests then removed it.