### PR TITLE
Update chart to be deployable with helm 3

### DIFF
--- a/chart/kubeapps/crds/apprepository-crd.yaml
+++ b/chart/kubeapps/crds/apprepository-crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apprepositories.kubeapps.com
+spec:
+  group: kubeapps.com
+  scope: Namespaced
+  names:
+    kind: AppRepository
+    plural: apprepositories
+    shortNames:
+    - apprepos
+  version: v1alpha1

--- a/chart/kubeapps/templates/apprepositories.yaml
+++ b/chart/kubeapps/templates/apprepositories.yaml
@@ -4,19 +4,7 @@ kind: AppRepository
 metadata:
   name: {{ .name }}
   annotations:
-{{- if semverCompare ">=2.14.0" $.Capabilities.TillerVersion.SemVer }}
-    # Using the hook pre-install because since Helm v2.14 the crd-install
-    # hook should be used only for CRDs and the issues related to install
-    # Custom Resources have been already fixed
-    # https://github.com/helm/helm/issues/5756#issuecomment-493653454
     "helm.sh/hook": pre-install
-{{- else }}
-    # Using the hook crd-install to avoid issue w/Helm v1.11
-    # https://github.com/kubeapps/kubeapps/pull/955#pullrequestreview-200764260
-    "helm.sh/hook": crd-install
-    # Make sure this runs after the AppRepository CRD install
-    "helm.sh/hook-weight": "10"
-{{- end }}
   labels:
     app: {{ template "kubeapps.apprepository.fullname" $ }}
     chart: {{ template "kubeapps.chart" $ }}


### PR DESCRIPTION
This results in Kubeapps deploying without issue in helm 3, but obviously not runnable (tiller-proxy currently errors if it can't connect to tiller).

Nonetheless, without this change the chart errors with helm 3. With this change, the chart can be installed successfully multiple times. It utilises the support for a `crds` directory in the chart, but note that these CRD files cannot be templated (nor should they need to be, since they are system-wide and not reference-counted?).

Verified that I can also install this chart successfully with helm 2.13.1 .