### PR TITLE
Update mongodb dependency to support deployment on k8s 1.16

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 2.1.3
+version: 2.1.4
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/requirements.lock
+++ b/chart/kubeapps/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 7.2.7
+  version: 7.2.9
 digest: sha256:415440e73af7d4b02a10a15f28bb2fc095cbdffdc2e1676d76e0f0eaa1632d50
-generated: "2019-09-05T17:11:21.302113+02:00"
+generated: 2019-09-24T07:04:11.615576228Z


### PR DESCRIPTION
While investigating installation on k8s 1.16 for a Sahel [1] I noticed that installing the Kubeapps chart would fail because the mongodb dependency version was using old api endpoints too.

Even though we've recently updated the dep, 2.7.7 still has the removed endpoints for the standalone deployment:
```
~$ helm fetch --untar stable/mongodb --version 7.2.7 && cd mongodb
~/mongodb$ rg extensions
templates/ingress.yaml
2:apiVersion: extensions/v1beta1

templates/deployment-standalone.yaml
2:apiVersion: extensions/v1beta1
```

2.7.9 does not:
```
$ helm fetch --untar stable/mongodb --version 7.2.9 && rg extensions mongodb/                                                                                                                                          
mongodb/README.md
256:The allowed extensions are `.sh`, and `.js`.

mongodb/templates/ingress.yaml
2:apiVersion: extensions/v1beta1
~$ 
```

[1] https://kubernetes.slack.com/archives/C9D3TSUG4/p1569292968011900