### PR TITLE
Replace GKE 1.11 with 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,8 @@ build_on_master: &build_on_master
   filters:
     tags:
       only: /^v.*/
-    # TESTING: Re-enable
-    # branches:
-    #   only: master
+    branches:
+      only: master
 # Build only in tags (release)
 build_on_tag: &build_on_tag
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,9 @@ build_on_master: &build_on_master
   filters:
     tags:
       only: /^v.*/
-    branches:
-      only: master
+    # TESTING: Re-enable
+    # branches:
+    #   only: master
 # Build only in tags (release)
 build_on_tag: &build_on_tag
   filters:
@@ -42,14 +43,14 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_11_MASTER:
+      - GKE_1_13_MASTER:
           <<: *build_on_master
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_11_LATEST_RELEASE:
+      - GKE_1_13_LATEST_RELEASE:
           <<: *build_on_master
           requires:
             - test_go
@@ -73,22 +74,22 @@ workflows:
       - sync_chart:
           <<: *build_on_master
           requires:
-            - GKE_1_11_MASTER
-            - GKE_1_11_LATEST_RELEASE
+            - GKE_1_13_MASTER
+            - GKE_1_13_LATEST_RELEASE
             - GKE_1_12_MASTER
             - GKE_1_12_LATEST_RELEASE
       - push_images:
           <<: *build_always
           requires:
-            - GKE_1_11_MASTER
-            - GKE_1_11_LATEST_RELEASE
+            - GKE_1_13_MASTER
+            - GKE_1_13_LATEST_RELEASE
             - GKE_1_12_MASTER
             - GKE_1_12_LATEST_RELEASE
       - release:
           <<: *build_on_tag
           requires:
-            - GKE_1_11_MASTER
-            - GKE_1_11_LATEST_RELEASE
+            - GKE_1_13_MASTER
+            - GKE_1_13_LATEST_RELEASE
             - GKE_1_12_MASTER
             - GKE_1_12_LATEST_RELEASE
 
@@ -266,14 +267,14 @@ jobs:
           at: /tmp/images
       - run: for image in /tmp/images/*; do kind load image-archive "$image"; done
       - <<: *run_e2e_tests
-  GKE_1_11_MASTER:
+  GKE_1_13_MASTER:
     <<: *gke_test
     environment:
-      GKE_BRANCH: "1.11"
-  GKE_1_11_LATEST_RELEASE:
+      GKE_BRANCH: "1.13"
+  GKE_1_13_LATEST_RELEASE:
     <<: *gke_test
     environment:
-      GKE_BRANCH: "1.11"
+      GKE_BRANCH: "1.13"
       TEST_LATEST_RELEASE: 1
   GKE_1_12_MASTER:
     <<: *gke_test

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -33,7 +33,9 @@ spec:
         - --namespace={{ .Release.Namespace }}
         - --mongo-url={{ template "kubeapps.mongodb.fullname" . }}
         - --mongo-secret-name={{ .Values.mongodb.existingSecret }}
+        {{- if .Values.apprepository.crontab }}
         - --crontab={{ .Values.apprepository.crontab }}
+        {{- end }}
         resources:
 {{ toYaml .Values.apprepository.resources | indent 12 }}
     {{- with .Values.apprepository.nodeSelector }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -97,8 +97,8 @@ frontend:
 apprepository:
   # Running a single controller replica to avoid sync job duplication
   replicaCount: 1
-  # Schedule for syncing apprepositories
-  crontab: "*/10 * * * *"
+  # Schedule for syncing apprepositories. Every ten minutes by default
+  # crontab: "*/10 * * * *"
   image:
     registry: docker.io
     repository: kubeapps/apprepository-controller


### PR DESCRIPTION
GKE branch 1.11 is not available, replace it with 1.13 to fix the CI 

Also to avoid breaking changes. Avoid the `--crontab` flag by default for the apprepository controller.

Tested on: https://circleci.com/gh/kubeapps/kubeapps/9416?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link