### PR TITLE
Add feature flag for basic form

### DIFF
--- a/dashboard/src/components/DeploymentForm/AdvancedDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/AdvancedDeploymentForm.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import AceEditor from "react-ace";
+
+import "brace/mode/yaml";
+import "brace/theme/xcode";
+
+export interface IAdvancedDeploymentForm {
+  appValues?: string;
+  handleValuesChange: (value: string) => void;
+}
+
+class AdvancedDeploymentForm extends React.Component<IAdvancedDeploymentForm> {
+  public render() {
+    return (
+      <div style={{ marginBottom: "1em" }}>
+        <label htmlFor="values">Values (YAML)</label>
+        <AceEditor
+          mode="yaml"
+          theme="xcode"
+          name="values"
+          width="100%"
+          onChange={this.props.handleValuesChange}
+          setOptions={{ showPrintMargin: false }}
+          editorProps={{ $blockScrolling: Infinity }}
+          value={this.props.appValues}
+        />
+      </div>
+    );
+  }
+}
+
+export default AdvancedDeploymentForm;

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+class BasicDeploymentForm extends React.Component {
+  public render() {
+    return <div>Basic Form!</div>;
+  }
+}
+
+export default BasicDeploymentForm;

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -1,6 +1,7 @@
 import { mount, shallow } from "enzyme";
 import * as Moniker from "moniker-native";
 import * as React from "react";
+import AceEditor from "react-ace";
 
 import itBehavesLike from "../../shared/specs";
 import { IChartState, IChartVersion, NotFoundError, UnprocessableEntity } from "../../shared/types";
@@ -20,6 +21,7 @@ const defaultProps = {
   getChartVersion: jest.fn(),
   getChartValues: jest.fn(),
   namespace: "default",
+  enableBasicForm: false,
 };
 let monikerChooseMock: jest.Mock;
 
@@ -126,4 +128,9 @@ it("renders a release name by default, relying in Monickers output", () => {
   );
   const name2 = wrapper.state("releaseName") as string;
   expect(name2).toBe("bar");
+});
+
+it("renders the basic form if enabled", () => {
+  const wrapper = shallow(<DeploymentForm {...defaultProps} enableBasicForm={true} />);
+  expect(wrapper.find(AceEditor)).not.toExist();
 });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -7,6 +7,7 @@ import itBehavesLike from "../../shared/specs";
 import { IChartState, IChartVersion, NotFoundError, UnprocessableEntity } from "../../shared/types";
 import { ErrorSelector } from "../ErrorAlert";
 import ErrorPageHeader from "../ErrorAlert/ErrorAlertHeader";
+import LoadingWrapper from "../LoadingWrapper";
 import DeploymentForm from "./DeploymentForm";
 
 const defaultProps = {
@@ -131,6 +132,14 @@ it("renders a release name by default, relying in Monickers output", () => {
 });
 
 it("renders the basic form if enabled", () => {
-  const wrapper = shallow(<DeploymentForm {...defaultProps} enableBasicForm={true} />);
+  const versions = [{ id: "foo", attributes: { version: "1.2.3" } }] as IChartVersion[];
+  const wrapper = shallow(
+    <DeploymentForm
+      {...defaultProps}
+      enableBasicForm={true}
+      selected={{ versions, version: versions[0] }}
+    />,
+  );
+  expect(wrapper.find(LoadingWrapper)).not.toExist();
   expect(wrapper.find(AceEditor)).not.toExist();
 });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -27,6 +27,7 @@ interface IDeploymentFormProps {
   getChartVersion: (id: string, chartVersion: string) => void;
   getChartValues: (id: string, chartVersion: string) => void;
   namespace: string;
+  enableBasicForm: boolean;
 }
 
 interface IDeploymentFormState {
@@ -94,7 +95,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   public render() {
     const { selected, chartID, chartVersion, namespace } = this.props;
     const { version, versions } = selected;
-    const { appValues, latestSubmittedReleaseName } = this.state;
+    const { latestSubmittedReleaseName } = this.state;
     if (selected.error) {
       return (
         <ErrorSelector error={selected.error} resource={`Chart "${chartID}" (${chartVersion})`} />
@@ -145,19 +146,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
                   ))}
                 </select>
               </div>
-              <div style={{ marginBottom: "1em" }}>
-                <label htmlFor="values">Values (YAML)</label>
-                <AceEditor
-                  mode="yaml"
-                  theme="xcode"
-                  name="values"
-                  width="100%"
-                  onChange={this.handleValuesChange}
-                  setOptions={{ showPrintMargin: false }}
-                  editorProps={{ $blockScrolling: Infinity }}
-                  value={appValues}
-                />
-              </div>
+              {this.props.enableBasicForm ? this.renderBasicForm() : this.renderAdvancedForm()}
               <div>
                 <button className="button button-primary" type="submit">
                   Submit
@@ -200,6 +189,28 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
 
   public handleValuesChange = (value: string) => {
     this.setState({ appValues: value, valuesModified: true });
+  };
+
+  private renderBasicForm = () => {
+    return <div>Basic Form!</div>;
+  };
+
+  private renderAdvancedForm = () => {
+    return (
+      <div style={{ marginBottom: "1em" }}>
+        <label htmlFor="values">Values (YAML)</label>
+        <AceEditor
+          mode="yaml"
+          theme="xcode"
+          name="values"
+          width="100%"
+          onChange={this.handleValuesChange}
+          setOptions={{ showPrintMargin: false }}
+          editorProps={{ $blockScrolling: Infinity }}
+          value={this.state.appValues}
+        />
+      </div>
+    );
   };
 }
 

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -1,14 +1,13 @@
 import { RouterAction } from "connected-react-router";
 import * as Moniker from "moniker-native";
 import * as React from "react";
-import AceEditor from "react-ace";
 
 import { IChartState, IChartVersion } from "../../shared/types";
 import { ErrorSelector } from "../ErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
 
-import "brace/mode/yaml";
-import "brace/theme/xcode";
+import AdvancedDeploymentForm from "./AdvancedDeploymentForm";
+import BasicDeploymentForm from "./BasicDeploymentForm";
 
 export interface IDeploymentFormProps {
   kubeappsNamespace: string;
@@ -95,7 +94,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   public render() {
     const { selected, chartID, chartVersion, namespace } = this.props;
     const { version, versions } = selected;
-    const { latestSubmittedReleaseName } = this.state;
+    const { latestSubmittedReleaseName, appValues } = this.state;
     if (selected.error) {
       return (
         <ErrorSelector error={selected.error} resource={`Chart "${chartID}" (${chartVersion})`} />
@@ -146,7 +145,14 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
                   ))}
                 </select>
               </div>
-              {this.props.enableBasicForm ? this.renderBasicForm() : this.renderAdvancedForm()}
+              {this.props.enableBasicForm ? (
+                <BasicDeploymentForm />
+              ) : (
+                <AdvancedDeploymentForm
+                  appValues={appValues}
+                  handleValuesChange={this.handleValuesChange}
+                />
+              )}
               <div>
                 <button className="button button-primary" type="submit">
                   Submit
@@ -189,28 +195,6 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
 
   public handleValuesChange = (value: string) => {
     this.setState({ appValues: value, valuesModified: true });
-  };
-
-  private renderBasicForm = () => {
-    return <div>Basic Form!</div>;
-  };
-
-  private renderAdvancedForm = () => {
-    return (
-      <div style={{ marginBottom: "1em" }}>
-        <label htmlFor="values">Values (YAML)</label>
-        <AceEditor
-          mode="yaml"
-          theme="xcode"
-          name="values"
-          width="100%"
-          onChange={this.handleValuesChange}
-          setOptions={{ showPrintMargin: false }}
-          editorProps={{ $blockScrolling: Infinity }}
-          value={this.state.appValues}
-        />
-      </div>
-    );
   };
 }
 

--- a/dashboard/src/components/DeploymentForm/__snapshots__/DeploymentForm.test.tsx.snap
+++ b/dashboard/src/components/DeploymentForm/__snapshots__/DeploymentForm.test.tsx.snap
@@ -61,63 +61,9 @@ exports[`renders the full DeploymentForm 1`] = `
             </option>
           </select>
         </div>
-        <div
-          style={
-            Object {
-              "marginBottom": "1em",
-            }
-          }
-        >
-          <label
-            htmlFor="values"
-          >
-            Values (YAML)
-          </label>
-          <ReactAce
-            cursorStart={1}
-            editorProps={
-              Object {
-                "$blockScrolling": Infinity,
-              }
-            }
-            enableBasicAutocompletion={false}
-            enableLiveAutocompletion={false}
-            focus={false}
-            fontSize={12}
-            height="500px"
-            highlightActiveLine={true}
-            maxLines={null}
-            minLines={null}
-            mode="yaml"
-            name="values"
-            onChange={[Function]}
-            onLoad={null}
-            onPaste={null}
-            onScroll={null}
-            readOnly={false}
-            scrollMargin={
-              Array [
-                0,
-                0,
-                0,
-                0,
-              ]
-            }
-            setOptions={
-              Object {
-                "showPrintMargin": false,
-              }
-            }
-            showGutter={true}
-            showPrintMargin={true}
-            style={Object {}}
-            tabSize={4}
-            theme="xcode"
-            value=""
-            width="100%"
-            wrapEnabled={false}
-          />
-        </div>
+        <AdvancedDeploymentForm
+          handleValuesChange={[Function]}
+        />
         <div>
           <button
             className="button button-primary"

--- a/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -26,6 +26,7 @@ function mapStateToProps(
     chartVersion: params.version,
     error: apps.error,
     kubeappsNamespace: config.namespace,
+    enableBasicForm: config.enableBasicForm,
     namespace: namespace.current,
     selected: charts.selected,
   };

--- a/dashboard/src/reducers/config.ts
+++ b/dashboard/src/reducers/config.ts
@@ -12,6 +12,7 @@ const initialState: IConfigState = {
   loaded: false,
   namespace: "",
   appVersion: "",
+  enableBasicForm: false,
 };
 
 const configReducer = (state: IConfigState = initialState, action: ConfigAction): IConfigState => {

--- a/dashboard/src/shared/Config.test.ts
+++ b/dashboard/src/shared/Config.test.ts
@@ -30,6 +30,11 @@ describe("Config", () => {
     expect(await Config.getConfig()).toEqual({ ...defaultJSON, namespace: "magic-playground" });
   });
 
+  it("returns the basic form feature flag", async () => {
+    process.env.REACT_APP_KUBEAPPS_ENABLE_BASIC_FORM = "true";
+    expect(await Config.getConfig()).toEqual({ ...defaultJSON, enableBasicForm: true });
+  });
+
   it("does not returns the overriden namespace if NODE_ENV=production", async () => {
     process.env.NODE_ENV = "production";
     process.env.REACT_APP_KUBEAPPS_NS = "magic-playground";

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -5,6 +5,7 @@ export interface IConfig {
   namespace: string;
   appVersion: string;
   error?: Error;
+  enableBasicForm: boolean;
 }
 
 export default class Config {
@@ -16,9 +17,14 @@ export default class Config {
     // TODO(miguel) Rename env variable to KUBEAPPS_NAMESPACE once/if we eject create-react-app
     // Currently we are using REACT_APP_* because it's the only way to inject env variables in a sealed setup.
     // Please note that this env variable gets mapped in the run command in the package.json file
-    if (process.env.NODE_ENV !== "production" && process.env.REACT_APP_KUBEAPPS_NS) {
-      data.namespace = process.env.REACT_APP_KUBEAPPS_NS;
+    if (process.env.NODE_ENV !== "production") {
       data.appVersion = "DEVEL";
+      if (process.env.REACT_APP_KUBEAPPS_NS) {
+        data.namespace = process.env.REACT_APP_KUBEAPPS_NS;
+      }
+      if (process.env.REACT_APP_KUBEAPPS_ENABLE_BASIC_FORM === "true") {
+        data.enableBasicForm = true;
+      }
     }
 
     return data;


### PR DESCRIPTION
Based on the design document #1152 

Right now this feature flag is only usable using `telepresence`. To use it, execute:

```
▶ REACT_APP_KUBEAPPS_ENABLE_BASIC_FORM=true TELEPRESENCE_CONTAINER_NAMESPACE=kubeapps yarn run start
```

![Screenshot from 2019-09-24 16-28-02](https://user-images.githubusercontent.com/4025665/65521023-dcd16480-dee8-11e9-929e-fd0ace16e326.png)
