### PR TITLE
Proxy chartsvc requests

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -52,6 +52,11 @@ data:
         rewrite /api/chartsvc/(.*) /$1 break;
         rewrite /api/chartsvc / break;
         proxy_pass http://{{ template "kubeapps.chartsvc.fullname" . }}:{{ .Values.chartsvc.service.port }};
+
+        # TODO(andresmgot): Enable this routing instead of the above once tiller-proxy releases a new version
+        # rewrite /api/chartsvc/(.*) /chartsvc/$1 break;
+        # rewrite /api/chartsvc /chartsvc break;
+        # proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
       }
 
       location ~* /api/tiller-deploy {

--- a/chart/kubeapps/templates/tiller-proxy-deployment.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-deployment.yaml
@@ -32,6 +32,8 @@ spec:
         args:
         - --host={{ .Values.tillerProxy.host }}
         - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
+        # TODO(andresmgot): Enable this flag once tiller-proxy releases a new version
+        # - --chartsvc-url=http://{{ template "kubeapps.chartsvc.fullname" . }}:{{ .Values.chartsvc.service.port }}
         {{- if .Values.tillerProxy.tls }}
         - --tls
         {{- if .Values.tillerProxy.tls.verify }}

--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -374,18 +373,4 @@ func (h *TillerProxy) DeleteRelease(w http.ResponseWriter, req *http.Request, pa
 	}
 	w.Header().Set("Status-Code", "200")
 	w.Write([]byte("OK"))
-}
-
-// ProxyChartSVC reverse-proxy requests to the chartsvc
-func (h *TillerProxy) ProxyChartSVC(w http.ResponseWriter, req *http.Request) {
-	// Remove root /chartsvc from the actual path
-	path := strings.Replace(req.URL.String(), "/chartsvc", "", -1)
-	var err error
-	req.URL, err = url.Parse(path)
-	if err != nil {
-		response.NewErrorResponse(errorCode(err), err.Error()).Write(w)
-		return
-	}
-
-	h.ChartsvcProxy.ServeHTTP(w, req)
 }

--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"net/http/httputil"
 	"regexp"
 	"strconv"
 	"strings"
@@ -151,11 +150,10 @@ func returnForbiddenActions(forbiddenActions []auth.Action, w http.ResponseWrite
 
 // TillerProxy client and configuration
 type TillerProxy struct {
-	DisableAuth   bool
-	ListLimit     int
-	ChartClient   chartUtils.Resolver
-	ProxyClient   proxy.TillerClient
-	ChartsvcProxy *httputil.ReverseProxy
+	DisableAuth bool
+	ListLimit   int
+	ChartClient chartUtils.Resolver
+	ProxyClient proxy.TillerClient
 }
 
 func (h *TillerProxy) logStatus(name string) {

--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -379,7 +379,7 @@ func (h *TillerProxy) DeleteRelease(w http.ResponseWriter, req *http.Request, pa
 // ProxyChartSVC reverse-proxy requests to the chartsvc
 func (h *TillerProxy) ProxyChartSVC(w http.ResponseWriter, req *http.Request) {
 	// Remove root /chartsvc from the actual path
-	path := strings.Replace(req.URL.EscapedPath(), "/chartsvc", "", -1)
+	path := strings.Replace(req.URL.String(), "/chartsvc", "", -1)
 	var err error
 	req.URL, err = url.Parse(path)
 	if err != nil {

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -187,14 +187,15 @@ func main() {
 	))
 
 	// Chartsvc reverse proxy
-	chartsvc := r.PathPrefix("/chartsvc").Subrouter()
+	chartsvcPrefix := "/chartsvc"
+	chartsvcRouter := r.PathPrefix(chartsvcPrefix).Subrouter()
 	// Logos don't require authentication so bypass that step
-	chartsvc.Methods("GET").Path("/v1/assets/{repo}/{id}/logo").Handler(negroni.New(
-		negroni.Wrap(handler.WithoutParams(h.ProxyChartSVC)),
+	chartsvcRouter.Methods("GET").Path("/v1/assets/{repo}/{id}/logo").Handler(negroni.New(
+		negroni.Wrap(http.StripPrefix(chartsvcPrefix, h.ChartsvcProxy)),
 	))
-	chartsvc.Methods("GET").Handler(negroni.New(
+	chartsvcRouter.Methods("GET").Handler(negroni.New(
 		authGate,
-		negroni.Wrap(handler.WithoutParams(h.ProxyChartSVC)),
+		negroni.Wrap(http.StripPrefix(chartsvcPrefix, h.ChartsvcProxy)),
 	))
 
 	n := negroni.Classic()

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -185,8 +185,14 @@ func main() {
 		authGate,
 		negroni.Wrap(handler.WithParams(h.DeleteRelease)),
 	))
+
 	// Chartsvc reverse proxy
-	r.PathPrefix("/chartsvc").Methods("GET").Handler(negroni.New(
+	chartsvc := r.PathPrefix("/chartsvc").Subrouter()
+	// Logos don't require authentication so bypass that step
+	chartsvc.Methods("GET").Path("/v1/assets/{repo}/{id}/logo").Handler(negroni.New(
+		negroni.Wrap(handler.WithoutParams(h.ProxyChartSVC)),
+	))
+	chartsvc.Methods("GET").Handler(negroni.New(
 		authGate,
 		negroni.Wrap(handler.WithoutParams(h.ProxyChartSVC)),
 	))

--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -1,7 +1,7 @@
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { getType } from "typesafe-actions";
-import { axios } from "../shared/AxiosInstance";
+import { axiosWithAuth } from "../shared/AxiosInstance";
 
 import actions from ".";
 import { NotFoundError } from "../shared/types";
@@ -22,7 +22,7 @@ beforeEach(() => {
       },
     };
   });
-  axios.get = axiosGetMock;
+  axiosWithAuth.get = axiosGetMock;
 });
 
 afterEach(() => {
@@ -44,16 +44,15 @@ describe("fetchCharts", () => {
   it("returns a 404 error", async () => {
     const expectedActions = [
       { type: getType(actions.charts.requestCharts) },
-      { type: getType(actions.charts.errorChart), payload: new NotFoundError("not found") },
+      {
+        type: getType(actions.charts.errorChart),
+        payload: new NotFoundError("could not find chart"),
+      },
     ];
     axiosGetMock = jest.fn(() => {
-      return {
-        ok: false,
-        status: 404,
-        data: "not found",
-      };
+      throw new Error("could not find chart");
     });
-    axios.get = axiosGetMock;
+    axiosWithAuth.get = axiosGetMock;
     await store.dispatch(actions.charts.fetchCharts("foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -64,13 +63,9 @@ describe("fetchCharts", () => {
       { type: getType(actions.charts.errorChart), payload: new Error("something went wrong") },
     ];
     axiosGetMock = jest.fn(() => {
-      return {
-        ok: false,
-        status: 500,
-        data: "something went wrong",
-      };
+      throw new Error("something went wrong");
     });
-    axios.get = axiosGetMock;
+    axiosWithAuth.get = axiosGetMock;
     await store.dispatch(actions.charts.fetchCharts("foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -119,16 +114,15 @@ describe("fetchChartVersionsAndSelectVersion", () => {
     response = [{ id: "foo", attributes: { version: "1.0.0" } }];
     const expectedActions = [
       { type: getType(actions.charts.requestCharts) },
-      { type: getType(actions.charts.errorChart), payload: new NotFoundError("not found") },
+      {
+        type: getType(actions.charts.errorChart),
+        payload: new NotFoundError("could not find chart"),
+      },
     ];
     axiosGetMock = jest.fn(() => {
-      return {
-        ok: false,
-        status: 404,
-        data: "not found",
-      };
+      throw new Error("could not find chart");
     });
-    axios.get = axiosGetMock;
+    axiosWithAuth.get = axiosGetMock;
     await store.dispatch(actions.charts.fetchChartVersionsAndSelectVersion("foo", "1.0.0"));
     expect(store.getActions()).toEqual(expectedActions);
     expect(axiosGetMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo/versions");

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -77,7 +77,7 @@ export function fetchCharts(
 
 export function fetchChartVersions(
   id: string,
-): ThunkAction<Promise<IChartVersion[] | null>, IStoreState, null, ChartsAction> {
+): ThunkAction<Promise<IChartVersion[] | undefined>, IStoreState, null, ChartsAction> {
   return async dispatch => {
     dispatch(requestCharts());
     try {
@@ -88,8 +88,8 @@ export function fetchChartVersions(
       return versions;
     } catch (e) {
       dispatchError(dispatch, e);
+      return;
     }
-    return null;
   };
 }
 

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -2,10 +2,8 @@ import { Dispatch } from "redux";
 import { ThunkAction } from "redux-thunk";
 import { ActionType, createAction } from "typesafe-actions";
 
-import { axios } from "../shared/AxiosInstance";
 import Chart from "../shared/Chart";
 import { IChart, IChartVersion, IStoreState, NotFoundError } from "../shared/types";
-import * as url from "../shared/url";
 
 export const requestCharts = createAction("REQUEST_CHARTS");
 
@@ -53,22 +51,11 @@ const allActions = [
 
 export type ChartsAction = ActionType<typeof allActions[number]>;
 
-async function httpGet(dispatch: Dispatch, targetURL: string): Promise<any> {
-  try {
-    const response = await axios.get(targetURL);
-    // If non-2XX response (not ok)
-    if (response.status < 200 || response.status > 299) {
-      const error = response.data || response.statusText;
-      if (response.status === 404) {
-        dispatch(errorChart(new NotFoundError(error)));
-      } else {
-        dispatch(errorChart(new Error(error)));
-      }
-    } else {
-      return response.data.data;
-    }
-  } catch (e) {
-    dispatch(errorChart(e));
+function dispatchError(dispatch: Dispatch, err: Error) {
+  if (err.message.match("could not find")) {
+    dispatch(errorChart(new NotFoundError(err.message)));
+  } else {
+    dispatch(errorChart(err));
   }
 }
 
@@ -77,23 +64,32 @@ export function fetchCharts(
 ): ThunkAction<Promise<void>, IStoreState, null, ChartsAction> {
   return async dispatch => {
     dispatch(requestCharts());
-    const response = await httpGet(dispatch, url.api.charts.list(repo));
-    if (response) {
-      dispatch(receiveCharts(response));
+    try {
+      const charts = await Chart.fetchCharts(repo);
+      if (charts) {
+        dispatch(receiveCharts(charts));
+      }
+    } catch (e) {
+      dispatchError(dispatch, e);
     }
   };
 }
 
 export function fetchChartVersions(
   id: string,
-): ThunkAction<Promise<IChartVersion[]>, IStoreState, null, ChartsAction> {
+): ThunkAction<Promise<IChartVersion[] | null>, IStoreState, null, ChartsAction> {
   return async dispatch => {
     dispatch(requestCharts());
-    const response = await httpGet(dispatch, url.api.charts.listVersions(id));
-    if (response) {
-      dispatch(receiveChartVersions(response));
+    try {
+      const versions = await Chart.fetchChartVersions(id);
+      if (versions) {
+        dispatch(receiveChartVersions(versions));
+      }
+      return versions;
+    } catch (e) {
+      dispatchError(dispatch, e);
     }
-    return response;
+    return null;
   };
 }
 
@@ -103,9 +99,13 @@ export function getChartVersion(
 ): ThunkAction<Promise<void>, IStoreState, null, ChartsAction> {
   return async dispatch => {
     dispatch(requestCharts());
-    const response = await httpGet(dispatch, url.api.charts.getVersion(id, version));
-    if (response) {
-      dispatch(selectChartVersion(response));
+    try {
+      const chartVersion = await Chart.getChartVersion(id, version);
+      if (chartVersion) {
+        dispatch(selectChartVersion(chartVersion));
+      }
+    } catch (e) {
+      dispatchError(dispatch, e);
     }
   };
 }

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+class BasicDeploymentForm extends React.Component {
+  public render() {
+    return <div>Basic Form!</div>;
+  }
+}
+
+export default BasicDeploymentForm;

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -1,9 +1,0 @@
-import * as React from "react";
-
-class BasicDeploymentForm extends React.Component {
-  public render() {
-    return <div>Basic Form!</div>;
-  }
-}
-
-export default BasicDeploymentForm;

--- a/dashboard/src/shared/Chart.ts
+++ b/dashboard/src/shared/Chart.ts
@@ -1,23 +1,40 @@
-import { axios } from "./AxiosInstance";
-import { IChart } from "./types";
+import { axiosWithAuth } from "./AxiosInstance";
+import { IChart, IChartVersion } from "./types";
+import * as URL from "./url";
 
 export default class Chart {
+  public static async fetchCharts(repo: string) {
+    const { data } = await axiosWithAuth.get<{ data: IChart[] }>(URL.api.charts.list(repo));
+    return data.data;
+  }
+
+  public static async fetchChartVersions(id: string) {
+    const { data } = await axiosWithAuth.get<{ data: IChartVersion[] }>(
+      URL.api.charts.listVersions(id),
+    );
+    return data.data;
+  }
+
+  public static async getChartVersion(id: string, version: string) {
+    const { data } = await axiosWithAuth.get<{ data: IChartVersion }>(
+      URL.api.charts.getVersion(id, version),
+    );
+    return data.data;
+  }
+
   public static async getReadme(id: string, version: string) {
-    const url = `${Chart.APIEndpoint}/assets/${id}/versions/${version}/README.md`;
-    const { data } = await axios.get<string>(url);
+    const { data } = await axiosWithAuth.get<string>(URL.api.charts.getReadme(id, version));
     return data;
   }
 
   public static async getValues(id: string, version: string) {
-    const url = `${Chart.APIEndpoint}/assets/${id}/versions/${version}/values.yaml`;
-    const { data } = await axios.get<string>(url);
+    const { data } = await axiosWithAuth.get<string>(URL.api.charts.getValues(id, version));
     return data;
   }
 
   public static async exists(id: string, version: string, repo: string) {
-    const url = `${Chart.APIEndpoint}/charts/${repo}/${id}/versions/${version}`;
     try {
-      await axios.get<string>(url);
+      await axiosWithAuth.get(URL.api.charts.getVersion(`${repo}/${id}`, version));
     } catch (e) {
       return false;
     }
@@ -28,7 +45,7 @@ export default class Chart {
     const url = `${
       Chart.APIEndpoint
     }/charts?name=${name}&version=${version}&appversion=${appVersion}`;
-    const { data } = await axios.get<{ data: IChart[] }>(url);
+    const { data } = await axiosWithAuth.get<{ data: IChart[] }>(url);
     return data.data;
   }
 


### PR DESCRIPTION
Use `tiller-proxy` to proxy traffic to the chartsvc (instead of direct usage).

Regarding the `Dashboard` I have moved the `chart` functions to the `shared` folder and use `axiosWithAuth` when needed.

Tested manually.