### PR TITLE
Fix empty default namespace for good

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -299,7 +299,7 @@ testImage:
   # Image used for the tests. The only requirement is to include curl
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.16.0-r99
+  tag: 1.16.1-debian-9-r49
 
 # Auth Proxy for OIDC support
 # ref: https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md

--- a/dashboard/src/reducers/auth.test.ts
+++ b/dashboard/src/reducers/auth.test.ts
@@ -19,7 +19,7 @@ describe("authReducer", () => {
       authenticated: false,
       authenticating: false,
       oidcAuthenticated: false,
-      defaultNamespace: "",
+      defaultNamespace: "default",
     };
   });
 

--- a/dashboard/src/reducers/auth.ts
+++ b/dashboard/src/reducers/auth.ts
@@ -2,6 +2,7 @@ import { getType } from "typesafe-actions";
 
 import actions from "../actions";
 import { AuthAction } from "../actions/auth";
+import { DEFAULT_NAMESPACE } from "../shared/Auth";
 
 export interface IAuthState {
   sessionExpired: boolean;
@@ -17,7 +18,7 @@ const initialState: IAuthState = {
   authenticated: !(localStorage.getItem("kubeapps_auth_token") === null),
   authenticating: false,
   oidcAuthenticated: localStorage.getItem("kubeapps_auth_token_oidc") === "true",
-  defaultNamespace: "",
+  defaultNamespace: DEFAULT_NAMESPACE,
 };
 
 const authReducer = (state: IAuthState = initialState, action: AuthAction): IAuthState => {
@@ -28,7 +29,7 @@ const authReducer = (state: IAuthState = initialState, action: AuthAction): IAut
         authenticated: action.payload.authenticated,
         oidcAuthenticated: action.payload.oidc,
         authenticating: false,
-        defaultNamespace: action.payload.defaultNamespace,
+        defaultNamespace: action.payload.defaultNamespace || DEFAULT_NAMESPACE,
       };
     case getType(actions.auth.authenticating):
       return { ...state, authenticated: false, authenticating: true };

--- a/dashboard/src/reducers/auth.ts
+++ b/dashboard/src/reducers/auth.ts
@@ -2,7 +2,7 @@ import { getType } from "typesafe-actions";
 
 import actions from "../actions";
 import { AuthAction } from "../actions/auth";
-import { DEFAULT_NAMESPACE } from "../shared/Auth";
+import { Auth, DEFAULT_NAMESPACE } from "../shared/Auth";
 
 export interface IAuthState {
   sessionExpired: boolean;
@@ -13,13 +13,17 @@ export interface IAuthState {
   defaultNamespace: string;
 }
 
-const initialState: IAuthState = {
-  sessionExpired: false,
-  authenticated: !(localStorage.getItem("kubeapps_auth_token") === null),
-  authenticating: false,
-  oidcAuthenticated: localStorage.getItem("kubeapps_auth_token_oidc") === "true",
-  defaultNamespace: DEFAULT_NAMESPACE,
+const getInitialState: () => IAuthState = (): IAuthState => {
+  const token = Auth.getAuthToken() || "";
+  return {
+    sessionExpired: false,
+    authenticated: token !== "",
+    authenticating: false,
+    oidcAuthenticated: Auth.usingOIDCToken(),
+    defaultNamespace: Auth.defaultNamespaceFromToken(token),
+  };
 };
+const initialState: IAuthState = getInitialState();
 
 const authReducer = (state: IAuthState = initialState, action: AuthAction): IAuthState => {
   switch (action.type) {


### PR DESCRIPTION
The issue was that the `initialState` for auth included `defaultNamespace = ""` rather than obtaining it from the token. With this change, defaultNamespace should never be empty.

The function `defaultNamespaceFromToken` already returns `DEFAULT_NAMESPACE` if it is unable to get it from the token (which is the case for OIDC tokens).

We may want to revert #1184 with this change? (as in, this issue also fixes the issue seen there, and the change there causes you to require logging in again when it is unnecessary - see what you think).

(Updated the test image to fix and test #1160 while there)