### PR TITLE
Use auth default namespace in namespace reducer

### DIFF
--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -54,11 +54,11 @@ describe("namespaceReducer", () => {
 
   context("when CLEAR_NAMESPACES", () => {
     const clearedState = {
-      current: "",
+      current: "default",
       namespaces: [],
     };
 
-    it("clears any namespaces state", () => {
+    it("returns to the default namespace", () => {
       expect(
         namespaceReducer(initialState, {
           type: getType(actions.namespace.clearNamespaces),

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -3,6 +3,7 @@ import { getType } from "typesafe-actions";
 
 import actions from "../actions";
 import { NamespaceAction } from "../actions/namespace";
+import { Auth } from "../shared/Auth";
 
 export interface INamespaceState {
   current: string;
@@ -10,10 +11,14 @@ export interface INamespaceState {
   errorMsg?: string;
 }
 
-const initialState: INamespaceState = {
-  current: "",
-  namespaces: [],
+const getInitialState: () => INamespaceState = (): INamespaceState => {
+  const token = Auth.getAuthToken() || "";
+  return {
+    current: Auth.defaultNamespaceFromToken(token),
+    namespaces: [],
+  };
 };
+const initialState: INamespaceState = getInitialState();
 
 const namespaceReducer = (
   state: INamespaceState = initialState,


### PR DESCRIPTION
I'm still getting some 404s since some components don't try to retrieve the default namespace from the `auth` state (only the root container does that):

```
▶ ag 'namespace.current' dashboard/src   
dashboard/src/components/Header/Header.tsx
105:                      <HeaderLink {...link} currentNamespace={namespace.current} />

dashboard/src/containers/AppListContainer/AppListContainer.tsx
18:    namespace: namespace.current,

dashboard/src/containers/ServiceInstanceListContainer/ServiceInstanceListContainer.ts
23:    namespace: namespace.current,

dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
30:    namespace: namespace.current,

dashboard/src/containers/ChartViewContainer/ChartViewContainer.tsx
23:    namespace: namespace.current,

dashboard/src/containers/RoutesContainer/RoutesContainer.tsx
8:  return { namespace: namespace.current || auth.defaultNamespace };

dashboard/src/containers/ServiceClassViewContainer/ServiceClassViewContainer.ts
26:    namespace: namespace.current,
```

So I have changed the default namespace in the `namespace` reducer to follow the same approach than in the `auth` reducer.