### PR TITLE
Fix currentNamespace

### DIFF
--- a/dashboard/src/actions/catalog.test.tsx
+++ b/dashboard/src/actions/catalog.test.tsx
@@ -119,7 +119,7 @@ const actionTestCases: ITestCase[] = [
 actionTestCases.forEach(tc => {
   describe(tc.name, () => {
     it("has expected structure", () => {
-      const actionResult = tc.action.call(null, ...tc.args);
+      const actionResult = tc.args ? tc.action.call(null, ...tc.args) : tc.action.call(null);
       expect(actionResult).toEqual({
         type: getType(tc.action),
         payload: tc.payload,

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -68,7 +68,7 @@ const actionTestCases: ITestCase[] = [
 actionTestCases.forEach(tc => {
   describe(tc.name, () => {
     it("has expected structure", () => {
-      const actionResult = tc.action.call(null, ...tc.args);
+      const actionResult = tc.args ? tc.action.call(null, ...tc.args) : tc.action.call(null);
       expect(actionResult).toEqual({
         type: getType(tc.action),
         payload: tc.payload,

--- a/dashboard/src/containers/RoutesContainer/Routes.test.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.test.tsx
@@ -26,7 +26,7 @@ const emptyRouteComponentProps: RouteComponentProps<{}> = {
 it("invalid path should show a 404 error", () => {
   const wrapper = mount(
     <StaticRouter location="/random" context={{}}>
-      <Routes {...emptyRouteComponentProps} namespace={"default"} />
+      <Routes {...emptyRouteComponentProps} namespace={"default"} authenticated={true} />
     </StaticRouter>,
   );
   expect(wrapper.find(NotFound)).toExist();
@@ -36,7 +36,7 @@ it("invalid path should show a 404 error", () => {
 it("should render a redirect to the default namespace", () => {
   const wrapper = mount(
     <StaticRouter location="/" context={{}}>
-      <Routes {...emptyRouteComponentProps} namespace={"default"} />
+      <Routes {...emptyRouteComponentProps} namespace={"default"} authenticated={true} />
     </StaticRouter>,
   );
   expect(wrapper.find(NotFound)).not.toExist();
@@ -46,7 +46,17 @@ it("should render a redirect to the default namespace", () => {
 it("should render a redirect to the login page", () => {
   const wrapper = mount(
     <StaticRouter location="/" context={{}}>
-      <Routes {...emptyRouteComponentProps} namespace={""} />
+      <Routes {...emptyRouteComponentProps} namespace={""} authenticated={true} />
+    </StaticRouter>,
+  );
+  expect(wrapper.find(NotFound)).not.toExist();
+  expect(wrapper.find(Redirect).props().to).toEqual("/login");
+});
+
+it("should render a redirect to the login page (when not authenticated)", () => {
+  const wrapper = mount(
+    <StaticRouter location="/" context={{}}>
+      <Routes {...emptyRouteComponentProps} namespace={"default"} authenticated={false} />
     </StaticRouter>,
   );
   expect(wrapper.find(NotFound)).not.toExist();

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -47,6 +47,7 @@ const routes: {
 
 interface IRoutesProps extends IRouteComponentPropsAndRouteProps {
   namespace: string;
+  authenticated: boolean;
 }
 
 class Routes extends React.Component<IRoutesProps> {
@@ -71,7 +72,7 @@ class Routes extends React.Component<IRoutesProps> {
     );
   }
   private rootNamespacedRedirect = () => {
-    if (this.props.namespace) {
+    if (this.props.namespace && this.props.authenticated) {
       return <Redirect to={`/apps/ns/${this.props.namespace}`} />;
     }
     // There is not a default namespace, redirect to login page

--- a/dashboard/src/containers/RoutesContainer/RoutesContainer.tsx
+++ b/dashboard/src/containers/RoutesContainer/RoutesContainer.tsx
@@ -5,7 +5,10 @@ import { IStoreState } from "../../shared/types";
 import Routes from "./Routes";
 
 function mapStateToProps({ auth, namespace }: IStoreState) {
-  return { namespace: namespace.current || auth.defaultNamespace };
+  return {
+    namespace: namespace.current || auth.defaultNamespace,
+    authenticated: auth.authenticated,
+  };
 }
 
 export default withRouter(connect(mapStateToProps)(Routes));

--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -53,12 +53,11 @@ describe("namespaceReducer", () => {
   });
 
   context("when CLEAR_NAMESPACES", () => {
-    const clearedState = {
-      current: "default",
-      namespaces: [],
-    };
-
-    it("returns to the default namespace", () => {
+    it("returns to the default namespace, maintaining the current namespace", () => {
+      const clearedState = {
+        current: initialState.current,
+        namespaces: [],
+      };
       expect(
         namespaceReducer(initialState, {
           type: getType(actions.namespace.clearNamespaces),

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -32,7 +32,8 @@ const namespaceReducer = (
     case getType(actions.namespace.errorNamespaces):
       return { ...state, errorMsg: action.payload.err.message };
     case getType(actions.namespace.clearNamespaces):
-      return { ...initialState };
+      // Clear namespaces info but keep "current" to avoid unexpected redirections
+      return { ...initialState, current: state.current };
     case LOCATION_CHANGE:
       const pathname = action.payload.location.pathname;
       // looks for /ns/:namespace in URL


### PR DESCRIPTION
Found a couple of issues while doing some QA:

 - After https://github.com/kubeapps/kubeapps/pull/1190, the `namespace` in `Routes.tsx` is always defined (and is pointing to `default` since the token has not been read yet). So, regardless of the content of the token once logged in, it was redirecting me to the `default` namespace. To avoid that I have added the additional check to only redirect to `/apps/ns/{ns}` when accessing the root path (`/`) if the user is already authenticated.
 - After login out the `current` namespace was cleared to the default value (`default`). This caused that after login out and in again the namespace changed from whatever it was to `default`. To avoid this, we should not remove the `current` namespace from the state.