### PR TITLE
Revamp default namespace setup

### DIFF
--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -65,6 +65,10 @@ describe("authenticate", () => {
         payload: { authenticated: true, oidc: false, defaultNamespace: "default" },
         type: getType(actions.auth.setAuthenticated),
       },
+      {
+        payload: "default",
+        type: getType(actions.namespace.setDefaultNamespace),
+      },
     ];
 
     return store.dispatch(actions.auth.authenticate(token, false)).then(() => {
@@ -107,6 +111,10 @@ describe("OIDC authentication", () => {
       {
         payload: { authenticated: true, oidc: true, defaultNamespace: "default" },
         type: getType(actions.auth.setAuthenticated),
+      },
+      {
+        payload: "default",
+        type: getType(actions.namespace.setDefaultNamespace),
       },
       {
         payload: { sessionExpired: false },

--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -67,7 +67,7 @@ describe("authenticate", () => {
       },
       {
         payload: "default",
-        type: getType(actions.namespace.setDefaultNamespace),
+        type: getType(actions.namespace.namespaceReceived),
       },
     ];
 
@@ -114,7 +114,7 @@ describe("OIDC authentication", () => {
       },
       {
         payload: "default",
-        type: getType(actions.namespace.setDefaultNamespace),
+        type: getType(actions.namespace.namespaceReceived),
       },
       {
         payload: { sessionExpired: false },

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -3,7 +3,7 @@ import { ActionType, createAction } from "typesafe-actions";
 
 import { Auth } from "../shared/Auth";
 import { IStoreState } from "../shared/types";
-import { clearNamespaces, NamespaceAction, setDefaultNamespace } from "./namespace";
+import { clearNamespaces, NamespaceAction, namespaceReceived } from "./namespace";
 
 export const setAuthenticated = createAction("SET_AUTHENTICATED", resolve => {
   return (authenticated: boolean, oidc: boolean, defaultNamespace: string) =>
@@ -35,7 +35,7 @@ export function authenticate(
       Auth.setAuthToken(token, oidc);
       const defaultNamespace = Auth.defaultNamespaceFromToken(token);
       dispatch(setAuthenticated(true, oidc, defaultNamespace));
-      dispatch(setDefaultNamespace(defaultNamespace));
+      dispatch(namespaceReceived(defaultNamespace));
       if (oidc) {
         dispatch(setSessionExpired(false));
       }

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -9,6 +9,10 @@ export const setNamespace = createAction("SET_NAMESPACE", resolve => {
   return (namespace: string) => resolve(namespace);
 });
 
+export const setDefaultNamespace = createAction("SET_DEFAULT_NAMESPACE", resolve => {
+  return (namespace: string) => resolve(namespace);
+});
+
 export const receiveNamespaces = createAction("RECEIVE_NAMESPACES", resolve => {
   return (namespaces: string[]) => resolve(namespaces);
 });
@@ -19,7 +23,13 @@ export const errorNamespaces = createAction("ERROR_NAMESPACES", resolve => {
 
 export const clearNamespaces = createAction("CLEAR_NAMESPACES");
 
-const allActions = [setNamespace, receiveNamespaces, errorNamespaces, clearNamespaces];
+const allActions = [
+  setNamespace,
+  receiveNamespaces,
+  errorNamespaces,
+  clearNamespaces,
+  setDefaultNamespace,
+];
 export type NamespaceAction = ActionType<typeof allActions[number]>;
 
 export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -9,10 +9,6 @@ export const setNamespace = createAction("SET_NAMESPACE", resolve => {
   return (namespace: string) => resolve(namespace);
 });
 
-export const setDefaultNamespace = createAction("SET_DEFAULT_NAMESPACE", resolve => {
-  return (namespace: string) => resolve(namespace);
-});
-
 export const receiveNamespaces = createAction("RECEIVE_NAMESPACES", resolve => {
   return (namespaces: string[]) => resolve(namespaces);
 });
@@ -23,12 +19,16 @@ export const errorNamespaces = createAction("ERROR_NAMESPACES", resolve => {
 
 export const clearNamespaces = createAction("CLEAR_NAMESPACES");
 
+export const namespaceReceived = createAction("NAMESPACE_RECEIVED", resolve => {
+  return (namespace: string) => resolve(namespace);
+});
+
 const allActions = [
   setNamespace,
   receiveNamespaces,
   errorNamespaces,
   clearNamespaces,
-  setDefaultNamespace,
+  namespaceReceived,
 ];
 export type NamespaceAction = ActionType<typeof allActions[number]>;
 

--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -53,9 +53,9 @@ describe("namespaceReducer", () => {
   });
 
   context("when CLEAR_NAMESPACES", () => {
-    it("returns to the default namespace, maintaining the current namespace", () => {
+    it("returns to the default namespace", () => {
       const clearedState = {
-        current: initialState.current,
+        current: "",
         namespaces: [],
       };
       expect(
@@ -64,5 +64,33 @@ describe("namespaceReducer", () => {
         }),
       ).toEqual(clearedState);
     });
+  });
+});
+
+context("when SET_DEFAULT_NAMESPACE", () => {
+  it("set current namespace if it's empty", () => {
+    const initialState = {
+      current: "",
+      namespaces: [],
+    };
+    expect(
+      namespaceReducer(initialState, {
+        type: getType(actions.namespace.setDefaultNamespace),
+        payload: "not-default",
+      }),
+    ).toEqual({ ...initialState, current: "not-default" });
+  });
+
+  it("does not set the current namespace if it is not empty", () => {
+    const initialState = {
+      current: "default",
+      namespaces: [],
+    };
+    expect(
+      namespaceReducer(initialState, {
+        type: getType(actions.namespace.setDefaultNamespace),
+        payload: "not-default",
+      }),
+    ).toEqual({ ...initialState, current: "default" });
   });
 });

--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -75,7 +75,7 @@ context("when SET_DEFAULT_NAMESPACE", () => {
     };
     expect(
       namespaceReducer(initialState, {
-        type: getType(actions.namespace.setDefaultNamespace),
+        type: getType(actions.namespace.namespaceReceived),
         payload: "not-default",
       }),
     ).toEqual({ ...initialState, current: "not-default" });
@@ -88,7 +88,7 @@ context("when SET_DEFAULT_NAMESPACE", () => {
     };
     expect(
       namespaceReducer(initialState, {
-        type: getType(actions.namespace.setDefaultNamespace),
+        type: getType(actions.namespace.namespaceReceived),
         payload: "not-default",
       }),
     ).toEqual({ ...initialState, current: "default" });

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -3,7 +3,6 @@ import { getType } from "typesafe-actions";
 
 import actions from "../actions";
 import { NamespaceAction } from "../actions/namespace";
-import { Auth } from "../shared/Auth";
 
 export interface INamespaceState {
   current: string;
@@ -12,9 +11,8 @@ export interface INamespaceState {
 }
 
 const getInitialState: () => INamespaceState = (): INamespaceState => {
-  const token = Auth.getAuthToken() || "";
   return {
-    current: Auth.defaultNamespaceFromToken(token),
+    current: "",
     namespaces: [],
   };
 };
@@ -32,8 +30,10 @@ const namespaceReducer = (
     case getType(actions.namespace.errorNamespaces):
       return { ...state, errorMsg: action.payload.err.message };
     case getType(actions.namespace.clearNamespaces):
-      // Clear namespaces info but keep "current" to avoid unexpected redirections
-      return { ...initialState, current: state.current };
+      return { ...initialState };
+    case getType(actions.namespace.setDefaultNamespace):
+      const currentNamespace = state.current === "" ? action.payload : state.current;
+      return { ...initialState, current: currentNamespace };
     case LOCATION_CHANGE:
       const pathname = action.payload.location.pathname;
       // looks for /ns/:namespace in URL

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -31,7 +31,7 @@ const namespaceReducer = (
       return { ...state, errorMsg: action.payload.err.message };
     case getType(actions.namespace.clearNamespaces):
       return { ...initialState };
-    case getType(actions.namespace.setDefaultNamespace):
+    case getType(actions.namespace.namespaceReceived):
       const currentNamespace = state.current === "" ? action.payload : state.current;
       return { ...initialState, current: currentNamespace };
     case LOCATION_CHANGE:


### PR DESCRIPTION
Again I found more issues (mostly related to my changes, sorry). The issue is that `current.namespace` was now always set to `default` because it was read at the very beginning when the token is not yet introduced.

To avoid all the issues I have found with my tests I have added the action `SET_DEFAULT_NAMESPACE` and store it only if the `current.namespace` has never been set.

I have added more tests, hopefully this is the last PR related to the issue :crossed_fingers: 

Sorry for the noise.