### PR TITLE
Helm chart: Add ability to set static IP addr when using load balancer service type

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-service.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-service.yaml
@@ -13,6 +13,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.frontend.service.type }}
+  {{- if and (.Values.frontend.service.loadBalancerIP) (eq .Values.frontend.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.frontend.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - port: {{ .Values.frontend.service.port }}
   {{- if .Values.authProxy.enabled }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -66,7 +66,10 @@ frontend:
   service:
     port: 80
     type: ClusterIP
-    loadBalancerIP:
+    # Set type to LoadBalancer and enable
+    # the parameter below with a value
+    # to have a static load balancer IP
+    #loadBalancerIP:
     annotations: {}
   livenessProbe:
     httpGet:

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -66,6 +66,7 @@ frontend:
   service:
     port: 80
     type: ClusterIP
+    loadBalancerIP:
     annotations: {}
   livenessProbe:
     httpGet:


### PR DESCRIPTION
I'm using metallb in a bare-metal setup, I'd like to assign a static IP address to the frontend when installing kubeapps with helm. This PR enables that. 