### PR TITLE
Read schema and add username to the basic form

### DIFF
--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -128,3 +128,26 @@ describe("fetchChartVersionsAndSelectVersion", () => {
     expect(axiosGetMock.mock.calls[0][0]).toBe("api/chartsvc/v1/charts/foo/versions");
   });
 });
+
+describe("getChartSchema", () => {
+  it("gets a chart schema", async () => {
+    response = [{ properties: "foo" }];
+    const expectedActions = [
+      { type: getType(actions.charts.selectSchema), payload: { data: response } },
+    ];
+    await store.dispatch(actions.charts.getChartSchema("foo", "1.0.0"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(axiosGetMock.mock.calls[0][0]).toBe(
+      "api/chartsvc/v1/assets/foo/versions/1.0.0/values.schema.json",
+    );
+  });
+
+  it("returns an empty schema if not found", async () => {
+    axiosWithAuth.get = jest.fn(() => {
+      throw new Error();
+    });
+    const expectedActions = [{ type: getType(actions.charts.selectSchema), payload: {} }];
+    await store.dispatch(actions.charts.getChartSchema("foo", "1.0.0"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});

--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -144,9 +144,20 @@ describe("getChartSchema", () => {
 
   it("returns an empty schema if not found", async () => {
     axiosWithAuth.get = jest.fn(() => {
-      throw new Error();
+      throw new NotFoundError();
     });
     const expectedActions = [{ type: getType(actions.charts.selectSchema), payload: {} }];
+    await store.dispatch(actions.charts.getChartSchema("foo", "1.0.0"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches an error if it's unexpected", async () => {
+    axiosWithAuth.get = jest.fn(() => {
+      throw new Error("Boom!");
+    });
+    const expectedActions = [
+      { type: getType(actions.charts.errorChart), payload: new Error("Boom!") },
+    ];
     await store.dispatch(actions.charts.getChartSchema("foo", "1.0.0"));
     expect(store.getActions()).toEqual(expectedActions);
   });

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -37,6 +37,10 @@ export const selectValues = createAction("SELECT_VALUES", resolve => {
   return (values: string) => resolve(values);
 });
 
+export const selectSchema = createAction("SELECT_SCHEMA", resolve => {
+  return (schema: {}) => resolve(schema);
+});
+
 const allActions = [
   requestCharts,
   errorChart,
@@ -47,6 +51,7 @@ const allActions = [
   selectReadme,
   errorReadme,
   selectValues,
+  selectSchema,
 ];
 
 export type ChartsAction = ActionType<typeof allActions[number]>;
@@ -154,6 +159,20 @@ export function getChartValues(
       dispatch(selectValues(values));
     } catch (e) {
       dispatch(selectValues(""));
+    }
+  };
+}
+
+export function getChartSchema(
+  id: string,
+  version: string,
+): ThunkAction<Promise<void>, IStoreState, null, ChartsAction> {
+  return async dispatch => {
+    try {
+      const schema = await Chart.getSchema(id, version);
+      dispatch(selectSchema(schema));
+    } catch (e) {
+      dispatch(selectSchema({}));
     }
   };
 }

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -172,7 +172,13 @@ export function getChartSchema(
       const schema = await Chart.getSchema(id, version);
       dispatch(selectSchema(schema));
     } catch (e) {
-      dispatch(selectSchema({}));
+      if (e.constructor === NotFoundError) {
+        // Schema not found
+        dispatch(selectSchema({}));
+      } else {
+        // Unexpecter error
+        dispatch(errorChart(e));
+      }
     }
   };
 }

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -68,7 +68,10 @@ const actionTestCases: ITestCase[] = [
 actionTestCases.forEach(tc => {
   describe(tc.name, () => {
     it("has expected structure", () => {
-      const actionResult = tc.args ? tc.action.call(null, ...tc.args) : tc.action.call(null);
+      const actionResult =
+        tc.args && tc.args.length && typeof tc.args === "object"
+          ? tc.action.call(null, ...tc.args)
+          : tc.action.call(null, tc.args);
       expect(actionResult).toEqual({
         type: getType(tc.action),
         payload: tc.payload,

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm.test.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+import { shallow } from "enzyme";
+import { IBasicFormParam } from "shared/types";
+import BasicDeploymentForm from "./BasicDeploymentForm";
+
+const defaultProps = {
+  params: [],
+  handleBasicFormParamChange: jest.fn(() => jest.fn()),
+};
+
+describe("username", () => {
+  const param = {
+    name: "username",
+    path: "wordpressUsername",
+    value: "user",
+  } as IBasicFormParam;
+
+  it("renders a basic deployment with a username", () => {
+    const onChange = jest.fn();
+    const handleBasicFormParamChange = jest.fn(() => onChange);
+    const wrapper = shallow(
+      <BasicDeploymentForm
+        {...defaultProps}
+        params={[param]}
+        handleBasicFormParamChange={handleBasicFormParamChange}
+      />,
+    );
+    wrapper.find("input").simulate("change");
+    expect(handleBasicFormParamChange.mock.calls[0][0]).toEqual(param);
+    expect(onChange.mock.calls.length).toBe(1);
+  });
+});

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm.test.tsx
@@ -11,7 +11,6 @@ const defaultProps = {
 
 describe("username", () => {
   const param = {
-    name: "username",
     path: "wordpressUsername",
     value: "user",
   } as IBasicFormParam;
@@ -22,12 +21,12 @@ describe("username", () => {
     const wrapper = shallow(
       <BasicDeploymentForm
         {...defaultProps}
-        params={[param]}
+        params={{ username: param }}
         handleBasicFormParamChange={handleBasicFormParamChange}
       />,
     );
-    wrapper.find("input").simulate("change");
-    expect(handleBasicFormParamChange.mock.calls[0][0]).toEqual(param);
+    wrapper.find("input#username").simulate("change");
+    expect(handleBasicFormParamChange.mock.calls[0]).toEqual(["username", param]);
     expect(onChange.mock.calls.length).toBe(1);
   });
 });

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm.tsx
@@ -2,28 +2,29 @@ import * as React from "react";
 import { IBasicFormParam } from "shared/types";
 
 export interface IBasicDeploymentFormProps {
-  params: IBasicFormParam[];
+  params: { [name: string]: IBasicFormParam };
   handleBasicFormParamChange: (
+    name: string,
     p: IBasicFormParam,
   ) => (e: React.FormEvent<HTMLInputElement>) => void;
 }
 
 class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
   public render() {
-    return this.props.params.map(param => {
-      return this.renderParam(param);
+    return Object.keys(this.props.params).map(paramName => {
+      return this.renderParam(paramName, this.props.params[paramName]);
     });
   }
 
-  private renderParam(param: IBasicFormParam) {
-    switch (param.name) {
+  private renderParam(name: string, param: IBasicFormParam) {
+    switch (name) {
       case "username":
         return (
-          <div key={param.name}>
+          <div key={name}>
             <label htmlFor="username">Username</label>
             <input
               id="username"
-              onChange={this.props.handleBasicFormParamChange(param)}
+              onChange={this.props.handleBasicFormParamChange(name, param)}
               value={param.value}
             />
           </div>

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm.tsx
@@ -1,8 +1,35 @@
 import * as React from "react";
+import { IBasicFormParam } from "shared/types";
 
-class BasicDeploymentForm extends React.Component {
+export interface IBasicDeploymentFormProps {
+  params: IBasicFormParam[];
+  handleBasicFormParamChange: (
+    p: IBasicFormParam,
+  ) => (e: React.FormEvent<HTMLInputElement>) => void;
+}
+
+class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
   public render() {
-    return <div>Basic Form!</div>;
+    return this.props.params.map(param => {
+      return this.renderParam(param);
+    });
+  }
+
+  private renderParam(param: IBasicFormParam) {
+    switch (param.name) {
+      case "username":
+        return (
+          <div key={param.name}>
+            <label htmlFor="username">Username</label>
+            <input
+              id="username"
+              onChange={this.props.handleBasicFormParamChange(param)}
+              value={param.value}
+            />
+          </div>
+        );
+    }
+    return null;
   }
 }
 

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -9,6 +9,7 @@ import { ErrorSelector } from "../ErrorAlert";
 import ErrorPageHeader from "../ErrorAlert/ErrorAlertHeader";
 import LoadingWrapper from "../LoadingWrapper";
 import AdvancedDeploymentForm from "./AdvancedDeploymentForm";
+import BasicDeploymentForm from "./BasicDeploymentForm";
 import DeploymentForm, { IDeploymentFormProps, IDeploymentFormState } from "./DeploymentForm";
 
 const defaultProps = {
@@ -22,6 +23,7 @@ const defaultProps = {
   fetchChartVersions: jest.fn(),
   getChartVersion: jest.fn(),
   getChartValues: jest.fn(),
+  getChartSchema: jest.fn(),
   namespace: "default",
   enableBasicForm: false,
 };
@@ -226,5 +228,31 @@ describe("when the basic form is enabled", () => {
     const wrapper = shallow(<DeploymentForm {...props} enableBasicForm={true} />);
     expect(wrapper.find(LoadingWrapper)).not.toExist();
     expect(wrapper.find(Tabs)).toExist();
+  });
+
+  it("changes the parameter value", () => {
+    const basicFormParameters = {
+      username: {
+        name: "username",
+        path: "wordpressUsername",
+        value: "user",
+      },
+    };
+    const wrapper = mount(<DeploymentForm {...props} enableBasicForm={true} />);
+    wrapper.setState({ basicFormParameters });
+    wrapper.update();
+
+    // Fake onChange
+    const input = wrapper.find(BasicDeploymentForm).find("input");
+    const onChange = input.prop("onChange") as (e: React.FormEvent<HTMLInputElement>) => void;
+    onChange({ currentTarget: { value: "foo" } } as React.FormEvent<HTMLInputElement>);
+
+    expect(wrapper.state("basicFormParameters")).toEqual({
+      username: {
+        name: "username",
+        path: "wordpressUsername",
+        value: "foo",
+      },
+    });
   });
 });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -233,7 +233,6 @@ describe("when the basic form is enabled", () => {
   it("changes the parameter value", () => {
     const basicFormParameters = {
       username: {
-        name: "username",
         path: "wordpressUsername",
         value: "user",
       },
@@ -249,7 +248,6 @@ describe("when the basic form is enabled", () => {
 
     expect(wrapper.state("basicFormParameters")).toEqual({
       username: {
-        name: "username",
         path: "wordpressUsername",
         value: "foo",
       },

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -200,7 +200,9 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
 
   public handleChartVersionChange = (e: React.FormEvent<HTMLSelectElement>) => {
     this.props.push(
-      `/apps/ns/${this.props.namespace}/new/${this.props.chartID}/versions/${e.currentTarget.value}`,
+      `/apps/ns/${this.props.namespace}/new/${this.props.chartID}/versions/${
+        e.currentTarget.value
+      }`,
     );
   };
 
@@ -218,7 +220,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
           </TabList>
           <TabPanel>
             <BasicDeploymentForm
-              params={Object.values(this.state.basicFormParameters)}
+              params={this.state.basicFormParameters}
               handleBasicFormParamChange={this.handleBasicFormParamChange}
             />
           </TabPanel>
@@ -233,7 +235,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
     );
   };
 
-  private handleBasicFormParamChange = (param: IBasicFormParam) => {
+  private handleBasicFormParamChange = (name: string, param: IBasicFormParam) => {
     return (e: React.FormEvent<HTMLInputElement>) => {
       // Change raw values
       this.handleValuesChange(setValue(this.state.appValues, param.path, e.currentTarget.value));
@@ -241,8 +243,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
       this.setState({
         basicFormParameters: {
           ...this.state.basicFormParameters,
-          [param.name]: {
-            name: param.name,
+          [name]: {
             path: param.path,
             value: e.currentTarget.value,
           },

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -3,10 +3,10 @@ import * as Moniker from "moniker-native";
 import * as React from "react";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 
-import { IChartState, IChartVersion } from "../../shared/types";
+import { retrieveBasicFormParams, setValue } from "../../shared/schema";
+import { IBasicFormParam, IChartState, IChartVersion } from "../../shared/types";
 import { ErrorSelector } from "../ErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
-
 import AdvancedDeploymentForm from "./AdvancedDeploymentForm";
 import BasicDeploymentForm from "./BasicDeploymentForm";
 
@@ -29,6 +29,7 @@ export interface IDeploymentFormProps {
   fetchChartVersions: (id: string) => void;
   getChartVersion: (id: string, chartVersion: string) => void;
   getChartValues: (id: string, chartVersion: string) => void;
+  getChartSchema: (id: string, chartVersion: string) => void;
   namespace: string;
   enableBasicForm: boolean;
 }
@@ -42,18 +43,20 @@ export interface IDeploymentFormState {
   // and we do not want to use releaseName since it is controller by the form field.
   latestSubmittedReleaseName: string;
   namespace: string;
-  appValues?: string;
+  appValues: string;
   valuesModified: boolean;
+  basicFormParameters: { [key: string]: IBasicFormParam };
 }
 
 class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFormState> {
   public state: IDeploymentFormState = {
-    appValues: undefined,
+    appValues: "",
     isDeploying: false,
     namespace: this.props.namespace,
     releaseName: Moniker.choose(),
     latestSubmittedReleaseName: "",
     valuesModified: false,
+    basicFormParameters: {},
   };
 
   public componentDidMount() {
@@ -67,6 +70,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
       chartID,
       chartVersion,
       getChartValues,
+      getChartSchema,
       getChartVersion,
       namespace,
       selected,
@@ -85,13 +89,18 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
 
     if (nextProps.selected.version && nextProps.selected.version !== this.props.selected.version) {
       getChartValues(chartID, nextProps.selected.version.attributes.version);
+      getChartSchema(chartID, nextProps.selected.version.attributes.version);
       return;
     }
 
     if (!this.state.valuesModified) {
       if (version) {
-        this.setState({ appValues: nextProps.selected.values });
+        this.setState({ appValues: nextProps.selected.values || "" });
       }
+    }
+
+    if (nextProps.selected.schema) {
+      this.setState({ basicFormParameters: retrieveBasicFormParams(nextProps.selected.schema) });
     }
   }
 
@@ -191,9 +200,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
 
   public handleChartVersionChange = (e: React.FormEvent<HTMLSelectElement>) => {
     this.props.push(
-      `/apps/ns/${this.props.namespace}/new/${this.props.chartID}/versions/${
-        e.currentTarget.value
-      }`,
+      `/apps/ns/${this.props.namespace}/new/${this.props.chartID}/versions/${e.currentTarget.value}`,
     );
   };
 
@@ -210,7 +217,10 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
             <Tab>Advanced</Tab>
           </TabList>
           <TabPanel>
-            <BasicDeploymentForm />
+            <BasicDeploymentForm
+              params={Object.values(this.state.basicFormParameters)}
+              handleBasicFormParamChange={this.handleBasicFormParamChange}
+            />
           </TabPanel>
           <TabPanel>
             <AdvancedDeploymentForm
@@ -221,6 +231,24 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
         </Tabs>
       </div>
     );
+  };
+
+  private handleBasicFormParamChange = (param: IBasicFormParam) => {
+    return (e: React.FormEvent<HTMLInputElement>) => {
+      // Change raw values
+      this.handleValuesChange(setValue(this.state.appValues, param.path, e.currentTarget.value));
+      // Change param definition
+      this.setState({
+        basicFormParameters: {
+          ...this.state.basicFormParameters,
+          [param.name]: {
+            name: param.name,
+            path: param.path,
+            value: e.currentTarget.value,
+          },
+        },
+      });
+    };
   };
 }
 

--- a/dashboard/src/components/DeploymentForm/__snapshots__/DeploymentForm.test.tsx.snap
+++ b/dashboard/src/components/DeploymentForm/__snapshots__/DeploymentForm.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`renders the full DeploymentForm 1`] = `
           </select>
         </div>
         <AdvancedDeploymentForm
+          appValues=""
           handleValuesChange={[Function]}
         />
         <div>

--- a/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -43,6 +43,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     fetchChartVersions: (id: string) => dispatch(actions.charts.fetchChartVersions(id)),
     getChartValues: (id: string, version: string) =>
       dispatch(actions.charts.getChartValues(id, version)),
+    getChartSchema: (id: string, version: string) =>
+      dispatch(actions.charts.getChartSchema(id, version)),
     getChartVersion: (id: string, version: string) =>
       dispatch(actions.charts.getChartVersion(id, version)),
     push: (location: string) => dispatch(push(location)),

--- a/dashboard/src/reducers/charts.ts
+++ b/dashboard/src/reducers/charts.ts
@@ -24,6 +24,7 @@ const chartsSelectedReducer = (
         readme: undefined,
         readmeError: undefined,
         values: undefined,
+        schema: undefined,
         version: action.payload,
       };
     case getType(actions.charts.receiveChartVersions):
@@ -40,6 +41,8 @@ const chartsSelectedReducer = (
       return { ...state, readmeError: action.payload };
     case getType(actions.charts.selectValues):
       return { ...state, values: action.payload };
+    case getType(actions.charts.selectSchema):
+      return { ...state, schema: action.payload };
     case getType(actions.charts.resetChartVersion):
       return initialState.selected;
     default:
@@ -74,6 +77,8 @@ const chartsReducer = (state: IChartState = initialState, action: ChartsAction):
     case getType(actions.charts.errorChart):
       return { ...state, selected: chartsSelectedReducer(state.selected, action) };
     case getType(actions.charts.selectValues):
+      return { ...state, selected: chartsSelectedReducer(state.selected, action) };
+    case getType(actions.charts.selectSchema):
       return { ...state, selected: chartsSelectedReducer(state.selected, action) };
     default:
   }

--- a/dashboard/src/reducers/charts.ts
+++ b/dashboard/src/reducers/charts.ts
@@ -69,15 +69,10 @@ const chartsReducer = (state: IChartState = initialState, action: ChartsAction):
         selected: chartsSelectedReducer(state.selected, action),
       };
     case getType(actions.charts.resetChartVersion):
-      return { ...state, selected: chartsSelectedReducer(state.selected, action) };
     case getType(actions.charts.selectReadme):
-      return { ...state, selected: chartsSelectedReducer(state.selected, action) };
     case getType(actions.charts.errorReadme):
-      return { ...state, selected: chartsSelectedReducer(state.selected, action) };
     case getType(actions.charts.errorChart):
-      return { ...state, selected: chartsSelectedReducer(state.selected, action) };
     case getType(actions.charts.selectValues):
-      return { ...state, selected: chartsSelectedReducer(state.selected, action) };
     case getType(actions.charts.selectSchema):
       return { ...state, selected: chartsSelectedReducer(state.selected, action) };
     default:

--- a/dashboard/src/shared/Chart.ts
+++ b/dashboard/src/shared/Chart.ts
@@ -47,7 +47,9 @@ export default class Chart {
   }
 
   public static async listWithFilters(name: string, version: string, appVersion: string) {
-    const url = `${Chart.APIEndpoint}/charts?name=${name}&version=${version}&appversion=${appVersion}`;
+    const url = `${
+      Chart.APIEndpoint
+    }/charts?name=${name}&version=${version}&appversion=${appVersion}`;
     const { data } = await axiosWithAuth.get<{ data: IChart[] }>(url);
     return data.data;
   }

--- a/dashboard/src/shared/Chart.ts
+++ b/dashboard/src/shared/Chart.ts
@@ -32,6 +32,11 @@ export default class Chart {
     return data;
   }
 
+  public static async getSchema(id: string, version: string) {
+    const { data } = await axiosWithAuth.get<string>(URL.api.charts.getSchema(id, version));
+    return data;
+  }
+
   public static async exists(id: string, version: string, repo: string) {
     try {
       await axiosWithAuth.get(URL.api.charts.getVersion(`${repo}/${id}`, version));
@@ -42,9 +47,7 @@ export default class Chart {
   }
 
   public static async listWithFilters(name: string, version: string, appVersion: string) {
-    const url = `${
-      Chart.APIEndpoint
-    }/charts?name=${name}&version=${version}&appversion=${appVersion}`;
+    const url = `${Chart.APIEndpoint}/charts?name=${name}&version=${version}&appversion=${appVersion}`;
     const { data } = await axiosWithAuth.get<{ data: IChart[] }>(url);
     return data.data;
   }

--- a/dashboard/src/shared/schema.ts
+++ b/dashboard/src/shared/schema.ts
@@ -4,7 +4,6 @@ export function retrieveBasicFormParams(schema: any) {
   // TBD
   return {
     username: {
-      name: "username",
       path: "wordpressUsername",
       value: "user",
     } as IBasicFormParam,

--- a/dashboard/src/shared/schema.ts
+++ b/dashboard/src/shared/schema.ts
@@ -1,0 +1,17 @@
+import { IBasicFormParam } from "./types";
+
+export function retrieveBasicFormParams(schema: any) {
+  // TBD
+  return {
+    username: {
+      name: "username",
+      path: "wordpressUsername",
+      value: "user",
+    } as IBasicFormParam,
+  };
+}
+
+export function setValue(values: string, path: string, newValue: any) {
+  // TBD
+  return values;
+}

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -377,7 +377,6 @@ export interface IKubeState {
 }
 
 export interface IBasicFormParam {
-  name: string;
   path: string;
   value?: any;
 }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -79,6 +79,7 @@ export interface IChartState {
     readme?: string;
     readmeError?: string;
     values?: string;
+    schema?: any;
   };
   items: IChart[];
 }
@@ -373,4 +374,10 @@ export interface IKubeItem<T> {
 export interface IKubeState {
   items: { [s: string]: IKubeItem<IResource> };
   sockets: { [s: string]: WebSocket };
+}
+
+export interface IBasicFormParam {
+  name: string;
+  path: string;
+  value?: any;
 }

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -6,7 +6,9 @@ import { IChartVersion } from "./types";
 export const app = {
   charts: {
     version: (cv: IChartVersion) =>
-      `/charts/${cv.relationships.chart.data.repo.name}/${cv.relationships.chart.data.name}/versions/${cv.attributes.version}`,
+      `/charts/${cv.relationships.chart.data.repo.name}/${
+        cv.relationships.chart.data.name
+      }/versions/${cv.attributes.version}`,
   },
 };
 

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -6,9 +6,7 @@ import { IChartVersion } from "./types";
 export const app = {
   charts: {
     version: (cv: IChartVersion) =>
-      `/charts/${cv.relationships.chart.data.repo.name}/${
-        cv.relationships.chart.data.name
-      }/versions/${cv.attributes.version}`,
+      `/charts/${cv.relationships.chart.data.repo.name}/${cv.relationships.chart.data.name}/versions/${cv.attributes.version}`,
   },
 };
 
@@ -26,6 +24,8 @@ export const api = {
       `${api.charts.base}/assets/${id}/versions/${version}/README.md`,
     getValues: (id: string, version: string) =>
       `${api.charts.base}/assets/${id}/versions/${version}/values.yaml`,
+    getSchema: (id: string, version: string) =>
+      `${api.charts.base}/assets/${id}/versions/${version}/values.schema.json`,
     getVersion: (id: string, version: string) =>
       `${api.charts.base}/charts/${id}/versions/${version}`,
     list: (repo?: string) => `${api.charts.base}/charts${repo ? `/${repo}` : ""}`,


### PR DESCRIPTION
Part 1 of 2

Ref #1182 

With this PR, the dashboard obtains the schema from the chartsvc (requires https://github.com/helm/monocular/pull/645) and pass it to the `DeploymentForm` component to parse it.

As an example, I have hardcoded the basic parameter `username` to show the proposed architecture.

I have defined a basic form parameter as:

```js
{
  name: username, // Name of the basic parameter
  path: account.username, // Path of the parameter in the JSON Object (e.g. {account: {username: "foo"} }
  value: user // Current value of the parameter
}
```

Result:

![Screenshot from 2019-10-01 16-11-47](https://user-images.githubusercontent.com/4025665/65970862-8ffd0900-e467-11e9-9b8d-c9c844b7a351.png)
