### PR TITLE
Fix missing namespace

### DIFF
--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -1,8 +1,16 @@
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { getType } from "typesafe-actions";
+import { Auth } from "../shared/Auth";
 import Namespace from "../shared/Namespace";
-import { errorNamespaces, fetchNamespaces, receiveNamespaces, setNamespace } from "./namespace";
+import {
+  errorNamespaces,
+  fetchNamespaces,
+  namespaceReceived,
+  receiveNamespaces,
+  setDefaultNamespace,
+  setNamespace,
+} from "./namespace";
 
 const mockStore = configureMockStore([thunk]);
 
@@ -73,6 +81,25 @@ describe("fetchNamespaces", () => {
 
     await store.dispatch(fetchNamespaces());
 
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+// Async action creators
+describe("setDefaultNamespace", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("dispatches namespaceReceived based on the received token", async () => {
+    Auth.getAuthToken = jest.fn(() => "token");
+    Auth.defaultNamespaceFromToken = jest.fn(() => "my-ns");
+    const expectedActions = [
+      {
+        type: getType(namespaceReceived),
+        payload: "my-ns",
+      },
+    ];
+    await store.dispatch(setDefaultNamespace());
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -2,6 +2,7 @@ import { ThunkAction } from "redux-thunk";
 
 import { ActionType, createAction } from "typesafe-actions";
 
+import { Auth } from "../shared/Auth";
 import Namespace from "../shared/Namespace";
 import { IResource, IStoreState } from "../shared/types";
 
@@ -42,5 +43,17 @@ export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null,
       dispatch(errorNamespaces(e, "list"));
       return;
     }
+  };
+}
+
+export function setDefaultNamespace(): ThunkAction<
+  Promise<void>,
+  IStoreState,
+  null,
+  NamespaceAction
+> {
+  return async dispatch => {
+    const token = Auth.getAuthToken() || "";
+    dispatch(namespaceReceived(Auth.defaultNamespaceFromToken(token)));
   };
 }

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -8,6 +8,7 @@ import Header from "./Header";
 const defaultProps = {
   authenticated: true,
   fetchNamespaces: jest.fn(),
+  setDefaultNamespace: jest.fn(),
   logout: jest.fn(),
   namespace: {
     current: "",

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -15,6 +15,7 @@ import "./Header.css";
 interface IHeaderProps {
   authenticated: boolean;
   fetchNamespaces: () => void;
+  setDefaultNamespace: () => void;
   logout: () => void;
   namespace: INamespaceState;
   defaultNamespace: string;
@@ -71,6 +72,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
       defaultNamespace,
       authenticated: showNav,
       hideLogoutLink,
+      setDefaultNamespace,
     } = this.props;
     const header = `header ${this.state.mobileOpen ? "header-open" : ""}`;
     const submenu = `header__nav__submenu ${
@@ -115,6 +117,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                   defaultNamespace={defaultNamespace}
                   onChange={this.handleNamespaceChange}
                   fetchNamespaces={fetchNamespaces}
+                  setDefaultNamespace={setDefaultNamespace}
                 />
                 <ul className="header__nav__menu" role="menubar">
                   <li

--- a/dashboard/src/components/Header/NamespaceSelector.test.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.test.tsx
@@ -6,6 +6,7 @@ import NamespaceSelector from "./NamespaceSelector";
 
 const defaultProps = {
   fetchNamespaces: jest.fn(),
+  setDefaultNamespace: jest.fn(),
   namespace: {
     current: "namespace-two",
     namespaces: ["namespace-one", "namespace-two"],

--- a/dashboard/src/components/Header/NamespaceSelector.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.tsx
@@ -11,11 +11,13 @@ interface INamespaceSelectorProps {
   defaultNamespace: string;
   onChange: (ns: string) => any;
   fetchNamespaces: () => void;
+  setDefaultNamespace: () => void;
 }
 
 class NamespaceSelector extends React.Component<INamespaceSelectorProps> {
   public componentDidMount() {
     this.props.fetchNamespaces();
+    this.props.setDefaultNamespace();
   }
 
   public render() {

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -34,6 +34,7 @@ function mapStateToProps({
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
     fetchNamespaces: () => dispatch(actions.namespace.fetchNamespaces()),
+    setDefaultNamespace: () => dispatch(actions.namespace.setDefaultNamespace()),
     logout: () => dispatch(actions.auth.logout()),
     push: (path: string) => dispatch(push(path)),
     setNamespace: (ns: string) => dispatch(actions.namespace.setNamespace(ns)),


### PR DESCRIPTION
I found a 404 when the user is already logged in and it loads for the first time the application in a route that doesn't contain the namespace (e.g. `/catalog`). In that case, the `authenticate` action is not executed (because the user is already logged) and none of the components rendered try to set that current namespace.

I have added that functionality to the `NamespaceSelector` component (which is loaded in the Header). There, along with fetching the existing namespaces, the default namespace is now set (from the token).