### PR TITLE
Fix broken links to NGINX Ingress Annotations docs

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 2.1.5
+version: 2.1.6
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -184,7 +184,7 @@ Most likely you will only want to have one hostname that maps to this Kubeapps i
 
 ##### Annotations
 
-For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers. Annotations can be set using `ingress.annotations`.
+For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers. Annotations can be set using `ingress.annotations`.
 
 ##### TLS
 

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -22,7 +22,7 @@ ingress:
 
   # Ingress annotations done as key:value pairs
   # For a full list of possible ingress annotations, please see
-  # ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  # ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   #
   # If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
   annotations:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

--

The NGINX Ingress Controller annotations documentation was moved from:

https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md

to:

https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md