### PR TITLE
Add slider component for adding the disk size

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -34,6 +34,7 @@
     "raf": "^3.4.0",
     "react": "^16.2.0",
     "react-ace": "^5.9.0",
+    "react-compound-slider": "^2.3.0",
     "react-dom": "^16.2.0",
     "react-feather": "^1.0.8",
     "react-jsonschema-form": "^1.0.3",

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.scss
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.scss
@@ -2,3 +2,7 @@
   color: #5f6369;
   font-size: 0.9em;
 }
+
+.disk_size_input {
+  width: 75%;
+}

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.test.tsx
@@ -31,6 +31,12 @@ const defaultProps = {
     },
   },
   {
+    description: "renders a basic deployment with a disk size",
+    params: {
+      diskSize: { path: "size", value: "10Gi", type: "string" } as IBasicFormParam,
+    },
+  },
+  {
     description: "renders a basic deployment with username, password, email and a generic string",
     params: {
       username: { path: "wordpressUsername", value: "user" } as IBasicFormParam,

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -3,6 +3,7 @@ import { IBasicFormParam } from "shared/types";
 import StringParam from "./StringParam";
 
 import "./BasicDeploymentForm.css";
+import DiskSizeParam from "./DiskSizeParam";
 
 export interface IBasicDeploymentFormProps {
   params: { [name: string]: IBasicFormParam };
@@ -48,6 +49,17 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
         return (
           <StringParam
             label="Email"
+            handleBasicFormParamChange={this.props.handleBasicFormParamChange}
+            key={id}
+            id={id}
+            name={name}
+            param={param}
+          />
+        );
+      case "diskSize":
+        return (
+          <DiskSizeParam
+            label="Disk Size"
             handleBasicFormParamChange={this.props.handleBasicFormParamChange}
             key={id}
             id={id}

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/DiskSizeParam.test.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/DiskSizeParam.test.tsx
@@ -52,7 +52,7 @@ it("changes the value of the param when the slider changes", () => {
   ]);
 });
 
-it("changes only the value of the state when the slider is being updated", () => {
+it("updates state but does not change param value during slider update (only when dropped in a point)", () => {
   const handleBasicFormParamChange = jest.fn();
   const wrapper = shallow(
     <DiskSizeParam {...defaultProps} handleBasicFormParamChange={handleBasicFormParamChange} />,
@@ -97,6 +97,22 @@ describe("when changing the value in the input", () => {
 
     expect(wrapper.state("Gi")).toBe(20);
     expect(valueChange.mock.calls[0]).toEqual([{ currentTarget: { value: "20Gi" } }]);
+  });
+
+  it("accept decimal values", () => {
+    const valueChange = jest.fn();
+    const handleBasicFormParamChange = jest.fn(() => valueChange);
+    const wrapper = shallow(
+      <DiskSizeParam {...defaultProps} handleBasicFormParamChange={handleBasicFormParamChange} />,
+    );
+    expect(wrapper.state("Gi")).toBe(10);
+
+    const input = wrapper.find("input#disk");
+    const event = { currentTarget: { value: "20.5" } } as React.FormEvent<HTMLInputElement>;
+    (input.prop("onChange") as ((e: React.FormEvent<HTMLInputElement>) => void))(event);
+
+    expect(wrapper.state("Gi")).toBe(20.5);
+    expect(valueChange.mock.calls[0]).toEqual([{ currentTarget: { value: "20.5Gi" } }]);
   });
 
   it("modifies the max value of the slider if the input is bigger than 100", () => {

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/DiskSizeParam.test.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/DiskSizeParam.test.tsx
@@ -1,0 +1,118 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+import { IBasicFormParam } from "shared/types";
+import Slider from "../../../components/Slider";
+import DiskSizeParam from "./DiskSizeParam";
+
+const defaultProps = {
+  id: "disk",
+  name: "diskSize",
+  label: "Disk Size",
+  param: {
+    value: "10Gi",
+    type: "string",
+    path: "disk",
+  } as IBasicFormParam,
+  handleBasicFormParamChange: jest.fn(),
+};
+
+it("renders a disk size param with a default value", () => {
+  const wrapper = shallow(<DiskSizeParam {...defaultProps} />);
+  expect(wrapper.state("Gi")).toBe(10);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("changes the value of the param when the slider changes", () => {
+  const param = {
+    value: "10Gi",
+    type: "string",
+    path: "disk",
+  } as IBasicFormParam;
+  const handleBasicFormParamChange = jest.fn(() => {
+    param.value = "20Gi";
+    return jest.fn();
+  });
+
+  const wrapper = shallow(
+    <DiskSizeParam
+      {...defaultProps}
+      param={param}
+      handleBasicFormParamChange={handleBasicFormParamChange}
+    />,
+  );
+  expect(wrapper.state("Gi")).toBe(10);
+
+  const slider = wrapper.find(Slider);
+  (slider.prop("onChange") as (values: number[]) => void)([20]);
+
+  expect(param.value).toBe("20Gi");
+  expect(handleBasicFormParamChange.mock.calls[0]).toEqual([
+    "diskSize",
+    { value: "20Gi", type: "string", path: "disk" },
+  ]);
+});
+
+it("changes only the value of the state when the slider is being updated", () => {
+  const handleBasicFormParamChange = jest.fn();
+  const wrapper = shallow(
+    <DiskSizeParam {...defaultProps} handleBasicFormParamChange={handleBasicFormParamChange} />,
+  );
+  expect(wrapper.state("Gi")).toBe(10);
+
+  const slider = wrapper.find(Slider);
+  (slider.prop("onUpdate") as (values: number[]) => void)([20]);
+
+  expect(wrapper.state("Gi")).toBe(20);
+  expect(handleBasicFormParamChange).not.toHaveBeenCalled();
+});
+
+describe("when changing the value in the input", () => {
+  it("parses a number and forwards it", () => {
+    const valueChange = jest.fn();
+    const handleBasicFormParamChange = jest.fn(() => valueChange);
+    const wrapper = shallow(
+      <DiskSizeParam {...defaultProps} handleBasicFormParamChange={handleBasicFormParamChange} />,
+    );
+    expect(wrapper.state("Gi")).toBe(10);
+
+    const input = wrapper.find("input#disk");
+    const event = { currentTarget: { value: "20" } } as React.FormEvent<HTMLInputElement>;
+    (input.prop("onChange") as ((e: React.FormEvent<HTMLInputElement>) => void))(event);
+
+    expect(wrapper.state("Gi")).toBe(20);
+    expect(valueChange.mock.calls[0]).toEqual([{ currentTarget: { value: "20Gi" } }]);
+  });
+
+  it("ignores values in the input that are not digits", () => {
+    const valueChange = jest.fn();
+    const handleBasicFormParamChange = jest.fn(() => valueChange);
+    const wrapper = shallow(
+      <DiskSizeParam {...defaultProps} handleBasicFormParamChange={handleBasicFormParamChange} />,
+    );
+    expect(wrapper.state("Gi")).toBe(10);
+
+    const input = wrapper.find("input#disk");
+    const event = { currentTarget: { value: "foo20*#@$" } } as React.FormEvent<HTMLInputElement>;
+    (input.prop("onChange") as ((e: React.FormEvent<HTMLInputElement>) => void))(event);
+
+    expect(wrapper.state("Gi")).toBe(20);
+    expect(valueChange.mock.calls[0]).toEqual([{ currentTarget: { value: "20Gi" } }]);
+  });
+
+  it("modifies the max value of the slider if the input is bigger than 100", () => {
+    const valueChange = jest.fn();
+    const handleBasicFormParamChange = jest.fn(() => valueChange);
+    const wrapper = shallow(
+      <DiskSizeParam {...defaultProps} handleBasicFormParamChange={handleBasicFormParamChange} />,
+    );
+    expect(wrapper.state("Gi")).toBe(10);
+
+    const input = wrapper.find("input#disk");
+    const event = { currentTarget: { value: "200" } } as React.FormEvent<HTMLInputElement>;
+    (input.prop("onChange") as ((e: React.FormEvent<HTMLInputElement>) => void))(event);
+
+    expect(wrapper.state("Gi")).toBe(200);
+    const slider = wrapper.find(Slider);
+    expect(slider.prop("max")).toBe(200);
+  });
+});

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/DiskSizeParam.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/DiskSizeParam.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import { IBasicFormParam } from "shared/types";
+import Slider from "../../../components/Slider";
+
+export interface IDiskSizeParamProps {
+  id: string;
+  name: string;
+  label: string;
+  param: IBasicFormParam;
+  handleBasicFormParamChange: (
+    name: string,
+    p: IBasicFormParam,
+  ) => (e: React.FormEvent<HTMLInputElement>) => void;
+}
+
+export interface IDiskSizeParamState {
+  Gi: number;
+}
+
+function toNumber(value: string) {
+  // Force to return a Number from a string removing any character that is not a digit
+  return Number(value.replace(/[^\d]/g, ""));
+}
+
+class DiskSizeParam extends React.Component<IDiskSizeParamProps, IDiskSizeParamState> {
+  public state: IDiskSizeParamState = {
+    Gi: toNumber(this.props.param.value) || 10,
+  };
+
+  // onChangeSlider is executed when the slider is dropped at one point
+  // at that point we update the parameter
+  public onChangeSlider = (values: number[]) => {
+    this.handleParamChange(values[0]);
+  };
+
+  // onUpdateSlider is executed when dragging the slider
+  // we just update the state here for a faster response
+  public onUpdateSlider = (values: number[]) => {
+    this.setState({ Gi: values[0] });
+  };
+
+  public onChangeInput = (e: React.FormEvent<HTMLInputElement>) => {
+    const value = toNumber(e.currentTarget.value);
+    this.setState({ Gi: value });
+    this.handleParamChange(value);
+  };
+
+  public render() {
+    const { param, label } = this.props;
+    return (
+      <div>
+        <label htmlFor={this.props.id}>
+          {label}
+          {param.description && (
+            <>
+              <br />
+              <span className="description">{param.description}</span>
+            </>
+          )}
+          <div className="row">
+            <div className="col-10">
+              <Slider
+                min={1}
+                max={Math.max(100, this.state.Gi)}
+                default={this.state.Gi}
+                onChange={this.onChangeSlider}
+                onUpdate={this.onUpdateSlider}
+                values={this.state.Gi}
+              />
+            </div>
+            <div className="col-2">
+              <input
+                className="disk_size_input"
+                id={this.props.id}
+                onChange={this.onChangeInput}
+                value={this.state.Gi}
+              />
+              <span className="margin-l-normal">Gi</span>
+            </div>
+          </div>
+        </label>
+      </div>
+    );
+  }
+
+  private handleParamChange = (value: number) => {
+    this.props.handleBasicFormParamChange(this.props.name, this.props.param)({
+      currentTarget: { value: `${value}Gi` },
+    } as React.FormEvent<HTMLInputElement>);
+  };
+}
+
+export default DiskSizeParam;

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/DiskSizeParam.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/DiskSizeParam.tsx
@@ -19,7 +19,7 @@ export interface IDiskSizeParamState {
 
 function toNumber(value: string) {
   // Force to return a Number from a string removing any character that is not a digit
-  return Number(value.replace(/[^\d]/g, ""));
+  return Number(value.replace(/[^\d\.]/g, ""));
 }
 
 class DiskSizeParam extends React.Component<IDiskSizeParamProps, IDiskSizeParamState> {

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
@@ -1,5 +1,313 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders a basic deployment with a disk size 1`] = `
+<BasicDeploymentForm
+  handleBasicFormParamChange={[Function]}
+  params={
+    Object {
+      "diskSize": Object {
+        "path": "size",
+        "type": "string",
+        "value": "10Gi",
+      },
+    }
+  }
+>
+  <DiskSizeParam
+    handleBasicFormParamChange={[Function]}
+    id="diskSize-0"
+    key="diskSize-0"
+    label="Disk Size"
+    name="diskSize"
+    param={
+      Object {
+        "path": "size",
+        "type": "string",
+        "value": "10Gi",
+      }
+    }
+  >
+    <div>
+      <label
+        htmlFor="diskSize-0"
+      >
+        Disk Size
+        <div
+          className="row"
+        >
+          <div
+            className="col-10"
+          >
+            <Slider
+              default={10}
+              max={100}
+              min={1}
+              onChange={[Function]}
+              onUpdate={[Function]}
+              values={10}
+            >
+              <Slider
+                component="div"
+                disabled={false}
+                domain={
+                  Array [
+                    1,
+                    100,
+                  ]
+                }
+                flatten={false}
+                mode={1}
+                onChange={[Function]}
+                onSlideEnd={[Function]}
+                onSlideStart={[Function]}
+                onUpdate={[Function]}
+                reversed={false}
+                rootProps={Object {}}
+                rootStyle={
+                  Object {
+                    "margin": "1em",
+                    "position": "relative",
+                    "width": "90%",
+                  }
+                }
+                step={1}
+                values={
+                  Array [
+                    10,
+                  ]
+                }
+                vertical={false}
+                warnOnChanges={false}
+              >
+                <div
+                  style={
+                    Object {
+                      "margin": "1em",
+                      "position": "relative",
+                      "width": "90%",
+                    }
+                  }
+                >
+                  <Rail
+                    activeHandleID={null}
+                    emitKeyboard={[Function]}
+                    emitMouse={[Function]}
+                    emitTouch={[Function]}
+                    getEventData={[Function]}
+                    handles={
+                      Array [
+                        Object {
+                          "id": "$$-0",
+                          "percent": 9.090909090909092,
+                          "value": 10,
+                        },
+                      ]
+                    }
+                    key=".0"
+                    scale={
+                      LinearScale {
+                        "domain": Array [
+                          1,
+                          100,
+                        ],
+                        "interpolator": [Function],
+                        "range": Array [
+                          0,
+                          100,
+                        ],
+                      }
+                    }
+                  >
+                    <div
+                      onMouseDown={[Function]}
+                      onTouchStart={[Function]}
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(155,155,155)",
+                          "borderRadius": 7,
+                          "cursor": "pointer",
+                          "height": 14,
+                          "position": "absolute",
+                          "width": "100%",
+                        }
+                      }
+                    />
+                  </Rail>
+                  <Handles
+                    activeHandleID={null}
+                    emitKeyboard={[Function]}
+                    emitMouse={[Function]}
+                    emitTouch={[Function]}
+                    getEventData={[Function]}
+                    handles={
+                      Array [
+                        Object {
+                          "id": "$$-0",
+                          "percent": 9.090909090909092,
+                          "value": 10,
+                        },
+                      ]
+                    }
+                    key=".1"
+                    scale={
+                      LinearScale {
+                        "domain": Array [
+                          1,
+                          100,
+                        ],
+                        "interpolator": [Function],
+                        "range": Array [
+                          0,
+                          100,
+                        ],
+                      }
+                    }
+                  >
+                    <div
+                      className="slider-handles"
+                    >
+                      <Component
+                        domain={
+                          Array [
+                            1,
+                            100,
+                          ]
+                        }
+                        getHandleProps={[Function]}
+                        handle={
+                          Object {
+                            "id": "$$-0",
+                            "percent": 9.090909090909092,
+                            "value": 10,
+                          }
+                        }
+                        key="$$-0"
+                      >
+                        <div
+                          aria-valuemax={100}
+                          aria-valuemin={1}
+                          aria-valuenow={10}
+                          onKeyDown={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchStart={[Function]}
+                          role="slider"
+                          style={
+                            Object {
+                              "backgroundColor": "#34568f",
+                              "borderRadius": "50%",
+                              "boxShadow": "1px 1px 1px 1px rgba(0, 0, 0, 0.2)",
+                              "cursor": "pointer",
+                              "height": 24,
+                              "left": "9.090909090909092%",
+                              "marginLeft": "-11px",
+                              "marginTop": "-6px",
+                              "position": "absolute",
+                              "width": 24,
+                              "zIndex": 2,
+                            }
+                          }
+                        />
+                      </Component>
+                    </div>
+                  </Handles>
+                  <Tracks
+                    activeHandleID={null}
+                    emitKeyboard={[Function]}
+                    emitMouse={[Function]}
+                    emitTouch={[Function]}
+                    getEventData={[Function]}
+                    handles={
+                      Array [
+                        Object {
+                          "id": "$$-0",
+                          "percent": 9.090909090909092,
+                          "value": 10,
+                        },
+                      ]
+                    }
+                    key=".2"
+                    left={true}
+                    right={false}
+                    scale={
+                      LinearScale {
+                        "domain": Array [
+                          1,
+                          100,
+                        ],
+                        "interpolator": [Function],
+                        "range": Array [
+                          0,
+                          100,
+                        ],
+                      }
+                    }
+                  >
+                    <div
+                      className="slider-tracks"
+                    >
+                      <Component
+                        getTrackProps={[Function]}
+                        key="$-$$-0"
+                        source={
+                          Object {
+                            "id": "$",
+                            "percent": 0,
+                            "value": 1,
+                          }
+                        }
+                        target={
+                          Object {
+                            "id": "$$-0",
+                            "percent": 9.090909090909092,
+                            "value": 10,
+                          }
+                        }
+                      >
+                        <div
+                          onMouseDown={[Function]}
+                          onTouchStart={[Function]}
+                          style={
+                            Object {
+                              "backgroundColor": "#7aa0c4",
+                              "borderRadius": 7,
+                              "cursor": "pointer",
+                              "height": 14,
+                              "left": "0%",
+                              "position": "absolute",
+                              "width": "9.090909090909092%",
+                              "zIndex": 1,
+                            }
+                          }
+                        />
+                      </Component>
+                    </div>
+                  </Tracks>
+                </div>
+              </Slider>
+            </Slider>
+          </div>
+          <div
+            className="col-2"
+          >
+            <input
+              className="disk_size_input"
+              id="diskSize-0"
+              onChange={[Function]}
+              value={10}
+            />
+            <span
+              className="margin-l-normal"
+            >
+              Gi
+            </span>
+          </div>
+        </div>
+      </label>
+    </div>
+  </DiskSizeParam>
+</BasicDeploymentForm>
+`;
+
 exports[`renders a basic deployment with a email 1`] = `
 <BasicDeploymentForm
   handleBasicFormParamChange={[Function]}

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/__snapshots__/DiskSizeParam.test.tsx.snap
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/__snapshots__/DiskSizeParam.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a disk size param with a default value 1`] = `
+<div>
+  <label
+    htmlFor="disk"
+  >
+    Disk Size
+    <div
+      className="row"
+    >
+      <div
+        className="col-10"
+      >
+        <Slider
+          default={10}
+          max={100}
+          min={1}
+          onChange={[Function]}
+          onUpdate={[Function]}
+          values={10}
+        />
+      </div>
+      <div
+        className="col-2"
+      >
+        <input
+          className="disk_size_input"
+          id="disk"
+          onChange={[Function]}
+          value={10}
+        />
+        <span
+          className="margin-l-normal"
+        >
+          Gi
+        </span>
+      </div>
+    </div>
+  </label>
+</div>
+`;

--- a/dashboard/src/components/Slider/Slider.tsx
+++ b/dashboard/src/components/Slider/Slider.tsx
@@ -1,0 +1,74 @@
+// CODE ADAPTED FROM: https://sghall.github.io/react-compound-slider/#/slider-demos/horizontal
+import * as React from "react";
+import { Handles, Rail, Slider as ReactSlider, Tracks } from "react-compound-slider";
+import { Handle, Track } from "./components"; // example render components
+
+const sliderStyle: React.CSSProperties = {
+  margin: "1em",
+  position: "relative",
+  width: "90%",
+};
+
+const railStyle: React.CSSProperties = {
+  position: "absolute",
+  width: "100%",
+  height: 14,
+  borderRadius: 7,
+  cursor: "pointer",
+  backgroundColor: "rgb(155,155,155)",
+};
+
+export interface ISliderProps {
+  min: number;
+  max: number;
+  default: number;
+  values: number;
+  onChange: (values: number[]) => void;
+  onUpdate: (values: number[]) => void;
+}
+
+class Slider extends React.Component<ISliderProps> {
+  public render() {
+    const { min, max, values, onUpdate, onChange } = this.props;
+    const domain = [min, max];
+
+    return (
+      <ReactSlider
+        mode={1}
+        step={1}
+        domain={domain}
+        rootStyle={sliderStyle}
+        onUpdate={onUpdate}
+        onChange={onChange}
+        values={[values]}
+      >
+        <Rail>{({ getRailProps }) => <div style={railStyle} {...getRailProps()} />}</Rail>
+        <Handles>
+          {({ handles, getHandleProps }) => (
+            <div className="slider-handles">
+              {handles.map(handle => (
+                <Handle
+                  key={handle.id}
+                  handle={handle}
+                  domain={domain}
+                  getHandleProps={getHandleProps}
+                />
+              ))}
+            </div>
+          )}
+        </Handles>
+        <Tracks right={false}>
+          {({ tracks, getTrackProps }) => (
+            <div className="slider-tracks">
+              {tracks.map(({ id, source, target }) => (
+                <Track key={id} source={source} target={target} getTrackProps={getTrackProps} />
+              ))}
+            </div>
+          )}
+        </Tracks>
+      </ReactSlider>
+    );
+  }
+}
+
+export default Slider;

--- a/dashboard/src/components/Slider/components.tsx
+++ b/dashboard/src/components/Slider/components.tsx
@@ -1,0 +1,64 @@
+// CODE FROM: https://sghall.github.io/react-compound-slider/#/slider-demos/horizontal
+import * as React from "react";
+import { GetHandleProps, GetTrackProps, SliderItem } from "react-compound-slider";
+
+// *******************************************************
+// HANDLE COMPONENT
+// *******************************************************
+interface IHandleProps {
+  domain: number[];
+  handle: SliderItem;
+  getHandleProps: GetHandleProps;
+}
+
+export const Handle: React.SFC<IHandleProps> = ({
+  domain: [min, max],
+  handle: { id, value, percent },
+  getHandleProps,
+}) => (
+  <div
+    role="slider"
+    aria-valuemin={min}
+    aria-valuemax={max}
+    aria-valuenow={value}
+    style={{
+      left: `${percent}%`,
+      position: "absolute",
+      marginLeft: "-11px",
+      marginTop: "-6px",
+      zIndex: 2,
+      width: 24,
+      height: 24,
+      cursor: "pointer",
+      borderRadius: "50%",
+      boxShadow: "1px 1px 1px 1px rgba(0, 0, 0, 0.2)",
+      backgroundColor: "#34568f",
+    }}
+    {...getHandleProps(id)}
+  />
+);
+
+// *******************************************************
+// TRACK COMPONENT
+// *******************************************************
+interface ITrackProps {
+  source: SliderItem;
+  target: SliderItem;
+  getTrackProps: GetTrackProps;
+}
+
+export const Track: React.SFC<ITrackProps> = ({ source, target, getTrackProps }) => (
+  <div
+    style={{
+      position: "absolute",
+      height: 14,
+      zIndex: 1,
+      backgroundColor: "#7aa0c4",
+      borderRadius: 7,
+      cursor: "pointer",
+      left: `${source.percent}%`,
+      width: `${target.percent - source.percent}%`,
+    }}
+    {...getTrackProps()}
+  />
+);

--- a/dashboard/src/components/Slider/index.tsx
+++ b/dashboard/src/components/Slider/index.tsx
@@ -1,0 +1,3 @@
+import Slider from "./Slider";
+
+export default Slider;

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -93,7 +93,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.5.5":
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0":
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
   integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
@@ -2932,6 +2932,11 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
+
+d3-array@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
 d@1:
   version "1.0.1"
@@ -8752,6 +8757,16 @@ react-ace@^5.9.0:
     lodash.get "^4.4.2"
     lodash.isequal "^4.1.1"
     prop-types "^15.5.8"
+
+react-compound-slider@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-compound-slider/-/react-compound-slider-2.3.0.tgz#6eb076e626be621246c2e77107273cca186beb73"
+  integrity sha512-b5gP7KZJwcaqKE8R3zhArR56Npg9I4h2pyAHzXXhII50nzF7boGTSJAfrgZ36mQPhCbijuzxV+9qqVjobfbZ+Q==
+  dependencies:
+    "@babel/runtime" "^7.6.0"
+    d3-array "^1.2.4"
+    prop-types "^15.7.2"
+    warning "^3.0.0"
 
 react-dev-utils@^5.0.2:
   version "5.0.3"


### PR DESCRIPTION
Ref #1182 

This PR adds a slider to select the disk size in the simplified form.

It's possible to modify it either dragging the slider or adding a custom number in the input field close to it.

Note that apart than the component `react-compound-slider` it's necessary to add some boilerplate code to make the slider work so I have created a wrapper of that component with the code avaliable [here](https://sghall.github.io/react-compound-slider/#/slider-demos/horizontal) to expose a simplified `Slider` component. That boilerplate code is not covered by unit tests and doesn't require a thoughtful review.

![Screenshot from 2019-10-04 13-19-56](https://user-images.githubusercontent.com/4025665/66203864-aeeadd80-e6a9-11e9-92b5-e0044ee66163.png)
