### PR TITLE
Add support for integer and boolean params

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -42,6 +42,7 @@
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
     "react-select": "^1.2.1",
+    "react-switch": "^5.0.1",
     "react-tabs": "^3.0.0",
     "react-test-renderer": "^16.2.0",
     "react-tooltip": "^3.10.0",

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.scss
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.scss
@@ -2,3 +2,8 @@
   color: #5f6369;
   font-size: 0.9em;
 }
+
+.react-switch {
+  vertical-align: middle;
+  margin-left: 10px;
+}

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.test.tsx
@@ -39,6 +39,18 @@ const defaultProps = {
       blogName: { path: "blogName", value: "my-blog", type: "string" } as IBasicFormParam,
     },
   },
+  {
+    description: "renders a basic deployment with a generic boolean",
+    params: {
+      enableMetrics: { path: "enableMetrics", value: true, type: "boolean" } as IBasicFormParam,
+    },
+  },
+  {
+    description: "renders a basic deployment with a generic number",
+    params: {
+      replicas: { path: "replicas", value: 1, type: "integer" } as IBasicFormParam,
+    },
+  },
 ].forEach(t => {
   it(t.description, () => {
     const onChange = jest.fn();

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { IBasicFormParam } from "shared/types";
-import StringParam from "./StringParam";
+import TextParam from "./TextParam";
 
 import "./BasicDeploymentForm.css";
+import BooleanParam from "./BooleanParam";
 
 export interface IBasicDeploymentFormProps {
   params: { [name: string]: IBasicFormParam };
@@ -24,7 +25,7 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
     switch (name) {
       case "username":
         return (
-          <StringParam
+          <TextParam
             label="Username"
             handleBasicFormParamChange={this.props.handleBasicFormParamChange}
             key={id}
@@ -35,7 +36,7 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
         );
       case "password":
         return (
-          <StringParam
+          <TextParam
             label="Password"
             handleBasicFormParamChange={this.props.handleBasicFormParamChange}
             key={id}
@@ -46,7 +47,7 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
         );
       case "email":
         return (
-          <StringParam
+          <TextParam
             label="Email"
             handleBasicFormParamChange={this.props.handleBasicFormParamChange}
             key={id}
@@ -56,20 +57,45 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
           />
         );
       default:
-        if (param.type === "string") {
-          return (
-            <StringParam
-              label={param.title || ""}
-              handleBasicFormParamChange={this.props.handleBasicFormParamChange}
-              key={id}
-              id={id}
-              name={name}
-              param={param}
-            />
-          );
+        switch (param.type) {
+          case "string":
+            return (
+              <TextParam
+                label={param.title || ""}
+                handleBasicFormParamChange={this.props.handleBasicFormParamChange}
+                key={id}
+                id={id}
+                name={name}
+                param={param}
+              />
+            );
+          case "integer":
+            return (
+              <TextParam
+                label={param.title || ""}
+                handleBasicFormParamChange={this.props.handleBasicFormParamChange}
+                key={id}
+                id={id}
+                name={name}
+                param={param}
+                inputType="number"
+              />
+            );
+          case "boolean":
+            return (
+              <BooleanParam
+                label={param.title || ""}
+                handleBasicFormParamChange={this.props.handleBasicFormParamChange}
+                key={id}
+                id={id}
+                name={name}
+                param={param}
+              />
+            );
+          default:
+          // TODO(andres): This should return an error once we add support for all the parameters that we expect
+          // throw new Error(`Param ${name} with type ${param.type} is not supported`);
         }
-      // TODO(andres): This should return an error once we add support for all the parameters that we expect
-      // throw new Error(`Param ${name} with type ${param.type} is not supported`);
     }
     return null;
   }

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BooleanParam.test.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BooleanParam.test.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import { mount } from "enzyme";
+import BooleanParam from "./BooleanParam";
+
+const param = { path: "enableMetrics", value: true, type: "boolean" };
+const defaultProps = {
+  id: "foo",
+  name: "enableMetrics",
+  label: "Enable Metrics",
+  param,
+  handleBasicFormParamChange: jest.fn(),
+};
+
+it("should render a boolean param with title and description", () => {
+  const wrapper = mount(<BooleanParam {...defaultProps} />);
+  const s = wrapper.find(".react-switch").first();
+  expect(s.prop("checked")).toBe(defaultProps.param.value);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("should send a checkbox event to handleBasicFormParamChange", () => {
+  const handler = jest.fn();
+  const handleBasicFormParamChange = jest.fn(() => handler);
+  const wrapper = mount(
+    <BooleanParam {...defaultProps} handleBasicFormParamChange={handleBasicFormParamChange} />,
+  );
+  const s = wrapper.find(".react-switch").first();
+
+  (s.prop("onChange") as any)(false);
+
+  expect(handleBasicFormParamChange.mock.calls[0][0]).toBe("enableMetrics");
+  expect(handler.mock.calls[0][0]).toMatchObject({
+    currentTarget: { value: "false", type: "checkbox", checked: false },
+  });
+});

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BooleanParam.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/BooleanParam.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import Switch from "react-switch";
+import { IBasicFormParam } from "shared/types";
+
+export interface IStringParamProps {
+  id: string;
+  name: string;
+  label: string;
+  param: IBasicFormParam;
+  handleBasicFormParamChange: (
+    name: string,
+    p: IBasicFormParam,
+  ) => (e: React.FormEvent<HTMLInputElement>) => void;
+}
+
+class BooleanParam extends React.Component<IStringParamProps> {
+  public render() {
+    const { id, param, label } = this.props;
+    return (
+      <label htmlFor={id}>
+        <div className="margin-b-normal">
+          <span>{label}</span>
+          <Switch
+            id={id}
+            onChange={this.handleChange}
+            checked={param.value}
+            className="react-switch"
+          />
+        </div>
+        {param.description && <span className="description">{param.description}</span>}
+      </label>
+    );
+  }
+
+  // handleChange transform the event received by the Switch component to a checkbox event
+  public handleChange = (checked: boolean) => {
+    const { name, param } = this.props;
+    const event = {
+      currentTarget: { value: String(checked), type: "checkbox", checked },
+    } as React.FormEvent<HTMLInputElement>;
+    this.props.handleBasicFormParamChange(name, param)(event);
+  };
+}
+
+export default BooleanParam;

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/TextParam.test.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/TextParam.test.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+
+import { mount } from "enzyme";
+import TextParam from "./TextParam";
+
+const param = { path: "username", value: "user", type: "string" };
+const defaultProps = {
+  id: "foo",
+  name: "username",
+  label: "Username",
+  param,
+  handleBasicFormParamChange: jest.fn(),
+};
+
+it("should render a text param with title and description", () => {
+  const wrapper = mount(<TextParam {...defaultProps} />);
+  const input = wrapper.find("input");
+  expect(input.prop("defaultValue")).toBe(defaultProps.param.value);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("should set the input type as number", () => {
+  const wrapper = mount(<TextParam {...defaultProps} inputType={"number"} />);
+  const input = wrapper.find("input");
+  expect(input.prop("type")).toBe("number");
+});
+
+it("should forward the proper value", () => {
+  const handler = jest.fn();
+  const handleBasicFormParamChange = jest.fn(() => handler);
+  const wrapper = mount(
+    <TextParam {...defaultProps} handleBasicFormParamChange={handleBasicFormParamChange} />,
+  );
+  const input = wrapper.find("input");
+
+  const event = { currentTarget: {} } as React.FormEvent<HTMLInputElement>;
+  (input.prop("onChange") as any)(event);
+
+  expect(handleBasicFormParamChange.mock.calls[0][0]).toBe("username");
+  expect(handler.mock.calls[0][0]).toMatchObject(event);
+});

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/TextParam.tsx
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/TextParam.tsx
@@ -5,6 +5,7 @@ export interface IStringParamProps {
   id: string;
   name: string;
   label: string;
+  inputType?: string;
   param: IBasicFormParam;
   handleBasicFormParamChange: (
     name: string,
@@ -12,9 +13,9 @@ export interface IStringParamProps {
   ) => (e: React.FormEvent<HTMLInputElement>) => void;
 }
 
-class StringParam extends React.Component<IStringParamProps> {
+class TextParam extends React.Component<IStringParamProps> {
   public render() {
-    const { id, name, param, label } = this.props;
+    const { id, name, param, label, inputType } = this.props;
     return (
       <div>
         <label htmlFor={id}>
@@ -28,7 +29,8 @@ class StringParam extends React.Component<IStringParamProps> {
           <input
             id={id}
             onChange={this.props.handleBasicFormParamChange(name, param)}
-            value={param.value}
+            defaultValue={param.value}
+            type={inputType ? inputType : "text"}
           />
         </label>
       </div>
@@ -36,4 +38,4 @@ class StringParam extends React.Component<IStringParamProps> {
   }
 }
 
-export default StringParam;
+export default TextParam;

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`renders a basic deployment with a email 1`] = `
     }
   }
 >
-  <StringParam
+  <TextParam
     handleBasicFormParamChange={[Function]}
     id="email-0"
     key="email-0"
@@ -31,13 +31,312 @@ exports[`renders a basic deployment with a email 1`] = `
       >
         Email
         <input
+          defaultValue="user@example.com"
           id="email-0"
           onChange={[Function]}
-          value="user@example.com"
+          type="text"
         />
       </label>
     </div>
-  </StringParam>
+  </TextParam>
+</BasicDeploymentForm>
+`;
+
+exports[`renders a basic deployment with a generic boolean 1`] = `
+<BasicDeploymentForm
+  handleBasicFormParamChange={[Function]}
+  params={
+    Object {
+      "enableMetrics": Object {
+        "path": "enableMetrics",
+        "type": "boolean",
+        "value": true,
+      },
+    }
+  }
+>
+  <BooleanParam
+    handleBasicFormParamChange={[Function]}
+    id="enableMetrics-0"
+    key="enableMetrics-0"
+    label=""
+    name="enableMetrics"
+    param={
+      Object {
+        "path": "enableMetrics",
+        "type": "boolean",
+        "value": true,
+      }
+    }
+  >
+    <label
+      htmlFor="enableMetrics-0"
+    >
+      <div
+        className="margin-b-normal"
+      >
+        <span />
+        <ReactSwitch
+          activeBoxShadow="0 0 2px 3px #3bf"
+          boxShadow={null}
+          checked={true}
+          checkedIcon={
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+              viewBox="-2 -5 17 21"
+              width="100%"
+            >
+              <path
+                d="M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0"
+                fill="#fff"
+                fillRule="evenodd"
+              />
+            </svg>
+          }
+          className="react-switch"
+          disabled={false}
+          height={28}
+          id="enableMetrics-0"
+          offColor="#888"
+          offHandleColor="#fff"
+          onChange={[Function]}
+          onColor="#080"
+          onHandleColor="#fff"
+          uncheckedIcon={
+            <svg
+              height="100%"
+              style={
+                Object {
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+              viewBox="-2 -5 14 20"
+              width="100%"
+            >
+              <path
+                d="M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12"
+                fill="#fff"
+                fillRule="evenodd"
+              />
+            </svg>
+          }
+          width={56}
+        >
+          <div
+            className="react-switch"
+            style={
+              Object {
+                "MozTransition": "opacity 0.25s",
+                "MozUserSelect": "none",
+                "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+                "WebkitTransition": "opacity 0.25s",
+                "WebkitUserSelect": "none",
+                "borderRadius": 14,
+                "direction": "ltr",
+                "display": "inline-block",
+                "msUserSelect": "none",
+                "opacity": 1,
+                "position": "relative",
+                "textAlign": "left",
+                "touchAction": "none",
+                "transition": "opacity 0.25s",
+                "userSelect": "none",
+              }
+            }
+          >
+            <div
+              className="react-switch-bg"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              style={
+                Object {
+                  "MozTransition": "background 0.25s",
+                  "WebkitTransition": "background 0.25s",
+                  "background": "#008800",
+                  "borderRadius": 14,
+                  "cursor": "pointer",
+                  "height": 28,
+                  "margin": 0,
+                  "position": "relative",
+                  "transition": "background 0.25s",
+                  "width": 56,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "MozTransition": "opacity 0.25s",
+                    "WebkitTransition": "opacity 0.25s",
+                    "height": 28,
+                    "opacity": 1,
+                    "pointerEvents": "none",
+                    "position": "relative",
+                    "transition": "opacity 0.25s",
+                    "width": 30,
+                  }
+                }
+              >
+                <svg
+                  height="100%"
+                  style={
+                    Object {
+                      "position": "absolute",
+                      "top": 0,
+                    }
+                  }
+                  viewBox="-2 -5 17 21"
+                  width="100%"
+                >
+                  <path
+                    d="M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0"
+                    fill="#fff"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </div>
+              <div
+                style={
+                  Object {
+                    "MozTransition": "opacity 0.25s",
+                    "WebkitTransition": "opacity 0.25s",
+                    "height": 28,
+                    "opacity": 0,
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "transition": "opacity 0.25s",
+                    "width": 30,
+                  }
+                }
+              >
+                <svg
+                  height="100%"
+                  style={
+                    Object {
+                      "position": "absolute",
+                      "top": 0,
+                    }
+                  }
+                  viewBox="-2 -5 14 20"
+                  width="100%"
+                >
+                  <path
+                    d="M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12"
+                    fill="#fff"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              className="react-switch-handle"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "MozTransition": "background-color 0.25s, transform 0.25s, box-shadow 0.15s",
+                  "WebkitTransition": "background-color 0.25s, transform 0.25s, box-shadow 0.15s",
+                  "background": "#ffffff",
+                  "border": 0,
+                  "borderRadius": "50%",
+                  "boxShadow": null,
+                  "cursor": "pointer",
+                  "display": "inline-block",
+                  "height": 26,
+                  "outline": 0,
+                  "position": "absolute",
+                  "top": 1,
+                  "transform": "translateX(29px)",
+                  "transition": "background-color 0.25s, transform 0.25s, box-shadow 0.15s",
+                  "width": 26,
+                }
+              }
+            />
+            <input
+              checked={true}
+              disabled={false}
+              id="enableMetrics-0"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyUp={[Function]}
+              role="switch"
+              style={
+                Object {
+                  "border": 0,
+                  "clip": "rect(0 0 0 0)",
+                  "height": 1,
+                  "margin": -1,
+                  "overflow": "hidden",
+                  "padding": 0,
+                  "position": "absolute",
+                  "width": 1,
+                }
+              }
+              type="checkbox"
+            />
+          </div>
+        </ReactSwitch>
+      </div>
+    </label>
+  </BooleanParam>
+</BasicDeploymentForm>
+`;
+
+exports[`renders a basic deployment with a generic number 1`] = `
+<BasicDeploymentForm
+  handleBasicFormParamChange={[Function]}
+  params={
+    Object {
+      "replicas": Object {
+        "path": "replicas",
+        "type": "integer",
+        "value": 1,
+      },
+    }
+  }
+>
+  <TextParam
+    handleBasicFormParamChange={[Function]}
+    id="replicas-0"
+    inputType="number"
+    key="replicas-0"
+    label=""
+    name="replicas"
+    param={
+      Object {
+        "path": "replicas",
+        "type": "integer",
+        "value": 1,
+      }
+    }
+  >
+    <div>
+      <label
+        htmlFor="replicas-0"
+      >
+        <input
+          defaultValue={1}
+          id="replicas-0"
+          onChange={[Function]}
+          type="number"
+        />
+      </label>
+    </div>
+  </TextParam>
 </BasicDeploymentForm>
 `;
 
@@ -54,7 +353,7 @@ exports[`renders a basic deployment with a generic string 1`] = `
     }
   }
 >
-  <StringParam
+  <TextParam
     handleBasicFormParamChange={[Function]}
     id="blogName-0"
     key="blogName-0"
@@ -73,13 +372,14 @@ exports[`renders a basic deployment with a generic string 1`] = `
         htmlFor="blogName-0"
       >
         <input
+          defaultValue="my-blog"
           id="blogName-0"
           onChange={[Function]}
-          value="my-blog"
+          type="text"
         />
       </label>
     </div>
-  </StringParam>
+  </TextParam>
 </BasicDeploymentForm>
 `;
 
@@ -95,7 +395,7 @@ exports[`renders a basic deployment with a password 1`] = `
     }
   }
 >
-  <StringParam
+  <TextParam
     handleBasicFormParamChange={[Function]}
     id="password-0"
     key="password-0"
@@ -114,13 +414,14 @@ exports[`renders a basic deployment with a password 1`] = `
       >
         Password
         <input
+          defaultValue="sserpdrow"
           id="password-0"
           onChange={[Function]}
-          value="sserpdrow"
+          type="text"
         />
       </label>
     </div>
-  </StringParam>
+  </TextParam>
 </BasicDeploymentForm>
 `;
 
@@ -136,7 +437,7 @@ exports[`renders a basic deployment with a username 1`] = `
     }
   }
 >
-  <StringParam
+  <TextParam
     handleBasicFormParamChange={[Function]}
     id="username-0"
     key="username-0"
@@ -155,13 +456,14 @@ exports[`renders a basic deployment with a username 1`] = `
       >
         Username
         <input
+          defaultValue="user"
           id="username-0"
           onChange={[Function]}
-          value="user"
+          type="text"
         />
       </label>
     </div>
-  </StringParam>
+  </TextParam>
 </BasicDeploymentForm>
 `;
 
@@ -190,7 +492,7 @@ exports[`renders a basic deployment with username, password, email and a generic
     }
   }
 >
-  <StringParam
+  <TextParam
     handleBasicFormParamChange={[Function]}
     id="username-0"
     key="username-0"
@@ -209,14 +511,15 @@ exports[`renders a basic deployment with username, password, email and a generic
       >
         Username
         <input
+          defaultValue="user"
           id="username-0"
           onChange={[Function]}
-          value="user"
+          type="text"
         />
       </label>
     </div>
-  </StringParam>
-  <StringParam
+  </TextParam>
+  <TextParam
     handleBasicFormParamChange={[Function]}
     id="password-1"
     key="password-1"
@@ -235,14 +538,15 @@ exports[`renders a basic deployment with username, password, email and a generic
       >
         Password
         <input
+          defaultValue="sserpdrow"
           id="password-1"
           onChange={[Function]}
-          value="sserpdrow"
+          type="text"
         />
       </label>
     </div>
-  </StringParam>
-  <StringParam
+  </TextParam>
+  <TextParam
     handleBasicFormParamChange={[Function]}
     id="email-2"
     key="email-2"
@@ -261,14 +565,15 @@ exports[`renders a basic deployment with username, password, email and a generic
       >
         Email
         <input
+          defaultValue="user@example.com"
           id="email-2"
           onChange={[Function]}
-          value="user@example.com"
+          type="text"
         />
       </label>
     </div>
-  </StringParam>
-  <StringParam
+  </TextParam>
+  <TextParam
     handleBasicFormParamChange={[Function]}
     id="blogName-3"
     key="blogName-3"
@@ -287,12 +592,13 @@ exports[`renders a basic deployment with username, password, email and a generic
         htmlFor="blogName-3"
       >
         <input
+          defaultValue="my-blog"
           id="blogName-3"
           onChange={[Function]}
-          value="my-blog"
+          type="text"
         />
       </label>
     </div>
-  </StringParam>
+  </TextParam>
 </BasicDeploymentForm>
 `;

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/__snapshots__/BooleanParam.test.tsx.snap
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/__snapshots__/BooleanParam.test.tsx.snap
@@ -1,0 +1,243 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a boolean param with title and description 1`] = `
+<BooleanParam
+  handleBasicFormParamChange={[Function]}
+  id="foo"
+  label="Enable Metrics"
+  name="enableMetrics"
+  param={
+    Object {
+      "path": "enableMetrics",
+      "type": "boolean",
+      "value": true,
+    }
+  }
+>
+  <label
+    htmlFor="foo"
+  >
+    <div
+      className="margin-b-normal"
+    >
+      <span>
+        Enable Metrics
+      </span>
+      <ReactSwitch
+        activeBoxShadow="0 0 2px 3px #3bf"
+        boxShadow={null}
+        checked={true}
+        checkedIcon={
+          <svg
+            height="100%"
+            style={
+              Object {
+                "position": "absolute",
+                "top": 0,
+              }
+            }
+            viewBox="-2 -5 17 21"
+            width="100%"
+          >
+            <path
+              d="M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0"
+              fill="#fff"
+              fillRule="evenodd"
+            />
+          </svg>
+        }
+        className="react-switch"
+        disabled={false}
+        height={28}
+        id="foo"
+        offColor="#888"
+        offHandleColor="#fff"
+        onChange={[Function]}
+        onColor="#080"
+        onHandleColor="#fff"
+        uncheckedIcon={
+          <svg
+            height="100%"
+            style={
+              Object {
+                "position": "absolute",
+                "top": 0,
+              }
+            }
+            viewBox="-2 -5 14 20"
+            width="100%"
+          >
+            <path
+              d="M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12"
+              fill="#fff"
+              fillRule="evenodd"
+            />
+          </svg>
+        }
+        width={56}
+      >
+        <div
+          className="react-switch"
+          style={
+            Object {
+              "MozTransition": "opacity 0.25s",
+              "MozUserSelect": "none",
+              "WebkitTapHighlightColor": "rgba(0, 0, 0, 0)",
+              "WebkitTransition": "opacity 0.25s",
+              "WebkitUserSelect": "none",
+              "borderRadius": 14,
+              "direction": "ltr",
+              "display": "inline-block",
+              "msUserSelect": "none",
+              "opacity": 1,
+              "position": "relative",
+              "textAlign": "left",
+              "touchAction": "none",
+              "transition": "opacity 0.25s",
+              "userSelect": "none",
+            }
+          }
+        >
+          <div
+            className="react-switch-bg"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            style={
+              Object {
+                "MozTransition": "background 0.25s",
+                "WebkitTransition": "background 0.25s",
+                "background": "#008800",
+                "borderRadius": 14,
+                "cursor": "pointer",
+                "height": 28,
+                "margin": 0,
+                "position": "relative",
+                "transition": "background 0.25s",
+                "width": 56,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "MozTransition": "opacity 0.25s",
+                  "WebkitTransition": "opacity 0.25s",
+                  "height": 28,
+                  "opacity": 1,
+                  "pointerEvents": "none",
+                  "position": "relative",
+                  "transition": "opacity 0.25s",
+                  "width": 30,
+                }
+              }
+            >
+              <svg
+                height="100%"
+                style={
+                  Object {
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+                viewBox="-2 -5 17 21"
+                width="100%"
+              >
+                <path
+                  d="M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0"
+                  fill="#fff"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </div>
+            <div
+              style={
+                Object {
+                  "MozTransition": "opacity 0.25s",
+                  "WebkitTransition": "opacity 0.25s",
+                  "height": 28,
+                  "opacity": 0,
+                  "pointerEvents": "none",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "transition": "opacity 0.25s",
+                  "width": 30,
+                }
+              }
+            >
+              <svg
+                height="100%"
+                style={
+                  Object {
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+                viewBox="-2 -5 14 20"
+                width="100%"
+              >
+                <path
+                  d="M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12"
+                  fill="#fff"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="react-switch-handle"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            style={
+              Object {
+                "MozTransition": "background-color 0.25s, transform 0.25s, box-shadow 0.15s",
+                "WebkitTransition": "background-color 0.25s, transform 0.25s, box-shadow 0.15s",
+                "background": "#ffffff",
+                "border": 0,
+                "borderRadius": "50%",
+                "boxShadow": null,
+                "cursor": "pointer",
+                "display": "inline-block",
+                "height": 26,
+                "outline": 0,
+                "position": "absolute",
+                "top": 1,
+                "transform": "translateX(29px)",
+                "transition": "background-color 0.25s, transform 0.25s, box-shadow 0.15s",
+                "width": 26,
+              }
+            }
+          />
+          <input
+            checked={true}
+            disabled={false}
+            id="foo"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyUp={[Function]}
+            role="switch"
+            style={
+              Object {
+                "border": 0,
+                "clip": "rect(0 0 0 0)",
+                "height": 1,
+                "margin": -1,
+                "overflow": "hidden",
+                "padding": 0,
+                "position": "absolute",
+                "width": 1,
+              }
+            }
+            type="checkbox"
+          />
+        </div>
+      </ReactSwitch>
+    </div>
+  </label>
+</BooleanParam>
+`;

--- a/dashboard/src/components/DeploymentForm/BasicDeploymentForm/__snapshots__/TextParam.test.tsx.snap
+++ b/dashboard/src/components/DeploymentForm/BasicDeploymentForm/__snapshots__/TextParam.test.tsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a text param with title and description 1`] = `
+<TextParam
+  handleBasicFormParamChange={[Function]}
+  id="foo"
+  label="Username"
+  name="username"
+  param={
+    Object {
+      "path": "username",
+      "type": "string",
+      "value": "user",
+    }
+  }
+>
+  <div>
+    <label
+      htmlFor="foo"
+    >
+      Username
+      <input
+        defaultValue="user"
+        id="foo"
+        type="text"
+      />
+    </label>
+  </div>
+</TextParam>
+`;

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -254,4 +254,62 @@ describe("when the basic form is enabled", () => {
     });
     expect(wrapper.state("appValues")).toBe("wordpressUsername: foo\n");
   });
+
+  it("handles a parameter as a number", () => {
+    const basicFormParameters = {
+      replicas: {
+        path: "replicas",
+        value: 1,
+        type: "integer",
+      },
+    };
+    const wrapper = mount(<DeploymentForm {...props} enableBasicForm={true} />);
+    wrapper.setState({ appValues: "replicas: 1", basicFormParameters });
+    wrapper.update();
+
+    // Fake onChange
+    const input = wrapper.find(BasicDeploymentForm).find("input");
+    const onChange = input.prop("onChange") as (e: React.FormEvent<HTMLInputElement>) => void;
+    onChange({ currentTarget: { value: "2", valueAsNumber: 2, type: "number" } } as React.FormEvent<
+      HTMLInputElement
+    >);
+
+    expect(wrapper.state("basicFormParameters")).toEqual({
+      replicas: {
+        path: "replicas",
+        value: 2,
+        type: "integer",
+      },
+    });
+    expect(wrapper.state("appValues")).toBe("replicas: 2\n");
+  });
+
+  it("handles a parameter as a boolean", () => {
+    const basicFormParameters = {
+      enableMetrics: {
+        path: "enableMetrics",
+        value: false,
+        type: "boolean",
+      },
+    };
+    const wrapper = mount(<DeploymentForm {...props} enableBasicForm={true} />);
+    wrapper.setState({ appValues: "enableMetrics: false", basicFormParameters });
+    wrapper.update();
+
+    // Fake onChange
+    const input = wrapper.find(BasicDeploymentForm).find("input");
+    const onChange = input.prop("onChange") as (e: React.FormEvent<HTMLInputElement>) => void;
+    onChange({
+      currentTarget: { value: "true", checked: true, type: "checkbox" },
+    } as React.FormEvent<HTMLInputElement>);
+
+    expect(wrapper.state("basicFormParameters")).toEqual({
+      enableMetrics: {
+        path: "enableMetrics",
+        value: true,
+        type: "boolean",
+      },
+    });
+    expect(wrapper.state("appValues")).toBe("enableMetrics: true\n");
+  });
 });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -250,15 +250,26 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
 
   private handleBasicFormParamChange = (name: string, param: IBasicFormParam) => {
     return (e: React.FormEvent<HTMLInputElement>) => {
+      let value: any = e.currentTarget.value;
+      switch (e.currentTarget.type) {
+        case "checkbox":
+          // value is a boolean
+          value = e.currentTarget.checked;
+          break;
+        case "number":
+          // value is a number
+          value = e.currentTarget.valueAsNumber;
+          break;
+      }
       // Change raw values
-      this.handleValuesChange(setValue(this.state.appValues, param.path, e.currentTarget.value));
+      this.handleValuesChange(setValue(this.state.appValues, param.path, value));
       // Change param definition
       this.setState({
         basicFormParameters: {
           ...this.state.basicFormParameters,
           [name]: {
             ...param,
-            value: e.currentTarget.value,
+            value,
           },
         },
       });

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -8944,6 +8944,13 @@ react-select@^1.2.1:
     prop-types "^15.5.8"
     react-input-autosize "^2.1.2"
 
+react-switch@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-switch/-/react-switch-5.0.1.tgz#449277f4c3aed5286fffd0f50d5cbc2a23330406"
+  integrity sha512-Pa5kvqRfX85QUCK1Jv0rxyeElbC3aNpCP5hV0LoJpU/Y6kydf0t4kRriQ6ZYA4kxWwAYk/cH51T4/sPzV9mCgQ==
+  dependencies:
+    prop-types "^15.6.2"
+
 react-tabs@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-3.0.0.tgz#60311a17c755eb6aa9b3310123e67db421605127"


### PR DESCRIPTION
Ref #1182 

This PR adds support to two new type of params (generic): integer and boolean:

![Screenshot from 2019-10-07 14-55-54](https://user-images.githubusercontent.com/4025665/66319220-080e7780-e91d-11e9-92e1-10a70c7b60d5.png)

The switch button is added with the package `react-switch`. The `StringParam` has been renamed to `TextParam` so it covers the use case for a number.