### PR TITLE
Make the slider param customizable via the schema

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
@@ -36,7 +36,12 @@ const defaultProps = {
   {
     description: "renders a basic deployment with a disk size",
     params: {
-      diskSize: { path: "size", value: "10Gi", type: "string" } as IBasicFormParam,
+      diskSize: {
+        path: "size",
+        value: "10Gi",
+        type: "string",
+        render: "slider",
+      } as IBasicFormParam,
     },
   },
   {

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -3,12 +3,9 @@ import { IBasicFormParam } from "shared/types";
 import TextParam from "./TextParam";
 
 import {
-  CPU_REQUEST,
-  DISK_SIZE,
   ENABLE_INGRESS,
   EXTERNAL_DB,
   INGRESS,
-  MEMORY_REQUEST,
   RESOURCES,
   USE_SELF_HOSTED_DB,
 } from "../../../shared/schema";
@@ -64,20 +61,6 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
             enablerCondition={false}
           />
         );
-      case DISK_SIZE:
-        return (
-          <SliderParam
-            label={param.title || "Disk Size"}
-            handleBasicFormParamChange={handleBasicFormParamChange}
-            key={id}
-            id={id}
-            name={name}
-            param={param}
-            min={1}
-            max={100}
-            unit="Gi"
-          />
-        );
       case RESOURCES:
         return (
           <Subsection
@@ -88,34 +71,6 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
             key={id}
             name={name}
             param={param}
-          />
-        );
-      case MEMORY_REQUEST:
-        return (
-          <SliderParam
-            label={param.title || "Memory Request"}
-            handleBasicFormParamChange={handleBasicFormParamChange}
-            key={id}
-            id={id}
-            name={name}
-            param={param}
-            min={10}
-            max={2048}
-            unit="Mi"
-          />
-        );
-      case CPU_REQUEST:
-        return (
-          <SliderParam
-            label={param.title || "CPU Request"}
-            handleBasicFormParamChange={handleBasicFormParamChange}
-            key={id}
-            id={id}
-            name={name}
-            param={param}
-            min={10}
-            max={2000}
-            unit="m"
           />
         );
       case INGRESS:
@@ -145,6 +100,23 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
                 param={param}
               />
             );
+          case "string": {
+            if (param.render === "slider") {
+              return (
+                <SliderParam
+                  label={param.title || name}
+                  handleBasicFormParamChange={handleBasicFormParamChange}
+                  key={id}
+                  id={id}
+                  name={name}
+                  param={param}
+                  min={param.sliderMin || 1}
+                  max={param.sliderMax || 1000}
+                  unit={param.sliderUnit || ""}
+                />
+              );
+            }
+          }
           default:
             return (
               <TextParam

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
     Object {
       "diskSize": Object {
         "path": "size",
+        "render": "slider",
         "type": "string",
         "value": "10Gi",
       },
@@ -19,24 +20,25 @@ exports[`renders a basic deployment with a disk size 1`] = `
     handleBasicFormParamChange={[Function]}
     id="diskSize-0"
     key="diskSize-0"
-    label="Disk Size"
-    max={100}
+    label="diskSize"
+    max={1000}
     min={1}
     name="diskSize"
     param={
       Object {
         "path": "size",
+        "render": "slider",
         "type": "string",
         "value": "10Gi",
       }
     }
-    unit="Gi"
+    unit=""
   >
     <div>
       <label
         htmlFor="diskSize-0"
       >
-        Disk Size
+        diskSize
         <div
           className="row"
         >
@@ -45,7 +47,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
           >
             <Slider
               default={10}
-              max={100}
+              max={1000}
               min={1}
               onChange={[Function]}
               onUpdate={[Function]}
@@ -57,7 +59,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                 domain={
                   Array [
                     1,
-                    100,
+                    1000,
                   ]
                 }
                 flatten={false}
@@ -103,7 +105,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                       Array [
                         Object {
                           "id": "$$-0",
-                          "percent": 9.090909090909092,
+                          "percent": 0.9009009009009009,
                           "value": 10,
                         },
                       ]
@@ -113,7 +115,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                       LinearScale {
                         "domain": Array [
                           1,
-                          100,
+                          1000,
                         ],
                         "interpolator": [Function],
                         "range": Array [
@@ -148,7 +150,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                       Array [
                         Object {
                           "id": "$$-0",
-                          "percent": 9.090909090909092,
+                          "percent": 0.9009009009009009,
                           "value": 10,
                         },
                       ]
@@ -158,7 +160,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                       LinearScale {
                         "domain": Array [
                           1,
-                          100,
+                          1000,
                         ],
                         "interpolator": [Function],
                         "range": Array [
@@ -175,21 +177,21 @@ exports[`renders a basic deployment with a disk size 1`] = `
                         domain={
                           Array [
                             1,
-                            100,
+                            1000,
                           ]
                         }
                         getHandleProps={[Function]}
                         handle={
                           Object {
                             "id": "$$-0",
-                            "percent": 9.090909090909092,
+                            "percent": 0.9009009009009009,
                             "value": 10,
                           }
                         }
                         key="$$-0"
                       >
                         <div
-                          aria-valuemax={100}
+                          aria-valuemax={1000}
                           aria-valuemin={1}
                           aria-valuenow={10}
                           onKeyDown={[Function]}
@@ -203,7 +205,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                               "boxShadow": "1px 1px 1px 1px rgba(0, 0, 0, 0.2)",
                               "cursor": "pointer",
                               "height": 24,
-                              "left": "9.090909090909092%",
+                              "left": "0.9009009009009009%",
                               "marginLeft": "-11px",
                               "marginTop": "-6px",
                               "position": "absolute",
@@ -225,7 +227,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                       Array [
                         Object {
                           "id": "$$-0",
-                          "percent": 9.090909090909092,
+                          "percent": 0.9009009009009009,
                           "value": 10,
                         },
                       ]
@@ -237,7 +239,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                       LinearScale {
                         "domain": Array [
                           1,
-                          100,
+                          1000,
                         ],
                         "interpolator": [Function],
                         "range": Array [
@@ -263,7 +265,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                         target={
                           Object {
                             "id": "$$-0",
-                            "percent": 9.090909090909092,
+                            "percent": 0.9009009009009009,
                             "value": 10,
                           }
                         }
@@ -279,7 +281,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                               "height": 14,
                               "left": "0%",
                               "position": "absolute",
-                              "width": "9.090909090909092%",
+                              "width": "0.9009009009009009%",
                               "zIndex": 1,
                             }
                           }
@@ -302,9 +304,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
             />
             <span
               className="margin-l-normal"
-            >
-              Gi
-            </span>
+            />
           </div>
         </div>
       </label>

--- a/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.test.tsx
@@ -107,6 +107,7 @@ describe("when there are changes in the selected version", () => {
       .state as IDeploymentFormBodyState;
     const basicFormParameters = {
       foo: {
+        form: "foo",
         path: "foo",
         value: "bar",
         type: "string",
@@ -130,6 +131,7 @@ describe("when there are changes in the selected version", () => {
       });
       const basicFormParameters = {
         foo: {
+          form: "foo",
           path: "foo",
           value: "notBar",
           type: "string",
@@ -154,6 +156,7 @@ describe("when there are changes in the selected version", () => {
       });
       const basicFormParameters = {
         foo: {
+          form: "foo",
           path: "foo",
           value: "notBar",
           type: "string",
@@ -188,6 +191,7 @@ describe("when there are changes in the selected version", () => {
       });
       const basicFormParameters = {
         foo: {
+          form: "foo",
           path: "foo",
           value: "notBar",
           type: "string",

--- a/dashboard/src/shared/schema.ts
+++ b/dashboard/src/shared/schema.ts
@@ -14,9 +14,6 @@ nullOptions.nullStr = "";
 // Form keys that require pre-definition. This list should be kept as small as possible
 export const EXTERNAL_DB = "externalDatabase";
 export const USE_SELF_HOSTED_DB = "useSelfHostedDatabase";
-export const DISK_SIZE = "diskSize";
-export const MEMORY_REQUEST = "memoryRequest";
-export const CPU_REQUEST = "cpuRequest";
 export const RESOURCES = "resources";
 export const INGRESS = "ingress";
 export const ENABLE_INGRESS = "enableIngress";
@@ -35,19 +32,16 @@ export function retrieveBasicFormParams(
     Object.keys(properties).map(propertyKey => {
       // The param path is its parent path + the object key
       const itemPath = `${parentPath || ""}${propertyKey}`;
-      const { type, title, description, form, minimum, maximum } = properties[propertyKey];
+      const { type, form } = properties[propertyKey];
       // If the property has the key "form", it's a basic parameter
       if (form) {
         // Use the default value either from the JSON schema or the default values
         const value = getValue(defaultValues, itemPath, properties[propertyKey].default);
         const param: IBasicFormParam = {
+          ...properties[propertyKey],
           path: itemPath,
           type: String(type),
           value,
-          title,
-          description,
-          minimum,
-          maximum,
           children:
             properties[propertyKey].type === "object"
               ? retrieveBasicFormParams(defaultValues, properties[propertyKey], `${itemPath}.`)

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -383,6 +383,10 @@ export interface IBasicFormParam {
   title?: string;
   minimum?: number;
   maximum?: number;
+  render?: string;
+  sliderMin?: number;
+  sliderMax?: number;
+  sliderUnit?: string;
   description?: string;
   children?: { [name: string]: IBasicFormParam };
 }


### PR DESCRIPTION
Ref: #1182 

In order to avoid dependencies with hardcoded references to key names in the logic, I have set some new properties that an element can define in order to be rendered as a slider (instead of a string). For example, the disk size can be represented as:

```json
        "size": { 
          "type": "string",
          "title": "Disk Size",
          "form": "diskSize",
          "render": "slider",
          "sliderMin": 1,
          "sliderMax": 100,
          "sliderUnit": "Gi"
        }
```