### PR TITLE
Split types for the different params

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { IBasicFormParam } from "shared/types";
+import { IBasicFormParam, IBasicFormSliderParam } from "shared/types";
 import TextParam from "./TextParam";
 
 import "./BasicDeploymentForm.css";
@@ -77,6 +77,7 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
           }
           case "string": {
             if (param.render === "slider") {
+              const p = param as IBasicFormSliderParam;
               return (
                 <SliderParam
                   label={param.title || name}
@@ -85,9 +86,9 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
                   id={id}
                   name={name}
                   param={param}
-                  min={param.sliderMin || 1}
-                  max={param.sliderMax || 1000}
-                  unit={param.sliderUnit || ""}
+                  min={p.sliderMin || 1}
+                  max={p.sliderMax || 1000}
+                  unit={p.sliderUnit || ""}
                 />
               );
             }

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { setValue } from "../../../shared/schema";
-import { IBasicFormParam } from "../../../shared/types";
+import { IBasicFormEnablerParam, IBasicFormParam } from "../../../shared/types";
 import { getValueFromEvent } from "../../../shared/utils";
 import BooleanParam from "./BooleanParam";
 
@@ -32,9 +32,10 @@ function findEnabler(name: string, param: IBasicFormParam) {
   if (children) {
     Object.keys(children).forEach(p => {
       if (children[p].type === "boolean") {
-        if (children[p].enables === name) {
+        const childrenParam = children[p] as IBasicFormEnablerParam;
+        if (childrenParam.enables === name) {
           result = { enablerChildrenParam: p, enablerCondition: true };
-        } else if (children[p].disables === name) {
+        } else if (childrenParam.disables === name) {
           result = { enablerChildrenParam: p, enablerCondition: false };
         }
       }

--- a/dashboard/src/shared/schema.ts
+++ b/dashboard/src/shared/schema.ts
@@ -4,7 +4,7 @@
 import * as AJV from "ajv";
 import * as jsonSchema from "json-schema";
 import * as YAML from "yaml";
-import { IBasicFormParam } from "./types";
+import { IBasicFormEnablerParam, IBasicFormParam } from "./types";
 
 // Avoid to explicitly add "null" when an element is not defined
 // tslint:disable-next-line
@@ -64,11 +64,12 @@ export function retrieveBasicFormParams(
 // enables/disables another.
 // CAVEAT: It only works with one level of depth
 function orderParams(params: {
-  [key: string]: IBasicFormParam;
+  [key: string]: IBasicFormParam | IBasicFormEnablerParam;
 }): { [key: string]: IBasicFormParam } {
   Object.keys(params).forEach(p => {
-    if (params[p].disables || params[p].enables) {
-      const relatedParam = params[p].disables || params[p].enables;
+    const param = params[p] as IBasicFormEnablerParam;
+    if (param.disables || param.enables) {
+      const relatedParam = param.disables || param.enables;
       if (relatedParam && params[relatedParam]) {
         params[relatedParam].children = {
           ...params[relatedParam].children,

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -384,11 +384,16 @@ export interface IBasicFormParam {
   minimum?: number;
   maximum?: number;
   render?: string;
+  description?: string;
+  children?: { [name: string]: IBasicFormParam };
+}
+export interface IBasicFormSliderParam extends IBasicFormParam {
   sliderMin?: number;
   sliderMax?: number;
   sliderUnit?: string;
+}
+
+export interface IBasicFormEnablerParam extends IBasicFormParam {
   disables?: string;
   enables?: string;
-  description?: string;
-  children?: { [name: string]: IBasicFormParam };
 }


### PR DESCRIPTION
Follow up of #1224 #1223 

As discussed in the above PRs, it's possible to define different types based on the information present in the param.

Let me know what you think (or if this is what you were suggesting @absoludity). I am not sure if this improves readability because you need to cast to the different types when needed, which can be confusing.