### PR TITLE
Don't depend on sourcing minishift oc-env.

### DIFF
--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -25,6 +25,7 @@ rules:
   - list
   - update
   - watch
+  - delete
 - apiGroups:
   - batch
   resources:

--- a/script/openshift-cluster.mk
+++ b/script/openshift-cluster.mk
@@ -1,66 +1,67 @@
-# This Makefile assumes that you have:
+# This Makefile aims to help local development with an OpenShift/Minishift cluster. It is not for production
+# use, but does document requirements for OpenShift. The targets assume that you have:
 # 1) helm installed 
-# 2) minishift installed and a cluster started.
-TILLER_NAMESPACE=tiller
-KUBEAPPS_NAMESPACE=kubeapps
+# 2) minishift installed and a cluster started (which automatically updates your KUBECONFIG).
+# 3) the `oc` cli setup (ie. you've run `eval $(minishift oc-env)`)
+TILLER_NAMESPACE ?= tiller
+KUBEAPPS_NAMESPACE ?= kubeapps
+
+MONGODB_CHART_VERSION = $(strip $(shell cat chart/kubeapps/requirements.lock | grep version | cut --delimiter=":" -f2))
 
 devel/openshift-tiller-project-created:
-	@$(shell minishift oc-env) && \
-		oc login -u developer && \
-		oc new-project ${TILLER_NAMESPACE} && \
-		touch $@
+	@oc login -u developer
+	oc new-project ${TILLER_NAMESPACE}
+	touch $@
 
 devel/openshift-tiller-with-crd-rbac.yaml: devel/openshift-tiller-project-created
-	@$(shell minishift oc-env) && \
-		oc process -f ./docs/user/manifests/openshift-tiller-with-crd-rbac.yaml \
-			-p TILLER_NAMESPACE="${TILLER_NAMESPACE}" \
-			-p HELM_VERSION=v2.14.3 \
-			-o yaml \
-		> $@
+	@oc process -f ./docs/user/manifests/openshift-tiller-with-crd-rbac.yaml \
+		-p TILLER_NAMESPACE="${TILLER_NAMESPACE}" \
+		-p HELM_VERSION=v2.14.3 \
+		-o yaml \
+	> $@
 
 devel/openshift-tiller-with-apprepository-rbac.yaml: devel/openshift-tiller-with-crd-rbac.yaml
-	@$(shell minishift oc-env) && \
-		oc process -f ./docs/user/manifests/openshift-tiller-with-apprepository-rbac.yaml \
-			-p TILLER_NAMESPACE="${TILLER_NAMESPACE}" \
-			-p KUBEAPPS_NAMESPACE="${KUBEAPPS_NAMESPACE}" \
-			-o yaml \
-		> $@
+	@oc process -f ./docs/user/manifests/openshift-tiller-with-apprepository-rbac.yaml \
+		-p TILLER_NAMESPACE="${TILLER_NAMESPACE}" \
+		-p KUBEAPPS_NAMESPACE="${KUBEAPPS_NAMESPACE}" \
+		-o yaml \
+	> $@
 
 # Openshift requires you to have a project selected when referencing roles, otherwise the following error results:
 # Error from server: invalid origin role binding tiller-apprepositories: attempts to reference
 # role in namespace "kubeapps" instead of current namespace "tiller"
+# The admin role is required because the following gives tiller a cluster-wide permission (crd-rbac).
 openshift-install-tiller: devel/openshift-tiller-with-crd-rbac.yaml devel/openshift-tiller-with-apprepository-rbac.yaml devel/openshift-kubeapps-project-created
-	$(shell minishift oc-env) && \
-		oc login -u system:admin && \
-		oc project ${TILLER_NAMESPACE} && \
-		oc apply -f devel/openshift-tiller-with-crd-rbac.yaml --wait=true && \
-		oc project ${KUBEAPPS_NAMESPACE} && \
-		oc apply -f devel/openshift-tiller-with-apprepository-rbac.yaml && \
-		helm init --tiller-namespace ${TILLER_NAMESPACE} --service-account tiller --wait && \
-		oc login -u developer
+	@oc login -u system:admin
+	oc project ${TILLER_NAMESPACE}
+	oc apply -f devel/openshift-tiller-with-crd-rbac.yaml --wait=true
+	oc project ${KUBEAPPS_NAMESPACE}
+	oc apply -f devel/openshift-tiller-with-apprepository-rbac.yaml
+	helm init --tiller-namespace ${TILLER_NAMESPACE} --service-account tiller --wait
+	oc login -u developer
 
 devel/openshift-kubeapps-project-created: devel/openshift-tiller-project-created
-	@$(shell minishift oc-env) && \
-		oc login -u developer && \
-		oc new-project ${KUBEAPPS_NAMESPACE} && \
-		oc policy add-role-to-user edit "system:serviceaccount:${TILLER_NAMESPACE}:tiller" && \
-		touch $@
+	@oc login -u developer
+	oc new-project ${KUBEAPPS_NAMESPACE}
+	oc policy add-role-to-user edit "system:serviceaccount:${TILLER_NAMESPACE}:tiller"
+	touch $@
 
-chart/kubeapps/charts/mongodb-%.tgz:
-	helm dep update ./chart/kubeapps
+chart/kubeapps/charts/mongodb-${MONGODB_CHART_VERSION}.tgz:
+	helm dep build ./chart/kubeapps
 
-devel/openshift-kubeapps-installed: openshift-install-tiller chart/kubeapps/charts/mongodb-%.tgz
-	@$(shell minishift oc-env) && \
-		oc project ${KUBEAPPS_NAMESPACE} && \
-		helm --tiller-namespace=${TILLER_NAMESPACE} install ./chart/kubeapps -n ${KUBEAPPS_NAMESPACE} \
-			--set tillerProxy.host=tiller-deploy.tiller:44134 \
-			--values ./docs/user/manifests/kubeapps-local-dev-values.yaml
+devel/openshift-kubeapps-installed: openshift-install-tiller chart/kubeapps/charts/mongodb-${MONGODB_CHART_VERSION}.tgz
+	@oc project ${KUBEAPPS_NAMESPACE}
+	helm --tiller-namespace=${TILLER_NAMESPACE} install ./chart/kubeapps -n ${KUBEAPPS_NAMESPACE} \
+		--set tillerProxy.host=tiller-deploy.tiller:44134 \
+		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml
 
 # Due to openshift having multiple secrets for the service account, the code is slightly different from
 # that at https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md#on-linuxmacos
-# TODO: potentially update the docs to use this. Note kubectl jsonpath support
-# does not yet support regex filtering, hence the separate grep
+# TODO: update the docs to use the similar bash command.
+# TODO: update this target to use a kubeapps user, rather than tiller service account.
+# Note kubectl jsonpath support does not yet support regex filtering:
 # https://github.com/kubernetes/kubernetes/issues/61406
+# hence the separate grep.
 openshift-tiller-token:
 	@kubectl get secret -n "${TILLER_NAMESPACE}" \
 		$(shell kubectl get serviceaccount -n "${TILLER_NAMESPACE}" tiller -o jsonpath='{range .secrets[*]}{.name}{"\n"}{end}' | grep tiller-token) \
@@ -68,17 +69,14 @@ openshift-tiller-token:
 
 openshift-kubeapps: devel/openshift-kubeapps-installed
 
-# TODO: Update so all steps carried out even when others fail (otherwise
-# resetting an incomplete install will fail.
 openshift-kubeapps-reset:
-	$(shell minishift oc-env) && \
-		oc login -u system:admin && \
-		oc delete project ${KUBEAPPS_NAMESPACE} && \
-		oc delete project ${TILLER_NAMESPACE} && \
-		#oc delete -f devel/openshift-tiller-with-crd-rbac.yaml && \
-		#oc delete -f devel/openshift-tiller-with-apprepository-rbac.yaml && \
-		oc delete customresourcedefinition apprepositories.kubeapps.com && \
-		oc login -u developer && \
-		rm devel/openshift-*	
+	@oc login -u system:admin
+	oc delete project ${KUBEAPPS_NAMESPACE} || true
+	oc delete project ${TILLER_NAMESPACE} || true
+	oc delete -f devel/openshift-tiller-with-crd-rbac.yaml || true
+	oc delete -f devel/openshift-tiller-with-apprepository-rbac.yaml || true
+	oc delete customresourcedefinition apprepositories.kubeapps.com || true
+	rm devel/openshift-* || true
+	oc login -u developer
 
 .PHONY: openshift-install-tiller openshift-kubeapps openshift-kubeapps-reset


### PR DESCRIPTION
I'd previously assumed that `script/openshift-cluster.mk` would run without the user necessarily having sourced the output of `minishift oc-env`, but this is unnecessary (ie. it's a valid assumption that the user will have done this), and complicates the targets (as it required running only a single command per target after having sourced).

This also fixes `helm dep update` to `helm dep build` (I didn't realise update was pulling charts from requirements.yaml rather than requirements.lock... build is the one we want, as it just ensures that what is in the lock file is present), and updates that target to use the specific mongodb version (otherwise it pulls it every time).

Also fixes the `-reset` target to ensure all items run even if some fail (as if you have an incomplete deployment, it would error if it couldn't delete something that didn't exist etc.)

Ref #676 