### PR TITLE
Add cronjob delete perm for app repo controller to avoid startup error

### DIFF
--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -25,6 +25,7 @@ rules:
   - list
   - update
   - watch
+  - delete
 - apiGroups:
   - batch
   resources:


### PR DESCRIPTION
When repeatedly testing installation on openshift (minishift), I'd find that the app repository controller failed to create the cron-jobs, with the error:

```
E1018 01:25:15.595721       1 controller.go:239] error syncing 'kubeapps/incubator': cronjobs.batch "apprepo-sync-incubator" is forbidden: cannot set blockOwnerDeletion in this case because cannot find RESTMapping for APIVersion kubeapps.com/v1alpha1 Kind AppRepository: no matches for kind "AppRepository" in version "kubeapps.com/v1alpha1" 
```

yet, if I force container restarts (just updating the deployment pull policy, for eg), they would restart without issue. So it appears to be a timing issue, that if the app repository controllers are up and running before the RESTMapping for the kubeapps.com/v1alpha is available, it will fail.

I found a reference to this error message in a [commit](https://gitlab.cncf.ci/kubernetes/kubernetes/commit/3b9eb1a8755d744d51a0be47cd85c0350307cc59) which indicates that this check is only done if the user (in our case, app-repo-controller) does not have delete permission on the object. Indeed, if I add delete, the check is skipped during startup and there are no errors on Openshift.

So it's not clear to me if this would be reproducible on vanilla k8s, depending on the timing (we don't appear to have reports of it), but given that we're creating the CronJob resources with an owner reference using metav1.NewControllerRef which sets `BlockOwnerDeletion: true`, I don't see any reason not to include delete here? That is, the cronjob ends up with an owner reference like:

```
kind: CronJob
metadata:
  creationTimestamp: 2019-10-18T02:01:01Z
  name: apprepo-sync-bitnami
  namespace: kubeapps
  ownerReferences:
  - apiVersion: kubeapps.com/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: AppRepository
    name: bitnami
    uid: 1738310b-f14b-11e9-b0c1-52540079aa76
  resourceVersion: "172956"
```
which says that deleting the `bitnami` app repository will cause the GC to first ensure the cron job is deleted.

Too long an explanation for a one-liner :P