### PR TITLE
Add tiller-proxy to the 'all' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GO_PACKAGES = ./...
 
 default: all
 
-all: kubeapps/dashboard kubeapps/apprepository-controller
+all: kubeapps/dashboard kubeapps/apprepository-controller kubeapps/tiller-proxy
 
 # TODO(miguel) Create Makefiles per component
 kubeapps/%:


### PR DESCRIPTION
We were surprised by the fact that tiller-proxy wasn't compiled when running `make all`.