### PR TITLE
Frontend injects wsprotocols only when not using oidc authn

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -44,7 +44,6 @@ spec:
         - -client-id={{ required "You must fill \".Values.authProxy.clientID\" with the Client ID of the provider" .Values.authProxy.clientID }}
         - -client-secret={{ required "You must fill \".Values.authProxy.clientSecret\" with the Client Secret of the provider" .Values.authProxy.clientSecret }}
         - -cookie-secret={{ required "You must fill \".Values.authProxy.cookieSecret\" with a 16, 24 or 32 byte base64 encoded seed string for secure cookies" .Values.authProxy.cookieSecret }}
-        - -cookie-name=kc-access
         - -upstream=http://localhost:8080/
         - -http-address=0.0.0.0:3000
         - -email-domain={{ .Values.authProxy.emailDomain }}

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -26,7 +26,9 @@ export class Auth {
 
   public static wsProtocols() {
     const token = this.getAuthToken();
-    if (!token) {
+    // If we're using OIDC for auth, then let the auth proxy handle
+    // injecting the ws creds.
+    if (!token || this.usingOIDCToken()) {
       return [];
     }
     return [

--- a/docs/user/using-an-OIDC-provider.md
+++ b/docs/user/using-an-OIDC-provider.md
@@ -162,7 +162,6 @@ spec:
         - -client-secret=$AUTH_PROXY_CLIENT_SECRET
         - -oidc-issuer-url=$AUTH_PROXY_DISCOVERY_URL
         - -cookie-secret=$AUTH_PROXY_COOKIE_SECRET
-        - -cookie-name=kc-access
         - -upstream=http://localhost:8080/
         - -http-address=0.0.0.0:3000
         - -email-domain="*"


### PR DESCRIPTION
Follows on from #1199. When QAing #1199, we noted that the websocket requests were 400ing. This was because with 1199, I've switched to no longer white-list requests to the k8s api, so they are sent via the proxy. The proxy handles adding any required auth headers for all requests (websocket requests included).

With this change, they upgrade without issue:
![oauth2-proxy-websockets](https://user-images.githubusercontent.com/497518/67183658-be9a4e00-f42d-11e9-9174-996aa852b563.png)

While there, I also removed the specific (key-cloak-based) cookie name which I'd added because I thought it would be referenced in the frontend and need updating there. Turns out its not at all, so we can just let `oauth2-proxy` use its default cookie name and avoid any confusion.