### PR TITLE
Use const assertions in Routes.tsx

### DIFF
--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -19,9 +19,7 @@ import ServiceInstanceViewContainer from "../../containers/ServiceInstanceViewCo
 
 type IRouteComponentPropsAndRouteProps = RouteProps & RouteComponentProps<any>;
 
-const privateRoutes: {
-  [route: string]: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
-} = {
+const privateRoutes = {
   "/apps/ns/:namespace": AppListContainer,
   "/apps/ns/:namespace/:releaseName": AppViewContainer,
   "/apps/ns/:namespace/new/:repo/:id/versions/:version": AppNewContainer,
@@ -36,14 +34,12 @@ const privateRoutes: {
   "/services/brokers/:brokerName/instances/ns/:namespace/:instanceName": ServiceInstanceViewContainer,
   "/services/classes": ServiceClassListContainer,
   "/services/instances/ns/:namespace": ServiceInstanceListContainer,
-};
+} as const;
 
 // Public routes that don't require authentication
-const routes: {
-  [route: string]: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
-} = {
+const routes = {
   "/login": LoginFormContainer,
-};
+} as const;
 
 interface IRoutesProps extends IRouteComponentPropsAndRouteProps {
   namespace: string;


### PR DESCRIPTION
With [`const` assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions), TypeScript infers as specific types as it can (and `readonly` recursively for properties). I think they're great in many situations, so I figured I'd try them out real quick. What do you guys think?