### PR TITLE
Replace Object.keys with Object.entries

### DIFF
--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -51,16 +51,11 @@ class Routes extends React.Component<IRoutesProps> {
     return (
       <Switch>
         <Route exact={true} path="/" render={this.rootNamespacedRedirect} />
-        {Object.keys(routes).map(route => (
-          <Route key={route} exact={true} path={route} component={routes[route]} />
+        {Object.entries(routes).map(([route, component]) => (
+          <Route key={route} exact={true} path={route} component={component} />
         ))}
-        {Object.keys(privateRoutes).map(route => (
-          <PrivateRouteContainer
-            key={route}
-            exact={true}
-            path={route}
-            component={privateRoutes[route]}
-          />
+        {Object.entries(privateRoutes).map(([route, component]) => (
+          <PrivateRouteContainer key={route} exact={true} path={route} component={component} />
         ))}
         {/* If the route doesn't match any expected path redirect to a 404 page  */}
         <Route component={NotFound} />


### PR DESCRIPTION
This is necessary for the `component` React property to be properly type checked. The reason is that, as far as TypeScript knows, `Object.keys` only returns plain strings, whereas with `Object.entries`, `component` in `[route, component]` is assigned as narrow a type as expected, derived from the values in the routes object.

Another advantage is that the routes objects are not repeated inside the mapped functions, so there is no risk of writing e.g.

    <Route ... component={privateRoutes[route]} />

instead of

    <Route ... component={routes[route]} />

**Possible caveat:** `Object.entries` is [not supported in IE](https://caniuse.com/#search=Object.entries). Will it be transpiled/polyfilled?