### PR TITLE
Improve resource kind typing

### DIFF
--- a/dashboard/src/shared/Kube.test.ts
+++ b/dashboard/src/shared/Kube.test.ts
@@ -100,23 +100,4 @@ describe("App", () => {
       socket.close();
     });
   });
-
-  describe("resourcePlural", () => {
-    const tests = [
-      { kind: "Service", expected: "services" },
-      { kind: "Ingress", expected: "ingresses" },
-      { kind: "Deployment", expected: "deployments" },
-    ];
-    tests.forEach(t => {
-      it(`returns the correct plural for ${t.kind}`, () => {
-        expect(Kube.resourcePlural(t.kind)).toBe(t.expected);
-      });
-    });
-
-    it("throws an error if the resource kind isn't registered", () => {
-      expect(() => Kube.resourcePlural("ThisKindWillNeverExist")).toThrow(
-        "Don't know plural for ThisKindWillNeverExist, register it in Kube",
-      );
-    });
-  });
 });

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -1,5 +1,6 @@
 import { Auth } from "./Auth";
 import { axiosWithAuth } from "./AxiosInstance";
+import { ResourceKind, ResourceKindsWithPlurals } from "./ResourceKinds";
 import { IResource } from "./types";
 
 export const APIBase = "api/kube";
@@ -9,19 +10,6 @@ if (location.protocol === "https:") {
 } else {
   WebSocketAPIBase = `ws://${window.location.host}${window.location.pathname}`;
 }
-
-// We explicitly define the plurals here, just in case a generic pluralizer
-// isn't sufficient. Note that CRDs can explicitly define pluralized forms,
-// which might not match with the Kind. If this becomes difficult to
-// maintain we can add a generic pluralizer and a way to override.
-const ResourceKindToPlural = {
-  Secret: "secrets",
-  Service: "services",
-  Ingress: "ingresses",
-  Deployment: "deployments",
-  StatefulSet: "statefulsets",
-  DaemonSet: "daemonsets",
-};
 
 // Kube is a lower-level class for interacting with the Kubernetes API. Use
 // ResourceRef to interact with a single API resource rather than using Kube
@@ -97,11 +85,7 @@ export class Kube {
   }
 
   // Gets the plural form of the resource Kind for use in the resource path
-  public static resourcePlural(kind: string) {
-    const plural = ResourceKindToPlural[kind];
-    if (!plural) {
-      throw new Error(`Don't know plural for ${kind}, register it in Kube`);
-    }
-    return plural;
+  public static resourcePlural(kind: ResourceKind) {
+    return ResourceKindsWithPlurals[kind];
   }
 }

--- a/dashboard/src/shared/ResourceKinds.ts
+++ b/dashboard/src/shared/ResourceKinds.ts
@@ -1,0 +1,16 @@
+// We explicitly define the plurals here, just in case a generic pluralizer
+// isn't sufficient. Note that CRDs can explicitly define pluralized forms,
+// which might not match with the Kind. If this becomes difficult to
+// maintain we can add a generic pluralizer and a way to override.
+export const ResourceKindsWithPlurals = {
+  ClusterRole: "clusterroles",
+  ConfigMap: "configmaps",
+  DaemonSet: "daemonsets",
+  Deployment: "deployments",
+  Ingress: "ingresses",
+  Secret: "secrets",
+  Service: "services",
+  StatefulSet: "statefulsets",
+} as const;
+
+export type ResourceKind = keyof typeof ResourceKindsWithPlurals;

--- a/dashboard/src/shared/ResourceRef.ts
+++ b/dashboard/src/shared/ResourceRef.ts
@@ -1,11 +1,12 @@
 import { Kube } from "./Kube";
+import { ResourceKind } from "./ResourceKinds";
 import { IResource } from "./types";
 
 // ResourceRef defines a reference to a namespaced Kubernetes API Object and
 // provides helpers to retrieve the resource URL
 class ResourceRef {
   public apiVersion: string;
-  public kind: string;
+  public kind: ResourceKind;
   public name: string;
   public namespace: string;
 

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -4,6 +4,7 @@ import { IConfigState } from "../reducers/config";
 import { INamespaceState } from "../reducers/namespace";
 import { IAppRepositoryState } from "../reducers/repos";
 import { hapi } from "./hapi/release";
+import { ResourceKind } from "./ResourceKinds";
 
 // Allow defining multiple error classes
 // tslint:disable:max-classes-per-file
@@ -141,7 +142,7 @@ export interface IIngressSpec {
 
 export interface IResource {
   apiVersion: string;
-  kind: string;
+  kind: ResourceKind;
   type: string;
   spec: any;
   status: any;


### PR DESCRIPTION
This PR is intended to facilitate a discussion on the possibility of introducing stronger typings where `string` is used today. `ResourceKind` is just one example of a narrower type that might be useful.

Actually, just by making this change and building, I found two resource kinds in the code base that were not included in the map from resource kinds to their plural representations, namely [`ClusterRole`](https://github.com/kubeapps/kubeapps/blob/16b04b9868596ff84dd3bb1b8054df5eb94fc702/dashboard/src/components/AppView/AppView.test.tsx#L344) and [`ConfigMap`](https://github.com/kubeapps/kubeapps/blob/16b04b9868596ff84dd3bb1b8054df5eb94fc702/dashboard/src/components/AppView/ResourceTable/ResourceItem/OtherResourceItem/OtherResourceItem.test.tsx#L10). However, I'm not familiar enough with the code base to understand whether they should be.

I'm aware that it might not be possible to make this change at all, especially due to [CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/). But what is then meant by ["register it in Kube"](https://github.com/kubeapps/kubeapps/blob/16b04b9868596ff84dd3bb1b8054df5eb94fc702/dashboard/src/shared/Kube.ts#L103)? Throwing an error there indicates to me that all "available" resource kinds should be declared in the code, and then we should be able to type them.

Basically, I'd appreciate any thoughts on why this is or isn't a good idea, and whether it might be possible to do something similar for other types realized as `string` today. Cheers!