### PR TITLE
Form key refactor

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
@@ -15,55 +15,47 @@ const defaultProps = {
 [
   {
     description: "renders a basic deployment with a username",
-    params: { username: { path: "wordpressUsername", value: "user" } as IBasicFormParam },
+    params: [{ path: "wordpressUsername", value: "user" } as IBasicFormParam],
   },
   {
     description: "renders a basic deployment with a password",
-    params: {
-      password: { path: "wordpressPassword", value: "sserpdrow" } as IBasicFormParam,
-    },
+    params: [{ path: "wordpressPassword", value: "sserpdrow" } as IBasicFormParam],
   },
   {
     description: "renders a basic deployment with a email",
-    params: { email: { path: "wordpressEmail", value: "user@example.com" } as IBasicFormParam },
+    params: [{ path: "wordpressEmail", value: "user@example.com" } as IBasicFormParam],
   },
   {
     description: "renders a basic deployment with a generic string",
-    params: {
-      blogName: { path: "blogName", value: "my-blog", type: "string" } as IBasicFormParam,
-    },
+    params: [{ path: "blogName", value: "my-blog", type: "string" } as IBasicFormParam],
   },
   {
     description: "renders a basic deployment with a disk size",
-    params: {
-      diskSize: {
+    params: [
+      {
         path: "size",
         value: "10Gi",
         type: "string",
         render: "slider",
       } as IBasicFormParam,
-    },
+    ],
   },
   {
     description: "renders a basic deployment with username, password, email and a generic string",
-    params: {
-      username: { path: "wordpressUsername", value: "user" } as IBasicFormParam,
-      password: { path: "wordpressPassword", value: "sserpdrow" } as IBasicFormParam,
-      email: { path: "wordpressEmail", value: "user@example.com" } as IBasicFormParam,
-      blogName: { path: "blogName", value: "my-blog", type: "string" } as IBasicFormParam,
-    },
+    params: [
+      { path: "wordpressUsername", value: "user" } as IBasicFormParam,
+      { path: "wordpressPassword", value: "sserpdrow" } as IBasicFormParam,
+      { path: "wordpressEmail", value: "user@example.com" } as IBasicFormParam,
+      { path: "blogName", value: "my-blog", type: "string" } as IBasicFormParam,
+    ],
   },
   {
     description: "renders a basic deployment with a generic boolean",
-    params: {
-      enableMetrics: { path: "enableMetrics", value: true, type: "boolean" } as IBasicFormParam,
-    },
+    params: [{ path: "enableMetrics", value: true, type: "boolean" } as IBasicFormParam],
   },
   {
     description: "renders a basic deployment with a generic number",
-    params: {
-      replicas: { path: "replicas", value: 1, type: "integer" } as IBasicFormParam,
-    },
+    params: [{ path: "replicas", value: 1, type: "integer" } as IBasicFormParam],
   },
 ].forEach(t => {
   it(t.description, () => {
@@ -78,26 +70,24 @@ const defaultProps = {
     );
     expect(wrapper).toMatchSnapshot();
 
-    Object.keys(t.params).map((param, i) => {
-      wrapper.find(`input#${param}-${i}`).simulate("change");
+    t.params.map((param, i) => {
+      wrapper.find(`input#${param.path}-${i}`).simulate("change");
       const mockCalls = handleBasicFormParamChange.mock.calls;
-      expect(mockCalls[i]).toEqual([param, t.params[param]]);
+      expect(mockCalls[i]).toEqual([param]);
       expect(onChange.mock.calls.length).toBe(i + 1);
     });
   });
 });
 
 it("should render an external database section", () => {
-  const params = {
-    externalDatabase: {
+  const params = [
+    {
       path: "edbs",
       value: {},
       type: "object",
-      children: {
-        useSelfHostedDatabase: { path: "mariadb.enabled", value: {}, type: "boolean" },
-      },
+      children: [{ path: "mariadb.enabled", value: {}, type: "boolean" }],
     },
-  };
+  ];
   const wrapper = mount(<BasicDeploymentForm {...defaultProps} params={params} />);
 
   const dbsec = wrapper.find(Subsection);
@@ -105,17 +95,17 @@ it("should render an external database section", () => {
 });
 
 it("should hide an element if it depends on a param (string)", () => {
-  const params = {
-    foo: {
+  const params = [
+    {
       path: "foo",
       type: "string",
       hidden: "bar",
     },
-    bar: {
+    {
       path: "bar",
       type: "boolean",
     },
-  };
+  ];
   const appValues = "foo: 1\nbar: true";
   const wrapper = shallow(
     <BasicDeploymentForm {...defaultProps} params={params} appValues={appValues} />,
@@ -126,8 +116,8 @@ it("should hide an element if it depends on a param (string)", () => {
 });
 
 it("should hide an element if it depends on a param (object)", () => {
-  const params = {
-    foo: {
+  const params = [
+    {
       path: "foo",
       type: "string",
       hidden: {
@@ -135,11 +125,11 @@ it("should hide an element if it depends on a param (object)", () => {
         condition: "enabled",
       },
     },
-    bar: {
+    {
       path: "bar",
       type: "string",
     },
-  };
+  ];
   const appValues = "foo: 1\nbar: enabled";
   const wrapper = shallow(
     <BasicDeploymentForm {...defaultProps} params={params} appValues={appValues} />,

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -9,9 +9,8 @@ import SliderParam from "./SliderParam";
 import Subsection from "./Subsection";
 
 export interface IBasicDeploymentFormProps {
-  params: { [name: string]: IBasicFormParam };
+  params: IBasicFormParam[];
   handleBasicFormParamChange: (
-    name: string,
     p: IBasicFormParam,
   ) => (e: React.FormEvent<HTMLInputElement>) => void;
   handleValuesChange: (value: string) => void;
@@ -22,16 +21,11 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
   public render() {
     return (
       <div className="margin-t-normal">
-        {Object.keys(this.props.params).map((paramName, i) => {
-          const id = `${paramName}-${i}`;
+        {this.props.params.map((param, i) => {
+          const id = `${param.path}-${i}`;
           return (
             <div key={id}>
-              {this.renderParam(
-                paramName,
-                this.props.params[paramName],
-                id,
-                this.props.handleBasicFormParamChange,
-              )}
+              {this.renderParam(param, id, this.props.handleBasicFormParamChange)}
               <hr />
             </div>
           );
@@ -55,72 +49,63 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
   };
 
   private renderParam = (
-    name: string,
     param: IBasicFormParam,
     id: string,
     handleBasicFormParamChange: (
-      name: string,
       p: IBasicFormParam,
     ) => (e: React.FormEvent<HTMLInputElement>) => void,
   ) => {
     let paramComponent: JSX.Element = <></>;
-    switch (name) {
-      default:
-        switch (param.type) {
-          case "boolean":
-            paramComponent = (
-              <BooleanParam
-                label={param.title || name}
-                handleBasicFormParamChange={handleBasicFormParamChange}
-                id={id}
-                name={name}
-                param={param}
-              />
-            );
-            break;
-          case "object": {
-            paramComponent = (
-              <Subsection
-                label={param.title || name}
-                handleValuesChange={this.props.handleValuesChange}
-                appValues={this.props.appValues}
-                renderParam={this.renderParam}
-                name={name}
-                param={param}
-              />
-            );
-            break;
-          }
-          case "string": {
-            if (param.render === "slider") {
-              const p = param as IBasicFormSliderParam;
-              paramComponent = (
-                <SliderParam
-                  label={param.title || name}
-                  handleBasicFormParamChange={handleBasicFormParamChange}
-                  id={id}
-                  name={name}
-                  param={param}
-                  min={p.sliderMin || 1}
-                  max={p.sliderMax || 1000}
-                  unit={p.sliderUnit || ""}
-                />
-              );
-              break;
-            }
-          }
-          default:
-            paramComponent = (
-              <TextParam
-                label={param.title || name}
-                handleBasicFormParamChange={handleBasicFormParamChange}
-                id={id}
-                name={name}
-                param={param}
-                inputType={param.type === "integer" ? "number" : "string"}
-              />
-            );
+    switch (param.type) {
+      case "boolean":
+        paramComponent = (
+          <BooleanParam
+            label={param.title || param.path}
+            handleBasicFormParamChange={handleBasicFormParamChange}
+            id={id}
+            param={param}
+          />
+        );
+        break;
+      case "object": {
+        paramComponent = (
+          <Subsection
+            label={param.title || param.path}
+            handleValuesChange={this.props.handleValuesChange}
+            appValues={this.props.appValues}
+            renderParam={this.renderParam}
+            param={param}
+          />
+        );
+        break;
+      }
+      case "string": {
+        if (param.render === "slider") {
+          const p = param as IBasicFormSliderParam;
+          paramComponent = (
+            <SliderParam
+              label={param.title || param.path}
+              handleBasicFormParamChange={handleBasicFormParamChange}
+              id={id}
+              param={param}
+              min={p.sliderMin || 1}
+              max={p.sliderMax || 1000}
+              unit={p.sliderUnit || ""}
+            />
+          );
+          break;
         }
+      }
+      default:
+        paramComponent = (
+          <TextParam
+            label={param.title || name}
+            handleBasicFormParamChange={handleBasicFormParamChange}
+            id={id}
+            param={param}
+            inputType={param.type === "integer" ? "number" : "string"}
+          />
+        );
     }
     return (
       <div key={id} hidden={this.isHidden(param)}>

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BooleanParam.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BooleanParam.test.tsx
@@ -6,7 +6,6 @@ import BooleanParam from "./BooleanParam";
 const param = { path: "enableMetrics", value: true, type: "boolean" };
 const defaultProps = {
   id: "foo",
-  name: "enableMetrics",
   label: "Enable Metrics",
   param,
   handleBasicFormParamChange: jest.fn(),
@@ -29,7 +28,11 @@ it("should send a checkbox event to handleBasicFormParamChange", () => {
 
   (s.prop("onChange") as any)(false);
 
-  expect(handleBasicFormParamChange.mock.calls[0][0]).toBe("enableMetrics");
+  expect(handleBasicFormParamChange.mock.calls[0][0]).toEqual({
+    path: "enableMetrics",
+    type: "boolean",
+    value: true,
+  });
   expect(handler.mock.calls[0][0]).toMatchObject({
     currentTarget: { value: "false", type: "checkbox", checked: false },
   });

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BooleanParam.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BooleanParam.tsx
@@ -4,11 +4,9 @@ import { IBasicFormParam } from "shared/types";
 
 export interface IStringParamProps {
   id: string;
-  name: string;
   label: string;
   param: IBasicFormParam;
   handleBasicFormParamChange: (
-    name: string,
     p: IBasicFormParam,
   ) => (e: React.FormEvent<HTMLInputElement>) => void;
 }
@@ -34,11 +32,11 @@ class BooleanParam extends React.Component<IStringParamProps> {
 
   // handleChange transform the event received by the Switch component to a checkbox event
   public handleChange = (checked: boolean) => {
-    const { name, param } = this.props;
+    const { param } = this.props;
     const event = {
       currentTarget: { value: String(checked), type: "checkbox", checked },
     } as React.FormEvent<HTMLInputElement>;
-    this.props.handleBasicFormParamChange(name, param)(event);
+    this.props.handleBasicFormParamChange(param)(event);
   };
 }
 

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/SliderParam.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/SliderParam.test.tsx
@@ -6,7 +6,6 @@ import SliderParam from "./SliderParam";
 
 const defaultProps = {
   id: "disk",
-  name: "diskSize",
   label: "Disk Size",
   param: {
     value: "10Gi",
@@ -50,7 +49,6 @@ it("changes the value of the param when the slider changes", () => {
 
   expect(param.value).toBe("20Gi");
   expect(handleBasicFormParamChange.mock.calls[0]).toEqual([
-    "diskSize",
     { value: "20Gi", type: "string", path: "disk" },
   ]);
 });

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/SliderParam.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/SliderParam.tsx
@@ -4,14 +4,12 @@ import Slider from "../../Slider";
 
 export interface ISliderParamProps {
   id: string;
-  name: string;
   label: string;
   param: IBasicFormParam;
   unit: string;
   min: number;
   max: number;
   handleBasicFormParamChange: (
-    name: string,
     p: IBasicFormParam,
   ) => (e: React.FormEvent<HTMLInputElement>) => void;
 }
@@ -89,7 +87,7 @@ class SliderParam extends React.Component<ISliderParamProps, ISliderParamState> 
   }
 
   private handleParamChange = (value: number) => {
-    this.props.handleBasicFormParamChange(this.props.name, this.props.param)({
+    this.props.handleBasicFormParamChange(this.props.param)({
       currentTarget: { value: `${value}${this.props.unit}` },
     } as React.FormEvent<HTMLInputElement>);
   };

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.test.tsx
@@ -7,29 +7,28 @@ import Subsection, { ISubsectionProps } from "./Subsection";
 
 const defaultProps = {
   label: "Enable an external database",
-  name: "externalDatabase",
   param: {
-    children: {
-      externalDatabaseDB: {
+    children: [
+      {
         path: "externalDatabase.database",
         type: "string",
         value: "bitnami_wordpress",
       },
-      externalDatabaseHost: { path: "externalDatabase.host", type: "string", value: "localhost" },
-      externalDatabasePassword: { path: "externalDatabase.password", type: "string" },
-      externalDatabasePort: { path: "externalDatabase.port", type: "integer", value: 3306 },
-      externalDatabaseUser: {
+      { path: "externalDatabase.host", type: "string", value: "localhost" },
+      { path: "externalDatabase.password", type: "string" },
+      { path: "externalDatabase.port", type: "integer", value: 3306 },
+      {
         path: "externalDatabase.user",
         type: "string",
         value: "bn_wordpress",
       },
-      useSelfHostedDatabase: {
+      {
         path: "mariadb.enabled",
         title: "Enable External Database",
         type: "boolean",
         value: true,
       } as IBasicFormParam,
-    },
+    ],
     path: "externalDatabase",
     title: "External Database Details",
     description: "description of the param",
@@ -53,10 +52,7 @@ it("should omit the enabler param if it doesn't exist", () => {
     ...defaultProps,
     param: {
       ...defaultProps.param,
-      children: {
-        ...defaultProps.param.children,
-        useSelfHostedDatabase: {} as IBasicFormParam,
-      },
+      children: defaultProps.param.children!.concat({} as IBasicFormParam),
     },
   };
   const wrapper = mount(<Subsection {...props} />);

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.tsx
@@ -6,14 +6,11 @@ import { getValueFromEvent } from "../../../shared/utils";
 export interface ISubsectionProps {
   label: string;
   param: IBasicFormParam;
-  name: string;
   handleValuesChange: (value: string) => void;
   renderParam: (
-    name: string,
     param: IBasicFormParam,
     id: string,
     handleBasicFormParamChange: (
-      name: string,
       p: IBasicFormParam,
     ) => (e: React.FormEvent<HTMLInputElement>) => void,
   ) => JSX.Element | null;
@@ -35,11 +32,10 @@ class Subsection extends React.Component<ISubsectionProps> {
           )}
         </div>
         {param.children &&
-          Object.keys(param.children).map((paramName, i) => {
+          param.children.map((childrenParam, i) => {
             return this.props.renderParam(
-              paramName,
-              param.children![paramName],
-              `${paramName}-${i}`,
+              childrenParam,
+              `${childrenParam.path}-${i}`,
               this.handleChildrenParamChange,
             );
           })}
@@ -47,10 +43,12 @@ class Subsection extends React.Component<ISubsectionProps> {
     );
   }
 
-  private handleChildrenParamChange = (name: string, param: IBasicFormParam) => {
+  private handleChildrenParamChange = (param: IBasicFormParam) => {
     return (e: React.FormEvent<HTMLInputElement>) => {
       const value = getValueFromEvent(e);
-      this.props.param.children![name] = { ...this.props.param.children![name], value };
+      this.props.param.children = this.props.param.children!.map(p =>
+        p.path === param.path ? { ...param, value } : p,
+      );
       this.props.handleValuesChange(setValue(this.props.appValues, param.path, value));
     };
   };

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/TextParam.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/TextParam.test.tsx
@@ -6,7 +6,6 @@ import TextParam from "./TextParam";
 const param = { path: "username", value: "user", type: "string" };
 const defaultProps = {
   id: "foo",
-  name: "username",
   label: "Username",
   param,
   handleBasicFormParamChange: jest.fn(() => jest.fn()),
@@ -36,7 +35,11 @@ it("should forward the proper value", () => {
   const event = { currentTarget: {} } as React.FormEvent<HTMLInputElement>;
   (input.prop("onChange") as any)(event);
 
-  expect(handleBasicFormParamChange.mock.calls[0][0]).toBe("username");
+  expect(handleBasicFormParamChange.mock.calls[0][0]).toEqual({
+    path: "username",
+    type: "string",
+    value: "user",
+  });
   expect(handler.mock.calls[0][0]).toMatchObject(event);
 });
 

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/TextParam.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/TextParam.tsx
@@ -3,19 +3,17 @@ import { IBasicFormParam } from "shared/types";
 
 export interface IStringParamProps {
   id: string;
-  name: string;
   label: string;
   inputType?: string;
   param: IBasicFormParam;
   handleBasicFormParamChange: (
-    name: string,
     p: IBasicFormParam,
   ) => (e: React.FormEvent<HTMLInputElement>) => void;
 }
 
 class TextParam extends React.Component<IStringParamProps> {
   public render() {
-    const { id, name, param, label, inputType } = this.props;
+    const { id, param, label, inputType } = this.props;
     return (
       <div>
         <label htmlFor={id}>
@@ -26,7 +24,7 @@ class TextParam extends React.Component<IStringParamProps> {
             <div className="col-9 margin-t-small">
               <input
                 id={id}
-                onChange={this.props.handleBasicFormParamChange(name, param)}
+                onChange={this.props.handleBasicFormParamChange(param)}
                 value={param.value === undefined ? "" : param.value}
                 type={inputType ? inputType : "text"}
               />

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
@@ -6,33 +6,32 @@ exports[`renders a basic deployment with a disk size 1`] = `
   handleBasicFormParamChange={[Function]}
   handleValuesChange={[Function]}
   params={
-    Object {
-      "diskSize": Object {
+    Array [
+      Object {
         "path": "size",
         "render": "slider",
         "type": "string",
         "value": "10Gi",
       },
-    }
+    ]
   }
 >
   <div
     className="margin-t-normal"
   >
     <div
-      key="diskSize-0"
+      key="size-0"
     >
       <div
         hidden={false}
-        key="diskSize-0"
+        key="size-0"
       >
         <SliderParam
           handleBasicFormParamChange={[Function]}
-          id="diskSize-0"
-          label="diskSize"
+          id="size-0"
+          label="size"
           max={1000}
           min={1}
-          name="diskSize"
           param={
             Object {
               "path": "size",
@@ -45,7 +44,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
         >
           <div>
             <label
-              htmlFor="diskSize-0"
+              htmlFor="size-0"
             >
               <div
                 className="row"
@@ -56,7 +55,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                   <div
                     className="centered"
                   >
-                    diskSize
+                    size
                   </div>
                 </div>
                 <div
@@ -321,7 +320,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
                     >
                       <input
                         className="disk_size_input"
-                        id="diskSize-0"
+                        id="size-0"
                         onChange={[Function]}
                         value={10}
                       />
@@ -348,30 +347,29 @@ exports[`renders a basic deployment with a email 1`] = `
   handleBasicFormParamChange={[Function]}
   handleValuesChange={[Function]}
   params={
-    Object {
-      "email": Object {
+    Array [
+      Object {
         "path": "wordpressEmail",
         "value": "user@example.com",
       },
-    }
+    ]
   }
 >
   <div
     className="margin-t-normal"
   >
     <div
-      key="email-0"
+      key="wordpressEmail-0"
     >
       <div
         hidden={false}
-        key="email-0"
+        key="wordpressEmail-0"
       >
         <TextParam
           handleBasicFormParamChange={[Function]}
-          id="email-0"
+          id="wordpressEmail-0"
           inputType="string"
-          label="email"
-          name="email"
+          label="nodejs"
           param={
             Object {
               "path": "wordpressEmail",
@@ -381,7 +379,7 @@ exports[`renders a basic deployment with a email 1`] = `
         >
           <div>
             <label
-              htmlFor="email-0"
+              htmlFor="wordpressEmail-0"
             >
               <div
                 className="row"
@@ -392,14 +390,14 @@ exports[`renders a basic deployment with a email 1`] = `
                   <div
                     className="centered"
                   >
-                    email
+                    nodejs
                   </div>
                 </div>
                 <div
                   className="col-9 margin-t-small"
                 >
                   <input
-                    id="email-0"
+                    id="wordpressEmail-0"
                     onChange={[Function]}
                     type="string"
                     value="user@example.com"
@@ -422,13 +420,13 @@ exports[`renders a basic deployment with a generic boolean 1`] = `
   handleBasicFormParamChange={[Function]}
   handleValuesChange={[Function]}
   params={
-    Object {
-      "enableMetrics": Object {
+    Array [
+      Object {
         "path": "enableMetrics",
         "type": "boolean",
         "value": true,
       },
-    }
+    ]
   }
 >
   <div
@@ -445,7 +443,6 @@ exports[`renders a basic deployment with a generic boolean 1`] = `
           handleBasicFormParamChange={[Function]}
           id="enableMetrics-0"
           label="enableMetrics"
-          name="enableMetrics"
           param={
             Object {
               "path": "enableMetrics",
@@ -693,13 +690,13 @@ exports[`renders a basic deployment with a generic number 1`] = `
   handleBasicFormParamChange={[Function]}
   handleValuesChange={[Function]}
   params={
-    Object {
-      "replicas": Object {
+    Array [
+      Object {
         "path": "replicas",
         "type": "integer",
         "value": 1,
       },
-    }
+    ]
   }
 >
   <div
@@ -716,8 +713,7 @@ exports[`renders a basic deployment with a generic number 1`] = `
           handleBasicFormParamChange={[Function]}
           id="replicas-0"
           inputType="number"
-          label="replicas"
-          name="replicas"
+          label="nodejs"
           param={
             Object {
               "path": "replicas",
@@ -739,7 +735,7 @@ exports[`renders a basic deployment with a generic number 1`] = `
                   <div
                     className="centered"
                   >
-                    replicas
+                    nodejs
                   </div>
                 </div>
                 <div
@@ -769,13 +765,13 @@ exports[`renders a basic deployment with a generic string 1`] = `
   handleBasicFormParamChange={[Function]}
   handleValuesChange={[Function]}
   params={
-    Object {
-      "blogName": Object {
+    Array [
+      Object {
         "path": "blogName",
         "type": "string",
         "value": "my-blog",
       },
-    }
+    ]
   }
 >
   <div
@@ -792,8 +788,7 @@ exports[`renders a basic deployment with a generic string 1`] = `
           handleBasicFormParamChange={[Function]}
           id="blogName-0"
           inputType="string"
-          label="blogName"
-          name="blogName"
+          label="nodejs"
           param={
             Object {
               "path": "blogName",
@@ -815,7 +810,7 @@ exports[`renders a basic deployment with a generic string 1`] = `
                   <div
                     className="centered"
                   >
-                    blogName
+                    nodejs
                   </div>
                 </div>
                 <div
@@ -845,30 +840,29 @@ exports[`renders a basic deployment with a password 1`] = `
   handleBasicFormParamChange={[Function]}
   handleValuesChange={[Function]}
   params={
-    Object {
-      "password": Object {
+    Array [
+      Object {
         "path": "wordpressPassword",
         "value": "sserpdrow",
       },
-    }
+    ]
   }
 >
   <div
     className="margin-t-normal"
   >
     <div
-      key="password-0"
+      key="wordpressPassword-0"
     >
       <div
         hidden={false}
-        key="password-0"
+        key="wordpressPassword-0"
       >
         <TextParam
           handleBasicFormParamChange={[Function]}
-          id="password-0"
+          id="wordpressPassword-0"
           inputType="string"
-          label="password"
-          name="password"
+          label="nodejs"
           param={
             Object {
               "path": "wordpressPassword",
@@ -878,7 +872,7 @@ exports[`renders a basic deployment with a password 1`] = `
         >
           <div>
             <label
-              htmlFor="password-0"
+              htmlFor="wordpressPassword-0"
             >
               <div
                 className="row"
@@ -889,14 +883,14 @@ exports[`renders a basic deployment with a password 1`] = `
                   <div
                     className="centered"
                   >
-                    password
+                    nodejs
                   </div>
                 </div>
                 <div
                   className="col-9 margin-t-small"
                 >
                   <input
-                    id="password-0"
+                    id="wordpressPassword-0"
                     onChange={[Function]}
                     type="string"
                     value="sserpdrow"
@@ -919,30 +913,29 @@ exports[`renders a basic deployment with a username 1`] = `
   handleBasicFormParamChange={[Function]}
   handleValuesChange={[Function]}
   params={
-    Object {
-      "username": Object {
+    Array [
+      Object {
         "path": "wordpressUsername",
         "value": "user",
       },
-    }
+    ]
   }
 >
   <div
     className="margin-t-normal"
   >
     <div
-      key="username-0"
+      key="wordpressUsername-0"
     >
       <div
         hidden={false}
-        key="username-0"
+        key="wordpressUsername-0"
       >
         <TextParam
           handleBasicFormParamChange={[Function]}
-          id="username-0"
+          id="wordpressUsername-0"
           inputType="string"
-          label="username"
-          name="username"
+          label="nodejs"
           param={
             Object {
               "path": "wordpressUsername",
@@ -952,7 +945,7 @@ exports[`renders a basic deployment with a username 1`] = `
         >
           <div>
             <label
-              htmlFor="username-0"
+              htmlFor="wordpressUsername-0"
             >
               <div
                 className="row"
@@ -963,14 +956,14 @@ exports[`renders a basic deployment with a username 1`] = `
                   <div
                     className="centered"
                   >
-                    username
+                    nodejs
                   </div>
                 </div>
                 <div
                   className="col-9 margin-t-small"
                 >
                   <input
-                    id="username-0"
+                    id="wordpressUsername-0"
                     onChange={[Function]}
                     type="string"
                     value="user"
@@ -993,43 +986,42 @@ exports[`renders a basic deployment with username, password, email and a generic
   handleBasicFormParamChange={[Function]}
   handleValuesChange={[Function]}
   params={
-    Object {
-      "blogName": Object {
+    Array [
+      Object {
+        "path": "wordpressUsername",
+        "value": "user",
+      },
+      Object {
+        "path": "wordpressPassword",
+        "value": "sserpdrow",
+      },
+      Object {
+        "path": "wordpressEmail",
+        "value": "user@example.com",
+      },
+      Object {
         "path": "blogName",
         "type": "string",
         "value": "my-blog",
       },
-      "email": Object {
-        "path": "wordpressEmail",
-        "value": "user@example.com",
-      },
-      "password": Object {
-        "path": "wordpressPassword",
-        "value": "sserpdrow",
-      },
-      "username": Object {
-        "path": "wordpressUsername",
-        "value": "user",
-      },
-    }
+    ]
   }
 >
   <div
     className="margin-t-normal"
   >
     <div
-      key="username-0"
+      key="wordpressUsername-0"
     >
       <div
         hidden={false}
-        key="username-0"
+        key="wordpressUsername-0"
       >
         <TextParam
           handleBasicFormParamChange={[Function]}
-          id="username-0"
+          id="wordpressUsername-0"
           inputType="string"
-          label="username"
-          name="username"
+          label="nodejs"
           param={
             Object {
               "path": "wordpressUsername",
@@ -1039,7 +1031,7 @@ exports[`renders a basic deployment with username, password, email and a generic
         >
           <div>
             <label
-              htmlFor="username-0"
+              htmlFor="wordpressUsername-0"
             >
               <div
                 className="row"
@@ -1050,14 +1042,14 @@ exports[`renders a basic deployment with username, password, email and a generic
                   <div
                     className="centered"
                   >
-                    username
+                    nodejs
                   </div>
                 </div>
                 <div
                   className="col-9 margin-t-small"
                 >
                   <input
-                    id="username-0"
+                    id="wordpressUsername-0"
                     onChange={[Function]}
                     type="string"
                     value="user"
@@ -1071,18 +1063,17 @@ exports[`renders a basic deployment with username, password, email and a generic
       <hr />
     </div>
     <div
-      key="password-1"
+      key="wordpressPassword-1"
     >
       <div
         hidden={false}
-        key="password-1"
+        key="wordpressPassword-1"
       >
         <TextParam
           handleBasicFormParamChange={[Function]}
-          id="password-1"
+          id="wordpressPassword-1"
           inputType="string"
-          label="password"
-          name="password"
+          label="nodejs"
           param={
             Object {
               "path": "wordpressPassword",
@@ -1092,7 +1083,7 @@ exports[`renders a basic deployment with username, password, email and a generic
         >
           <div>
             <label
-              htmlFor="password-1"
+              htmlFor="wordpressPassword-1"
             >
               <div
                 className="row"
@@ -1103,14 +1094,14 @@ exports[`renders a basic deployment with username, password, email and a generic
                   <div
                     className="centered"
                   >
-                    password
+                    nodejs
                   </div>
                 </div>
                 <div
                   className="col-9 margin-t-small"
                 >
                   <input
-                    id="password-1"
+                    id="wordpressPassword-1"
                     onChange={[Function]}
                     type="string"
                     value="sserpdrow"
@@ -1124,18 +1115,17 @@ exports[`renders a basic deployment with username, password, email and a generic
       <hr />
     </div>
     <div
-      key="email-2"
+      key="wordpressEmail-2"
     >
       <div
         hidden={false}
-        key="email-2"
+        key="wordpressEmail-2"
       >
         <TextParam
           handleBasicFormParamChange={[Function]}
-          id="email-2"
+          id="wordpressEmail-2"
           inputType="string"
-          label="email"
-          name="email"
+          label="nodejs"
           param={
             Object {
               "path": "wordpressEmail",
@@ -1145,7 +1135,7 @@ exports[`renders a basic deployment with username, password, email and a generic
         >
           <div>
             <label
-              htmlFor="email-2"
+              htmlFor="wordpressEmail-2"
             >
               <div
                 className="row"
@@ -1156,14 +1146,14 @@ exports[`renders a basic deployment with username, password, email and a generic
                   <div
                     className="centered"
                   >
-                    email
+                    nodejs
                   </div>
                 </div>
                 <div
                   className="col-9 margin-t-small"
                 >
                   <input
-                    id="email-2"
+                    id="wordpressEmail-2"
                     onChange={[Function]}
                     type="string"
                     value="user@example.com"
@@ -1187,8 +1177,7 @@ exports[`renders a basic deployment with username, password, email and a generic
           handleBasicFormParamChange={[Function]}
           id="blogName-3"
           inputType="string"
-          label="blogName"
-          name="blogName"
+          label="nodejs"
           param={
             Object {
               "path": "blogName",
@@ -1210,7 +1199,7 @@ exports[`renders a basic deployment with username, password, email and a generic
                   <div
                     className="centered"
                   >
-                    blogName
+                    nodejs
                   </div>
                 </div>
                 <div

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/BooleanParam.test.tsx.snap
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/BooleanParam.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`should render a boolean param with title and description 1`] = `
   handleBasicFormParamChange={[Function]}
   id="foo"
   label="Enable Metrics"
-  name="enableMetrics"
   param={
     Object {
       "path": "enableMetrics",

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/TextParam.test.tsx.snap
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/TextParam.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`should render a text param with title and description 1`] = `
   handleBasicFormParamChange={[Function]}
   id="foo"
   label="Username"
-  name="username"
   param={
     Object {
       "path": "username",

--- a/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.test.tsx
@@ -103,14 +103,14 @@ describe("when there are changes in the selected version", () => {
     wrapper.setProps({ selected: props.selected });
     const localState: IDeploymentFormBodyState = wrapper.instance()
       .state as IDeploymentFormBodyState;
-    const basicFormParameters = {
-      foo: {
+    const basicFormParameters = [
+      {
         form: true,
         path: "foo",
         value: "bar",
         type: "string",
       },
-    };
+    ];
     expect(localState.basicFormParameters).toEqual(basicFormParameters);
   });
 
@@ -127,14 +127,14 @@ describe("when there are changes in the selected version", () => {
           values: "foo: ignored-value",
         },
       });
-      const basicFormParameters = {
-        foo: {
+      const basicFormParameters = [
+        {
           form: true,
           path: "foo",
           value: "notBar",
           type: "string",
         },
-      };
+      ];
       const localState: IDeploymentFormBodyState = wrapper.instance()
         .state as IDeploymentFormBodyState;
       expect(localState.basicFormParameters).toEqual(basicFormParameters);
@@ -152,14 +152,14 @@ describe("when there are changes in the selected version", () => {
           values: "foo: notBar",
         },
       });
-      const basicFormParameters = {
-        foo: {
+      const basicFormParameters = [
+        {
           form: true,
           path: "foo",
           value: "notBar",
           type: "string",
         },
-      };
+      ];
       const localState: IDeploymentFormBodyState = wrapper.instance()
         .state as IDeploymentFormBodyState;
       expect(localState.basicFormParameters).toEqual(basicFormParameters);
@@ -187,14 +187,14 @@ describe("when there are changes in the selected version", () => {
           values: "foo: another-ignored-value",
         },
       });
-      const basicFormParameters = {
-        foo: {
+      const basicFormParameters = [
+        {
           form: true,
           path: "foo",
           value: "notBar",
           type: "string",
         },
-      };
+      ];
       const localState: IDeploymentFormBodyState = wrapper.instance()
         .state as IDeploymentFormBodyState;
       expect(localState.basicFormParameters).toEqual(basicFormParameters);
@@ -205,12 +205,12 @@ describe("when there are changes in the selected version", () => {
 
 describe("when the basic form is enabled", () => {
   it("renders the different tabs", () => {
-    const basicFormParameters = {
-      username: {
+    const basicFormParameters = [
+      {
         path: "wordpressUsername",
         value: "user",
       },
-    };
+    ];
     const wrapper = mount(<DeploymentFormBody {...props} />);
     wrapper.setState({ appValues: "wordpressUsername: user", basicFormParameters });
     wrapper.update();
@@ -225,12 +225,12 @@ describe("when the basic form is enabled", () => {
   });
 
   it("changes the parameter value", () => {
-    const basicFormParameters = {
-      username: {
+    const basicFormParameters = [
+      {
         path: "wordpressUsername",
         value: "user",
       },
-    };
+    ];
     const setValuesModified = jest.fn();
     const setValues = jest.fn();
     const wrapper = mount(
@@ -249,12 +249,9 @@ describe("when the basic form is enabled", () => {
     const onChange = input.prop("onChange") as (e: React.FormEvent<HTMLInputElement>) => void;
     onChange({ currentTarget: { value: "foo" } } as React.FormEvent<HTMLInputElement>);
 
-    expect(wrapper.state("basicFormParameters")).toEqual({
-      username: {
-        path: "wordpressUsername",
-        value: "foo",
-      },
-    });
+    expect(wrapper.state("basicFormParameters")).toEqual([
+      { path: "wordpressUsername", value: "foo" },
+    ]);
     expect(setValuesModified).toHaveBeenCalled();
     expect(setValues).toHaveBeenCalledWith("wordpressUsername: foo\n");
   });
@@ -267,12 +264,12 @@ describe("when the basic form is enabled", () => {
         schema: { properties: { wordpressUsername: { type: "string", form: true } } },
       },
     };
-    const basicFormParameters = {
-      wordpressUsername: {
+    const basicFormParameters = [
+      {
         path: "wordpressUsername",
         value: "user",
       },
-    };
+    ];
     const wrapper = mount(<DeploymentFormBody {...testProps} />);
     wrapper.setState({ basicFormParameters });
     wrapper.setProps({ appValues: "wordpressUsername: foo" });
@@ -284,23 +281,23 @@ describe("when the basic form is enabled", () => {
       .first();
     tab.simulate("click");
 
-    expect(wrapper.state("basicFormParameters")).toMatchObject({
-      wordpressUsername: {
+    expect(wrapper.state("basicFormParameters")).toMatchObject([
+      {
         path: "wordpressUsername",
         value: "foo",
       },
-    });
+    ]);
   });
 
   it("handles a parameter as a number", () => {
     const setValues = jest.fn();
-    const basicFormParameters = {
-      replicas: {
+    const basicFormParameters = [
+      {
         path: "replicas",
         value: 1,
         type: "integer",
       },
-    };
+    ];
     const wrapper = mount(<DeploymentFormBody {...props} setValues={setValues} />);
     wrapper.setState({ basicFormParameters });
     wrapper.setProps({ appValues: "replicas: 1" });
@@ -313,25 +310,25 @@ describe("when the basic form is enabled", () => {
       HTMLInputElement
     >);
 
-    expect(wrapper.state("basicFormParameters")).toEqual({
-      replicas: {
+    expect(wrapper.state("basicFormParameters")).toEqual([
+      {
         path: "replicas",
         value: 2,
         type: "integer",
       },
-    });
+    ]);
     expect(setValues).toHaveBeenCalledWith("replicas: 2\n");
   });
 
   it("handles a parameter as a boolean", () => {
     const setValues = jest.fn();
-    const basicFormParameters = {
-      enableMetrics: {
+    const basicFormParameters = [
+      {
         path: "enableMetrics",
         value: false,
         type: "boolean",
       },
-    };
+    ];
     const wrapper = mount(<DeploymentFormBody {...props} setValues={setValues} />);
     wrapper.setState({ basicFormParameters });
     wrapper.setProps({ appValues: "enableMetrics: false" });
@@ -344,13 +341,13 @@ describe("when the basic form is enabled", () => {
       currentTarget: { value: "true", checked: true, type: "checkbox" },
     } as React.FormEvent<HTMLInputElement>);
 
-    expect(wrapper.state("basicFormParameters")).toEqual({
-      enableMetrics: {
+    expect(wrapper.state("basicFormParameters")).toEqual([
+      {
         path: "enableMetrics",
         value: true,
         type: "boolean",
       },
-    });
+    ]);
     expect(setValues).toHaveBeenCalledWith("enableMetrics: true\n");
   });
 });

--- a/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.test.tsx
@@ -66,7 +66,7 @@ it("renders the full DeploymentFormBody", () => {
 });
 
 const initialValues = "foo: bar";
-const initialSchema = { properties: { foo: { type: "string", form: "foo" } } };
+const initialSchema = { properties: { foo: { type: "string", form: true } } };
 const chartVersion = {
   id: "foo",
   attributes: { version: "1.0.0", app_version: "1.0", created: "1" },
@@ -105,7 +105,7 @@ describe("when there are changes in the selected version", () => {
       .state as IDeploymentFormBodyState;
     const basicFormParameters = {
       foo: {
-        form: "foo",
+        form: true,
         path: "foo",
         value: "bar",
         type: "string",
@@ -129,7 +129,7 @@ describe("when there are changes in the selected version", () => {
       });
       const basicFormParameters = {
         foo: {
-          form: "foo",
+          form: true,
           path: "foo",
           value: "notBar",
           type: "string",
@@ -154,7 +154,7 @@ describe("when there are changes in the selected version", () => {
       });
       const basicFormParameters = {
         foo: {
-          form: "foo",
+          form: true,
           path: "foo",
           value: "notBar",
           type: "string",
@@ -189,7 +189,7 @@ describe("when there are changes in the selected version", () => {
       });
       const basicFormParameters = {
         foo: {
-          form: "foo",
+          form: true,
           path: "foo",
           value: "notBar",
           type: "string",
@@ -264,11 +264,11 @@ describe("when the basic form is enabled", () => {
       ...props,
       selected: {
         ...props.selected,
-        schema: { properties: { wordpressUsername: { type: "string", form: "username" } } },
+        schema: { properties: { wordpressUsername: { type: "string", form: true } } },
       },
     };
     const basicFormParameters = {
-      username: {
+      wordpressUsername: {
         path: "wordpressUsername",
         value: "user",
       },
@@ -285,7 +285,7 @@ describe("when the basic form is enabled", () => {
     tab.simulate("click");
 
     expect(wrapper.state("basicFormParameters")).toMatchObject({
-      username: {
+      wordpressUsername: {
         path: "wordpressUsername",
         value: "foo",
       },

--- a/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.tsx
@@ -32,7 +32,7 @@ export interface IDeploymentFormBodyProps {
 }
 
 export interface IDeploymentFormBodyState {
-  basicFormParameters: { [key: string]: IBasicFormParam };
+  basicFormParameters: IBasicFormParam[];
 }
 
 class DeploymentFormBody extends React.Component<
@@ -40,7 +40,7 @@ class DeploymentFormBody extends React.Component<
   IDeploymentFormBodyState
 > {
   public state: IDeploymentFormBodyState = {
-    basicFormParameters: {},
+    basicFormParameters: [],
   };
 
   public componentDidMount() {
@@ -212,19 +212,15 @@ class DeploymentFormBody extends React.Component<
     );
   };
 
-  private handleBasicFormParamChange = (name: string, param: IBasicFormParam) => {
+  private handleBasicFormParamChange = (param: IBasicFormParam) => {
     return (e: React.FormEvent<HTMLInputElement>) => {
       this.props.setValuesModified();
       const value = getValueFromEvent(e);
       this.setState({
         // Change param definition
-        basicFormParameters: {
-          ...this.state.basicFormParameters,
-          [name]: {
-            ...param,
-            value,
-          },
-        },
+        basicFormParameters: this.state.basicFormParameters.map(p =>
+          p.path === param.path ? { ...param, value } : p,
+        ),
       });
       // Change raw values
       this.props.setValues(setValue(this.props.appValues, param.path, value));

--- a/dashboard/src/shared/schema.test.ts
+++ b/dashboard/src/shared/schema.test.ts
@@ -8,47 +8,47 @@ describe("retrieveBasicFormParams", () => {
     {
       description: "should retrieve a param",
       values: "user: andres",
-      schema: { properties: { user: { type: "string", form: "username" } } } as JSONSchema4,
+      schema: { properties: { user: { type: "string", form: true } } } as JSONSchema4,
       result: {
-        username: { path: "user", value: "andres" } as IBasicFormParam,
+        user: { path: "user", value: "andres" } as IBasicFormParam,
       },
     },
     {
       description: "should retrieve a param without default value",
       values: "user:",
-      schema: { properties: { user: { type: "string", form: "username" } } } as JSONSchema4,
+      schema: { properties: { user: { type: "string", form: true } } } as JSONSchema4,
       result: {
-        username: { path: "user" } as IBasicFormParam,
+        user: { path: "user" } as IBasicFormParam,
       },
     },
     {
       description: "should retrieve a param with default value in the schema",
       values: "user:",
       schema: {
-        properties: { user: { type: "string", form: "username", default: "michael" } },
+        properties: { user: { type: "string", form: true, default: "michael" } },
       } as JSONSchema4,
       result: {
-        username: { path: "user", value: "michael" } as IBasicFormParam,
+        user: { path: "user", value: "michael" } as IBasicFormParam,
       },
     },
     {
       description: "values prevail over default values",
       values: "user: foo",
       schema: {
-        properties: { user: { type: "string", form: "username", default: "bar" } },
+        properties: { user: { type: "string", form: true, default: "bar" } },
       } as JSONSchema4,
       result: {
-        username: { path: "user", value: "foo" } as IBasicFormParam,
+        user: { path: "user", value: "foo" } as IBasicFormParam,
       },
     },
     {
       description: "it should return params even if the values don't include it",
       values: "foo: bar",
       schema: {
-        properties: { user: { type: "string", form: "username", default: "andres" } },
+        properties: { user: { type: "string", form: true, default: "andres" } },
       } as JSONSchema4,
       result: {
-        username: { path: "user", value: "andres" } as IBasicFormParam,
+        user: { path: "user", value: "andres" } as IBasicFormParam,
       },
     },
     {
@@ -58,12 +58,12 @@ describe("retrieveBasicFormParams", () => {
         properties: {
           credentials: {
             type: "object",
-            properties: { user: { type: "string", form: "username" } },
+            properties: { user: { type: "string", form: true } },
           },
         },
       } as JSONSchema4,
       result: {
-        username: {
+        "credentials.user": {
           path: "credentials.user",
           value: "andres",
         } as IBasicFormParam,
@@ -92,22 +92,22 @@ service: ClusterIP
               admin: {
                 type: "object",
                 properties: {
-                  user: { type: "string", form: "username" },
-                  pass: { type: "string", form: "password" },
+                  user: { type: "string", form: true },
+                  pass: { type: "string", form: true },
                 },
               },
             },
           },
-          replicas: { type: "number", form: "replicas" },
+          replicas: { type: "number", form: true },
           service: { type: "string" },
         },
       } as JSONSchema4,
       result: {
-        username: {
+        "credentials.admin.user": {
           path: "credentials.admin.user",
           value: "andres",
         } as IBasicFormParam,
-        password: {
+        "credentials.admin.pass": {
           path: "credentials.admin.pass",
           value: "myPassword",
         } as IBasicFormParam,
@@ -124,7 +124,7 @@ service: ClusterIP
         properties: {
           blogName: {
             type: "string",
-            form: "blogName",
+            form: true,
             title: "Blog Name",
             description: "Title of the blog",
           },
@@ -151,10 +151,10 @@ externalDatabase:
         properties: {
           externalDatabase: {
             type: "object",
-            form: "externalDatabase",
+            form: true,
             properties: {
-              name: { type: "string", form: "externalDatabaseName" },
-              port: { type: "integer", form: "externalDatabasePort" },
+              name: { type: "string", form: true },
+              port: { type: "integer", form: true },
             },
           },
         },
@@ -164,11 +164,11 @@ externalDatabase:
           path: "externalDatabase",
           type: "object",
           children: {
-            externalDatabaseName: {
+            "externalDatabase.name": {
               path: "externalDatabase.name",
               type: "string",
             },
-            externalDatabasePort: {
+            "externalDatabase.port": {
               path: "externalDatabase.port",
               type: "integer",
             },
@@ -181,7 +181,7 @@ externalDatabase:
       values: "foo: false",
       schema: {
         properties: {
-          foo: { type: "boolean", form: "foo" },
+          foo: { type: "boolean", form: true },
         },
       } as JSONSchema4,
       result: {

--- a/dashboard/src/shared/schema.test.ts
+++ b/dashboard/src/shared/schema.test.ts
@@ -9,17 +9,22 @@ describe("retrieveBasicFormParams", () => {
       description: "should retrieve a param",
       values: "user: andres",
       schema: { properties: { user: { type: "string", form: true } } } as JSONSchema4,
-      result: {
-        user: { path: "user", value: "andres" } as IBasicFormParam,
-      },
+      result: [
+        {
+          path: "user",
+          value: "andres",
+        } as IBasicFormParam,
+      ],
     },
     {
       description: "should retrieve a param without default value",
       values: "user:",
       schema: { properties: { user: { type: "string", form: true } } } as JSONSchema4,
-      result: {
-        user: { path: "user" } as IBasicFormParam,
-      },
+      result: [
+        {
+          path: "user",
+        } as IBasicFormParam,
+      ],
     },
     {
       description: "should retrieve a param with default value in the schema",
@@ -27,9 +32,12 @@ describe("retrieveBasicFormParams", () => {
       schema: {
         properties: { user: { type: "string", form: true, default: "michael" } },
       } as JSONSchema4,
-      result: {
-        user: { path: "user", value: "michael" } as IBasicFormParam,
-      },
+      result: [
+        {
+          path: "user",
+          value: "michael",
+        } as IBasicFormParam,
+      ],
     },
     {
       description: "values prevail over default values",
@@ -37,9 +45,12 @@ describe("retrieveBasicFormParams", () => {
       schema: {
         properties: { user: { type: "string", form: true, default: "bar" } },
       } as JSONSchema4,
-      result: {
-        user: { path: "user", value: "foo" } as IBasicFormParam,
-      },
+      result: [
+        {
+          path: "user",
+          value: "foo",
+        } as IBasicFormParam,
+      ],
     },
     {
       description: "it should return params even if the values don't include it",
@@ -47,9 +58,12 @@ describe("retrieveBasicFormParams", () => {
       schema: {
         properties: { user: { type: "string", form: true, default: "andres" } },
       } as JSONSchema4,
-      result: {
-        user: { path: "user", value: "andres" } as IBasicFormParam,
-      },
+      result: [
+        {
+          path: "user",
+          value: "andres",
+        } as IBasicFormParam,
+      ],
     },
     {
       description: "should retrieve a nested param",
@@ -62,12 +76,12 @@ describe("retrieveBasicFormParams", () => {
           },
         },
       } as JSONSchema4,
-      result: {
-        "credentials.user": {
+      result: [
+        {
           path: "credentials.user",
           value: "andres",
         } as IBasicFormParam,
-      },
+      ],
     },
     {
       description: "should retrieve several params and ignore the ones not marked",
@@ -102,20 +116,20 @@ service: ClusterIP
           service: { type: "string" },
         },
       } as JSONSchema4,
-      result: {
-        "credentials.admin.user": {
+      result: [
+        {
           path: "credentials.admin.user",
           value: "andres",
         } as IBasicFormParam,
-        "credentials.admin.pass": {
+        {
           path: "credentials.admin.pass",
           value: "myPassword",
         } as IBasicFormParam,
-        replicas: {
+        {
           path: "replicas",
           value: 1,
         } as IBasicFormParam,
-      },
+      ],
     },
     {
       description: "should retrieve a param with title and description",
@@ -130,15 +144,15 @@ service: ClusterIP
           },
         },
       } as JSONSchema4,
-      result: {
-        blogName: {
+      result: [
+        {
           path: "blogName",
           type: "string",
           value: "myBlog",
           title: "Blog Name",
           description: "Title of the blog",
         } as IBasicFormParam,
-      },
+      ],
     },
     {
       description: "should retrieve a param with children params",
@@ -159,22 +173,22 @@ externalDatabase:
           },
         },
       } as JSONSchema4,
-      result: {
-        externalDatabase: {
+      result: [
+        {
           path: "externalDatabase",
           type: "object",
-          children: {
-            "externalDatabase.name": {
+          children: [
+            {
               path: "externalDatabase.name",
               type: "string",
             },
-            "externalDatabase.port": {
+            {
               path: "externalDatabase.port",
               type: "integer",
             },
-          },
+          ],
         } as IBasicFormParam,
-      },
+      ],
     },
     {
       description: "should retrieve a false param",
@@ -184,9 +198,7 @@ externalDatabase:
           foo: { type: "boolean", form: true },
         },
       } as JSONSchema4,
-      result: {
-        foo: { path: "foo", type: "boolean", value: false } as IBasicFormParam,
-      },
+      result: [{ path: "foo", type: "boolean", value: false } as IBasicFormParam],
     },
   ].forEach(t => {
     it(t.description, () => {

--- a/dashboard/src/shared/schema.ts
+++ b/dashboard/src/shared/schema.ts
@@ -19,8 +19,8 @@ export function retrieveBasicFormParams(
   defaultValues: string,
   schema?: jsonSchema.JSONSchema4,
   parentPath?: string,
-): { [key: string]: IBasicFormParam } {
-  let params = {};
+): IBasicFormParam[] {
+  let params: IBasicFormParam[] = [];
   if (schema && schema.properties) {
     const properties = schema.properties!;
     Object.keys(properties).map(propertyKey => {
@@ -41,17 +41,13 @@ export function retrieveBasicFormParams(
               ? retrieveBasicFormParams(defaultValues, properties[propertyKey], `${itemPath}.`)
               : undefined,
         };
-        params = {
-          ...params,
-          [itemPath]: param,
-        };
+        params = params.concat(param);
       } else {
         // If the property is an object, iterate recursively
         if (schema.properties![propertyKey].type === "object") {
-          params = {
-            ...params,
-            ...retrieveBasicFormParams(defaultValues, properties[propertyKey], `${itemPath}.`),
-          };
+          params = params.concat(
+            retrieveBasicFormParams(defaultValues, properties[propertyKey], `${itemPath}.`),
+          );
         }
       }
     });

--- a/dashboard/src/shared/schema.ts
+++ b/dashboard/src/shared/schema.ts
@@ -43,8 +43,7 @@ export function retrieveBasicFormParams(
         };
         params = {
           ...params,
-          // The key of the param is the value of the form tag
-          [form]: param,
+          [itemPath]: param,
         };
       } else {
         // If the property is an object, iterate recursively

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -392,7 +392,7 @@ export interface IBasicFormParam {
         value: string;
       }
     | string;
-  children?: { [name: string]: IBasicFormParam };
+  children?: IBasicFormParam[];
 }
 export interface IBasicFormSliderParam extends IBasicFormParam {
   sliderMin?: number;


### PR DESCRIPTION
Code refactor after #1257 

After removing the keys `enables` and `disables` we no longer need to use the `form` key as a unique ID. I have changed that for a boolean in the first commit (a0995aa).

Then, since the `form` is not a name or an ID, I have changed the code to use an array instead of a `map<string:IBasicFormParam>` when working with basic params (b85f936).