### PR TITLE
Fix browser tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,8 @@ workflows:
             - build_go_images
             - build_dashboard
       - GKE_1_13_MASTER:
-          <<: *build_on_master
+        # TODO: REVERT!
+          <<: *build_always
           requires:
             - test_go
             - test_dashboard
@@ -57,7 +58,8 @@ workflows:
             - build_go_images
             - build_dashboard
       - GKE_1_12_MASTER:
-          <<: *build_on_master
+        # TODO: REVERT!
+          <<: *build_always
           requires:
             - test_go
             - test_dashboard

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,7 @@ workflows:
             - build_go_images
             - build_dashboard
       - GKE_1_13_MASTER:
-        # TODO: REVERT!
-          <<: *build_always
+          <<: *build_on_master
           requires:
             - test_go
             - test_dashboard
@@ -58,8 +57,7 @@ workflows:
             - build_go_images
             - build_dashboard
       - GKE_1_12_MASTER:
-        # TODO: REVERT!
-          <<: *build_always
+          <<: *build_on_master
           requires:
             - test_go
             - test_dashboard

--- a/integration/jest-puppeteer.config.js
+++ b/integration/jest-puppeteer.config.js
@@ -3,7 +3,7 @@ const { headless } = require("./args");
 module.exports = {
   launch: {
     headless,
-    args: ["--no-sandbox"]
+    args: ["--no-sandbox", "--window-size=1200,780"]
   },
   browserContext: "incognito"
 };

--- a/integration/jest.environment.js
+++ b/integration/jest.environment.js
@@ -49,6 +49,12 @@ class ScreenshotOnFailureEnvironment extends PuppeteerEnvironment {
     await this.generateScreenshotsFolder();
     await this.waitOnService();
     await super.setup();
+    await this.global.page.setViewport({
+      width: 1200,
+      height: 780,
+      deviceScaleFactor: 1
+    });
+    await this.global.page.setDefaultTimeout(8000);
   }
 
   async teardown() {

--- a/integration/jest.setup.js
+++ b/integration/jest.setup.js
@@ -1,5 +1,9 @@
-require("expect-puppeteer");
 const { endpoint } = require("./args");
+const { setDefaultOptions } = require("expect-puppeteer");
+
+setDefaultOptions({ timeout: 4000 });
+
+jest.setTimeout(120000);
 
 // endpoint argument is mandatory
 if (endpoint == null || endpoint == "") {

--- a/integration/jest.setup.js
+++ b/integration/jest.setup.js
@@ -3,8 +3,6 @@ const { setDefaultOptions } = require("expect-puppeteer");
 
 setDefaultOptions({ timeout: 4000 });
 
-jest.setTimeout(120000);
-
 // endpoint argument is mandatory
 if (endpoint == null || endpoint == "") {
   console.error("The INTEGRATION_ENDPOINT environment variable is mandatory");

--- a/integration/use-cases/create-registry.js
+++ b/integration/use-cases/create-registry.js
@@ -1,3 +1,5 @@
+jest.setTimeout(120000);
+
 test("Deploys an application with the values by default", async () => {
   await page.goto(getUrl("/#/login"));
 

--- a/integration/use-cases/create-registry.js
+++ b/integration/use-cases/create-registry.js
@@ -1,7 +1,4 @@
-jest.setTimeout(120000);
-
 test("Deploys an application with the values by default", async () => {
-  page.setDefaultTimeout(4000);
   await page.goto(getUrl("/#/login"));
 
   await expect(page).toFillForm("form", {

--- a/integration/use-cases/default-deployment.js
+++ b/integration/use-cases/default-deployment.js
@@ -1,3 +1,5 @@
+jest.setTimeout(120000);
+
 test("Deploys an application with the values by default", async () => {
   await page.goto(getUrl("/#/login"));
 

--- a/integration/use-cases/default-deployment.js
+++ b/integration/use-cases/default-deployment.js
@@ -1,7 +1,4 @@
-jest.setTimeout(120000);
-
 test("Deploys an application with the values by default", async () => {
-  page.setDefaultTimeout(4000);
   await page.goto(getUrl("/#/login"));
 
   await expect(page).toFillForm("form", {

--- a/integration/use-cases/missing-permissions.js
+++ b/integration/use-cases/missing-permissions.js
@@ -1,14 +1,9 @@
-jest.setTimeout(120000);
-
 test("Fails to deploy an application due to missing permissions", async () => {
-  page.setDefaultTimeout(4000);
   await page.goto(getUrl("/#/login"));
 
   await expect(page).toFillForm("form", {
     token: process.env.VIEW_TOKEN
   });
-
-  await page.screenshot({ path: "example.png" });
 
   await expect(page).toClick("button", { text: "Login" });
 

--- a/integration/use-cases/missing-permissions.js
+++ b/integration/use-cases/missing-permissions.js
@@ -1,3 +1,5 @@
+jest.setTimeout(120000);
+
 test("Fails to deploy an application due to missing permissions", async () => {
   await page.goto(getUrl("/#/login"));
 

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -89,9 +89,6 @@ for dep in ${deployments[@]}; do
   echo "Deployment ${dep} ready"
 done
 
-# Wait for DNS to be ready
-k8s_wait_for_deployment kube-system coredns
-
 # Wait for Kubeapps Jobs
 k8s_wait_for_job_completed kubeapps apprepositories.kubeapps.com/repo-name=stable
 echo "Job apprepositories.kubeapps.com/repo-name=stable ready"


### PR DESCRIPTION
Fixes issues in master: https://circleci.com/workflow-run/aec97cdb-f9e7-40dc-b192-e102ddc8456e

 - The `expect()` timeout is set using `setDefaultTimeout`.
 ~~- I have moved independent timeout sets from each test file to common configuration files.~~ Had to remove this. I don't know why it doesn't work in the CI environment.
 - I have increased the size of the browser window so the screenshots are more useful.
 - GKE doesn't use `coredns` so I removed the check for that component.