### PR TITLE
Update instruction for getting token to work on vanilla k8s and openshift

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -37,7 +37,7 @@ To retrieve the token,
 ### On Linux/macOS:
 
 ```bash
-kubectl get secret $(kubectl get serviceaccount kubeapps-operator -o jsonpath='{.secrets[].name}') -o jsonpath='{.data.token}' -o go-template='{{.data.token | base64decode}}' && echo
+kubectl get secret $(kubectl get serviceaccount kubeapps-operator -o jsonpath='{range .secrets[*]}{.name}{"\n"}{end}' | grep kubeapps-operator-token) -o jsonpath='{.data.token}' -o go-template='{{.data.token | base64decode}}' && echo
 ```
 
 ### On Windows:


### PR DESCRIPTION
Fixes #842 .

The service account created in this way with OpenShift has two secrets associated with it, and the kubeapps-operator token is not the first.

Unfortunately we can't use RegExp in jsonpath (see #842) but we can display the secrets one per line and simply grep. Confirmed this works with both openshift and vanilla K8s.