### PR TITLE
Update twitter link in the footer

### DIFF
--- a/dashboard/src/components/Footer/Footer.tsx
+++ b/dashboard/src/components/Footer/Footer.tsx
@@ -30,7 +30,7 @@ const Footer: React.SFC<IFooterProps> = props => {
             </p>
           </div>
           <div className="col-6 text-r">
-            <a href="https://twitter.com/kubeapps" className="socialIcon margin-small">
+            <a href="https://twitter.com/search?q=(kubeapps%20OR%20%23kubeapps)" className="socialIcon margin-small">
               <svg
                 role="img"
                 aria-label="Kubeapps on Twitter"


### PR DESCRIPTION
The account `kubeapps` is not being used so I changed to a search of Kubeapps mentions (https://twitter.com/search?q=(kubeapps%20OR%20%23kubeapps))