### PR TITLE
Fix z-index of the editor

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/AdvancedDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/AdvancedDeploymentForm.tsx
@@ -23,6 +23,7 @@ class AdvancedDeploymentForm extends React.Component<IAdvancedDeploymentForm> {
           setOptions={{ showPrintMargin: false }}
           editorProps={{ $blockScrolling: Infinity }}
           value={this.props.appValues}
+          className="editor"
         />
       </div>
     );

--- a/dashboard/src/components/DeploymentFormBody/Tabs.scss
+++ b/dashboard/src/components/DeploymentFormBody/Tabs.scss
@@ -6,3 +6,7 @@
     }
   }
 }
+
+.editor {
+  z-index: 0;
+}


### PR DESCRIPTION
The code editor was being printed on top of the modal:

![Screenshot from 2019-11-07 16-18-42](https://user-images.githubusercontent.com/4025665/68401615-5b712100-017a-11ea-86f5-03c62914c8f1.png)

After the fix:

![Screenshot from 2019-11-07 16-22-50](https://user-images.githubusercontent.com/4025665/68401977-e5b98500-017a-11ea-898a-27f5d9428082.png)
