### PR TITLE
Enable logout when using OIDC for auth

### DIFF
--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -1,7 +1,6 @@
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import { NavLink } from "react-router-dom";
 import { INamespaceState } from "../../reducers/namespace";
 import Header from "./Header";
 
@@ -17,7 +16,7 @@ const defaultProps = {
   pathname: "",
   push: jest.fn(),
   setNamespace: jest.fn(),
-  hideLogoutLink: false,
+  logoutUrl: "",
 };
 it("renders the header links and titles", () => {
   const wrapper = shallow(<Header {...defaultProps} />);
@@ -48,11 +47,9 @@ it("renders the namespace switcher", () => {
   );
 });
 
-it("disables the logout link when hideLogoutLink is set", () => {
-  const wrapper = shallow(<Header {...defaultProps} hideLogoutLink={true} />);
-  const links = wrapper.find(NavLink);
-  expect(links.length).toBeGreaterThan(1);
-  links.children().forEach(link => {
-    expect(link.text).not.toContain("Logout");
-  });
+it("renders an anchor logout link when logoutUrl is set", () => {
+  const wrapper = shallow(<Header {...defaultProps} logoutUrl="http://localhost/log/out" />);
+  const link = wrapper.find('a[href="http://localhost/log/out"]');
+  expect(link.length).toBe(1);
+  expect(link.text()).toContain("Logout");
 });

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -21,7 +21,7 @@ interface IHeaderProps {
   pathname: string;
   push: (path: string) => void;
   setNamespace: (ns: string) => void;
-  hideLogoutLink: boolean;
+  logoutUrl: string;
 }
 
 interface IHeaderState {
@@ -70,12 +70,24 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
       namespace,
       defaultNamespace,
       authenticated: showNav,
-      hideLogoutLink,
+      logoutUrl,
     } = this.props;
     const header = `header ${this.state.mobileOpen ? "header-open" : ""}`;
     const submenu = `header__nav__submenu ${
       this.state.configOpen ? "header__nav__submenu-open" : ""
     }`;
+    const logoutButton = (
+      <>
+        <LogOut size={16} className="icon margin-r-tiny" /> Logout
+      </>
+    );
+    const logoutLink = logoutUrl ? (
+      <a href={logoutUrl}> {logoutButton} </a>
+    ) : (
+      <NavLink to="#" onClick={this.handleLogout}>
+        {logoutButton}
+      </NavLink>
+    );
 
     return (
       <section className="gradient-135-brand type-color-reverse type-color-reverse-anchor-reset">
@@ -134,13 +146,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                       </li>
                     </ul>
                   </li>
-                  {!hideLogoutLink && (
-                    <li>
-                      <NavLink to="#" onClick={this.handleLogout}>
-                        <LogOut size={16} className="icon margin-r-tiny" /> Logout
-                      </NavLink>
-                    </li>
-                  )}
+                  <li>{logoutLink}</li>
                 </ul>
               </div>
             )}

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.test.tsx
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.test.tsx
@@ -25,13 +25,22 @@ const makeStore = (authenticated: boolean, oidcAuthenticated: boolean) => {
 };
 
 describe("LoginFormContainer props", () => {
-  it("maps authentication redux states to props", () => {
+  it("passes logoutUrl when authenticated with oidc", () => {
     const store = makeStore(true, true);
     const wrapper = shallow(<Header store={store} />);
     const form = wrapper.find("Header");
     expect(form).toHaveProp({
       authenticated: true,
-      hideLogoutLink: true,
+      logoutUrl: "/oauth2/sign_out",
+    });
+  });
+  it("does not pass logoutUrl when authenticated without oidc", () => {
+    const store = makeStore(true, false);
+    const wrapper = shallow(<Header store={store} />);
+    const form = wrapper.find("Header");
+    expect(form).toHaveProp({
+      authenticated: true,
+      logoutUrl: "",
     });
   });
 });

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -24,10 +24,8 @@ function mapStateToProps({
     namespace,
     defaultNamespace,
     pathname,
-    // If oidcAuthenticated it's not yet supported to logout
-    // Some IdP like Keycloak allows to hit an endpoint to logout:
-    // https://www.keycloak.org/docs/latest/securing_apps/index.html#logout-endpoint
-    hideLogoutLink: oidcAuthenticated,
+    // TODO(mnelson): Allow logoutURL to be configurable.
+    logoutUrl: oidcAuthenticated ? "/oauth2/sign_out" : "",
   };
 }
 


### PR DESCRIPTION
Updates the Header so that it no longer hides the logout link when authenticated via oidc. Instead, an actual anchor link is used to ensure that the SPA doesn't handle the route.

There's an issue which I'll address in a follow-up, in that once the SPA has loaded, it automatically handles `/ -> /#/`, so the second logout works and redirects back to `/` but the app then handles this as usual, no longer hitting the auth-proxy.

We could whitelist the request for `/config.json` but this may not be enough... I'll investigate further as part of #1249.