### PR TITLE
Don't use or store id_token when using cookie-based auth

### DIFF
--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -31,7 +31,9 @@ export function authenticate(
   return async dispatch => {
     dispatch(authenticating());
     try {
-      await Auth.validateToken(token);
+      if (!oidc) {
+        await Auth.validateToken(token);
+      }
       Auth.setAuthToken(token, oidc);
       dispatch(setAuthenticated(true, oidc, Auth.defaultNamespaceFromToken(token)));
       if (oidc) {
@@ -65,17 +67,16 @@ export function expireSession(): ThunkAction<Promise<void>, IStoreState, null, A
   };
 }
 
-export function tryToAuthenticateWithOIDC(): ThunkAction<
+export function checkCookieAuthentication(): ThunkAction<
   Promise<void>,
   IStoreState,
   null,
   AuthAction
 > {
   return async dispatch => {
-    dispatch(authenticating());
-    const token = await Auth.fetchOIDCToken();
-    if (token) {
-      dispatch(authenticate(token, true));
+    const isAuthed = await Auth.isAuthenticatedWithCookie();
+    if (isAuthed) {
+      dispatch(authenticate("", true));
     } else {
       dispatch(setAuthenticated(false, false, ""));
     }

--- a/dashboard/src/components/LoginForm/LoginForm.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.test.tsx
@@ -20,16 +20,16 @@ const defaultProps = {
   authenticating: false,
   authenticationError: undefined,
   location: emptyLocation,
-  tryToAuthenticateWithOIDC: jest.fn(),
+  checkCookieAuthentication: jest.fn(),
 };
 
 const authenticationError = "it's a trap";
 
 describe("componentDidMount", () => {
-  it("should call tryToAuthenticateWithOIDC", () => {
-    const tryToAuthenticateWithOIDC = jest.fn();
-    shallow(<LoginForm {...defaultProps} tryToAuthenticateWithOIDC={tryToAuthenticateWithOIDC} />);
-    expect(tryToAuthenticateWithOIDC).toHaveBeenCalled();
+  it("should call checkCookieAuthentication", () => {
+    const checkCookieAuthentication = jest.fn();
+    shallow(<LoginForm {...defaultProps} checkCookieAuthentication={checkCookieAuthentication} />);
+    expect(checkCookieAuthentication).toHaveBeenCalled();
   });
 });
 

--- a/dashboard/src/components/LoginForm/LoginForm.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.tsx
@@ -11,7 +11,7 @@ interface ILoginFormProps {
   authenticating: boolean;
   authenticationError: string | undefined;
   authenticate: (token: string) => any;
-  tryToAuthenticateWithOIDC: () => void;
+  checkCookieAuthentication: () => void;
   location: Location;
 }
 
@@ -23,7 +23,7 @@ class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
   public state: ILoginFormState = { token: "" };
 
   public componentDidMount() {
-    this.props.tryToAuthenticateWithOIDC();
+    this.props.checkCookieAuthentication();
   }
 
   public render() {

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
@@ -19,7 +19,7 @@ function mapStateToProps({
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
     authenticate: (token: string) => dispatch(actions.auth.authenticate(token, false)),
-    tryToAuthenticateWithOIDC: () => dispatch(actions.auth.tryToAuthenticateWithOIDC()),
+    checkCookieAuthentication: () => dispatch(actions.auth.checkCookieAuthentication()),
   };
 }
 

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -62,7 +62,7 @@ describe("Auth", () => {
   describe("isAuthenticatedWithCookie", () => {
     it("returns true if request to API root succeeds", async () => {
       Axios.get = jest.fn(path => {
-        return { headers: { status: 200 } };
+        return Promise.resolve({ headers: { status: 200 } });
       });
       const isAuthed = await Auth.isAuthenticatedWithCookie();
 

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -61,23 +61,35 @@ describe("Auth", () => {
 
   describe("isAuthenticatedWithCookie", () => {
     it("returns true if request to API root succeeds", async () => {
-      Axios.head = jest.fn(path => {
+      Axios.get = jest.fn(path => {
         return { headers: { status: 200 } };
       });
       const isAuthed = await Auth.isAuthenticatedWithCookie();
 
-      expect(Axios.head).toBeCalledWith(APIBase + "/");
+      expect(Axios.get).toBeCalledWith(APIBase + "/");
       expect(isAuthed).toBe(true);
     });
-    it("should return true if the request to api root results in a 403", async () => {
-      Axios.head = jest.fn(() => {
+    it("returns false if the request to api root results in a 403 for an anonymous request", async () => {
+      Axios.get = jest.fn(() => {
+        return Promise.reject({
+          response: {
+            status: 403,
+            data: { message: "Something with system:anonymous in there" },
+          },
+        });
+      });
+      const isAuthed = await Auth.isAuthenticatedWithCookie();
+      expect(isAuthed).toBe(false);
+    });
+    it("returns true if the request to api root results in a 403 (but not anonymous)", async () => {
+      Axios.get = jest.fn(() => {
         return Promise.reject({ response: { status: 403 } });
       });
       const isAuthed = await Auth.isAuthenticatedWithCookie();
       expect(isAuthed).toBe(true);
     });
-    it("should return fals if the request results in a 401", async () => {
-      Axios.head = jest.fn(() => {
+    it("should return false if the request results in a 401", async () => {
+      Axios.get = jest.fn(() => {
         return Promise.reject({ response: { status: 401 } });
       });
       const isAuthed = await Auth.isAuthenticatedWithCookie();

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -1,6 +1,7 @@
 import Axios from "axios";
 import * as jwt from "jsonwebtoken";
 import { Auth } from "./Auth";
+import { APIBase } from "./Kube";
 
 describe("Auth", () => {
   beforeEach(() => {
@@ -58,29 +59,30 @@ describe("Auth", () => {
     });
   });
 
-  describe("fetchOIDCToken", () => {
-    it("should fetch a token", async () => {
+  describe("isAuthenticatedWithCookie", () => {
+    it("returns true if request to API root succeeds", async () => {
       Axios.head = jest.fn(path => {
-        expect(path).toEqual("");
-        return { headers: { authorization: "Bearer foo" } };
+        return { headers: { status: 200 } };
       });
-      const token = await Auth.fetchOIDCToken();
-      expect(token).toEqual("foo");
+      const isAuthed = await Auth.isAuthenticatedWithCookie();
+
+      expect(Axios.head).toBeCalledWith(APIBase + "/");
+      expect(isAuthed).toBe(true);
     });
-  });
-  it("should not return a token if the info is not present", async () => {
-    Axios.head = jest.fn(() => {
-      return {};
+    it("should return true if the request to api root results in a 403", async () => {
+      Axios.head = jest.fn(() => {
+        return Promise.reject({ response: { status: 403 } });
+      });
+      const isAuthed = await Auth.isAuthenticatedWithCookie();
+      expect(isAuthed).toBe(true);
     });
-    const token = await Auth.fetchOIDCToken();
-    expect(token).toEqual(null);
-  });
-  it("should not return a token if the call fails", async () => {
-    Axios.head = jest.fn(() => {
-      throw new Error();
+    it("should return fals if the request results in a 401", async () => {
+      Axios.head = jest.fn(() => {
+        return Promise.reject({ response: { status: 401 } });
+      });
+      const isAuthed = await Auth.isAuthenticatedWithCookie();
+      expect(isAuthed).toBe(false);
     });
-    const token = await Auth.fetchOIDCToken();
-    expect(token).toEqual(null);
   });
 
   describe("defaultNamespaceFromToken", () => {


### PR DESCRIPTION
This is a prequel to re-enabling the logout option for oidc. When I first re-enabled logout, I found that the cookie would be removed as would the id_token (from localStorage), but then the client would just re-get the id_token from the server (`fetchOIDCToken`) and therefore assume it was logged in again.

One of the benefits of using OAuth/OIDC is that the client doesn't need to ever see (or store) the actual access token... the http-only cookie is all that is required (and the auth-proxy adds the id-token to the request), which is not only much safer, but means we can logout also :)