### PR TITLE
Enable logout when logged in via cookie/oauth

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -40,5 +40,6 @@ data:
   config.json: |-
     {
       "namespace": "{{ .Release.Namespace }}",
-      "appVersion": "{{ .Chart.AppVersion }}"
+      "appVersion": "{{ .Chart.AppVersion }}",
+      "logoutURI": "/oauth2/sign_out"
     }

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -50,6 +50,8 @@ spec:
         - -pass-basic-auth=false
         - -pass-access-token=true
         - -pass-authorization-header=true
+        - -skip-auth-regex=^\/config\.json$
+        - -skip-auth-regex=^\/favicon.*\.png$
         {{- range .Values.authProxy.additionalFlags }}
         - {{ . }}
         {{- end }}

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -52,6 +52,7 @@ spec:
         - -pass-authorization-header=true
         - -skip-auth-regex=^\/config\.json$
         - -skip-auth-regex=^\/favicon.*\.png$
+        - -skip-auth-regex=^\/static\/
         {{- range .Values.authProxy.additionalFlags }}
         - {{ . }}
         {{- end }}

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -1,4 +1,5 @@
 {
   "namespace": "default",
-  "appVersion": "DEVEL"
+  "appVersion": "DEVEL",
+  "logoutURI": "/oauth2/sign_out"
 }

--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -29,6 +29,9 @@ beforeEach(() => {
     auth: {
       state,
     },
+    config: {
+      logoutURI: "/log/out",
+    },
   });
 });
 
@@ -120,24 +123,20 @@ describe("OIDC authentication", () => {
   });
 
   it("expires the session and logs out ", () => {
-    // TODO(mnelson): this is not currently logging out.
     Auth.usingOIDCToken = jest.fn(() => true);
+    localStorage.removeItem = jest.fn();
+    document.location.assign = jest.fn();
     const expectedActions = [
       {
         payload: { sessionExpired: true },
         type: getType(actions.auth.setSessionExpired),
       },
-      {
-        payload: { authenticated: false, oidc: false, defaultNamespace: "" },
-        type: getType(actions.auth.setAuthenticated),
-      },
-      {
-        type: getType(actions.namespace.clearNamespaces),
-      },
     ];
 
     return store.dispatch(actions.auth.expireSession()).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
+      expect(localStorage.removeItem).toBeCalled();
+      expect(document.location.assign).toBeCalledWith("/log/out");
     });
   });
 });

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -51,10 +51,17 @@ export function logout(): ThunkAction<
   null,
   AuthAction | NamespaceAction
 > {
-  return async dispatch => {
-    Auth.unsetAuthToken();
-    dispatch(setAuthenticated(false, false, ""));
-    dispatch(clearNamespaces());
+  return async (dispatch, getState) => {
+    // We can't do anything before calling unsetAuthCookie as otherwise the
+    // state changes and the redirect to the logout URI is lost.
+    if (Auth.usingOIDCToken()) {
+      const { config } = getState();
+      Auth.unsetAuthCookie(config);
+    } else {
+      Auth.unsetAuthToken();
+      dispatch(setAuthenticated(false, false, ""));
+      dispatch(clearNamespaces());
+    }
   };
 }
 

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -1,7 +1,6 @@
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import { NavLink } from "react-router-dom";
 import { INamespaceState } from "../../reducers/namespace";
 import Header from "./Header";
 
@@ -17,7 +16,6 @@ const defaultProps = {
   pathname: "",
   push: jest.fn(),
   setNamespace: jest.fn(),
-  hideLogoutLink: false,
 };
 it("renders the header links and titles", () => {
   const wrapper = shallow(<Header {...defaultProps} />);
@@ -53,13 +51,4 @@ it("renders the namespace switcher", () => {
       namespace: defaultProps.namespace,
     }),
   );
-});
-
-it("disables the logout link when hideLogoutLink is set", () => {
-  const wrapper = shallow(<Header {...defaultProps} hideLogoutLink={true} />);
-  const links = wrapper.find(NavLink);
-  expect(links.length).toBeGreaterThan(1);
-  links.children().forEach(link => {
-    expect(link.text).not.toContain("Logout");
-  });
 });

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -21,7 +21,6 @@ interface IHeaderProps {
   pathname: string;
   push: (path: string) => void;
   setNamespace: (ns: string) => void;
-  hideLogoutLink: boolean;
 }
 
 interface IHeaderState {
@@ -68,13 +67,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   }
 
   public render() {
-    const {
-      fetchNamespaces,
-      namespace,
-      defaultNamespace,
-      authenticated: showNav,
-      hideLogoutLink,
-    } = this.props;
+    const { fetchNamespaces, namespace, defaultNamespace, authenticated: showNav } = this.props;
     const header = `header ${this.state.mobileOpen ? "header-open" : ""}`;
     const submenu = `header__nav__submenu ${
       this.state.configOpen ? "header__nav__submenu-open" : ""
@@ -137,13 +130,11 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                       </li>
                     </ul>
                   </li>
-                  {!hideLogoutLink && (
-                    <li>
-                      <NavLink to="#" onClick={this.handleLogout}>
-                        <LogOut size={16} className="icon margin-r-tiny" /> Logout
-                      </NavLink>
-                    </li>
-                  )}
+                  <li>
+                    <NavLink to="#" onClick={this.handleLogout}>
+                      <LogOut size={16} className="icon margin-r-tiny" /> Logout
+                    </NavLink>
+                  </li>
                 </ul>
               </div>
             )}

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.test.tsx
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.test.tsx
@@ -31,7 +31,6 @@ describe("LoginFormContainer props", () => {
     const form = wrapper.find("Header");
     expect(form).toHaveProp({
       authenticated: true,
-      hideLogoutLink: true,
     });
   });
 });

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -13,7 +13,7 @@ interface IState extends IStoreState {
 }
 
 function mapStateToProps({
-  auth: { authenticated, oidcAuthenticated, defaultNamespace },
+  auth: { authenticated, defaultNamespace },
   namespace,
   router: {
     location: { pathname },
@@ -24,10 +24,6 @@ function mapStateToProps({
     namespace,
     defaultNamespace,
     pathname,
-    // If oidcAuthenticated it's not yet supported to logout
-    // Some IdP like Keycloak allows to hit an endpoint to logout:
-    // https://www.keycloak.org/docs/latest/securing_apps/index.html#logout-endpoint
-    hideLogoutLink: oidcAuthenticated,
   };
 }
 

--- a/dashboard/src/reducers/config.ts
+++ b/dashboard/src/reducers/config.ts
@@ -12,6 +12,7 @@ const initialState: IConfigState = {
   loaded: false,
   namespace: "",
   appVersion: "",
+  logoutURI: "",
 };
 
 const configReducer = (state: IConfigState = initialState, action: ConfigAction): IConfigState => {

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -81,12 +81,11 @@ describe("Auth", () => {
       const isAuthed = await Auth.isAuthenticatedWithCookie();
       expect(isAuthed).toBe(false);
     });
-    it("returns false if the request to api root results in a text/html 403", async () => {
+    it("returns false if the request to api root results in a non-json response (ie. without data.message)", async () => {
       Axios.get = jest.fn(() => {
         return Promise.reject({
           response: {
             status: 403,
-            headers: { "content-type": "text/html" },
           },
         });
       });
@@ -95,7 +94,12 @@ describe("Auth", () => {
     });
     it("returns true if the request to api root results in a 403 (but not anonymous)", async () => {
       Axios.get = jest.fn(() => {
-        return Promise.reject({ response: { status: 403 } });
+        return Promise.reject({
+          response: {
+            status: 403,
+            data: { message: "some message for other-user" },
+          },
+        });
       });
       const isAuthed = await Auth.isAuthenticatedWithCookie();
       expect(isAuthed).toBe(true);

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -135,4 +135,24 @@ describe("Auth", () => {
       expect(defaultNamespace).toEqual("default");
     });
   });
+
+  describe("unsetAuthCookie", () => {
+    let mockedAssign: jest.Mocked<(url: string) => void>;
+    let mockedLocalStorageRemove: jest.Mocked<(url: string) => void>;
+    beforeEach(() => {
+      mockedAssign = jest.fn();
+      document.location.assign = mockedAssign;
+      mockedLocalStorageRemove = jest.fn();
+      localStorage.removeItem = mockedLocalStorageRemove;
+    });
+
+    it("uses the config to redirect to a logout URL", () => {
+      const logoutURI = "/example/logout";
+
+      Auth.unsetAuthCookie({ logoutURI, namespace: "ns", appVersion: "2" });
+
+      expect(mockedAssign).toBeCalledWith(logoutURI);
+      expect(mockedLocalStorageRemove).toBeCalled();
+    });
+  });
 });

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -81,6 +81,18 @@ describe("Auth", () => {
       const isAuthed = await Auth.isAuthenticatedWithCookie();
       expect(isAuthed).toBe(false);
     });
+    it("returns false if the request to api root results in a text/html 403", async () => {
+      Axios.get = jest.fn(() => {
+        return Promise.reject({
+          response: {
+            status: 403,
+            headers: { "content-type": "text/html" },
+          },
+        });
+      });
+      const isAuthed = await Auth.isAuthenticatedWithCookie();
+      expect(isAuthed).toBe(false);
+    });
     it("returns true if the request to api root results in a 403 (but not anonymous)", async () => {
       Axios.get = jest.fn(() => {
         return Promise.reject({ response: { status: 403 } });

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -2,6 +2,7 @@ import Axios, { AxiosResponse } from "axios";
 import * as jwt from "jsonwebtoken";
 const AuthTokenKey = "kubeapps_auth_token";
 const AuthTokenOIDCKey = "kubeapps_auth_token_oidc";
+import { IConfig } from "./Config";
 import { APIBase } from "./Kube";
 
 export const DEFAULT_NAMESPACE = "default";
@@ -20,7 +21,14 @@ export class Auth {
 
   public static unsetAuthToken() {
     localStorage.removeItem(AuthTokenKey);
+  }
+
+  public static unsetAuthCookie(config: IConfig) {
+    // http cookies cannot be deleted (or modified or read) from client-side
+    // JS, so force browser to load the sign-out URI (which expires the
+    // session cookie).
     localStorage.removeItem(AuthTokenOIDCKey);
+    document.location.assign(config.logoutURI);
   }
 
   public static usingOIDCToken() {

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -93,17 +93,14 @@ export class Auth {
       // A non json 403 error response means we did not get through to the API server but
       // instead were rejected by the auth proxy (ie. no http-only cookie).
       // TODO(mnelson): Check why doesn't the auth proxy return a 401 for a request without auth?
-      if (response.headers && response.headers["content-type"] !== "application/json") {
+      if (!response.data || !response.data.message) {
         return false;
       }
       // Finally, the k8s api server nowadays defaults to allowing anonymous
       // requests, so that rather than returning a 401, a 403 is returned if
       // RBAC does not allow the anonymous user access. An http-only cookie
       // will not result in an anonymous request, so...
-      const isAnon =
-        response.data &&
-        response.data.message &&
-        response.data.message.includes("system:anonymous");
+      const isAnon = response.data.message.includes("system:anonymous");
       return !isAnon;
     }
     return true;

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -76,21 +76,35 @@ export class Auth {
     }
   }
 
-  // isAuthenticatedWithCookie() does a HEAD request (without any token obviously)
-  // to determine if the request is authenticated (ie. not a 401). Unfortunately
-  // Kubernetes defaulting to allow anonymous requests means that this will be a 403
-  // even if there are no credentials, so we additionally check the message and assume
-  // we are authenticated with a cookie if a 403 is not for an anon user.
+  // isAuthenticatedWithCookie() does an anonymous GET request to determine if
+  // the request is authenticated with an http-only cookie (there is, by design,
+  // no way to determine via client JS whether an http-only cookie is present).
   public static async isAuthenticatedWithCookie(): Promise<boolean> {
     try {
       await Axios.get(APIBase + "/");
     } catch (e) {
       const response = e.response as AxiosResponse;
+      // The only error response which can possibly mean we did authenticate is
+      // a 403 from the k8s api server (ie. we got through to k8s api server
+      // but RBAC doesn't authorize us).
+      if (response.status !== 403) {
+        return false;
+      }
+      // A non json 403 error response means we did not get through to the API server but
+      // instead were rejected by the auth proxy (ie. no http-only cookie).
+      // TODO(mnelson): Check why doesn't the auth proxy return a 401 for a request without auth?
+      if (response.headers && response.headers["content-type"] !== "application/json") {
+        return false;
+      }
+      // Finally, the k8s api server nowadays defaults to allowing anonymous
+      // requests, so that rather than returning a 401, a 403 is returned if
+      // RBAC does not allow the anonymous user access. An http-only cookie
+      // will not result in an anonymous request, so...
       const isAnon =
         response.data &&
         response.data.message &&
         response.data.message.includes("system:anonymous");
-      return response.status === 403 && !isAnon;
+      return !isAnon;
     }
     return true;
   }

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 export interface IConfig {
   namespace: string;
   appVersion: string;
+  logoutURI: string;
   error?: Error;
 }
 


### PR DESCRIPTION
This PR un-hides the logout action (it was previously explicitly hidden when logged in via oauth).

The `Auth.unsetAuthCookie` does the work (just redirecting to the configured logout point which removes the cookie - it's impossible to remove the cookie from the client-side JS as it is http-only).

A lot of fun was had (sarcasm) updating the `isAuthenticatedWithCookie` function to handle all cases. It's basically tricky because the the client can't detect an http-only cookie at all.

The result looks like this (sorry, low res):
![oidc-login-logout](https://user-images.githubusercontent.com/497518/69122627-72593100-0af3-11ea-9221-b18fc92cb7db.gif)

This is a second prequel to #1249 (after #1294).
