### PR TITLE
Fix filter in Catalog view

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -44,6 +44,13 @@ it("updates the filter from props", () => {
   expect(wrapper.state("filter")).toBe("foo");
 });
 
+it("keeps the filter from the state", () => {
+  const wrapper = shallow(<Catalog {...defaultProps} />);
+  expect(wrapper.state("filter")).toBe("");
+  wrapper.setState({ filter: "foo" });
+  expect(wrapper.state("filter")).toBe("foo");
+});
+
 describe("renderization", () => {
   context("when no charts", () => {
     it("should render an error", () => {

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -35,7 +35,7 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
   }
 
   public componentDidUpdate(prevProps: ICatalogProps) {
-    if (this.props.filter !== this.state.filter) {
+    if (this.props.filter !== prevProps.filter) {
       this.setState({ filter: this.props.filter });
     }
     if (this.props.repo !== prevProps.repo) {


### PR DESCRIPTION
`componentDidUpdate` (a difference from `componentWillReceiveProps`) gets executed when the state changes.

If the `state.filter` of the `Catalog` changes, the value was being put back to whatever the `props.filter` said, losing the changes. This was working before since the hook `componentWillReceiveProps` was not being executed with changes in the state.