### PR TITLE
Add templates for new issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,58 @@
+<!--
+If you are reporting a new issue, make sure that we do not have any duplicates
+already open. You can ensure this by searching the issue list for this
+repository. If there is a duplicate, please close your issue and add a comment
+to the existing issue instead.
+
+If you suspect your issue is a bug, please edit your issue description to
+include the BUG REPORT INFORMATION shown below. If you fail to provide this
+information within 7 days, we cannot debug your issue and we'll close it. We
+will, however, reopen it if you later provide the information.
+-------------------------------
+    BUG REPORT INFORMATION
+-------------------------------
+Use the commands below to provide key information from your environment:
+You do NOT have to include this information if this is a FEATURE REQUEST
+-->
+
+**Description**
+
+<!-- Briefly describe the problem you are having in a few paragraphs. -->
+
+**Steps to reproduce the issue:**
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Describe the results you received:**
+
+<!-- What actually happens -->
+
+**Describe the results you expected:**
+
+<!-- What you expect to happen -->
+
+**Additional information you deem important (e.g. issue happens only occasionally):**
+
+<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->
+
+**Version of Helm, Kubeapps and Kubernetes**:
+
+- Output of `helm version`:
+
+```
+(paste your output here)
+```
+
+- Output of `helm list <kubeapps-release-name>`:
+
+```
+(paste your output here)
+```
+
+- Output of `kubectl version`:
+
+```
+(paste your output here)
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+ Before you open the request please review the following guidelines and tips to help it be more easily integrated:
+
+ - Describe the scope of your change - i.e. what the change does.
+ - Describe any known limitations with your change.
+ - Please run any tests or examples that can exercise your modified code.
+
+ Thank you for contributing!
+ -->
+
+**Description of the change**
+
+<!-- Describe the scope of your change - i.e. what the change does. -->
+
+**Benefits**
+
+<!-- What benefits will be realized by the code change? -->
+
+**Possible drawbacks**
+
+<!-- Describe any known limitations with your change -->
+
+**Applicable issues**
+
+<!-- Enter any applicable Issues here (You can reference an issue using #) -->
+  - fixes #
+
+**Additional information**
+
+<!-- If there's anything else that's important and relevant to your pull
+request, mention that information here.-->


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR adds basic templates for issues and pull requests so:

-  Users fill al the required information for Kubeapps maintainers to debug their issues and provide an efficient support.
- Contributors provide all the context Kubeapps maintainers need to review their contributions.

More info at: https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates