### PR TITLE
Move dex-related oauth2 options out of default auth options.

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -50,9 +50,6 @@ spec:
         - -pass-basic-auth=false
         - -pass-access-token=true
         - -pass-authorization-header=true
-        - -skip-auth-regex=^\/config\.json$
-        - -skip-auth-regex=^\/favicon.*\.png$
-        - -skip-auth-regex=^\/static\/
         {{- range .Values.authProxy.additionalFlags }}
         - {{ . }}
         {{- end }}

--- a/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml
@@ -8,3 +8,6 @@ authProxy:
     - -cookie-secure=false
     - -oidc-issuer-url=https://dex.dex:32000
     - -ssl-insecure-skip-verify=true
+    - -skip-auth-regex=^\/config\.json$
+    - -skip-auth-regex=^\/favicon.*\.png$
+    - -skip-auth-regex=^\/static\/


### PR DESCRIPTION
**Description of the change**
I realised with https://github.com/kubeapps/kubeapps/pull/1295/files that I had added changes to the default oauth2-proxy chart install, whereas I intended to just test them there, and add them as specific changes for dex.

This change ensures those dex-related options aren't part of the default install when using oauth2 proxy.

