### PR TITLE
Avoid SELECT action when requesting the deployed version

### DIFF
--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -242,11 +242,6 @@ describe("getDeployedChartVersion", () => {
     response = { id: "foo" };
     const expectedActions = [
       { type: getType(actions.charts.requestDeployedChartVersion) },
-      { type: getType(actions.charts.requestCharts) },
-      {
-        type: getType(actions.charts.selectChartVersion),
-        payload: { chartVersion: response, schema: { data: response }, values: { data: response } },
-      },
       {
         type: getType(actions.charts.receiveDeployedChartVersion),
         payload: { chartVersion: response, schema: { data: response }, values: { data: response } },


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

I noticed a race condition in the UpgradeForm, due to that the `getDeployedVersion` triggered the `selectChartVersion` action, sometimes, the form goes back to the current deployed version (instead of the last one. This PR fixes that, getting the deployed version doesn't mean the user is selecting it.

