### PR TITLE
Fix slow response of the form

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.test.tsx
@@ -207,6 +207,96 @@ describe("when the basic form is enabled", () => {
     ]);
   });
 
+  it("should update existing params when receiving new values", () => {
+    const testProps = {
+      ...props,
+      selected: {
+        ...props.selected,
+        schema: { properties: { wordpressUsername: { type: "string", form: true } } },
+      },
+      appValues: "",
+    };
+    const basicFormParameters = [
+      {
+        path: "wordpressUsername",
+        value: "user",
+      },
+    ];
+    const wrapper = mount(<DeploymentFormBody {...testProps} />);
+    wrapper.setState({ basicFormParameters });
+    wrapper.setProps({ appValues: "wordpressUsername: foo" });
+    wrapper.update();
+    expect(wrapper.state("basicFormParameters")).toMatchObject([
+      {
+        path: "wordpressUsername",
+        value: "foo",
+      },
+    ]);
+  });
+
+  it("should update existing params when receiving new values (for a new version)", () => {
+    const testProps = {
+      ...props,
+      selected: {
+        ...props.selected,
+        schema: { properties: { wordpressUsername: { type: "string", form: true } } },
+        values: "wordpressUsername: foo",
+      },
+    };
+    const basicFormParameters = [
+      {
+        path: "wordpressUsername",
+        value: "user",
+      },
+    ];
+    const wrapper = mount(<DeploymentFormBody {...testProps} />);
+    wrapper.setState({ basicFormParameters });
+    const updatedProps = {
+      selected: {
+        ...props.selected,
+        schema: { properties: { wordpressUsername: { type: "string", form: true } } },
+        values: "wordpressUsername: bar",
+      },
+      appValues: "wordpressUsername: bar",
+    };
+
+    wrapper.setProps(updatedProps);
+    wrapper.update();
+    expect(wrapper.state("basicFormParameters")).toMatchObject([
+      {
+        path: "wordpressUsername",
+        value: "bar",
+      },
+    ]);
+  });
+
+  it("should not re-render the basic params if appValues changes (because it's handled by the parameter itself)", () => {
+    const testProps = {
+      ...props,
+      selected: {
+        ...props.selected,
+        schema: { properties: { wordpressUsername: { type: "string", form: true } } },
+      },
+      appValues: "wordpressUsername: foo",
+    };
+    const basicFormParameters = [
+      {
+        path: "wordpressUsername",
+        value: "foo",
+      },
+    ];
+    const wrapper = mount(<DeploymentFormBody {...testProps} />);
+    wrapper.setState({ basicFormParameters });
+    wrapper.setProps({ appValues: "wordpressUsername: bar" });
+    wrapper.update();
+    expect(wrapper.state("basicFormParameters")).toMatchObject([
+      {
+        path: "wordpressUsername",
+        value: "foo",
+      },
+    ]);
+  });
+
   it("handles a parameter as a number", () => {
     const setValues = jest.fn();
     const testProps = {

--- a/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.tsx
@@ -61,7 +61,15 @@ class DeploymentFormBody extends React.Component<
       return;
     }
 
-    if (prevProps.selected.schema !== selected.schema || prevProps.appValues !== appValues) {
+    if (
+      // If the selected schema changes
+      prevProps.selected.schema !== selected.schema ||
+      // or the selected values (because it's a different version)
+      prevProps.selected.values !== selected.values ||
+      // or the current values (and we hadn't process those values yet)
+      (prevProps.appValues !== appValues && prevProps.appValues.length === 0)
+    ) {
+      // Parse the basic parameters
       this.setState({
         basicFormParameters: retrieveBasicFormParams(appValues, selected.schema),
       });


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

I have noticed that the `componentDidUpdate` method of the `BasicFormBody` is being executed with every stroke of the keyboard while writing in the basic form. This cause a re-render of the whole values.yaml to look an parse params which made the form response slow.

To fix that, now the whole values are just re-rendered if the version changes (and the schema or the default values changes) or if it's the first time we receive values.
