### PR TITLE
Add missing Nginx configuration for GKE

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -56,6 +56,12 @@ data:
       location ~* /api/chartsvc {
         rewrite /api/chartsvc/(.*) /chartsvc/$1 break;
         rewrite /api/chartsvc /chartsvc break;
+
+        {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
+        # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
+        proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
+        {{- end }}
+
         proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
       }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

As we do for the calls to `tiller-proxy` and the kubernetes API, we need to forward the access_token to the chartsvc (because we are authenticating it through tiller-proxy).