### PR TITLE
Add default logout URI if non defined in config

### DIFF
--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -170,5 +170,11 @@ describe("Auth", () => {
       expect(mockedAssign).toBeCalledWith(logoutURI);
       expect(mockedLocalStorageRemove).toBeCalled();
     });
+
+    it("defaults to the oauth2-proxy logout URI", () => {
+      Auth.unsetAuthCookie({ logoutURI: "", namespace: "ns", appVersion: "2" });
+
+      expect(mockedAssign).toBeCalledWith("/oauth2/sign_out");
+    });
   });
 });

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -28,7 +28,7 @@ export class Auth {
     // JS, so force browser to load the sign-out URI (which expires the
     // session cookie).
     localStorage.removeItem(AuthTokenOIDCKey);
-    document.location.assign(config.logoutURI);
+    document.location.assign(config.logoutURI || "/oauth2/sign_out");
   }
 
   public static usingOIDCToken() {


### PR DESCRIPTION
**Description of the change**
Ensure there is a default value for the oauth logout URI

**Benefits**

If the current code is deployed with an older chart which does not define the `config.logoutURI`, then clicking logout (when authed via a cookie) redirects to `/undefined` and you are not logged out.

**Additional information**
Just noticed this as unexpected behaviour on a recent environment. Turns out it's because `logoutURI` was not defined in the config (due to the older chart).