### PR TITLE
Upgrade to Go 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ run_e2e_tests: &run_e2e_tests
     fi
 gke_test: &gke_test
   docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.13
   steps:
     - checkout
     - run: |
@@ -214,7 +214,7 @@ jobs:
     environment:
       CGO_ENABLED: "0"
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.13
     steps:
       - checkout
       - <<: *exports
@@ -229,7 +229,7 @@ jobs:
       - run: yarn --cwd=dashboard run test --maxWorkers=4 --coverage
   test_chart_render:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.13
     steps:
       - <<: *exports
       - checkout
@@ -238,7 +238,7 @@ jobs:
       - run: ./script/chart-template-test.sh
   build_go_images:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.13
     working_directory: /go/src/github.com/kubeapps/kubeapps
     environment:
       GOPATH: /home/circleci/.go_workspace
@@ -246,13 +246,13 @@ jobs:
     <<: *build_images
   build_dashboard:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.13
     environment:
       IMAGES: "dashboard"
     <<: *build_images
   release:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.13
     steps:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
@@ -298,7 +298,7 @@ jobs:
       TEST_LATEST_RELEASE: 1
   sync_chart:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.13
     steps:
       - checkout
       - add_ssh_keys:
@@ -313,7 +313,7 @@ jobs:
           ./script/chart_sync.sh kubernetes-bitnami kubernetes@bitnami.com
   push_images:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.13
     steps:
       - setup_remote_docker
       - <<: *exports

--- a/cmd/apprepository-controller/Dockerfile
+++ b/cmd/apprepository-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 as builder
+FROM golang:1.13 as builder
 COPY . /go/src/github.com/kubeapps/kubeapps
 WORKDIR /go/src/github.com/kubeapps/kubeapps
 RUN CGO_ENABLED=0 go build -a -installsuffix cgo ./cmd/apprepository-controller

--- a/cmd/tiller-proxy/Dockerfile
+++ b/cmd/tiller-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 as builder
+FROM golang:1.13 as builder
 COPY . /go/src/github.com/kubeapps/kubeapps
 WORKDIR /go/src/github.com/kubeapps/kubeapps
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeapps/kubeapps
 
-go 1.12
+go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
@@ -53,6 +53,7 @@ require (
 	google.golang.org/appengine v1.2.0 // indirect
 	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	google.golang.org/grpc v1.16.0
+	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/api v0.0.0-20181005203742-357ec6384fa7
 	k8s.io/apimachinery v0.0.0-20180913025736-6dd46049f395

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e h1:I5s8aUkxqPjgAss
 google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.16.0 h1:dz5IJGuC2BB7qXR5AyHNwAUBhZscK2xVez7mznh72sY=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=


### PR DESCRIPTION
I think this will make it easier to use external modules going forward. Notably, this change is among the ones we made in order to be able to import `helm.sh/helm/v3` in #1309.

The `gopkg.in/DATA-DOG/go-sqlmock.v1` changes were made by `go mod tidy`.