### PR TITLE
Oauth logout login 2

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -41,7 +41,7 @@ data:
     {
       "namespace": "{{ .Release.Namespace }}",
       "appVersion": "{{ .Chart.AppVersion }}",
-      "authProxyEnabled": {{ .authProxy.enabled }},
+      "authProxyEnabled": {{ .Values.authProxy.enabled }},
       "loginURI": "/oauth2/start",
       "logoutURI": "/oauth2/sign_out"
     }

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -41,5 +41,7 @@ data:
     {
       "namespace": "{{ .Release.Namespace }}",
       "appVersion": "{{ .Chart.AppVersion }}",
+      "authProxyEnabled": {{ .authProxy.enabled }},
+      "loginURI": "/oauth2/start",
       "logoutURI": "/oauth2/sign_out"
     }

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -70,6 +70,7 @@ spec:
             - -skip-auth-regex=^\/config\.json$
             - -skip-auth-regex=^\/favicon.*\.png$
             - -skip-auth-regex=^\/static\/
+            - -skip-auth-regex=^\/$
             {{- range .Values.authProxy.additionalFlags }}
             - {{ . }}
             {{- end }}

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -1,5 +1,7 @@
 {
   "namespace": "default",
   "appVersion": "DEVEL",
+  "authProxyEnabled": true,
+  "loginURI": "/oauth2/start",
   "logoutURI": "/oauth2/sign_out"
 }

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -1,7 +1,7 @@
 {
   "namespace": "default",
   "appVersion": "DEVEL",
-  "authProxyEnabled": true,
+  "authProxyEnabled": false,
   "loginURI": "/oauth2/start",
   "logoutURI": "/oauth2/sign_out"
 }

--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -108,6 +108,9 @@ describe("OIDC authentication", () => {
         type: getType(actions.auth.authenticating),
       },
       {
+        type: getType(actions.auth.authenticating),
+      },
+      {
         payload: { authenticated: true, oidc: true, defaultNamespace: "default" },
         type: getType(actions.auth.setAuthenticated),
       },

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -81,6 +81,10 @@ export function checkCookieAuthentication(): ThunkAction<
   AuthAction
 > {
   return async dispatch => {
+    // The call to authenticate below will also dispatch authenticating,
+    // but we dispatch it early so that the login screen is shown as
+    // loading while we query isAuthenticatedWithCookie().
+    dispatch(authenticating());
     const isAuthed = await Auth.isAuthenticatedWithCookie();
     if (isAuthed) {
       dispatch(authenticate("", true));

--- a/dashboard/src/components/LoginForm/LoginForm.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.test.tsx
@@ -21,15 +21,26 @@ const defaultProps = {
   authenticationError: undefined,
   location: emptyLocation,
   checkCookieAuthentication: jest.fn(),
+  loginURI: "",
 };
 
 const authenticationError = "it's a trap";
 
 describe("componentDidMount", () => {
-  it("should call checkCookieAuthentication", () => {
+  it("calls checkCookieAuthentication when loginURI provided", () => {
+    const props = {
+      ...defaultProps,
+      loginURI: "/sign/in",
+    };
+    const checkCookieAuthentication = jest.fn();
+    shallow(<LoginForm {...props} checkCookieAuthentication={checkCookieAuthentication} />);
+    expect(checkCookieAuthentication).toHaveBeenCalled();
+  });
+
+  it("does not call checkCookieAuthentication when loginURI not provided", () => {
     const checkCookieAuthentication = jest.fn();
     shallow(<LoginForm {...defaultProps} checkCookieAuthentication={checkCookieAuthentication} />);
-    expect(checkCookieAuthentication).toHaveBeenCalled();
+    expect(checkCookieAuthentication).not.toHaveBeenCalled();
   });
 });
 
@@ -40,57 +51,93 @@ context("while authenticating", () => {
   });
 });
 
-it("renders a token login form", () => {
-  const wrapper = shallow(<LoginForm {...defaultProps} />);
-  expect(wrapper.find("input#token").exists()).toBe(true);
-  expect(wrapper.find(Redirect).exists()).toBe(false);
-  expect(wrapper).toMatchSnapshot();
-});
-
-it("renders a link to the access control documentation", () => {
-  const wrapper = shallow(<LoginForm {...defaultProps} />);
-  expect(wrapper.find("a").props()).toMatchObject({
-    href: "https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md",
-    target: "_blank",
-  });
-});
-
-it("updates the token in the state when the input is changed", () => {
-  const wrapper = shallow(<LoginForm {...defaultProps} />);
-  wrapper.find("input#token").simulate("change", { currentTarget: { value: "f00b4r" } });
-  expect(wrapper.state("token")).toBe("f00b4r");
-});
-
-describe("redirect if authenticated", () => {
-  it("redirects to / if no current location", () => {
-    const wrapper = shallow(<LoginForm {...defaultProps} authenticated={true} />);
-    const redirect = wrapper.find(Redirect);
-    expect(redirect.props()).toEqual({ to: { pathname: "/" } });
+describe("token login form", () => {
+  it("renders a token login form", () => {
+    const wrapper = shallow(<LoginForm {...defaultProps} />);
+    expect(wrapper.find("input#token").exists()).toBe(true);
+    expect(wrapper.find(Redirect).exists()).toBe(false);
+    expect(wrapper).toMatchSnapshot();
   });
 
-  it("redirects to previous location", () => {
-    const location = Object.assign({}, emptyLocation);
-    location.state = { from: "/test" };
+  it("renders a link to the access control documentation", () => {
+    const wrapper = shallow(<LoginForm {...defaultProps} />);
+    expect(wrapper.find("a").props()).toMatchObject({
+      href: "https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md",
+      target: "_blank",
+    });
+  });
+
+  it("updates the token in the state when the input is changed", () => {
+    const wrapper = shallow(<LoginForm {...defaultProps} />);
+    wrapper.find("input#token").simulate("change", { currentTarget: { value: "f00b4r" } });
+    expect(wrapper.state("token")).toBe("f00b4r");
+  });
+
+  describe("redirect if authenticated", () => {
+    it("redirects to / if no current location", () => {
+      const wrapper = shallow(<LoginForm {...defaultProps} authenticated={true} />);
+      const redirect = wrapper.find(Redirect);
+      expect(redirect.props()).toEqual({ to: { pathname: "/" } });
+    });
+
+    it("redirects to previous location", () => {
+      const location = Object.assign({}, emptyLocation);
+      location.state = { from: "/test" };
+      const wrapper = shallow(
+        <LoginForm {...defaultProps} authenticated={true} location={location} />,
+      );
+      const redirect = wrapper.find(Redirect);
+      expect(redirect.props()).toEqual({ to: "/test" });
+    });
+  });
+
+  it("calls the authenticate handler when the form is submitted", () => {
+    const wrapper = shallow(<LoginForm {...defaultProps} />);
+    wrapper.find("input#token").simulate("change", { currentTarget: { value: "f00b4r" } });
+    wrapper.find("form").simulate("submit", { preventDefault: jest.fn() });
+    expect(defaultProps.authenticate).toBeCalledWith("f00b4r");
+  });
+
+  it("displays an error if the authentication error is passed", () => {
     const wrapper = shallow(
-      <LoginForm {...defaultProps} authenticated={true} location={location} />,
+      <LoginForm {...defaultProps} authenticationError={authenticationError} />,
     );
-    const redirect = wrapper.find(Redirect);
-    expect(redirect.props()).toEqual({ to: "/test" });
+
+    expect(wrapper.find(".alert-error").exists()).toBe(true);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("does not display the oauth login if loginURI provided", () => {
+    const props = {
+      ...defaultProps,
+      loginURI: "",
+    };
+
+    const wrapper = shallow(<LoginForm {...props} />);
+
+    expect(wrapper.find("a.button").exists()).toBe(false);
   });
 });
 
-it("calls the authenticate handler when the form is submitted", () => {
-  const wrapper = shallow(<LoginForm {...defaultProps} />);
-  wrapper.find("input#token").simulate("change", { currentTarget: { value: "f00b4r" } });
-  wrapper.find("form").simulate("submit", { preventDefault: jest.fn() });
-  expect(defaultProps.authenticate).toBeCalledWith("f00b4r");
-});
+describe("oauth login form", () => {
+  const props = {
+    ...defaultProps,
+    loginURI: "/sign/in",
+  };
+  it("does not display the token login if loginURI provided", () => {
+    const wrapper = shallow(<LoginForm {...props} />);
 
-it("displays an error if the authentication error is passed", () => {
-  const wrapper = shallow(
-    <LoginForm {...defaultProps} authenticationError={authenticationError} />,
-  );
+    expect(wrapper.find("input#token").exists()).toBe(false);
+  });
 
-  expect(wrapper.find(".alert-error").exists()).toBe(true);
-  expect(wrapper).toMatchSnapshot();
+  it("displays the oauth login if loginURI provided", () => {
+    const wrapper = shallow(<LoginForm {...props} />);
+
+    expect(wrapper.find("a.button").exists()).toBe(true);
+  });
+
+  it("renders a login button link", () => {
+    const wrapper = shallow(<LoginForm {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/dashboard/src/components/LoginForm/LoginForm.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.tsx
@@ -10,6 +10,7 @@ interface ILoginFormProps {
   authenticated: boolean;
   authenticating: boolean;
   authenticationError: string | undefined;
+  loginURI: string;
   authenticate: (token: string) => any;
   checkCookieAuthentication: () => void;
   location: Location;
@@ -23,7 +24,9 @@ class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
   public state: ILoginFormState = { token: "" };
 
   public componentDidMount() {
-    this.props.checkCookieAuthentication();
+    if (this.props.loginURI) {
+      this.props.checkCookieAuthentication();
+    }
   }
 
   public render() {
@@ -34,6 +37,7 @@ class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
       const { from } = this.props.location.state || { from: { pathname: "/" } };
       return <Redirect to={from} />;
     }
+
     return (
       <section className="LoginForm">
         <div className="LoginForm__container padding-v-bigger bg-skew">
@@ -50,37 +54,7 @@ class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
               <h2>
                 <Lock /> Login
               </h2>
-              <p>
-                Your cluster operator should provide you with a Kubernetes API token.{" "}
-                <a
-                  href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md"
-                  target="_blank"
-                >
-                  Click here
-                </a>{" "}
-                for more info on how to create and use Bearer Tokens.
-              </p>
-              <div className="bg-skew__content">
-                <form onSubmit={this.handleSubmit}>
-                  <div>
-                    <label htmlFor="token">Kubernetes API Token</label>
-                    <input
-                      name="token"
-                      id="token"
-                      type="password"
-                      placeholder="Token"
-                      required={true}
-                      onChange={this.handleTokenChange}
-                      value={this.state.token}
-                    />
-                  </div>
-                  <p>
-                    <button type="submit" className="button button-accent">
-                      Login
-                    </button>
-                  </p>
-                </form>
-              </div>
+              {this.props.loginURI ? this.oauthLogin() : this.tokenLogin()}
             </div>
           </div>
         </div>
@@ -96,6 +70,64 @@ class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
 
   private handleTokenChange = (e: React.FormEvent<HTMLInputElement>) => {
     this.setState({ token: e.currentTarget.value });
+  };
+
+  private oauthLogin = () => {
+    return (
+      <>
+        <p>
+          Your cluster operator has enabled login via an authentication provider.{" "}
+          <a
+            href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md"
+            target="_blank"
+          >
+            Click here
+          </a>{" "}
+          for more info about using authentication providers with Kubeapps.
+        </p>
+        <a href={this.props.loginURI} className="button button-accent">
+          Login
+        </a>
+      </>
+    );
+  };
+
+  private tokenLogin = () => {
+    return (
+      <>
+        <p>
+          Your cluster operator should provide you with a Kubernetes API token.{" "}
+          <a
+            href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md"
+            target="_blank"
+          >
+            Click here
+          </a>{" "}
+          for more info on how to create and use Bearer Tokens.
+        </p>
+        <div className="bg-skew__content">
+          <form onSubmit={this.handleSubmit}>
+            <div>
+              <label htmlFor="token">Kubernetes API Token</label>
+              <input
+                name="token"
+                id="token"
+                type="password"
+                placeholder="Token"
+                required={true}
+                onChange={this.handleTokenChange}
+                value={this.state.token}
+              />
+            </div>
+            <p>
+              <button type="submit" className="button button-accent">
+                Login
+              </button>
+            </p>
+          </form>
+        </div>
+      </>
+    );
   };
 }
 

--- a/dashboard/src/components/LoginForm/__snapshots__/LoginForm.test.tsx.snap
+++ b/dashboard/src/components/LoginForm/__snapshots__/LoginForm.test.tsx.snap
@@ -1,6 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`displays an error if the authentication error is passed 1`] = `
+exports[`oauth login form renders a login button link 1`] = `
+<section
+  className="LoginForm"
+>
+  <div
+    className="LoginForm__container padding-v-bigger bg-skew"
+  >
+    <div
+      className="container container-tiny"
+    />
+    <div
+      className="bg-skew__pattern bg-skew__pattern-dark type-color-reverse"
+    >
+      <div
+        className="container"
+      >
+        <h2>
+          <Lock
+            color="currentColor"
+            size="24"
+          />
+           Login
+        </h2>
+        <p>
+          Your cluster operator has enabled login via an authentication provider.
+           
+          <a
+            href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md"
+            target="_blank"
+          >
+            Click here
+          </a>
+           
+          for more info about using authentication providers with Kubeapps.
+        </p>
+        <a
+          className="button button-accent"
+          href="/sign/in"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`token login form displays an error if the authentication error is passed 1`] = `
 <section
   className="LoginForm"
 >
@@ -80,7 +127,7 @@ exports[`displays an error if the authentication error is passed 1`] = `
 </section>
 `;
 
-exports[`renders a token login form 1`] = `
+exports[`token login form renders a token login form 1`] = `
 <section
   className="LoginForm"
 >

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -2,6 +2,7 @@ import { shallow } from "enzyme";
 import { Location } from "history";
 import * as React from "react";
 import { IAuthState } from "reducers/auth";
+import { IConfigState } from "reducers/config";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import LoginForm from "./LoginFormContainer";
@@ -15,8 +16,10 @@ const makeStore = (
   oidcAuthenticated: boolean,
   authenticationError: string,
   defaultNamespace: string,
+  authProxyEnabled: boolean,
+  loginURI: string,
 ) => {
-  const state: IAuthState = {
+  const auth: IAuthState = {
     sessionExpired,
     authenticated,
     authenticating,
@@ -24,7 +27,15 @@ const makeStore = (
     authenticationError,
     defaultNamespace,
   };
-  return mockStore({ auth: state });
+  const config: IConfigState = {
+    authProxyEnabled,
+    loginURI,
+    loaded: true,
+    namespace: "",
+    appVersion: "",
+    logoutURI: "",
+  };
+  return mockStore({ auth, config });
 };
 
 const emptyLocation: Location = {
@@ -36,13 +47,46 @@ const emptyLocation: Location = {
 
 describe("LoginFormContainer props", () => {
   it("maps authentication redux states to props", () => {
-    const store = makeStore(true, true, true, true, "It's a trap", "");
+    const authProxyEnabled = true;
+    const store = makeStore(
+      true,
+      true,
+      true,
+      true,
+      "It's a trap",
+      "",
+      authProxyEnabled,
+      "/myoauth/start",
+    );
     const wrapper = shallow(<LoginForm store={store} location={emptyLocation} />);
     const form = wrapper.find("LoginForm");
     expect(form).toHaveProp({
       authenticated: true,
       authenticating: true,
       authenticationError: "It's a trap",
+      loginURI: "/myoauth/start",
+    });
+  });
+
+  it("does not receive loginURI if authProxyEnabled is false", () => {
+    const authProxyEnabled = false;
+    const store = makeStore(
+      true,
+      true,
+      true,
+      true,
+      "It's a trap",
+      "",
+      authProxyEnabled,
+      "/myoauth/start",
+    );
+    const wrapper = shallow(<LoginForm store={store} location={emptyLocation} />);
+    const form = wrapper.find("LoginForm");
+    expect(form).toHaveProp({
+      authenticated: true,
+      authenticating: true,
+      authenticationError: "It's a trap",
+      loginURI: "",
     });
   });
 });

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
@@ -8,11 +8,13 @@ import { IStoreState } from "../../shared/types";
 
 function mapStateToProps({
   auth: { authenticated, authenticating, authenticationError },
+  config: { authProxyEnabled, loginURI },
 }: IStoreState) {
   return {
     authenticated,
     authenticating,
     authenticationError,
+    loginURI: authProxyEnabled ? loginURI : "",
   };
 }
 

--- a/dashboard/src/reducers/config.ts
+++ b/dashboard/src/reducers/config.ts
@@ -12,6 +12,8 @@ const initialState: IConfigState = {
   loaded: false,
   namespace: "",
   appVersion: "",
+  authProxyEnabled: false,
+  loginURI: "",
   logoutURI: "",
 };
 

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -165,14 +165,26 @@ describe("Auth", () => {
     it("uses the config to redirect to a logout URL", () => {
       const logoutURI = "/example/logout";
 
-      Auth.unsetAuthCookie({ logoutURI, namespace: "ns", appVersion: "2" });
+      Auth.unsetAuthCookie({
+        loginURI: "",
+        authProxyEnabled: true,
+        logoutURI,
+        namespace: "ns",
+        appVersion: "2",
+      });
 
       expect(mockedAssign).toBeCalledWith(logoutURI);
       expect(mockedLocalStorageRemove).toBeCalled();
     });
 
     it("defaults to the oauth2-proxy logout URI", () => {
-      Auth.unsetAuthCookie({ logoutURI: "", namespace: "ns", appVersion: "2" });
+      Auth.unsetAuthCookie({
+        loginURI: "",
+        authProxyEnabled: true,
+        logoutURI: "",
+        namespace: "ns",
+        appVersion: "2",
+      });
 
       expect(mockedAssign).toBeCalledWith("/oauth2/sign_out");
     });

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -4,6 +4,8 @@ import axios from "axios";
 export interface IConfig {
   namespace: string;
   appVersion: string;
+  authProxyEnabled: boolean;
+  loginURI: string;
   logoutURI: string;
   error?: Error;
 }


### PR DESCRIPTION
**Description of the change**
Enables oauth login to use our normal Kubeapps login page (rather than the rather blank oauth2-proxy default).

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

A unified login view for Kubeapps, regardless of whether token login or oauth/oidc is being used.

Also ensures we don't see a flash of the login screen after auth'ing.

**Applicable issues**
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1249 

**Additional information**
Enables the root route to pass through the proxy, so that our own login form can trigger the authentication as it currently does for token auth also.

![oauth2-login-screen](https://user-images.githubusercontent.com/497518/69509540-8a1a3480-0f8d-11ea-8619-69d6f1cd6b07.gif)

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
