### PR TITLE
Fix URL table for ingresses

### DIFF
--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
@@ -19,18 +19,18 @@ const defaultProps = {
 
 describe("when receiving ingresses", () => {
   it("fetches ingresses at mount time", () => {
+    const ingress = { name: "ing" } as ResourceRef;
     const mock = jest.fn();
-    shallow(
-      <AccessURLTable {...defaultProps} ingressRefs={[{} as ResourceRef]} getResource={mock} />,
-    );
-    expect(mock).toHaveBeenCalled();
+    shallow(<AccessURLTable {...defaultProps} ingressRefs={[ingress]} getResource={mock} />);
+    expect(mock).toHaveBeenCalledWith(ingress);
   });
 
-  it("fetches new ingresses when received", () => {
+  it("fetches when new ingress refs received", () => {
+    const ingress = { name: "ing" } as ResourceRef;
     const mock = jest.fn();
     const wrapper = shallow(<AccessURLTable {...defaultProps} getResource={mock} />);
-    wrapper.setProps({ ingressRefs: [{} as ResourceRef] });
-    expect(mock).toHaveBeenCalled();
+    wrapper.setProps({ ingressRefs: [ingress] });
+    expect(mock).toHaveBeenCalledWith(ingress);
   });
 });
 

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
@@ -18,7 +18,7 @@ const defaultProps = {
 };
 
 describe("when receiving ingresses", () => {
-  it("fetches new ingresses", () => {
+  it("fetches ingresses at mount time", () => {
     const mock = jest.fn();
     shallow(
       <AccessURLTable {...defaultProps} ingressRefs={[{} as ResourceRef]} getResource={mock} />,
@@ -26,7 +26,7 @@ describe("when receiving ingresses", () => {
     expect(mock).toHaveBeenCalled();
   });
 
-  it("fetches new ingresses", () => {
+  it("fetches new ingresses when received", () => {
     const mock = jest.fn();
     const wrapper = shallow(<AccessURLTable {...defaultProps} getResource={mock} />);
     wrapper.setProps({ ingressRefs: [{} as ResourceRef] });

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
@@ -4,15 +4,24 @@ import * as React from "react";
 
 import itBehavesLike from "../../../shared/specs";
 
+import ResourceRef from "shared/ResourceRef";
 import LoadingWrapper from "../../../components/LoadingWrapper";
 import { IIngressSpec, IResource, IServiceSpec, IServiceStatus } from "../../../shared/types";
 import AccessURLItem from "./AccessURLItem";
 import AccessURLTable from "./AccessURLTable";
 
-describe("componentDidMount", () => {
-  it("fetches ingresses", () => {
+const defaultProps = {
+  services: [],
+  ingresses: [],
+  ingressRefs: [],
+  getResource: jest.fn(),
+};
+
+describe("componentDidUpdate", () => {
+  it("fetches new ingresses", () => {
     const mock = jest.fn();
-    shallow(<AccessURLTable services={[]} ingresses={[]} fetchIngresses={mock} />);
+    const wrapper = shallow(<AccessURLTable {...defaultProps} getResource={mock} />);
+    wrapper.setProps({ ingressRefs: [{} as ResourceRef] });
     expect(mock).toHaveBeenCalled();
   });
 });
@@ -21,29 +30,21 @@ context("when fetching ingresses or services", () => {
   itBehavesLike("aLoadingComponent", {
     component: AccessURLTable,
     props: {
+      ...defaultProps,
       ingresses: [{ isFetching: true }],
-      services: [],
-      fetchIngresses: jest.fn(),
-      watchServices: jest.fn(),
-      closeWatches: jest.fn(),
     },
   });
   itBehavesLike("aLoadingComponent", {
     component: AccessURLTable,
     props: {
-      ingresses: [],
+      ...defaultProps,
       services: [{ isFetching: true }],
-      fetchIngresses: jest.fn(),
-      watchServices: jest.fn(),
-      closeWatches: jest.fn(),
     },
   });
 });
 
 it("renders a message if there are no services or ingresses", () => {
-  const wrapper = shallow(
-    <AccessURLTable services={[]} ingresses={[]} fetchIngresses={jest.fn()} />,
-  );
+  const wrapper = shallow(<AccessURLTable {...defaultProps} />);
   expect(
     wrapper
       .find(LoadingWrapper)
@@ -74,9 +75,7 @@ context("when the app contains services", () => {
       } as IServiceStatus,
     } as IResource;
     const services = [{ isFetching: false, item: service }];
-    const wrapper = shallow(
-      <AccessURLTable services={services} ingresses={[]} fetchIngresses={jest.fn()} />,
-    );
+    const wrapper = shallow(<AccessURLTable {...defaultProps} services={services} />);
     expect(
       wrapper
         .find(LoadingWrapper)
@@ -100,9 +99,7 @@ context("when the app contains services", () => {
       } as IServiceStatus,
     } as IResource;
     const services = [{ isFetching: false, item: service }];
-    const wrapper = shallow(
-      <AccessURLTable services={services} ingresses={[]} fetchIngresses={jest.fn()} />,
-    );
+    const wrapper = shallow(<AccessURLTable {...defaultProps} services={services} />);
     expect(wrapper.find(AccessURLItem)).toExist();
     expect(wrapper).toMatchSnapshot();
   });
@@ -127,9 +124,7 @@ context("when the app contains ingresses", () => {
       } as IIngressSpec,
     } as IResource;
     const ingresses = [{ isFetching: false, item: ingress }];
-    const wrapper = shallow(
-      <AccessURLTable services={[]} ingresses={ingresses} fetchIngresses={jest.fn()} />,
-    );
+    const wrapper = shallow(<AccessURLTable {...defaultProps} ingresses={ingresses} />);
     expect(wrapper.find(AccessURLItem)).toExist();
     expect(wrapper).toMatchSnapshot();
   });
@@ -169,7 +164,7 @@ context("when the app contains services and ingresses", () => {
     } as IResource;
     const ingresses = [{ isFetching: false, item: ingress }];
     const wrapper = shallow(
-      <AccessURLTable services={services} ingresses={ingresses} fetchIngresses={jest.fn()} />,
+      <AccessURLTable {...defaultProps} services={services} ingresses={ingresses} />,
     );
     expect(wrapper.find(AccessURLItem)).toExist();
     expect(wrapper).toMatchSnapshot();
@@ -181,7 +176,7 @@ context("when the app contains resources with errors", () => {
     const services = [{ isFetching: false, error: new Error("could not find Service") }];
     const ingresses = [{ isFetching: false, error: new Error("could not find Ingress") }];
     const wrapper = shallow(
-      <AccessURLTable services={services} ingresses={ingresses} fetchIngresses={jest.fn()} />,
+      <AccessURLTable {...defaultProps} services={services} ingresses={ingresses} />,
     );
 
     // The Service error is not shown, as it is filtered out because without the

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
@@ -17,7 +17,15 @@ const defaultProps = {
   getResource: jest.fn(),
 };
 
-describe("componentDidUpdate", () => {
+describe("when receiving ingresses", () => {
+  it("fetches new ingresses", () => {
+    const mock = jest.fn();
+    shallow(
+      <AccessURLTable {...defaultProps} ingressRefs={[{} as ResourceRef]} getResource={mock} />,
+    );
+    expect(mock).toHaveBeenCalled();
+  });
+
   it("fetches new ingresses", () => {
     const mock = jest.fn();
     const wrapper = shallow(<AccessURLTable {...defaultProps} getResource={mock} />);

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
@@ -16,11 +16,13 @@ interface IAccessURLTableProps {
 }
 
 class AccessURLTable extends React.Component<IAccessURLTableProps> {
+  public componentDidMount() {
+    this.fetchIngresses();
+  }
+
   public componentDidUpdate(prevProps: IAccessURLTableProps) {
-    // Fetch all related Ingress resources. We don't need to fetch Services as
-    // they are expected to be watched by the ServiceTable.
     if (prevProps.ingressRefs.length !== this.props.ingressRefs.length) {
-      this.props.ingressRefs.forEach(r => this.props.getResource(r));
+      this.fetchIngresses();
     }
   }
 
@@ -93,6 +95,12 @@ class AccessURLTable extends React.Component<IAccessURLTableProps> {
       return <AccessURLItem key={`accessURL/${i.item.metadata.name}`} URLItem={urlItem} />;
     }
     return;
+  }
+
+  private fetchIngresses() {
+    // Fetch all related Ingress resources. We don't need to fetch Services as
+    // they are expected to be watched by the ServiceTable.
+    this.props.ingressRefs.forEach(r => this.props.getResource(r));
   }
 }
 

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import ResourceRef from "shared/ResourceRef";
 import LoadingWrapper, { LoaderType } from "../../../components/LoadingWrapper";
 import { IKubeItem, IResource, IServiceSpec } from "../../../shared/types";
 import isSomeResourceLoading from "../helpers";
@@ -10,14 +11,17 @@ import { GetURLItemFromService } from "./AccessURLItem/AccessURLServiceHelper";
 interface IAccessURLTableProps {
   services: Array<IKubeItem<IResource>>;
   ingresses: Array<IKubeItem<IResource>>;
-  fetchIngresses: () => void;
+  ingressRefs: ResourceRef[];
+  getResource: (r: ResourceRef) => void;
 }
 
 class AccessURLTable extends React.Component<IAccessURLTableProps> {
-  public componentDidMount() {
+  public componentDidUpdate(prevProps: IAccessURLTableProps) {
     // Fetch all related Ingress resources. We don't need to fetch Services as
     // they are expected to be watched by the ServiceTable.
-    this.props.fetchIngresses();
+    if (prevProps.ingressRefs.length !== this.props.ingressRefs.length) {
+      this.props.ingressRefs.forEach(r => this.props.getResource(r));
+    }
   }
 
   public render() {

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.tsx
@@ -19,19 +19,13 @@ function mapStateToProps({ kube }: IStoreState, props: IAccessURLTableContainerP
   return {
     services: filterByResourceRefs(props.serviceRefs, kube.items),
     ingresses: filterByResourceRefs(props.ingressRefs, kube.items),
+    ingressRefs: props.ingressRefs,
   };
 }
 
-function mapDispatchToProps(
-  dispatch: ThunkDispatch<IStoreState, null, Action>,
-  props: IAccessURLTableContainerProps,
-) {
+function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    fetchIngresses: () => {
-      props.ingressRefs.forEach(r => {
-        dispatch(actions.kube.getResource(r));
-      });
-    },
+    getResource: (r: ResourceRef) => dispatch(actions.kube.getResource(r)),
   };
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

The component `AccessURLTable` is now being mounted *before* the references to the ingress objects are populated. This caused the AccessURLTable to be empty. To avoid that, we are now fetching also the ingresses when there are changes in the list.

Another subtle change is that instead of relying on the implementation of `fetchIngresses`, which was defined in the container, I have moved the implementation to the component so it's clear what it's doing.

**Applicable issues**

Fixes #1307
