### PR TITLE
Delete failed installations

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -260,9 +260,9 @@ func (p *Proxy) CreateRelease(name, namespace, values string, ch *chart.Chart) (
 	if err != nil {
 		errDelete := p.deleteRelease(name, namespace, true)
 		if errDelete != nil {
-			return nil, fmt.Errorf("Unable to create the release: %v and unable to uninstall it: %v", err, errDelete)
+			return nil, fmt.Errorf("Release %q failed: %v. Unable to purge failed release: %v", name, err, errDelete)
 		}
-		return nil, fmt.Errorf("Unable to create the release and has been uninstalled: %v", err)
+		return nil, fmt.Errorf("Release %q failed and has been uninstalled: %v", name, err)
 	}
 
 	log.Printf("%s successfully installed in %s", name, namespace)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -242,6 +242,13 @@ func unlock(name string) {
 func (p *Proxy) CreateRelease(name, namespace, values string, ch *chart.Chart) (*release.Release, error) {
 	lock(name)
 	defer unlock(name)
+
+	// Validate if the release already exists
+	_, err := p.helmClient.ReleaseContent(name)
+	if err == nil {
+		return nil, fmt.Errorf("Release %s already exists", name)
+	}
+
 	log.Printf("Installing release %s into namespace %s", name, namespace)
 	res, err := p.helmClient.InstallReleaseFromChart(
 		ch,
@@ -251,8 +258,13 @@ func (p *Proxy) CreateRelease(name, namespace, values string, ch *chart.Chart) (
 		helm.InstallTimeout(p.timeout),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to create the release: %v", err)
+		errDelete := p.deleteRelease(name, namespace, true)
+		if errDelete != nil {
+			return nil, fmt.Errorf("Unable to create the release: %v and unable to uninstall it: %v", err, errDelete)
+		}
+		return nil, fmt.Errorf("Unable to create the release and has been uninstalled: %v", err)
 	}
+
 	log.Printf("%s successfully installed in %s", name, namespace)
 	return res.GetRelease(), nil
 }
@@ -307,10 +319,7 @@ func (p *Proxy) GetRelease(name, namespace string) (*release.Release, error) {
 	return p.getRelease(name, namespace)
 }
 
-// DeleteRelease deletes a release
-func (p *Proxy) DeleteRelease(name, namespace string, purge bool) error {
-	lock(name)
-	defer unlock(name)
+func (p *Proxy) deleteRelease(name, namespace string, purge bool) error {
 	// Validate that the release actually belongs to the namespace
 	_, err := p.getRelease(name, namespace)
 	if err != nil {
@@ -325,6 +334,13 @@ func (p *Proxy) DeleteRelease(name, namespace string, purge bool) error {
 		return fmt.Errorf("Unable to delete the release: %v", err)
 	}
 	return nil
+}
+
+// DeleteRelease deletes a release
+func (p *Proxy) DeleteRelease(name, namespace string, purge bool) error {
+	lock(name)
+	defer unlock(name)
+	return p.deleteRelease(name, namespace, purge)
 }
 
 // extracted from https://github.com/helm/helm/blob/master/cmd/helm/helm.go#L227

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -364,7 +364,31 @@ func TestCreateConflictingHelmRelease(t *testing.T) {
 	if err == nil {
 		t.Error("Release should fail, an existing release in a different namespace already exists")
 	}
-	if !strings.Contains(err.Error(), "name that is still in use") {
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("Unexpected error %v", err)
+	}
+}
+
+func TestCreateExistingHelmRelease(t *testing.T) {
+	ns := "myns"
+	rs := "foo"
+	chartName := "bar"
+	version := "v1.0.0"
+	ch := &chart.Chart{
+		Metadata: &chart.Metadata{Name: chartName, Version: version},
+	}
+	app := AppOverview{rs, version, ns, "icon.png", "DEPLOYED", "wordpress", chart.Metadata{
+		Version: "1.0.0",
+		Icon:    "icon.png",
+		Name:    "wordpress",
+	}}
+	proxy := newFakeProxy([]AppOverview{app})
+
+	_, err := proxy.CreateRelease(rs, ns, "", ch)
+	if err == nil {
+		t.Error("Release should fail, an existing release in a different namespace already exists")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
 		t.Errorf("Unexpected error %v", err)
 	}
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

When creating a release, if it fails for some reason (like band inputs) clean up the release afterwards so the same name can be reused.

BTW, there is no an "atomic" flag that we can use in the CreateRelease action for helm, this is the code:

https://github.com/helm/helm/blob/456eb7f4118a635427bd43daa3d7aabf29304f13/pkg/action/install.go#L313

**Possible drawbacks**

If the release failed to be installed but it's not stored as a failed release (for example for an invalid name) we will be returning also an error for the missing release when trying to delete it, which might be confusing.

**Applicable issues**

  - fixes #1163

cc/ @SimonAlling since these changes affect to tiller-proxy
