### PR TITLE
Remove WithoutParams

### DIFF
--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -236,7 +236,7 @@ func (h *TillerProxy) UpgradeRelease(w http.ResponseWriter, req *http.Request, p
 }
 
 // ListAllReleases list all releases that Tiller stores
-func (h *TillerProxy) ListAllReleases(w http.ResponseWriter, req *http.Request) {
+func (h *TillerProxy) ListAllReleases(w http.ResponseWriter, req *http.Request, _ handlerutil.Params) {
 	apps, err := h.ProxyClient.ListReleases("", h.ListLimit, req.URL.Query().Get("statuses"))
 	if err != nil {
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)

--- a/cmd/tiller-proxy/internal/handler/handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/handler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	authFake "github.com/kubeapps/kubeapps/pkg/auth/fake"
 	chartFake "github.com/kubeapps/kubeapps/pkg/chart/fake"
+	"github.com/kubeapps/kubeapps/pkg/handlerutil"
 	proxyFake "github.com/kubeapps/kubeapps/pkg/proxy/fake"
 )
 
@@ -444,7 +445,7 @@ func TestActions(t *testing.T) {
 		case "list":
 			handler.ListReleases(response, req, test.Params)
 		case "listall":
-			handler.ListAllReleases(response, req)
+			handler.ListAllReleases(response, req, make(handlerutil.Params))
 		default:
 			t.Errorf("Unexpected action %s", test.Action)
 		}

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -157,7 +157,7 @@ func main() {
 	apiv1 := r.PathPrefix("/v1").Subrouter()
 	apiv1.Methods("GET").Path("/releases").Handler(negroni.New(
 		authGate,
-		negroni.Wrap(handlerutil.WithoutParams(h.ListAllReleases)),
+		negroni.Wrap(handlerutil.WithParams(h.ListAllReleases)),
 	))
 	apiv1.Methods("GET").Path("/namespaces/{namespace}/releases").Handler(negroni.New(
 		authGate,

--- a/pkg/handlerutil/handlerutil.go
+++ b/pkg/handlerutil/handlerutil.go
@@ -19,13 +19,6 @@ func (h WithParams) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h(w, req, vars)
 }
 
-// WithoutParams can be used to wrap handlers that doesn't take params
-type WithoutParams func(http.ResponseWriter, *http.Request)
-
-func (h WithoutParams) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	h(w, req)
-}
-
 func isNotFound(err error) bool {
 	return strings.Contains(err.Error(), "not found")
 }


### PR DESCRIPTION
It is a special case of `WithParams` only used for `ListAllReleases`.

(Removing the `WithParams` abstraction altogether seems to be a completely different story – much harder than implied by the types of `CreateRelease` et al., [`mux.Vars`](https://github.com/kubeapps/kubeapps/blob/d904fdfe22579ac753c2d9c7ac17629ea7e25e63/pkg/handlerutil/handlerutil.go#L18) and [`http.HandlerFunc`](https://golang.org/pkg/net/http/#HandlerFunc).)