### PR TITLE
Allow to configure the command for the sync image

### DIFF
--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -461,7 +461,7 @@ func syncJobSpec(apprepo *apprepov1alpha1.AppRepository) batchv1.JobSpec {
 	}
 	podTemplateSpec.Spec.Containers[0].Name = "sync"
 	podTemplateSpec.Spec.Containers[0].Image = repoSyncImage
-	podTemplateSpec.Spec.Containers[0].Command = []string{"/chart-repo"}
+	podTemplateSpec.Spec.Containers[0].Command = []string{repoSyncCommand}
 	podTemplateSpec.Spec.Containers[0].Args = apprepoSyncJobArgs(apprepo)
 	podTemplateSpec.Spec.Containers[0].Env = append(podTemplateSpec.Spec.Containers[0].Env, apprepoSyncJobEnvVars(apprepo)...)
 	podTemplateSpec.Spec.Containers[0].VolumeMounts = append(podTemplateSpec.Spec.Containers[0].VolumeMounts, volumeMounts...)
@@ -496,7 +496,7 @@ func cleanupJobSpec(repoName string) batchv1.JobSpec {
 					{
 						Name:    "delete",
 						Image:   repoSyncImage,
-						Command: []string{"/chart-repo"},
+						Command: []string{repoSyncCommand},
 						Args:    apprepoCleanupJobArgs(repoName),
 						Env: []corev1.EnvVar{
 							{

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -33,6 +33,7 @@ var (
 	masterURL        string
 	kubeconfig       string
 	repoSyncImage    string
+	repoSyncCommand  string
 	namespace        string
 	mongoURL         string
 	mongoSecretName  string
@@ -78,6 +79,7 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&repoSyncImage, "repo-sync-image", "quay.io/helmpack/chart-repo:latest", "container repo/image to use in CronJobs")
+	flag.StringVar(&repoSyncCommand, "repo-sync-cmd", "/chart-repo", "command used to sync/delete repos for repo-sync-image")
 	flag.StringVar(&namespace, "namespace", "kubeapps", "Namespace to discover AppRepository resources")
 	flag.StringVar(&mongoURL, "mongo-url", "localhost", "MongoDB URL (see https://godoc.org/labix.org/v2/mgo#Dial for format)")
 	flag.StringVar(&mongoSecretName, "mongo-secret-name", "mongodb", "Kubernetes secret name for MongoDB credentials")


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

Remove the hardcoded reference to the command executed in the chart-repo image. It's needed to replace `chart-repo` for something else.

**Benefits**

The image and the command can now change.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #651
