### PR TITLE
Move AuthGate to pkg/auth

### DIFF
--- a/cmd/tiller-proxy/internal/handler/handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/handler_test.go
@@ -424,7 +424,7 @@ func TestActions(t *testing.T) {
 			fauth := &authFake.FakeAuth{
 				ForbiddenActions: test.ForbiddenActions,
 			}
-			ctx := context.WithValue(req.Context(), userKey, fauth)
+			ctx := context.WithValue(req.Context(), auth.UserKey, fauth)
 			req = req.WithContext(ctx)
 		}
 		response := httptest.NewRecorder()

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/heptiolabs/healthcheck"
 	appRepo "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
 	"github.com/kubeapps/kubeapps/cmd/tiller-proxy/internal/handler"
+	"github.com/kubeapps/kubeapps/pkg/auth"
 	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
 	"github.com/kubeapps/kubeapps/pkg/handlerutil"
 	tillerProxy "github.com/kubeapps/kubeapps/pkg/proxy"
@@ -143,7 +144,7 @@ func main() {
 	r.Handle("/live", health)
 	r.Handle("/ready", health)
 
-	authGate := handler.AuthGate()
+	authGate := auth.AuthGate()
 
 	// HTTP Handler
 	h := handler.TillerProxy{

--- a/pkg/auth/authgate.go
+++ b/pkg/auth/authgate.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/kubeapps/common/response"
+	"github.com/urfave/negroni"
+)
+
+// Context key type for request contexts
+type contextKey int
+
+// UserKey is the context key for the User data in the request context
+const UserKey contextKey = 0
+
+// AuthGate implements middleware to check if the user is logged in before continuing
+func AuthGate() negroni.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+		authHeader := strings.Split(req.Header.Get("Authorization"), "Bearer ")
+		if len(authHeader) != 2 {
+			response.NewErrorResponse(http.StatusUnauthorized, "Unauthorized").Write(w)
+			return
+		}
+		userAuth, err := NewAuth(authHeader[1])
+		if err != nil {
+			response.NewErrorResponse(http.StatusInternalServerError, err.Error()).Write(w)
+			return
+		}
+		err = userAuth.Validate()
+		if err != nil {
+			response.NewErrorResponse(http.StatusUnauthorized, err.Error()).Write(w)
+			return
+		}
+		ctx := context.WithValue(req.Context(), UserKey, userAuth)
+		next(w, req.WithContext(ctx))
+	}
+}


### PR DESCRIPTION
Moving forward, it will be needed to implement Helm 3 support (see #1309), and it was in an internal package, so it couldn't be imported outside the `cmd/tiller-proxy` directory.