### PR TITLE
Add Delete method for the postgres driver in asset-syncer

### DIFF
--- a/cmd/asset-syncer/main.go
+++ b/cmd/asset-syncer/main.go
@@ -42,9 +42,14 @@ func init() {
 
 	for _, cmd := range cmds {
 		rootCmd.AddCommand(cmd)
+		cmd.Flags().String("database-type", "mongodb", "Database to use. Choice: mongodb, postgresql")
 		cmd.Flags().String("mongo-url", "localhost", "MongoDB URL (see https://godoc.org/github.com/globalsign/mgo#Dial for format)")
 		cmd.Flags().String("mongo-database", "charts", "MongoDB database")
 		cmd.Flags().String("mongo-user", "", "MongoDB user")
+		cmd.Flags().String("pg-host", "localhost", "PostgreSQL Hostname")
+		cmd.Flags().String("pg-port", "5432", "PostgreSQL Port")
+		cmd.Flags().String("pg-database", "assets", "PostgreSQL database")
+		cmd.Flags().String("pg-user", "", "PostgreSQL user")
 		// see version.go
 		cmd.Flags().StringVarP(&userAgentComment, "user-agent-comment", "", "", "UserAgent comment used during outbound requests")
 		cmd.Flags().Bool("debug", false, "verbose logging")

--- a/cmd/asset-syncer/mongodb_utils.go
+++ b/cmd/asset-syncer/mongodb_utils.go
@@ -1,0 +1,356 @@
+/*
+Copyright (c) 2018 The Helm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/disintegration/imaging"
+	"github.com/globalsign/mgo/bson"
+	"github.com/kubeapps/common/datastore"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	chartCollection      = "charts"
+	repositoryCollection = "repos"
+	chartFilesCollection = "files"
+)
+
+type mongodbAssetManager struct {
+	DBSession datastore.Session
+}
+
+// Syncing is performed in the following steps:
+// 1. Update database to match chart metadata from index
+// 2. Concurrently process icons for charts (concurrently)
+// 3. Concurrently process the README and values.yaml for the latest chart version of each chart
+// 4. Concurrently process READMEs and values.yaml for historic chart versions
+//
+// These steps are processed in this way to ensure relevant chart data is
+// imported into the database as fast as possible. E.g. we want all icons for
+// charts before fetching readmes for each chart and version pair.
+func (m *mongodbAssetManager) Sync(repoName, repoURL string, authorizationHeader string) error {
+	url, err := parseRepoURL(repoURL)
+	if err != nil {
+		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
+		return err
+	}
+
+	r := repo{Name: repoName, URL: url.String(), AuthorizationHeader: authorizationHeader}
+	repoBytes, err := fetchRepoIndex(r)
+	if err != nil {
+		return err
+	}
+
+	repoChecksum, err := getSha256(repoBytes)
+	if err != nil {
+		return err
+	}
+
+	// Check if the repo has been already processed
+	if repoAlreadyProcessed(m.DBSession, repoName, repoChecksum) {
+		log.WithFields(log.Fields{"url": repoURL}).Info("Skipping repository since there are no updates")
+		return nil
+	}
+
+	index, err := parseRepoIndex(repoBytes)
+	if err != nil {
+		return err
+	}
+
+	charts := chartsFromIndex(index, r)
+	if len(charts) == 0 {
+		return errors.New("no charts in repository index")
+	}
+	err = importCharts(m.DBSession, charts)
+	if err != nil {
+		return err
+	}
+
+	// Process 10 charts at a time
+	numWorkers := 10
+	iconJobs := make(chan chart, numWorkers)
+	chartFilesJobs := make(chan importChartFilesJob, numWorkers)
+	var wg sync.WaitGroup
+
+	log.Debugf("starting %d workers", numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go importWorker(m.DBSession, &wg, iconJobs, chartFilesJobs)
+	}
+
+	// Enqueue jobs to process chart icons
+	for _, c := range charts {
+		iconJobs <- c
+	}
+	// Close the iconJobs channel to signal the worker pools to move on to the
+	// chart files jobs
+	close(iconJobs)
+
+	// Iterate through the list of charts and enqueue the latest chart version to
+	// be processed. Append the rest of the chart versions to a list to be
+	// enqueued later
+	var toEnqueue []importChartFilesJob
+	for _, c := range charts {
+		chartFilesJobs <- importChartFilesJob{c.Name, c.Repo, c.ChartVersions[0]}
+		for _, cv := range c.ChartVersions[1:] {
+			toEnqueue = append(toEnqueue, importChartFilesJob{c.Name, c.Repo, cv})
+		}
+	}
+
+	// Enqueue all the remaining chart versions
+	for _, cfj := range toEnqueue {
+		chartFilesJobs <- cfj
+	}
+	// Close the chartFilesJobs channel to signal the worker pools that there are
+	// no more jobs to process
+	close(chartFilesJobs)
+
+	// Wait for the worker pools to finish processing
+	wg.Wait()
+
+	// Update cache in the database
+	if err = updateLastCheck(m.DBSession, repoName, repoChecksum, time.Now()); err != nil {
+		return err
+	}
+	log.WithFields(log.Fields{"url": repoURL}).Info("Stored repository update in cache")
+
+	return nil
+}
+
+func repoAlreadyProcessed(dbSession datastore.Session, repoName string, checksum string) bool {
+	db, closer := dbSession.DB()
+	defer closer()
+	lastCheck := &repoCheck{}
+	err := db.C(repositoryCollection).Find(bson.M{"_id": repoName}).One(lastCheck)
+	return err == nil && checksum == lastCheck.Checksum
+}
+
+func updateLastCheck(dbSession datastore.Session, repoName string, checksum string, now time.Time) error {
+	db, closer := dbSession.DB()
+	defer closer()
+	_, err := db.C(repositoryCollection).UpsertId(repoName, bson.M{"$set": bson.M{"last_update": now, "checksum": checksum}})
+	return err
+}
+
+func (m *mongodbAssetManager) Delete(repoName string) error {
+	db, closer := m.DBSession.DB()
+	defer closer()
+	_, err := db.C(chartCollection).RemoveAll(bson.M{
+		"repo.name": repoName,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = db.C(chartFilesCollection).RemoveAll(bson.M{
+		"repo.name": repoName,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = db.C(repositoryCollection).RemoveAll(bson.M{
+		"_id": repoName,
+	})
+	return err
+}
+
+func importCharts(dbSession datastore.Session, charts []chart) error {
+	var pairs []interface{}
+	var chartIDs []string
+	for _, c := range charts {
+		chartIDs = append(chartIDs, c.ID)
+		// charts to upsert - pair of selector, chart
+		pairs = append(pairs, bson.M{"_id": c.ID}, c)
+	}
+
+	db, closer := dbSession.DB()
+	defer closer()
+	bulk := db.C(chartCollection).Bulk()
+
+	// Upsert pairs of selectors, charts
+	bulk.Upsert(pairs...)
+
+	// Remove charts no longer existing in index
+	bulk.RemoveAll(bson.M{
+		"_id": bson.M{
+			"$nin": chartIDs,
+		},
+		"repo.name": charts[0].Repo.Name,
+	})
+
+	_, err := bulk.Run()
+	return err
+}
+
+func importWorker(dbSession datastore.Session, wg *sync.WaitGroup, icons <-chan chart, chartFiles <-chan importChartFilesJob) {
+	defer wg.Done()
+	for c := range icons {
+		log.WithFields(log.Fields{"name": c.Name}).Debug("importing icon")
+		if err := fetchAndImportIcon(dbSession, c); err != nil {
+			log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to import icon")
+		}
+	}
+	for j := range chartFiles {
+		log.WithFields(log.Fields{"name": j.Name, "version": j.ChartVersion.Version}).Debug("importing readme and values")
+		if err := fetchAndImportFiles(dbSession, j.Name, j.Repo, j.ChartVersion); err != nil {
+			log.WithFields(log.Fields{"name": j.Name, "version": j.ChartVersion.Version}).WithError(err).Error("failed to import files")
+		}
+	}
+}
+
+func fetchAndImportIcon(dbSession datastore.Session, c chart) error {
+	if c.Icon == "" {
+		log.WithFields(log.Fields{"name": c.Name}).Info("icon not found")
+		return nil
+	}
+
+	req, err := http.NewRequest("GET", c.Icon, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", userAgent())
+	if len(c.Repo.AuthorizationHeader) > 0 {
+		req.Header.Set("Authorization", c.Repo.AuthorizationHeader)
+	}
+
+	res, err := netClient.Do(req)
+	if res != nil {
+		defer res.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("%d %s", res.StatusCode, c.Icon)
+	}
+
+	b := []byte{}
+	contentType := ""
+	if strings.Contains(res.Header.Get("Content-Type"), "image/svg") {
+		// if the icon is a SVG file simply read it
+		b, err = ioutil.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+		contentType = res.Header.Get("Content-Type")
+	} else {
+		// if the icon is in any other format try to convert it to PNG
+		orig, err := imaging.Decode(res.Body)
+		if err != nil {
+			log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to decode icon")
+			return err
+		}
+
+		// TODO: make this configurable?
+		icon := imaging.Fit(orig, 160, 160, imaging.Lanczos)
+
+		var buf bytes.Buffer
+		imaging.Encode(&buf, icon, imaging.PNG)
+		b = buf.Bytes()
+		contentType = "image/png"
+	}
+
+	db, closer := dbSession.DB()
+	defer closer()
+	return db.C(chartCollection).UpdateId(c.ID, bson.M{"$set": bson.M{"raw_icon": b, "icon_content_type": contentType}})
+}
+
+func fetchAndImportFiles(dbSession datastore.Session, name string, r repo, cv chartVersion) error {
+	chartFilesID := fmt.Sprintf("%s/%s-%s", r.Name, name, cv.Version)
+	db, closer := dbSession.DB()
+	defer closer()
+
+	// Check if we already have indexed files for this chart version and digest
+	if err := db.C(chartFilesCollection).Find(bson.M{"_id": chartFilesID, "digest": cv.Digest}).One(&chartFiles{}); err == nil {
+		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Debug("skipping existing files")
+		return nil
+	}
+	log.WithFields(log.Fields{"name": name, "version": cv.Version}).Debug("fetching files")
+
+	url := chartTarballURL(r, cv)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", userAgent())
+	if len(r.AuthorizationHeader) > 0 {
+		req.Header.Set("Authorization", r.AuthorizationHeader)
+	}
+
+	res, err := netClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	// We read the whole chart into memory, this should be okay since the chart
+	// tarball needs to be small enough to fit into a GRPC call (Tiller
+	// requirement)
+	gzf, err := gzip.NewReader(res.Body)
+	if err != nil {
+		return err
+	}
+	defer gzf.Close()
+
+	tarf := tar.NewReader(gzf)
+
+	readmeFileName := name + "/README.md"
+	valuesFileName := name + "/values.yaml"
+	schemaFileName := name + "/values.schema.json"
+	filenames := []string{valuesFileName, readmeFileName, schemaFileName}
+
+	files, err := extractFilesFromTarball(filenames, tarf)
+	if err != nil {
+		return err
+	}
+
+	chartFiles := chartFiles{ID: chartFilesID, Repo: r, Digest: cv.Digest}
+	if v, ok := files[readmeFileName]; ok {
+		chartFiles.Readme = v
+	} else {
+		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("README.md not found")
+	}
+	if v, ok := files[valuesFileName]; ok {
+		chartFiles.Values = v
+	} else {
+		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.yaml not found")
+	}
+	if v, ok := files[schemaFileName]; ok {
+		chartFiles.Schema = v
+	} else {
+		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.schema.json not found")
+	}
+
+	// inserts the chart files if not already indexed, or updates the existing
+	// entry if digest has changed
+	db.C(chartFilesCollection).UpsertId(chartFilesID, chartFiles)
+
+	return nil
+}

--- a/cmd/asset-syncer/mongodb_utils_test.go
+++ b/cmd/asset-syncer/mongodb_utils_test.go
@@ -1,0 +1,255 @@
+/*
+Copyright (c) 2018 The Helm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"image"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/arschles/assert"
+	"github.com/globalsign/mgo/bson"
+	"github.com/kubeapps/common/datastore/mockstore"
+	"github.com/stretchr/testify/mock"
+)
+
+func Test_syncURLInvalidity(t *testing.T) {
+	tests := []struct {
+		name    string
+		repoURL string
+	}{
+		{"invalid URL", "not-a-url"},
+		{"invalid URL", "https//google.com"},
+	}
+	m := mock.Mock{}
+	dbSession := mockstore.NewMockSession(&m)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mongoManager := mongodbAssetManager{dbSession}
+			err := mongoManager.Sync("test", tt.repoURL, "")
+			assert.ExistsErr(t, err, tt.name)
+		})
+	}
+}
+
+func Test_importCharts(t *testing.T) {
+	m := &mock.Mock{}
+	// Ensure Upsert func is called with some arguments
+	m.On("Upsert", mock.Anything)
+	m.On("RemoveAll", mock.Anything)
+	dbSession := mockstore.NewMockSession(m)
+	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
+	charts := chartsFromIndex(index, repo{Name: "test", URL: "http://testrepo.com"})
+	importCharts(dbSession, charts)
+
+	m.AssertExpectations(t)
+	// The Bulk Upsert method takes an array that consists of a selector followed by an interface to upsert.
+	// So for x charts to upsert, there should be x*2 elements (each chart has it's own selector)
+	// e.g. [selector1, chart1, selector2, chart2, ...]
+	args := m.Calls[0].Arguments.Get(0).([]interface{})
+	assert.Equal(t, len(args), len(charts)*2, "number of selector, chart pairs to upsert")
+	for i := 0; i < len(args); i += 2 {
+		c := args[i+1].(chart)
+		assert.Equal(t, args[i], bson.M{"_id": "test/" + c.Name}, "selector")
+	}
+}
+
+func Test_DeleteRepo(t *testing.T) {
+	m := &mock.Mock{}
+	m.On("RemoveAll", bson.M{
+		"repo.name": "test",
+	})
+	m.On("RemoveAll", bson.M{
+		"_id": "test",
+	})
+	dbSession := mockstore.NewMockSession(m)
+
+	mongoManager := mongodbAssetManager{dbSession}
+	err := mongoManager.Delete("test")
+	if err != nil {
+		t.Errorf("failed to delete chart repo test: %v", err)
+	}
+	m.AssertExpectations(t)
+}
+
+func Test_fetchAndImportIcon(t *testing.T) {
+	t.Run("no icon", func(t *testing.T) {
+		m := mock.Mock{}
+		dbSession := mockstore.NewMockSession(&m)
+		c := chart{ID: "test/acs-engine-autoscaler"}
+		assert.NoErr(t, fetchAndImportIcon(dbSession, c))
+	})
+
+	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
+	charts := chartsFromIndex(index, repo{Name: "test", URL: "http://testrepo.com"})
+
+	t.Run("failed download", func(t *testing.T) {
+		netClient = &badHTTPClient{}
+		c := charts[0]
+		m := mock.Mock{}
+		dbSession := mockstore.NewMockSession(&m)
+		assert.Err(t, fmt.Errorf("500 %s", c.Icon), fetchAndImportIcon(dbSession, c))
+	})
+
+	t.Run("bad icon", func(t *testing.T) {
+		netClient = &badIconClient{}
+		c := charts[0]
+		m := mock.Mock{}
+		dbSession := mockstore.NewMockSession(&m)
+		assert.Err(t, image.ErrFormat, fetchAndImportIcon(dbSession, c))
+	})
+
+	t.Run("valid icon", func(t *testing.T) {
+		netClient = &goodIconClient{}
+		c := charts[0]
+		m := mock.Mock{}
+		dbSession := mockstore.NewMockSession(&m)
+		m.On("UpdateId", c.ID, bson.M{"$set": bson.M{"raw_icon": iconBytes(), "icon_content_type": "image/png"}}).Return(nil)
+		assert.NoErr(t, fetchAndImportIcon(dbSession, c))
+		m.AssertExpectations(t)
+	})
+
+	t.Run("valid SVG icon", func(t *testing.T) {
+		netClient = &svgIconClient{}
+		c := chart{
+			ID:   "foo",
+			Icon: "https://foo/bar/logo.svg",
+			Repo: repo{},
+		}
+		m := mock.Mock{}
+		dbSession := mockstore.NewMockSession(&m)
+		m.On("UpdateId", c.ID, bson.M{"$set": bson.M{"raw_icon": []byte("foo"), "icon_content_type": "image/svg"}}).Return(nil)
+		assert.NoErr(t, fetchAndImportIcon(dbSession, c))
+		m.AssertExpectations(t)
+	})
+}
+
+func Test_fetchAndImportFiles(t *testing.T) {
+	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
+	charts := chartsFromIndex(index, repo{Name: "test", URL: "http://testrepo.com", AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient1s"})
+	cv := charts[0].ChartVersions[0]
+
+	t.Run("http error", func(t *testing.T) {
+		m := mock.Mock{}
+		m.On("One", mock.Anything).Return(errors.New("return an error when checking if readme already exists to force fetching"))
+		dbSession := mockstore.NewMockSession(&m)
+		netClient = &badHTTPClient{}
+		assert.Err(t, io.EOF, fetchAndImportFiles(dbSession, charts[0].Name, charts[0].Repo, cv))
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		netClient = &goodTarballClient{c: charts[0], skipValues: true, skipReadme: true, skipSchema: true}
+		m := mock.Mock{}
+		m.On("One", mock.Anything).Return(errors.New("return an error when checking if files already exists to force fetching"))
+		chartFilesID := fmt.Sprintf("%s/%s-%s", charts[0].Repo.Name, charts[0].Name, cv.Version)
+		m.On("UpsertId", chartFilesID, chartFiles{chartFilesID, "", "", "", charts[0].Repo, cv.Digest})
+		dbSession := mockstore.NewMockSession(&m)
+		err := fetchAndImportFiles(dbSession, charts[0].Name, charts[0].Repo, cv)
+		assert.NoErr(t, err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("authenticated request", func(t *testing.T) {
+		netClient = &authenticatedTarballClient{c: charts[0]}
+		m := mock.Mock{}
+		m.On("One", mock.Anything).Return(errors.New("return an error when checking if files already exists to force fetching"))
+		chartFilesID := fmt.Sprintf("%s/%s-%s", charts[0].Repo.Name, charts[0].Name, cv.Version)
+		m.On("UpsertId", chartFilesID, chartFiles{chartFilesID, testChartReadme, testChartValues, testChartSchema, charts[0].Repo, cv.Digest})
+		dbSession := mockstore.NewMockSession(&m)
+		err := fetchAndImportFiles(dbSession, charts[0].Name, charts[0].Repo, cv)
+		assert.NoErr(t, err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("valid tarball", func(t *testing.T) {
+		netClient = &goodTarballClient{c: charts[0]}
+		m := mock.Mock{}
+		m.On("One", mock.Anything).Return(errors.New("return an error when checking if files already exists to force fetching"))
+		chartFilesID := fmt.Sprintf("%s/%s-%s", charts[0].Repo.Name, charts[0].Name, cv.Version)
+		m.On("UpsertId", chartFilesID, chartFiles{chartFilesID, testChartReadme, testChartValues, testChartSchema, charts[0].Repo, cv.Digest})
+		dbSession := mockstore.NewMockSession(&m)
+		err := fetchAndImportFiles(dbSession, charts[0].Name, charts[0].Repo, cv)
+		assert.NoErr(t, err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("file exists", func(t *testing.T) {
+		m := mock.Mock{}
+		// don't return an error when checking if files already exists
+		m.On("One", mock.Anything).Return(nil)
+		dbSession := mockstore.NewMockSession(&m)
+		err := fetchAndImportFiles(dbSession, charts[0].Name, charts[0].Repo, cv)
+		assert.NoErr(t, err)
+		m.AssertNotCalled(t, "UpsertId", mock.Anything, mock.Anything)
+	})
+}
+
+func Test_emptyChartRepo(t *testing.T) {
+	netClient = &emptyChartRepoHTTPClient{}
+	m := mock.Mock{}
+	m.On("One", &repoCheck{}).Return(nil)
+	dbSession := mockstore.NewMockSession(&m)
+	mongoManager := mongodbAssetManager{dbSession}
+	err := mongoManager.Sync("testRepo", "https://my.examplerepo.com", "")
+	assert.ExistsErr(t, err, "Failed Request")
+}
+
+func Test_repoAlreadyProcessed(t *testing.T) {
+	tests := []struct {
+		name            string
+		checksum        string
+		mockedLastCheck repoCheck
+		processed       bool
+	}{
+		{"not processed yet", "bar", repoCheck{}, false},
+		{"already processed", "bar", repoCheck{Checksum: "bar"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := mock.Mock{}
+			repo := &repoCheck{}
+			m.On("One", repo).Run(func(args mock.Arguments) {
+				*args.Get(0).(*repoCheck) = tt.mockedLastCheck
+			}).Return(nil)
+			dbSession := mockstore.NewMockSession(&m)
+			res := repoAlreadyProcessed(dbSession, "", tt.checksum)
+			if res != tt.processed {
+				t.Errorf("Expected alreadyProcessed to be %v got %v", tt.processed, res)
+			}
+		})
+	}
+}
+
+func Test_updateLastCheck(t *testing.T) {
+	m := mock.Mock{}
+	repoName := "foo"
+	checksum := "bar"
+	now := time.Now()
+	m.On("UpsertId", repoName, bson.M{"$set": bson.M{"last_update": now, "checksum": checksum}}).Return(nil)
+	dbSession := mockstore.NewMockSession(&m)
+	err := updateLastCheck(dbSession, repoName, checksum, now)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if len(m.Calls) != 1 {
+		t.Errorf("Expected one call got %d", len(m.Calls))
+	}
+}

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2018 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/lib/pq"
+)
+
+const (
+	chartTable      = "charts"
+	repositoryTable = "repos"
+	chartFilesTable = "files"
+)
+
+type postgresDB interface {
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+}
+
+type postgresAssetManager struct {
+	db postgresDB
+}
+
+// Syncing is performed in the following steps:
+// 1. Update database to match chart metadata from index
+// 2. Concurrently process icons for charts (concurrently)
+// 3. Concurrently process the README and values.yaml for the latest chart version of each chart
+// 4. Concurrently process READMEs and values.yaml for historic chart versions
+//
+// These steps are processed in this way to ensure relevant chart data is
+// imported into the database as fast as possible. E.g. we want all icons for
+// charts before fetching readmes for each chart and version pair.
+func (m *postgresAssetManager) Sync(repoName, repoURL string, authorizationHeader string) error {
+	// TODO(andresmgot): Implement this :)
+	return nil
+}
+
+func (m *postgresAssetManager) Delete(repoName string) error {
+	tables := []string{chartTable, repositoryTable, chartFilesTable}
+	for _, table := range tables {
+		_, err := m.db.Query(fmt.Sprintf("DELETE FROM %s WHERE info -> 'repo' ->> 'name' = '%s'", table, repoName))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/asset-syncer/postgresql_utils_test.go
+++ b/cmd/asset-syncer/postgresql_utils_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type mockDB struct {
+	*mock.Mock
+}
+
+func (d *mockDB) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	d.Called(query, args)
+	return nil, nil
+}
+
+func Test_DeletePGRepo(t *testing.T) {
+	repoName := "test"
+	m := &mockDB{&mock.Mock{}}
+	tables := []string{chartTable, repositoryTable, chartFilesTable}
+	for _, table := range tables {
+		q := fmt.Sprintf("DELETE FROM %s WHERE info -> 'repo' ->> 'name' = '%s'", table, repoName)
+		// Since we are not specifying any argument, Query is called with []interface{}(nil)
+		m.On("Query", q, []interface{}(nil))
+	}
+
+	pgManager := &postgresAssetManager{m}
+	err := pgManager.Delete(repoName)
+	if err != nil {
+		t.Errorf("failed to delete chart repo test: %v", err)
+	}
+	m.AssertExpectations(t)
+}

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -19,7 +19,6 @@ package main
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -32,22 +31,15 @@ import (
 	"os"
 	"path"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/disintegration/imaging"
 	"github.com/ghodss/yaml"
-	"github.com/globalsign/mgo/bson"
 	"github.com/jinzhu/copier"
-	"github.com/kubeapps/common/datastore"
 	log "github.com/sirupsen/logrus"
 	helmrepo "k8s.io/helm/pkg/repo"
 )
 
 const (
-	chartCollection       = "charts"
-	repositoryCollection  = "repos"
-	chartFilesCollection  = "files"
 	defaultTimeoutSeconds = 10
 	additionalCAFile      = "/usr/local/share/ca-certificates/ca.crt"
 )
@@ -82,108 +74,6 @@ type assetManager interface {
 	Sync(repo, url, authorizationHeader string) error
 }
 
-type mongodbAssetManager struct {
-	DBSession datastore.Session
-}
-
-// Syncing is performed in the following steps:
-// 1. Update database to match chart metadata from index
-// 2. Concurrently process icons for charts (concurrently)
-// 3. Concurrently process the README and values.yaml for the latest chart version of each chart
-// 4. Concurrently process READMEs and values.yaml for historic chart versions
-//
-// These steps are processed in this way to ensure relevant chart data is
-// imported into the database as fast as possible. E.g. we want all icons for
-// charts before fetching readmes for each chart and version pair.
-func (m *mongodbAssetManager) Sync(repoName, repoURL string, authorizationHeader string) error {
-	url, err := parseRepoURL(repoURL)
-	if err != nil {
-		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
-		return err
-	}
-
-	r := repo{Name: repoName, URL: url.String(), AuthorizationHeader: authorizationHeader}
-	repoBytes, err := fetchRepoIndex(r)
-	if err != nil {
-		return err
-	}
-
-	repoChecksum, err := getSha256(repoBytes)
-	if err != nil {
-		return err
-	}
-
-	// Check if the repo has been already processed
-	if repoAlreadyProcessed(m.DBSession, repoName, repoChecksum) {
-		log.WithFields(log.Fields{"url": repoURL}).Info("Skipping repository since there are no updates")
-		return nil
-	}
-
-	index, err := parseRepoIndex(repoBytes)
-	if err != nil {
-		return err
-	}
-
-	charts := chartsFromIndex(index, r)
-	if len(charts) == 0 {
-		return errors.New("no charts in repository index")
-	}
-	err = importCharts(m.DBSession, charts)
-	if err != nil {
-		return err
-	}
-
-	// Process 10 charts at a time
-	numWorkers := 10
-	iconJobs := make(chan chart, numWorkers)
-	chartFilesJobs := make(chan importChartFilesJob, numWorkers)
-	var wg sync.WaitGroup
-
-	log.Debugf("starting %d workers", numWorkers)
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
-		go importWorker(m.DBSession, &wg, iconJobs, chartFilesJobs)
-	}
-
-	// Enqueue jobs to process chart icons
-	for _, c := range charts {
-		iconJobs <- c
-	}
-	// Close the iconJobs channel to signal the worker pools to move on to the
-	// chart files jobs
-	close(iconJobs)
-
-	// Iterate through the list of charts and enqueue the latest chart version to
-	// be processed. Append the rest of the chart versions to a list to be
-	// enqueued later
-	var toEnqueue []importChartFilesJob
-	for _, c := range charts {
-		chartFilesJobs <- importChartFilesJob{c.Name, c.Repo, c.ChartVersions[0]}
-		for _, cv := range c.ChartVersions[1:] {
-			toEnqueue = append(toEnqueue, importChartFilesJob{c.Name, c.Repo, cv})
-		}
-	}
-
-	// Enqueue all the remaining chart versions
-	for _, cfj := range toEnqueue {
-		chartFilesJobs <- cfj
-	}
-	// Close the chartFilesJobs channel to signal the worker pools that there are
-	// no more jobs to process
-	close(chartFilesJobs)
-
-	// Wait for the worker pools to finish processing
-	wg.Wait()
-
-	// Update cache in the database
-	if err = updateLastCheck(m.DBSession, repoName, repoChecksum, time.Now()); err != nil {
-		return err
-	}
-	log.WithFields(log.Fields{"url": repoURL}).Info("Stored repository update in cache")
-
-	return nil
-}
-
 func getSha256(src []byte) (string, error) {
 	f := bytes.NewReader(src)
 	h := sha256.New()
@@ -191,44 +81,6 @@ func getSha256(src []byte) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
-}
-
-func repoAlreadyProcessed(dbSession datastore.Session, repoName string, checksum string) bool {
-	db, closer := dbSession.DB()
-	defer closer()
-	lastCheck := &repoCheck{}
-	err := db.C(repositoryCollection).Find(bson.M{"_id": repoName}).One(lastCheck)
-	return err == nil && checksum == lastCheck.Checksum
-}
-
-func updateLastCheck(dbSession datastore.Session, repoName string, checksum string, now time.Time) error {
-	db, closer := dbSession.DB()
-	defer closer()
-	_, err := db.C(repositoryCollection).UpsertId(repoName, bson.M{"$set": bson.M{"last_update": now, "checksum": checksum}})
-	return err
-}
-
-func (m *mongodbAssetManager) Delete(repoName string) error {
-	db, closer := m.DBSession.DB()
-	defer closer()
-	_, err := db.C(chartCollection).RemoveAll(bson.M{
-		"repo.name": repoName,
-	})
-	if err != nil {
-		return err
-	}
-
-	_, err = db.C(chartFilesCollection).RemoveAll(bson.M{
-		"repo.name": repoName,
-	})
-	if err != nil {
-		return err
-	}
-
-	_, err = db.C(repositoryCollection).RemoveAll(bson.M{
-		"_id": repoName,
-	})
-	return err
 }
 
 func fetchRepoIndex(r repo) ([]byte, error) {
@@ -301,181 +153,6 @@ func newChart(entry helmrepo.ChartVersions, r repo) chart {
 	c.Repo = r
 	c.ID = fmt.Sprintf("%s/%s", r.Name, c.Name)
 	return c
-}
-
-func importCharts(dbSession datastore.Session, charts []chart) error {
-	var pairs []interface{}
-	var chartIDs []string
-	for _, c := range charts {
-		chartIDs = append(chartIDs, c.ID)
-		// charts to upsert - pair of selector, chart
-		pairs = append(pairs, bson.M{"_id": c.ID}, c)
-	}
-
-	db, closer := dbSession.DB()
-	defer closer()
-	bulk := db.C(chartCollection).Bulk()
-
-	// Upsert pairs of selectors, charts
-	bulk.Upsert(pairs...)
-
-	// Remove charts no longer existing in index
-	bulk.RemoveAll(bson.M{
-		"_id": bson.M{
-			"$nin": chartIDs,
-		},
-		"repo.name": charts[0].Repo.Name,
-	})
-
-	_, err := bulk.Run()
-	return err
-}
-
-func importWorker(dbSession datastore.Session, wg *sync.WaitGroup, icons <-chan chart, chartFiles <-chan importChartFilesJob) {
-	defer wg.Done()
-	for c := range icons {
-		log.WithFields(log.Fields{"name": c.Name}).Debug("importing icon")
-		if err := fetchAndImportIcon(dbSession, c); err != nil {
-			log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to import icon")
-		}
-	}
-	for j := range chartFiles {
-		log.WithFields(log.Fields{"name": j.Name, "version": j.ChartVersion.Version}).Debug("importing readme and values")
-		if err := fetchAndImportFiles(dbSession, j.Name, j.Repo, j.ChartVersion); err != nil {
-			log.WithFields(log.Fields{"name": j.Name, "version": j.ChartVersion.Version}).WithError(err).Error("failed to import files")
-		}
-	}
-}
-
-func fetchAndImportIcon(dbSession datastore.Session, c chart) error {
-	if c.Icon == "" {
-		log.WithFields(log.Fields{"name": c.Name}).Info("icon not found")
-		return nil
-	}
-
-	req, err := http.NewRequest("GET", c.Icon, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("User-Agent", userAgent())
-	if len(c.Repo.AuthorizationHeader) > 0 {
-		req.Header.Set("Authorization", c.Repo.AuthorizationHeader)
-	}
-
-	res, err := netClient.Do(req)
-	if res != nil {
-		defer res.Body.Close()
-	}
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("%d %s", res.StatusCode, c.Icon)
-	}
-
-	b := []byte{}
-	contentType := ""
-	if strings.Contains(res.Header.Get("Content-Type"), "image/svg") {
-		// if the icon is a SVG file simply read it
-		b, err = ioutil.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-		contentType = res.Header.Get("Content-Type")
-	} else {
-		// if the icon is in any other format try to convert it to PNG
-		orig, err := imaging.Decode(res.Body)
-		if err != nil {
-			log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to decode icon")
-			return err
-		}
-
-		// TODO: make this configurable?
-		icon := imaging.Fit(orig, 160, 160, imaging.Lanczos)
-
-		var buf bytes.Buffer
-		imaging.Encode(&buf, icon, imaging.PNG)
-		b = buf.Bytes()
-		contentType = "image/png"
-	}
-
-	db, closer := dbSession.DB()
-	defer closer()
-	return db.C(chartCollection).UpdateId(c.ID, bson.M{"$set": bson.M{"raw_icon": b, "icon_content_type": contentType}})
-}
-
-func fetchAndImportFiles(dbSession datastore.Session, name string, r repo, cv chartVersion) error {
-	chartFilesID := fmt.Sprintf("%s/%s-%s", r.Name, name, cv.Version)
-	db, closer := dbSession.DB()
-	defer closer()
-
-	// Check if we already have indexed files for this chart version and digest
-	if err := db.C(chartFilesCollection).Find(bson.M{"_id": chartFilesID, "digest": cv.Digest}).One(&chartFiles{}); err == nil {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Debug("skipping existing files")
-		return nil
-	}
-	log.WithFields(log.Fields{"name": name, "version": cv.Version}).Debug("fetching files")
-
-	url := chartTarballURL(r, cv)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("User-Agent", userAgent())
-	if len(r.AuthorizationHeader) > 0 {
-		req.Header.Set("Authorization", r.AuthorizationHeader)
-	}
-
-	res, err := netClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	// We read the whole chart into memory, this should be okay since the chart
-	// tarball needs to be small enough to fit into a GRPC call (Tiller
-	// requirement)
-	gzf, err := gzip.NewReader(res.Body)
-	if err != nil {
-		return err
-	}
-	defer gzf.Close()
-
-	tarf := tar.NewReader(gzf)
-
-	readmeFileName := name + "/README.md"
-	valuesFileName := name + "/values.yaml"
-	schemaFileName := name + "/values.schema.json"
-	filenames := []string{valuesFileName, readmeFileName, schemaFileName}
-
-	files, err := extractFilesFromTarball(filenames, tarf)
-	if err != nil {
-		return err
-	}
-
-	chartFiles := chartFiles{ID: chartFilesID, Repo: r, Digest: cv.Digest}
-	if v, ok := files[readmeFileName]; ok {
-		chartFiles.Readme = v
-	} else {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("README.md not found")
-	}
-	if v, ok := files[valuesFileName]; ok {
-		chartFiles.Values = v
-	} else {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.yaml not found")
-	}
-	if v, ok := files[schemaFileName]; ok {
-		chartFiles.Schema = v
-	} else {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.schema.json not found")
-	}
-
-	// inserts the chart files if not already indexed, or updates the existing
-	// entry if digest has changed
-	db.C(chartFilesCollection).UpsertId(chartFilesID, chartFiles)
-
-	return nil
 }
 
 func extractFilesFromTarball(filenames []string, tarf *tar.Reader) (map[string]string, error) {

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/kubeapps/common v0.0.0-20190307100129-fcd6537ca4e3
+	github.com/lib/pq v1.2.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/kubeapps/common v0.0.0-20180208112310-707d33bc9333 h1:RRLxBMt+t732hFT
 github.com/kubeapps/common v0.0.0-20180208112310-707d33bc9333/go.mod h1:TsgmjeDpbftqhwPKInJ3v+l+xbHs4goiB6DFb2WqY9c=
 github.com/kubeapps/common v0.0.0-20190307100129-fcd6537ca4e3 h1:KgYtsAFQPknkG9eZoQ5VsH7kPQV9nUvYaWnIO0SSyOE=
 github.com/kubeapps/common v0.0.0-20190307100129-fcd6537ca4e3/go.mod h1:TsgmjeDpbftqhwPKInJ3v+l+xbHs4goiB6DFb2WqY9c=
+github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

This PR adds the method `Delete` (which is simpler) for the postgres driver in the asset-syncer. To achieve that I have split the `utils.go` (and `utils_test.go`) in two different files, depending if the method required a database connection so we have now `mongodb_utils.go` and `postgresql_utils.go`. Each one of those with their tests.

It's only necessary to review the files `delete.go`, `main.go`, `postgresql_utlils.go` and `postgresql_utils_test.go`. The rest is just moving methods around.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #651 
