### PR TITLE
Cache dependencies between tiller-proxy builds

### DIFF
--- a/cmd/tiller-proxy/Dockerfile
+++ b/cmd/tiller-proxy/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.13 as builder
-COPY . /go/src/github.com/kubeapps/kubeapps
 WORKDIR /go/src/github.com/kubeapps/kubeapps
-
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
 ARG VERSION
 RUN CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-X main.version=$VERSION" ./cmd/tiller-proxy
 


### PR DESCRIPTION
### Description of the change

It modifies tiller-proxy's `Dockerfile` so that dependencies are kept between builds.

### Benefits

It becomes faster (or possible at all) to `make` tiller-proxy after modifying the source code. I saw a speedup from about 30 to under 20 seconds on a stable connection. On a slow or unstable connection, it wasn't possible to `make` tiller-proxy at all before this change (at least not after #1312).
