### PR TITLE
Kubeapps - Add JSON Schema & standardize ingress configuration

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 3.1.0
+version: 3.2.0
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -109,7 +109,7 @@ To enable ingress integration, please set `ingress.enabled` to `true`
 
 ##### Hosts
 
-Most likely you will only want to have one hostname that maps to this Kubeapps installation (use the `ingress.hostname` parameter to set the hostname), however, it is possible to have more than one host. To facilitate this, the `ingress.hosts` object is an array.
+Most likely you will only want to have one hostname that maps to this Kubeapps installation (use the `ingress.hostname` parameter to set the hostname), however, it is possible to have more than one host. To facilitate this, the `ingress.extraHosts` object is an array.
 
 ##### Annotations
 
@@ -117,7 +117,9 @@ For annotations, please see [this document](https://github.com/kubernetes/ingres
 
 ##### TLS
 
-TLS can be configured using setting the `ingress.tls` array, you can choose the TLS secret name for each host setting `ingress.tls[].hosts` and `ingress.tls[].secretName` parameters. Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls) for more information.
+To enable TLS, please set `ingress.tls` to `true`. When enabling this parameter, the TLS certificates will be retrieved from a TLS secret with name *INGRESS_HOSTNAME-tls* (where *INGRESS_HOSTNAME* is a placeholder to be replaced with the hostname you set using the `ingress.hostname` parameter).
+
+You can use the `ingress.extraTls` to provide the TLS configuration for the extra hosts you set using the `ingress.extraHosts` array. Please see [this example](https://kubernetes.github.io/ingress-nginx/examples/tls-termination/) for more information.
 
 You can provide your own certificates using the `ingress.secrets` object. If your cluster has a [cert-manager](https://github.com/jetstack/cert-manager) add-on to automate the management and issuance of TLS certificates, set `ingress.certManager` boolean to true to enable the corresponding annotations for cert-manager. For a full list of configuration parameters related to configuring TLS can see the [values.yaml](values.yaml) file.
 

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -79,7 +79,7 @@ By default, Kubeapps will track the [community Helm charts](https://github.com/h
 
 By default, Kubeapps connects to the Tiller Service in the `kube-system` namespace, the default install location for Helm.
 
-If your instance of Tiller is running in a different namespace or you want to have different instances of Kubeapps connected to different Tiller instances, you can achieve it by setting the `tillerProxy.host` paramater. For example, you can set `tillerProxy.host=tiller-deploy.my-custom-namespace:44134`
+If your instance of Tiller is running in a different namespace or you want to have different instances of Kubeapps connected to different Tiller instances, you can achieve it by setting the `tillerProxy.host` parameter. For example, you can set `tillerProxy.host=tiller-deploy.my-custom-namespace:44134`
 
 ### Configuring connection to a secure Tiller instance
 
@@ -109,7 +109,7 @@ To enable ingress integration, please set `ingress.enabled` to `true`
 
 ##### Hosts
 
-Most likely you will only want to have one hostname that maps to this Kubeapps installation, however, it is possible to have more than one host. To facilitate this, the `ingress.hosts` object is an array.
+Most likely you will only want to have one hostname that maps to this Kubeapps installation (use the `ingress.hostname` parameter to set the hostname), however, it is possible to have more than one host. To facilitate this, the `ingress.hosts` object is an array.
 
 ##### Annotations
 
@@ -117,10 +117,9 @@ For annotations, please see [this document](https://github.com/kubernetes/ingres
 
 ##### TLS
 
-TLS can be configured using setting the `ingress.hosts[].tls` boolean of the corresponding hostname to true, then you can choose the TLS secret name setting `ingress.hosts[].tlsSecret`. Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls) for more information.
+TLS can be configured using setting the `ingress.tls` array, you can choose the TLS secret name for each host setting `ingress.tls[].hosts` and `ingress.tls[].secretName` parameters. Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls) for more information.
 
-You can provide your own certificates using the `ingress.secrets` object. If your cluster has a [cert-manager](https://github.com/jetstack/cert-manager) add-on to automate the management and issuance of TLS certificates, set `ingress.hosts[].certManager` boolean to true to enable the corresponding annotations for cert-manager. For a full list of configuration parameters related to configuring TLS can see the [values.yaml](values.yaml) file.
-
+You can provide your own certificates using the `ingress.secrets` object. If your cluster has a [cert-manager](https://github.com/jetstack/cert-manager) add-on to automate the management and issuance of TLS certificates, set `ingress.certManager` boolean to true to enable the corresponding annotations for cert-manager. For a full list of configuration parameters related to configuring TLS can see the [values.yaml](values.yaml) file.
 
 ## Upgrading Kubeapps
 

--- a/chart/kubeapps/templates/NOTES.txt
+++ b/chart/kubeapps/templates/NOTES.txt
@@ -25,10 +25,8 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
 1. Get the Kubeapps URL and associate Kubeapps hostname to your cluster external IP:
 
    export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
-   {{- range .Values.ingress.hosts }}
-   echo "Kubeapps URL: http{{ if .tls }}s{{ end }}://{{ .name }}{{ default "/" .path }}"
-   echo "$CLUSTER_IP  {{ .name }}" | sudo tee -a /etc/hosts
-   {{- end }}
+   echo "Kubeapps URL: http://{{ .Values.ingress.hostname }}/"
+   echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
 
 {{- else }}
 

--- a/chart/kubeapps/templates/NOTES.txt
+++ b/chart/kubeapps/templates/NOTES.txt
@@ -25,7 +25,7 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
 1. Get the Kubeapps URL and associate Kubeapps hostname to your cluster external IP:
 
    export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
-   echo "Kubeapps URL: http://{{ .Values.ingress.hostname }}/"
+   echo "Kubeapps URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}/"
    echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
 
 {{- else }}

--- a/chart/kubeapps/templates/ingress.yaml
+++ b/chart/kubeapps/templates/ingress.yaml
@@ -22,6 +22,16 @@ spec:
             serviceName: {{ template "kubeapps.fullname" . }}
             servicePort: http
     {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "kubeapps.fullname" $ }}
+            servicePort: http
+    {{- end }}
+    ## The block below is deprecated and must removed on 3.0.0
     {{- range .Values.ingress.hosts }}
     - host: {{ .name }}
       http:
@@ -31,7 +41,25 @@ spec:
             serviceName: {{ template "kubeapps.fullname" $ }}
             servicePort: http
     {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls: {{- toYaml .Values.ingress.tls | nindent 4 }}
+    ## end of block
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls .Values.ingress.hosts }}
+  tls:
+    ## The block below is deprecated and must removed on 3.0.0
+    {{- range .Values.ingress.hosts }}
+    {{- if .tls }}
+    - hosts:
+        - {{ .name }}
+      secretName: {{ .tlsSecret }}
+    {{- end }}
+    {{- end }}
+    ## end of block
+    {{- if .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/kubeapps/templates/ingress.yaml
+++ b/chart/kubeapps/templates/ingress.yaml
@@ -13,6 +13,15 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: {{ template "kubeapps.fullname" . }}
+            servicePort: http
+    {{- end }}
     {{- range .Values.ingress.hosts }}
     - host: {{ .name }}
       http:
@@ -22,12 +31,7 @@ spec:
             serviceName: {{ template "kubeapps.fullname" $ }}
             servicePort: http
     {{- end }}
-  tls:
-  {{- range .Values.ingress.hosts }}
-    {{- if .tls }}
-    - hosts:
-        - {{ .name }}
-      secretName: {{ .tlsSecret }}
-    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls: {{- toYaml .Values.ingress.tls | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/kubeapps/values.schema.json
+++ b/chart/kubeapps/values.schema.json
@@ -78,6 +78,16 @@
             "condition": false,
             "value": "ingress.enabled"
           }
+        },
+        "certManager": {
+          "type": "boolean",
+          "form": true,
+          "title": "Use cert-manager to auto-generate the TLS certificate",
+          "description": "Add the corresponding annotations for cert-manager to auto-generate the TLS certificate",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
         }
       }
     },
@@ -116,6 +126,16 @@
           "form": true,
           "title": "Client Secret",
           "description": "Secret used to validate the Client ID",
+          "hidden": {
+            "condition": false,
+            "value": "authProxy.enabled"
+          }
+        },
+        "cookieSecret": {
+          "type": "string",
+          "form": true,
+          "title": "Cookie Secret",
+          "description": "Used by OAuth2 Proxy to encrypt any credentials",
           "hidden": {
             "condition": false,
             "value": "authProxy.enabled"

--- a/chart/kubeapps/values.schema.json
+++ b/chart/kubeapps/values.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "frontend": {
+      "type": "object",
+      "title": "Frontend configuration",
+      "form": true,
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "title": "Number of replicas",
+          "form": true
+        }
+      }
+    },
+    "apprepository": {
+      "type": "object",
+      "title": "Chart repositories configuration",
+      "form": true,
+      "properties": {
+        "initialRepos": {
+          "type": "array",
+          "title": "Initial chart repositories",
+          "description": "Initial chart repositories to configure on Kubeapps",
+          "form": true
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "form": true,
+      "title": "Ingress Details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Use a custom hostname",
+          "description": "Enable the ingress resource that allows you to access the Kubeapps dashboard."
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
+        }
+      }
+    },
+    "mongodb": {
+      "type": "object",
+      "title": "MongoDB Details",
+      "form": true,
+      "properties": {
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "form": true,
+              "title": "Enable persistence",
+              "description": "Enable persistence using Persistent Volume Claims"
+            },
+            "size": {
+              "type": "string",
+              "title": "Volume Size",
+              "form": true,
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 100,
+              "sliderUnit": "Gi",
+              "hidden": {
+                "condition": false,
+                "value": "mongodb.persistence.enabled"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/chart/kubeapps/values.schema.json
+++ b/chart/kubeapps/values.schema.json
@@ -14,15 +14,38 @@
         }
       }
     },
-    "apprepository": {
+    "dashboard": {
       "type": "object",
-      "title": "Chart repositories configuration",
+      "title": "Dashboard configuration",
       "form": true,
       "properties": {
-        "initialRepos": {
-          "type": "array",
-          "title": "Initial chart repositories",
-          "description": "Initial chart repositories to configure on Kubeapps",
+        "replicaCount": {
+          "type": "integer",
+          "title": "Number of replicas",
+          "form": true
+        }
+      }
+    },
+    "chartsvc": {
+      "type": "object",
+      "title": "Chartsvc configuration",
+      "form": true,
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "title": "Number of replicas",
+          "form": true
+        }
+      }
+    },
+    "tillerProxy": {
+      "type": "object",
+      "title": "Tiller Proxy configuration",
+      "form": true,
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "title": "Number of replicas",
           "form": true
         }
       }
@@ -30,7 +53,7 @@
     "ingress": {
       "type": "object",
       "form": true,
-      "title": "Ingress Details",
+      "title": "Ingress configuration",
       "properties": {
         "enabled": {
           "type": "boolean",
@@ -46,12 +69,63 @@
             "condition": false,
             "value": "ingress.enabled"
           }
+        },
+        "tls": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable TLS configuration",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
+        }
+      }
+    },
+    "authProxy": {
+      "type": "object",
+      "title": "OIDC Proxy configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable OIDC proxy",
+          "description": "Use an OIDC provider in order to manage accounts, groups and roles with a single application"
+        },
+        "provider": {
+          "type": "string",
+          "form": true,
+          "title": "Identity Provider name",
+          "description": "See https://pusher.github.io/oauth2_proxy/auth-configuration to find available providers",
+          "hidden": {
+            "condition": false,
+            "value": "authProxy.enabled"
+          }
+        },
+        "clientID": {
+          "type": "string",
+          "form": true,
+          "title": "Client ID:",
+          "description": "Client ID of the Identity Provider",
+          "hidden": {
+            "condition": false,
+            "value": "authProxy.enabled"
+          }
+        },
+        "clientSecret": {
+          "type": "string",
+          "form": true,
+          "title": "Client Secret",
+          "description": "Secret used to validate the Client ID",
+          "hidden": {
+            "condition": false,
+            "value": "authProxy.enabled"
+          }
         }
       }
     },
     "mongodb": {
       "type": "object",
-      "title": "MongoDB Details",
+      "title": "MongoDB configuration",
       "form": true,
       "properties": {
         "persistence": {

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -22,6 +22,10 @@ ingress:
   ##
   certManager: false
 
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: kubeapps.local
+
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations,
   ## please see https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
@@ -35,18 +39,18 @@ ingress:
     ##
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
 
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  ##
-  hosts:
-    - name: kubeapps.local
-      path: /
-      ## Set this to true in order to enable TLS on the ingress record
-      ##
-      tls: false
-      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-      ##
-      tlsSecret: kubeapps.local-tls
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## hosts:
+  ## - name: kubeapps.local
+  ##   path: /
+
+  ## The tls configuration for the ingress
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## tls:
+  ## - hosts:
+  ##     - kubeapps.local
+  ##   secretName: kubeapps.local-tls
 
   ## If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or
@@ -430,6 +434,7 @@ mongodb:
   ##
   persistence:
     enabled: false
+    size: 8Gi
   ## MongoDB credentials are handled by kubeapps to facilitate upgrades
   ##
   existingSecret: kubeapps-mongodb

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -26,6 +26,12 @@ ingress:
   ##
   hostname: kubeapps.local
 
+  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
+  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
+  ##
+  tls: false
+
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations,
   ## please see https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
@@ -41,13 +47,13 @@ ingress:
 
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## hosts:
+  ## extraHosts:
   ## - name: kubeapps.local
   ##   path: /
 
-  ## The tls configuration for the ingress
+  ## The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## tls:
+  ## extraTls:
   ## - hosts:
   ##     - kubeapps.local
   ##   secretName: kubeapps.local-tls
@@ -63,9 +69,23 @@ ingress:
   ## Please see README.md for more information
   ##
   secrets: []
-  # - name: kubeapps.local-tls
-  #   key:
-  #   certificate:
+  ## - name: kubeapps.local-tls
+  ##   key:
+  ##   certificate:
+
+  ## DEPRECATED: to be removed on 3.0.0
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  ##
+  hosts:
+    - name: kubeapps.local
+      path: /
+      ## Set this to true in order to enable TLS on the ingress record
+      ##
+      tls: false
+      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+      ##
+      tlsSecret: kubeapps.local-tls
 
 ## Frontend paramters
 ##
@@ -493,15 +513,15 @@ authProxy:
     tag: 4.0.0-r32
   ## Mandatory parameters
   ##
-  provider:
-  clientID:
-  clientSecret:
+  provider: ""
+  clientID: ""
+  clientSecret: ""
   ## cookieSecret is used by oauth2-proxy to encrypt any credentials so that it requires
   ## no storage. Note that it must be a particular number of bytes. Recommend using the
   ## following to generate a cookieSecret as per the oauth2 configuration documentation
   ## at https://pusher.github.io/oauth2_proxy/configuration :
   ## python -c 'import os,base64; print base64.urlsafe_b64encode(os.urandom(16))'
-  cookieSecret:
+  cookieSecret: ""
   ## Use "example.com" to restrict logins to emails from example.com
   emailDomain: "*"
   ## Additional flags for oauth2-proxy

--- a/docs/user/login-alternatives.md
+++ b/docs/user/login-alternatives.md
@@ -19,10 +19,7 @@ This is an example of the values that you can configure in the Kubeapps chart in
 ```yaml
 ingress:
   enabled: true
-  hosts:
-    - name: kubeapps.local
-      path: /
-      tls: false
+  hostname: kubeapps.local
   annotations:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/configuration-snippet: |


### PR DESCRIPTION
**Description of the change**

This PR includes a basic JSON schema for the Kubeapps chart. It doesn't cover all the possible values of the chart but just the ones that, in my opinion, are more likely to be modified.

This is valid for Helm 3 to validate some values and, at the same time, for Kubeapps to render a simple form so the chart containing it is easier to configure and deploy. See https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md for more information.

This is an example of the file rendered by Kubeapps:

![Screenshot 2019-12-02 at 15 25 09](https://user-images.githubusercontent.com/6740773/69967055-f1992c80-1517-11ea-8f7c-a95399580d9b.png)

This PR also standardizes the way we configure Ingress.