### PR TITLE
Break a word in the console if there is no other wrap option.

### DIFF
--- a/dashboard/src/components/AppView/AppNotes.scss
+++ b/dashboard/src/components/AppView/AppNotes.scss
@@ -1,0 +1,3 @@
+.Terminal {
+  overflow-wrap: break-word;
+}

--- a/dashboard/src/components/AppView/AppNotes.tsx
+++ b/dashboard/src/components/AppView/AppNotes.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import "./AppNotes.css";
+
 interface IAppNotesProps {
   notes?: string | null;
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**
Before:
![Screenshot from 2019-11-27 17-32-10](https://user-images.githubusercontent.com/4025665/69741803-f76bc800-113b-11ea-9e31-d7ee14bd728b.png)

After:
![word-break](https://user-images.githubusercontent.com/497518/70026489-0e0a9700-15f4-11ea-8c6b-19e0ff20f1a8.png)

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
All text can be read without overflowing.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
Each line in the terminal text is no longer a single line necessarily?
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1326

**Additional information**
We could instead use `overflow: hidden` but it's then difficult to actually see (or copy-n-paste) the text.
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
