### PR TITLE
Remove content from repo struct

### DIFF
--- a/cmd/asset-syncer/mongodb_utils_test.go
+++ b/cmd/asset-syncer/mongodb_utils_test.go
@@ -194,7 +194,7 @@ func Test_fetchAndImportFiles(t *testing.T) {
 }
 
 func Test_emptyChartRepo(t *testing.T) {
-	r := &repo{Name: "testRepo", URL: "https://my.examplerepo.com", Checksum: "123", Content: emptyRepoIndexYAMLBytes}
+	r := &repo{Name: "testRepo", URL: "https://my.examplerepo.com", Checksum: "123"}
 	i, err := parseRepoIndex(emptyRepoIndexYAMLBytes)
 	assert.NoErr(t, err)
 	charts := chartsFromIndex(i, r)

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -101,7 +101,7 @@ var syncCmd = &cobra.Command{
 		}
 
 		authorizationHeader := os.Getenv("AUTHORIZATION_HEADER")
-		r, err := getRepo(args[0], args[1], authorizationHeader)
+		r, repoContent, err := getRepo(args[0], args[1], authorizationHeader)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -112,7 +112,7 @@ var syncCmd = &cobra.Command{
 			return
 		}
 
-		index, err := parseRepoIndex(r.Content)
+		index, err := parseRepoIndex(repoContent)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/asset-syncer/types.go
+++ b/cmd/asset-syncer/types.go
@@ -25,7 +25,6 @@ type repo struct {
 	URL                 string
 	AuthorizationHeader string `bson:"-"`
 	Checksum            string
-	Content             []byte
 }
 
 type maintainer struct {

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -85,24 +85,24 @@ func getSha256(src []byte) (string, error) {
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
-func getRepo(name, repoURL, authorizationHeader string) (*repo, error) {
+func getRepo(name, repoURL, authorizationHeader string) (*repo, []byte, error) {
 	url, err := parseRepoURL(repoURL)
 	if err != nil {
 		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
-		return nil, err
+		return nil, []byte{}, err
 	}
 
 	repoBytes, err := fetchRepoIndex(url.String(), authorizationHeader)
 	if err != nil {
-		return nil, err
+		return nil, []byte{}, err
 	}
 
 	repoChecksum, err := getSha256(repoBytes)
 	if err != nil {
-		return nil, err
+		return nil, []byte{}, err
 	}
 
-	return &repo{Name: name, URL: url.String(), AuthorizationHeader: authorizationHeader, Checksum: repoChecksum, Content: repoBytes}, nil
+	return &repo{Name: name, URL: url.String(), AuthorizationHeader: authorizationHeader, Checksum: repoChecksum}, repoBytes, nil
 }
 
 func fetchRepoIndex(url, authHeader string) ([]byte, error) {

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -174,7 +174,7 @@ func Test_syncURLInvalidity(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := getRepo("test", tt.repoURL, "")
+			_, _, err := getRepo("test", tt.repoURL, "")
 			assert.ExistsErr(t, err, tt.name)
 		})
 	}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

When refactoring the `Sync` logic, I didn't see that each chart entry in the database holds a copy of the `repo` struct. Since I added the actual repository content to that struct, the mongoDB connection was crashing (because it was trying to flush to much data).

**Benefits**

This PR fixes the e2e tests for the `assetSyncer` branch.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #651 
