### PR TITLE
Refactor flags and manager initialization

### DIFF
--- a/cmd/asset-syncer/delete.go
+++ b/cmd/asset-syncer/delete.go
@@ -17,12 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
-	"os"
-
-	"database/sql"
-
-	"github.com/kubeapps/common/datastore"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -36,67 +30,17 @@ var deleteCmd = &cobra.Command{
 			cmd.Help()
 			return
 		}
-		debug, err := cmd.Flags().GetBool("debug")
-		if err != nil {
-			logrus.Fatal(err)
-		}
+
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
-		database, err := cmd.Flags().GetString("database-type")
-		var manager assetManager
-		if database == "mongodb" {
-			mongoURL, err := cmd.Flags().GetString("mongo-url")
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			mongoDB, err := cmd.Flags().GetString("mongo-database")
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			mongoUser, err := cmd.Flags().GetString("mongo-user")
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			mongoPW := os.Getenv("MONGO_PASSWORD")
-			mongoConfig := datastore.Config{URL: mongoURL, Database: mongoDB, Username: mongoUser, Password: mongoPW}
-			dbSession, err := datastore.NewSession(mongoConfig)
-			if err != nil {
-				logrus.Fatalf("Can't connect to mongoDB: %v", err)
-			}
-			manager = &mongodbAssetManager{dbSession}
-		} else if database == "postgresql" {
-			pgHost, err := cmd.Flags().GetString("pg-host")
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			pgPort, err := cmd.Flags().GetString("pg-port")
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			pgDB, err := cmd.Flags().GetString("pg-database")
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			pgUser, err := cmd.Flags().GetString("pg-user")
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			pgPW := os.Getenv("POSTGRESQL_PASSWORD")
 
-			connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", pgHost, pgPort, pgUser, pgPW, pgDB)
-			// TODO(andresmgot): Open the DB connection only when needed.
-			// We are opening the connection now to be able to test the Delete method
-			// but ideally this method should be mocked.
-			db, err := sql.Open("postgres", connStr)
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			defer db.Close()
-			manager = &postgresAssetManager{db}
-		} else {
-			logrus.Fatalf("Unsupported database type %s", database)
+		manager, err := newManager(databaseType, databaseURL, databaseName, databaseUser, databasePassword)
+		if err != nil {
+			logrus.Fatal(err)
 		}
+		manager.Init()
+		defer manager.Close()
 
 		if err = manager.Delete(args[0]); err != nil {
 			logrus.Fatalf("Can't delete chart repository %s from database: %v", args[0], err)

--- a/cmd/asset-syncer/delete.go
+++ b/cmd/asset-syncer/delete.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"github.com/kubeapps/common/datastore"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -35,11 +36,15 @@ var deleteCmd = &cobra.Command{
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 
-		manager, err := newManager(databaseType, databaseURL, databaseName, databaseUser, databasePassword)
+		dbConfig := datastore.Config{URL: databaseURL, Database: databaseName, Username: databaseUser, Password: databasePassword}
+		manager, err := newManager(databaseType, dbConfig)
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		manager.Init()
+		err = manager.Init()
+		if err != nil {
+			logrus.Fatal(err)
+		}
 		defer manager.Close()
 
 		if err = manager.Delete(args[0]); err != nil {

--- a/cmd/asset-syncer/main.go
+++ b/cmd/asset-syncer/main.go
@@ -48,10 +48,10 @@ func main() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&databaseType, "database-type", "mongodb", "Database to use. Choice: mongodb, postgresql")
-	rootCmd.PersistentFlags().StringVar(&databaseURL, "database-url", "localhost", "MongoDB URL (see https://godoc.org/github.com/globalsign/mgo#Dial for format)")
-	rootCmd.PersistentFlags().StringVar(&databaseName, "database-name", "charts", "MongoDB database")
-	rootCmd.PersistentFlags().StringVar(&databaseUser, "database-user", "", "MongoDB user")
-	// see version.go
+	rootCmd.PersistentFlags().StringVar(&databaseURL, "database-url", "localhost", "Database URL")
+	rootCmd.PersistentFlags().StringVar(&databaseName, "database-name", "charts", "Name of the database to use")
+	rootCmd.PersistentFlags().StringVar(&databaseUser, "database-user", "", "Database user")
+	// User agent configuration can be found in version.go. Check that file for more details
 	rootCmd.PersistentFlags().StringVar(&userAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "verbose logging")
 

--- a/cmd/asset-syncer/main.go
+++ b/cmd/asset-syncer/main.go
@@ -22,6 +22,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	databaseType     string
+	databaseURL      string
+	databaseName     string
+	databaseUser     string
+	databasePassword string
+	debug            bool
+)
+
 var rootCmd = &cobra.Command{
 	Use:   "asset-syncer",
 	Short: "Asset Synchronization utility",
@@ -38,21 +47,19 @@ func main() {
 }
 
 func init() {
-	cmds := []*cobra.Command{syncCmd, deleteCmd}
+	rootCmd.PersistentFlags().StringVar(&databaseType, "database-type", "mongodb", "Database to use. Choice: mongodb, postgresql")
+	rootCmd.PersistentFlags().StringVar(&databaseURL, "database-url", "localhost", "MongoDB URL (see https://godoc.org/github.com/globalsign/mgo#Dial for format)")
+	rootCmd.PersistentFlags().StringVar(&databaseName, "database-name", "charts", "MongoDB database")
+	rootCmd.PersistentFlags().StringVar(&databaseUser, "database-user", "", "MongoDB user")
+	// see version.go
+	rootCmd.PersistentFlags().StringVar(&userAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
+	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "verbose logging")
 
+	databasePassword = os.Getenv("DB_PASSWORD")
+
+	cmds := []*cobra.Command{syncCmd, deleteCmd}
 	for _, cmd := range cmds {
 		rootCmd.AddCommand(cmd)
-		cmd.Flags().String("database-type", "mongodb", "Database to use. Choice: mongodb, postgresql")
-		cmd.Flags().String("mongo-url", "localhost", "MongoDB URL (see https://godoc.org/github.com/globalsign/mgo#Dial for format)")
-		cmd.Flags().String("mongo-database", "charts", "MongoDB database")
-		cmd.Flags().String("mongo-user", "", "MongoDB user")
-		cmd.Flags().String("pg-host", "localhost", "PostgreSQL Hostname")
-		cmd.Flags().String("pg-port", "5432", "PostgreSQL Port")
-		cmd.Flags().String("pg-database", "assets", "PostgreSQL database")
-		cmd.Flags().String("pg-user", "", "PostgreSQL user")
-		// see version.go
-		cmd.Flags().StringVarP(&userAgentComment, "user-agent-comment", "", "", "UserAgent comment used during outbound requests")
-		cmd.Flags().Bool("debug", false, "verbose logging")
 	}
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/asset-syncer/mongodb_utils.go
+++ b/cmd/asset-syncer/mongodb_utils.go
@@ -44,6 +44,10 @@ type mongodbAssetManager struct {
 	dbSession   datastore.Session
 }
 
+func newMongoDBManager(config datastore.Config) assetManager {
+	return &mongodbAssetManager{config, nil}
+}
+
 func (m *mongodbAssetManager) Init() error {
 	dbSession, err := datastore.NewSession(m.mongoConfig)
 	if err != nil {

--- a/cmd/asset-syncer/mongodb_utils.go
+++ b/cmd/asset-syncer/mongodb_utils.go
@@ -40,7 +40,21 @@ const (
 )
 
 type mongodbAssetManager struct {
-	DBSession datastore.Session
+	mongoConfig datastore.Config
+	dbSession   datastore.Session
+}
+
+func (m *mongodbAssetManager) Init() error {
+	dbSession, err := datastore.NewSession(m.mongoConfig)
+	if err != nil {
+		return fmt.Errorf("Can't connect to mongoDB: %v", err)
+	}
+	m.dbSession = dbSession
+	return nil
+}
+
+func (m *mongodbAssetManager) Close() error {
+	return nil
 }
 
 // Syncing is performed in the following steps:
@@ -106,7 +120,7 @@ func (m *mongodbAssetManager) fetchFiles(charts []chart) {
 }
 
 func (m *mongodbAssetManager) RepoAlreadyProcessed(repoName string, checksum string) bool {
-	db, closer := m.DBSession.DB()
+	db, closer := m.dbSession.DB()
 	defer closer()
 	lastCheck := &repoCheck{}
 	err := db.C(repositoryCollection).Find(bson.M{"_id": repoName}).One(lastCheck)
@@ -114,14 +128,14 @@ func (m *mongodbAssetManager) RepoAlreadyProcessed(repoName string, checksum str
 }
 
 func (m *mongodbAssetManager) UpdateLastCheck(repoName string, checksum string, now time.Time) error {
-	db, closer := m.DBSession.DB()
+	db, closer := m.dbSession.DB()
 	defer closer()
 	_, err := db.C(repositoryCollection).UpsertId(repoName, bson.M{"$set": bson.M{"last_update": now, "checksum": checksum}})
 	return err
 }
 
 func (m *mongodbAssetManager) Delete(repoName string) error {
-	db, closer := m.DBSession.DB()
+	db, closer := m.dbSession.DB()
 	defer closer()
 	_, err := db.C(chartCollection).RemoveAll(bson.M{
 		"repo.name": repoName,
@@ -152,7 +166,7 @@ func (m *mongodbAssetManager) importCharts(charts []chart) error {
 		pairs = append(pairs, bson.M{"_id": c.ID}, c)
 	}
 
-	db, closer := m.DBSession.DB()
+	db, closer := m.dbSession.DB()
 	defer closer()
 	bulk := db.C(chartCollection).Bulk()
 
@@ -240,14 +254,14 @@ func (m *mongodbAssetManager) fetchAndImportIcon(c chart) error {
 		contentType = "image/png"
 	}
 
-	db, closer := m.DBSession.DB()
+	db, closer := m.dbSession.DB()
 	defer closer()
 	return db.C(chartCollection).UpdateId(c.ID, bson.M{"$set": bson.M{"raw_icon": b, "icon_content_type": contentType}})
 }
 
 func (m *mongodbAssetManager) fetchAndImportFiles(name string, r *repo, cv chartVersion) error {
 	chartFilesID := fmt.Sprintf("%s/%s-%s", r.Name, name, cv.Version)
-	db, closer := m.DBSession.DB()
+	db, closer := m.dbSession.DB()
 	defer closer()
 
 	// Check if we already have indexed files for this chart version and digest

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -39,10 +39,25 @@ type postgresDB interface {
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 	Begin() (*sql.Tx, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
+	Close() error
 }
 
 type postgresAssetManager struct {
-	db postgresDB
+	connStr string
+	db      postgresDB
+}
+
+func (m *postgresAssetManager) Init() error {
+	db, err := sql.Open("postgres", m.connStr)
+	if err != nil {
+		return err
+	}
+	m.db = db
+	return nil
+}
+
+func (m *postgresAssetManager) Close() error {
+	return m.db.Close()
 }
 
 // Syncing is performed in the following steps:

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kubeapps/common/datastore"
 	"github.com/lib/pq"
 	log "github.com/sirupsen/logrus"
 )
@@ -45,6 +46,18 @@ type postgresDB interface {
 type postgresAssetManager struct {
 	connStr string
 	db      postgresDB
+}
+
+func newPGManager(config datastore.Config) (assetManager, error) {
+	url := strings.Split(config.URL, ":")
+	if len(url) != 2 {
+		return nil, fmt.Errorf("Can't parse database URL: %s", config.URL)
+	}
+	connStr := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+		url[0], url[1], config.Username, config.Password, config.Database,
+	)
+	return &postgresAssetManager{connStr, nil}, nil
 }
 
 func (m *postgresAssetManager) Init() error {

--- a/cmd/asset-syncer/postgresql_utils_test.go
+++ b/cmd/asset-syncer/postgresql_utils_test.go
@@ -27,6 +27,10 @@ func (d *mockDB) QueryRow(query string, args ...interface{}) *sql.Row {
 	return nil
 }
 
+func (d *mockDB) Close() error {
+	return nil
+}
+
 func Test_DeletePGRepo(t *testing.T) {
 	repoName := "test"
 	m := &mockDB{&mock.Mock{}}
@@ -37,7 +41,7 @@ func Test_DeletePGRepo(t *testing.T) {
 		m.On("Query", q, []interface{}(nil))
 	}
 
-	pgManager := &postgresAssetManager{m}
+	pgManager := &postgresAssetManager{"", m}
 	err := pgManager.Delete(repoName)
 	if err != nil {
 		t.Errorf("failed to delete chart repo test: %v", err)

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/kubeapps/common/datastore"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -38,11 +39,15 @@ var syncCmd = &cobra.Command{
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 
-		manager, err := newManager(databaseType, databaseURL, databaseName, databaseUser, databasePassword)
+		dbConfig := datastore.Config{URL: databaseURL, Database: databaseName, Username: databaseUser, Password: databasePassword}
+		manager, err := newManager(databaseType, dbConfig)
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		manager.Init()
+		err = manager.Init()
+		if err != nil {
+			logrus.Fatal(err)
+		}
 		defer manager.Close()
 
 		authorizationHeader := os.Getenv("AUTHORIZATION_HEADER")

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -79,20 +79,11 @@ type assetManager interface {
 	Close() error
 }
 
-func newManager(databaseType, databaseURL, databaseName, databaseUser, databasePassword string) (assetManager, error) {
+func newManager(databaseType string, config datastore.Config) (assetManager, error) {
 	if databaseType == "mongodb" {
-		mongoConfig := datastore.Config{URL: databaseURL, Database: databaseName, Username: databaseUser, Password: databasePassword}
-		return &mongodbAssetManager{mongoConfig, nil}, nil
+		return newMongoDBManager(config), nil
 	} else if databaseType == "postgresql" {
-		url := strings.Split(databaseURL, ":")
-		if len(url) != 2 {
-			return nil, fmt.Errorf("Can't parse database URL: %s", databaseURL)
-		}
-		connStr := fmt.Sprintf(
-			"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
-			url[0], url[1], databaseUser, databasePassword, databaseName,
-		)
-		return &postgresAssetManager{connStr, nil}, nil
+		return newPGManager(config)
 	} else {
 		return nil, fmt.Errorf("Unsupported database type %s", databaseType)
 	}

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/rand"
+	"fmt"
 	"image/color"
 	"io"
 	"io/ioutil"
@@ -461,4 +462,28 @@ func Test_getSha256(t *testing.T) {
 	sha, err := getSha256([]byte("this is a test"))
 	assert.Equal(t, err, nil, "Unable to get sha")
 	assert.Equal(t, sha, "2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c", "Unable to get sha")
+}
+
+func Test_newManager(t *testing.T) {
+	tests := []struct {
+		name            string
+		database        string
+		dbName          string
+		dbURL           string
+		dbUser          string
+		dbPass          string
+		expectedManager string
+	}{
+		{"mongodb database", "mongodb", "charts", "example.com", "admin", "root", "&{{example.com charts admin root 0} <nil>}"},
+		{"postgresql database", "postgresql", "assets", "example.com:44124", "postgres", "root", "&{host=example.com port=44124 user=postgres password=root dbname=assets sslmode=disable <nil>}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager, err := newManager(tt.database, tt.dbURL, tt.dbName, tt.dbUser, tt.dbPass)
+			m := fmt.Sprintf("%v", manager)
+			assert.NoErr(t, err)
+			assert.Equal(t, m, tt.expectedManager, "manager")
+		})
+	}
+
 }

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/arschles/assert"
 	"github.com/disintegration/imaging"
+	"github.com/kubeapps/common/datastore"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -479,7 +480,8 @@ func Test_newManager(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager, err := newManager(tt.database, tt.dbURL, tt.dbName, tt.dbUser, tt.dbPass)
+			config := datastore.Config{URL: tt.dbURL, Database: tt.dbName, Username: tt.dbUser, Password: tt.dbPass}
+			manager, err := newManager(tt.database, config)
 			m := fmt.Sprintf("%v", manager)
 			assert.NoErr(t, err)
 			assert.Equal(t, m, tt.expectedManager, "manager")


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

Follow up of the conversation here:
https://github.com/kubeapps/kubeapps/pull/1328#pullrequestreview-325900983

The goal is to refactor the current flag initialization to reduce duplicated code and move code to the `main.go` flags.

Unfortunately, it's not possible to execute code in the `main.go` file *after* the flags are populated so still the manager initialization happens in the `sync.go` and `delete.go` files.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #651 

