### PR TITLE
Improve tiller-proxy build time with BuildKit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,8 @@ exports: &exports
     echo "export HELM_VERSION=v2.14.0" >> $BASH_ENV
 build_images: &build_images
   steps:
-    - setup_remote_docker
+    - setup_remote_docker:
+        version: 18.09.3
     - checkout
     - <<: *exports
     - run: |

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: kubeapps/dashboard kubeapps/apprepository-controller kubeapps/tiller-proxy
 
 # TODO(miguel) Create Makefiles per component
 kubeapps/%:
-	docker build -t kubeapps/$*$(IMG_MODIFIER):$(IMAGE_TAG) --build-arg "VERSION=${VERSION}" -f cmd/$*/Dockerfile .
+	DOCKER_BUILDKIT=1 docker build -t kubeapps/$*$(IMG_MODIFIER):$(IMAGE_TAG) --build-arg "VERSION=${VERSION}" -f cmd/$*/Dockerfile .
 
 kubeapps/dashboard:
 	docker build -t kubeapps/dashboard$(IMG_MODIFIER):$(IMAGE_TAG) -f dashboard/Dockerfile dashboard/

--- a/cmd/tiller-proxy/Dockerfile
+++ b/cmd/tiller-proxy/Dockerfile
@@ -1,10 +1,17 @@
+# syntax = docker/dockerfile:experimental
+
 FROM golang:1.13 as builder
 WORKDIR /go/src/github.com/kubeapps/kubeapps
 COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
+COPY vendor vendor
+COPY pkg pkg
+COPY cmd cmd
 ARG VERSION
-RUN CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-X main.version=$VERSION" ./cmd/tiller-proxy
+# With the trick below, Go's build cache is kept between builds.
+# https://github.com/golang/go/issues/27719#issuecomment-514747274
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X main.version=$VERSION" ./cmd/tiller-proxy
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
### Description of the change

  * [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements) is used for `docker build`.
  * `COPY . .` is replaced with more explicit directives.
  * `--mount` flag preserves Go build cache between builds.
  * Removing the `-a` flag makes `go build` use Go build cache.

### Benefits

This brought the build time (after modifying the source code) down from 20 seconds to about 5 seconds on my laptop.

### Possible drawbacks

* BuildKit requires Docker 18.09 or later. I don't know if building still works on older versions of Docker.
