### PR TITLE
Use headings instead of bold in GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,29 +15,29 @@ Use the commands below to provide key information from your environment:
 You do NOT have to include this information if this is a FEATURE REQUEST
 -->
 
-**Description**
+### Description:
 
 <!-- Briefly describe the problem you are having in a few paragraphs. -->
 
-**Steps to reproduce the issue:**
+### Steps to reproduce the issue:
 
 1. [First Step]
 2. [Second Step]
 3. [and so on...]
 
-**Describe the results you received:**
+### Describe the results you received:
 
 <!-- What actually happens -->
 
-**Describe the results you expected:**
+### Describe the results you expected:
 
 <!-- What you expect to happen -->
 
-**Additional information you deem important (e.g. issue happens only occasionally):**
+### Additional information you deem important (e.g. issue happens only occasionally):
 
 <!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->
 
-**Version of Helm, Kubeapps and Kubernetes**:
+### Version of Helm, Kubeapps and Kubernetes:
 
 - Output of `helm version`:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,24 +8,24 @@
  Thank you for contributing!
  -->
 
-**Description of the change**
+### Description of the change
 
 <!-- Describe the scope of your change - i.e. what the change does. -->
 
-**Benefits**
+### Benefits
 
 <!-- What benefits will be realized by the code change? -->
 
-**Possible drawbacks**
+### Possible drawbacks
 
 <!-- Describe any known limitations with your change -->
 
-**Applicable issues**
+### Applicable issues
 
 <!-- Enter any applicable Issues here (You can reference an issue using #) -->
   - fixes #
 
-**Additional information**
+### Additional information
 
 <!-- If there's anything else that's important and relevant to your pull
 request, mention that information here.-->


### PR DESCRIPTION
It's much closer to what we actually _mean_ compared to plain bold text. (I've been replacing bold with headings manually for my latest PRs.)