### PR TITLE
Add useHelm3 flag

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -62,7 +62,11 @@ data:
         proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
         {{- end }}
 
+        {{- if not .Values.useHelm3 }}
         proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
+        {{- else }}
+        # TODO proxy_pass for Helm 3
+        {{- end }}
       }
 
       location ~* /api/tiller-deploy {
@@ -71,7 +75,11 @@ data:
         proxy_read_timeout 10m;
         rewrite /api/tiller-deploy/(.*) /$1 break;
         rewrite /api/tiller-deploy / break;
+        {{- if not .Values.useHelm3 }}
         proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
+        {{- else }}
+        # TODO proxy_pass for Helm 3
+        {{- end }}
 
         {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
         # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -62,10 +62,10 @@ data:
         proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
         {{- end }}
 
-        {{- if not .Values.useHelm3 }}
-        proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
-        {{- else }}
+        {{- if .Values.useHelm3 }}
         # TODO proxy_pass for Helm 3
+        {{- else }}
+        proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
         {{- end }}
       }
 
@@ -75,10 +75,10 @@ data:
         proxy_read_timeout 10m;
         rewrite /api/tiller-deploy/(.*) /$1 break;
         rewrite /api/tiller-deploy / break;
-        {{- if not .Values.useHelm3 }}
-        proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
-        {{- else }}
+        {{- if .Values.useHelm3 }}
         # TODO proxy_pass for Helm 3
+        {{- else }}
+        proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
         {{- end }}
 
         {{- if .Values.frontend.proxypassAccessTokenAsBearer }}

--- a/chart/kubeapps/templates/tiller-proxy-deployment.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-deployment.yaml
@@ -81,4 +81,4 @@ spec:
           secret:
             secretName: {{ template "kubeapps.tiller-proxy.fullname" . }}
       {{- end }}
-{{- end }} # matches useHelm3
+{{- end }}{{/* matches useHelm3 */}}

--- a/chart/kubeapps/templates/tiller-proxy-deployment.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useHelm3 -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,3 +81,4 @@ spec:
           secret:
             secretName: {{ template "kubeapps.tiller-proxy.fullname" . }}
       {{- end }}
+{{- end }} # matches useHelm3

--- a/chart/kubeapps/templates/tiller-proxy-rbac.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useHelm3 -}}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
@@ -40,3 +41,4 @@ subjects:
     name: {{ template "kubeapps.tiller-proxy.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}
+{{- end }} # matches useHelm3

--- a/chart/kubeapps/templates/tiller-proxy-rbac.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-rbac.yaml
@@ -41,4 +41,4 @@ subjects:
     name: {{ template "kubeapps.tiller-proxy.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}
-{{- end }} # matches useHelm3
+{{- end }}{{/* matches useHelm3 */}}

--- a/chart/kubeapps/templates/tiller-proxy-secret.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-secret.yaml
@@ -23,4 +23,4 @@ data:
   tls.key: |-
 {{ .Values.tillerProxy.tls.key | b64enc | indent 4 }}
 {{- end -}}
-{{- end }} # matches useHelm3
+{{- end }}{{/* matches useHelm3 */}}

--- a/chart/kubeapps/templates/tiller-proxy-secret.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useHelm3 -}}
 # The tls ca certificate is only required when tls.verify is set to true, we fail otherwise.
 {{- if .Values.tillerProxy.tls -}}
 {{- if and (.Values.tillerProxy.tls.verify) (not (.Values.tillerProxy.tls.ca)) -}}
@@ -22,3 +23,4 @@ data:
   tls.key: |-
 {{ .Values.tillerProxy.tls.key | b64enc | indent 4 }}
 {{- end -}}
+{{- end }} # matches useHelm3

--- a/chart/kubeapps/templates/tiller-proxy-service.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useHelm3 -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
   selector:
     app: {{ template "kubeapps.tiller-proxy.fullname" . }}
     release: {{ .Release.Name }}
+{{- end }} # matches useHelm3

--- a/chart/kubeapps/templates/tiller-proxy-service.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-service.yaml
@@ -18,4 +18,4 @@ spec:
   selector:
     app: {{ template "kubeapps.tiller-proxy.fullname" . }}
     release: {{ .Release.Name }}
-{{- end }} # matches useHelm3
+{{- end }}{{/* matches useHelm3 */}}

--- a/chart/kubeapps/templates/tiller-proxy-serviceaccount.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useHelm3 -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,3 +8,4 @@ metadata:
     chart: {{ template "kubeapps.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- end }} # matches useHelm3

--- a/chart/kubeapps/templates/tiller-proxy-serviceaccount.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-serviceaccount.yaml
@@ -8,4 +8,4 @@ metadata:
     chart: {{ template "kubeapps.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- end }} # matches useHelm3
+{{- end }}{{/* matches useHelm3 */}}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -8,6 +8,9 @@
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
 
+# true for Helm 3; false for Helm 2:
+useHelm3: false # DOES NOT WORK YET; will act as a feature flag later on when we have Helm 3 support.
+
 ## The frontend service is the main reverse proxy used to access the Kubeapps UI
 ## To expose Kubeapps externally either configure the ingress object below or
 ## set frontend.service.type=LoadBalancer in the frontend configuration.


### PR DESCRIPTION
It doesn't work yet, but will be needed later on (see #1309).

As [pointed out](https://github.com/kubeapps/kubeapps/pull/1309#pullrequestreview-321255789) by @absoludity: "I think it's fine to land with the useHelm2/3 switch available but clearly document that it's not yet working, as long as it isn't changing current behaviour […]."
