### PR TITLE
Don't panic in ParseDriverType

### DIFF
--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -50,10 +50,13 @@ func main() {
 		Timeout:   timeout,
 	}
 
-	// Will panic below if an invalid driver type is provided.
 	driverType := defaultHelmDriver
 	if helmDriverArg != "" {
-		driverType = agent.ParseDriverType(helmDriverArg)
+		d, err := agent.ParseDriverType(helmDriverArg)
+		if err != nil {
+			panic(err.Error())
+		}
+		driverType = d // Necessary detour to please typechecker.
 	}
 	withAgentConfig := handler.WithAgentConfig(driverType, options)
 	r := mux.NewRouter()

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -54,7 +54,7 @@ func main() {
 	if helmDriverArg != "" {
 		d, err := agent.ParseDriverType(helmDriverArg)
 		if err != nil {
-			panic(err.Error())
+			panic(err)
 		}
 		driverType = d // Necessary detour to please typechecker.
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"strconv"
 
 	"github.com/kubeapps/kubeapps/pkg/proxy"
@@ -90,16 +91,16 @@ func createStorage(driverType DriverType, namespace string, clientset *kubernete
 	return store
 }
 
-func ParseDriverType(raw string) DriverType {
+func ParseDriverType(raw string) (DriverType, error) {
 	switch raw {
 	case "secret", "secrets":
-		return Secret
+		return Secret, nil
 	case "configmap", "configmaps":
-		return ConfigMap
+		return ConfigMap, nil
 	case "memory":
-		return Memory
+		return Memory, nil
 	default:
-		panic("Invalid Helm driver type: " + raw)
+		return Memory, errors.New("Invalid Helm driver type: " + raw)
 	}
 }
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -146,3 +146,50 @@ func TestListReleases(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDriverType(t *testing.T) {
+	validTestCases := []struct {
+		input  string
+		output DriverType
+	}{
+		{
+			input:  "secret",
+			output: Secret,
+		},
+		{
+			input:  "secrets",
+			output: Secret,
+		},
+		{
+			input:  "configmap",
+			output: ConfigMap,
+		},
+		{
+			input:  "configmaps",
+			output: ConfigMap,
+		},
+		{
+			input:  "memory",
+			output: Memory,
+		},
+	}
+
+	for _, tc := range validTestCases {
+		t.Run(tc.input, func(t *testing.T) {
+			driverType, err := ParseDriverType(tc.input)
+			if err != nil {
+				t.Errorf("%v", err)
+			} else if driverType != tc.output {
+				t.Errorf("expected: %s, actual: %s", tc.output, driverType)
+			}
+		})
+	}
+
+	invalidTestCase := "andresmgot"
+	t.Run(invalidTestCase, func(t *testing.T) {
+		driverType, err := ParseDriverType(invalidTestCase)
+		if err == nil {
+			t.Errorf("Expected \"%s\" to be an invalid driver type, but it was parsed as %v", invalidTestCase, driverType)
+		}
+	})
+}


### PR DESCRIPTION
### Description of the change

It rewrites `agent.ParseDriverType` to return an error instead of panicking if it doesn't recognize its input.

### Benefits

* `ParseDriverType` is made more faithful to its declared type.
* It's made more obvious in `main.go` that the application may panic.

### Possible drawbacks

* `ParseDriverType` becomes more verbose.

### Applicable issues

Excerpt from a [related discussion](https://github.com/kubeapps/kubeapps/pull/1359#discussion_r355911774) with @andresmgot in #1359:

> I'm much more inclined to make `agent.ParseDriverType` return an error instead of panicking, because, unlike `createStorage`, it promises that it can handle any `string`. Its current deceitfulness stems from my interpretation of @absoludity's [suggestion](https://github.com/kubeapps/kubeapps/pull/1309#discussion_r349377228) that Kubeops should refuse to start if an invalid driver type has been specified. I'll be more than happy to return an error instead.


