### PR TITLE
Asset Syncer: Fetch files for postgres

### DIFF
--- a/cmd/asset-syncer/mongodb_utils.go
+++ b/cmd/asset-syncer/mongodb_utils.go
@@ -17,20 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"strings"
-	"sync"
 	"time"
 
-	"github.com/disintegration/imaging"
 	"github.com/globalsign/mgo/bson"
 	"github.com/kubeapps/common/datastore"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -71,56 +62,7 @@ func (m *mongodbAssetManager) Close() error {
 // imported into the database as fast as possible. E.g. we want all icons for
 // charts before fetching readmes for each chart and version pair.
 func (m *mongodbAssetManager) Sync(charts []chart) error {
-	err := m.importCharts(charts)
-	if err != nil {
-		return err
-	}
-	m.fetchFiles(charts)
-	return nil
-}
-
-func (m *mongodbAssetManager) fetchFiles(charts []chart) {
-	// Process 10 charts at a time
-	numWorkers := 10
-	iconJobs := make(chan chart, numWorkers)
-	chartFilesJobs := make(chan importChartFilesJob, numWorkers)
-	var wg sync.WaitGroup
-
-	log.Debugf("starting %d workers", numWorkers)
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
-		go m.importWorker(&wg, iconJobs, chartFilesJobs)
-	}
-
-	// Enqueue jobs to process chart icons
-	for _, c := range charts {
-		iconJobs <- c
-	}
-	// Close the iconJobs channel to signal the worker pools to move on to the
-	// chart files jobs
-	close(iconJobs)
-
-	// Iterate through the list of charts and enqueue the latest chart version to
-	// be processed. Append the rest of the chart versions to a list to be
-	// enqueued later
-	var toEnqueue []importChartFilesJob
-	for _, c := range charts {
-		chartFilesJobs <- importChartFilesJob{c.Name, c.Repo, c.ChartVersions[0]}
-		for _, cv := range c.ChartVersions[1:] {
-			toEnqueue = append(toEnqueue, importChartFilesJob{c.Name, c.Repo, cv})
-		}
-	}
-
-	// Enqueue all the remaining chart versions
-	for _, cfj := range toEnqueue {
-		chartFilesJobs <- cfj
-	}
-	// Close the chartFilesJobs channel to signal the worker pools that there are
-	// no more jobs to process
-	close(chartFilesJobs)
-
-	// Wait for the worker pools to finish processing
-	wg.Wait()
+	return m.importCharts(charts)
 }
 
 func (m *mongodbAssetManager) RepoAlreadyProcessed(repoName string, checksum string) bool {
@@ -189,149 +131,22 @@ func (m *mongodbAssetManager) importCharts(charts []chart) error {
 	return err
 }
 
-func (m *mongodbAssetManager) importWorker(wg *sync.WaitGroup, icons <-chan chart, chartFiles <-chan importChartFilesJob) {
-	defer wg.Done()
-	for c := range icons {
-		log.WithFields(log.Fields{"name": c.Name}).Debug("importing icon")
-		if err := m.fetchAndImportIcon(c); err != nil {
-			log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to import icon")
-		}
-	}
-	for j := range chartFiles {
-		log.WithFields(log.Fields{"name": j.Name, "version": j.ChartVersion.Version}).Debug("importing readme and values")
-		if err := m.fetchAndImportFiles(j.Name, j.Repo, j.ChartVersion); err != nil {
-			log.WithFields(log.Fields{"name": j.Name, "version": j.ChartVersion.Version}).WithError(err).Error("failed to import files")
-		}
-	}
-}
-
-func (m *mongodbAssetManager) fetchAndImportIcon(c chart) error {
-	if c.Icon == "" {
-		log.WithFields(log.Fields{"name": c.Name}).Info("icon not found")
-		return nil
-	}
-
-	req, err := http.NewRequest("GET", c.Icon, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("User-Agent", userAgent())
-	if len(c.Repo.AuthorizationHeader) > 0 {
-		req.Header.Set("Authorization", c.Repo.AuthorizationHeader)
-	}
-
-	res, err := netClient.Do(req)
-	if res != nil {
-		defer res.Body.Close()
-	}
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("%d %s", res.StatusCode, c.Icon)
-	}
-
-	b := []byte{}
-	contentType := ""
-	if strings.Contains(res.Header.Get("Content-Type"), "image/svg") {
-		// if the icon is a SVG file simply read it
-		b, err = ioutil.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-		contentType = res.Header.Get("Content-Type")
-	} else {
-		// if the icon is in any other format try to convert it to PNG
-		orig, err := imaging.Decode(res.Body)
-		if err != nil {
-			log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to decode icon")
-			return err
-		}
-
-		// TODO: make this configurable?
-		icon := imaging.Fit(orig, 160, 160, imaging.Lanczos)
-
-		var buf bytes.Buffer
-		imaging.Encode(&buf, icon, imaging.PNG)
-		b = buf.Bytes()
-		contentType = "image/png"
-	}
-
+func (m *mongodbAssetManager) updateIcon(data []byte, contentType, ID string) error {
 	db, closer := m.dbSession.DB()
 	defer closer()
-	return db.C(chartCollection).UpdateId(c.ID, bson.M{"$set": bson.M{"raw_icon": b, "icon_content_type": contentType}})
+	return db.C(chartCollection).UpdateId(ID, bson.M{"$set": bson.M{"raw_icon": data, "icon_content_type": contentType}})
 }
 
-func (m *mongodbAssetManager) fetchAndImportFiles(name string, r *repo, cv chartVersion) error {
-	chartFilesID := fmt.Sprintf("%s/%s-%s", r.Name, name, cv.Version)
+func (m *mongodbAssetManager) filesExist(chartFilesID, digest string) bool {
 	db, closer := m.dbSession.DB()
 	defer closer()
+	err := db.C(chartFilesCollection).Find(bson.M{"_id": chartFilesID, "digest": digest}).One(&chartFiles{})
+	return err == nil
+}
 
-	// Check if we already have indexed files for this chart version and digest
-	if err := db.C(chartFilesCollection).Find(bson.M{"_id": chartFilesID, "digest": cv.Digest}).One(&chartFiles{}); err == nil {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Debug("skipping existing files")
-		return nil
-	}
-	log.WithFields(log.Fields{"name": name, "version": cv.Version}).Debug("fetching files")
-
-	url := chartTarballURL(r, cv)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("User-Agent", userAgent())
-	if len(r.AuthorizationHeader) > 0 {
-		req.Header.Set("Authorization", r.AuthorizationHeader)
-	}
-
-	res, err := netClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	// We read the whole chart into memory, this should be okay since the chart
-	// tarball needs to be small enough to fit into a GRPC call (Tiller
-	// requirement)
-	gzf, err := gzip.NewReader(res.Body)
-	if err != nil {
-		return err
-	}
-	defer gzf.Close()
-
-	tarf := tar.NewReader(gzf)
-
-	readmeFileName := name + "/README.md"
-	valuesFileName := name + "/values.yaml"
-	schemaFileName := name + "/values.schema.json"
-	filenames := []string{valuesFileName, readmeFileName, schemaFileName}
-
-	files, err := extractFilesFromTarball(filenames, tarf)
-	if err != nil {
-		return err
-	}
-
-	chartFiles := chartFiles{ID: chartFilesID, Repo: r, Digest: cv.Digest}
-	if v, ok := files[readmeFileName]; ok {
-		chartFiles.Readme = v
-	} else {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("README.md not found")
-	}
-	if v, ok := files[valuesFileName]; ok {
-		chartFiles.Values = v
-	} else {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.yaml not found")
-	}
-	if v, ok := files[schemaFileName]; ok {
-		chartFiles.Schema = v
-	} else {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.schema.json not found")
-	}
-
-	// inserts the chart files if not already indexed, or updates the existing
-	// entry if digest has changed
-	db.C(chartFilesCollection).UpsertId(chartFilesID, chartFiles)
-
-	return nil
+func (m *mongodbAssetManager) insertFiles(chartFilesID string, files chartFiles) error {
+	db, closer := m.dbSession.DB()
+	defer closer()
+	_, err := db.C(chartFilesCollection).UpsertId(chartFilesID, files)
+	return err
 }

--- a/cmd/asset-syncer/mongodb_utils_test.go
+++ b/cmd/asset-syncer/mongodb_utils_test.go
@@ -17,10 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"errors"
-	"fmt"
-	"image"
-	"io"
 	"testing"
 	"time"
 
@@ -70,128 +66,6 @@ func Test_DeleteRepo(t *testing.T) {
 		t.Errorf("failed to delete chart repo test: %v", err)
 	}
 	m.AssertExpectations(t)
-}
-
-func Test_fetchAndImportIcon(t *testing.T) {
-	t.Run("no icon", func(t *testing.T) {
-		m := mock.Mock{}
-		dbSession := mockstore.NewMockSession(&m)
-		c := chart{ID: "test/acs-engine-autoscaler"}
-		manager := mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
-		assert.NoErr(t, manager.fetchAndImportIcon(c))
-	})
-
-	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
-	charts := chartsFromIndex(index, &repo{Name: "test", URL: "http://testrepo.com"})
-
-	t.Run("failed download", func(t *testing.T) {
-		netClient = &badHTTPClient{}
-		c := charts[0]
-		m := mock.Mock{}
-		dbSession := mockstore.NewMockSession(&m)
-		manager := mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
-		assert.Err(t, fmt.Errorf("500 %s", c.Icon), manager.fetchAndImportIcon(c))
-	})
-
-	t.Run("bad icon", func(t *testing.T) {
-		netClient = &badIconClient{}
-		c := charts[0]
-		m := mock.Mock{}
-		dbSession := mockstore.NewMockSession(&m)
-		manager := mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
-		assert.Err(t, image.ErrFormat, manager.fetchAndImportIcon(c))
-	})
-
-	t.Run("valid icon", func(t *testing.T) {
-		netClient = &goodIconClient{}
-		c := charts[0]
-		m := mock.Mock{}
-		dbSession := mockstore.NewMockSession(&m)
-		m.On("UpdateId", c.ID, bson.M{"$set": bson.M{"raw_icon": iconBytes(), "icon_content_type": "image/png"}}).Return(nil)
-		manager := mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
-		assert.NoErr(t, manager.fetchAndImportIcon(c))
-		m.AssertExpectations(t)
-	})
-
-	t.Run("valid SVG icon", func(t *testing.T) {
-		netClient = &svgIconClient{}
-		c := chart{
-			ID:   "foo",
-			Icon: "https://foo/bar/logo.svg",
-			Repo: &repo{},
-		}
-		m := mock.Mock{}
-		dbSession := mockstore.NewMockSession(&m)
-		m.On("UpdateId", c.ID, bson.M{"$set": bson.M{"raw_icon": []byte("foo"), "icon_content_type": "image/svg"}}).Return(nil)
-		manager := mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
-		assert.NoErr(t, manager.fetchAndImportIcon(c))
-		m.AssertExpectations(t)
-	})
-}
-
-func Test_fetchAndImportFiles(t *testing.T) {
-	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
-	charts := chartsFromIndex(index, &repo{Name: "test", URL: "http://testrepo.com", AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient1s"})
-	cv := charts[0].ChartVersions[0]
-
-	t.Run("http error", func(t *testing.T) {
-		m := mock.Mock{}
-		m.On("One", mock.Anything).Return(errors.New("return an error when checking if readme already exists to force fetching"))
-		dbSession := mockstore.NewMockSession(&m)
-		netClient = &badHTTPClient{}
-		manager := mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
-		assert.Err(t, io.EOF, manager.fetchAndImportFiles(charts[0].Name, charts[0].Repo, cv))
-	})
-
-	t.Run("file not found", func(t *testing.T) {
-		netClient = &goodTarballClient{c: charts[0], skipValues: true, skipReadme: true, skipSchema: true}
-		m := mock.Mock{}
-		m.On("One", mock.Anything).Return(errors.New("return an error when checking if files already exists to force fetching"))
-		chartFilesID := fmt.Sprintf("%s/%s-%s", charts[0].Repo.Name, charts[0].Name, cv.Version)
-		m.On("UpsertId", chartFilesID, chartFiles{chartFilesID, "", "", "", charts[0].Repo, cv.Digest})
-		dbSession := mockstore.NewMockSession(&m)
-		manager := mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
-		err := manager.fetchAndImportFiles(charts[0].Name, charts[0].Repo, cv)
-		assert.NoErr(t, err)
-		m.AssertExpectations(t)
-	})
-
-	t.Run("authenticated request", func(t *testing.T) {
-		netClient = &authenticatedTarballClient{c: charts[0]}
-		m := mock.Mock{}
-		m.On("One", mock.Anything).Return(errors.New("return an error when checking if files already exists to force fetching"))
-		chartFilesID := fmt.Sprintf("%s/%s-%s", charts[0].Repo.Name, charts[0].Name, cv.Version)
-		m.On("UpsertId", chartFilesID, chartFiles{chartFilesID, testChartReadme, testChartValues, testChartSchema, charts[0].Repo, cv.Digest})
-		dbSession := mockstore.NewMockSession(&m)
-		manager := mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
-		err := manager.fetchAndImportFiles(charts[0].Name, charts[0].Repo, cv)
-		assert.NoErr(t, err)
-		m.AssertExpectations(t)
-	})
-
-	t.Run("valid tarball", func(t *testing.T) {
-		netClient = &goodTarballClient{c: charts[0]}
-		m := mock.Mock{}
-		m.On("One", mock.Anything).Return(errors.New("return an error when checking if files already exists to force fetching"))
-		chartFilesID := fmt.Sprintf("%s/%s-%s", charts[0].Repo.Name, charts[0].Name, cv.Version)
-		m.On("UpsertId", chartFilesID, chartFiles{chartFilesID, testChartReadme, testChartValues, testChartSchema, charts[0].Repo, cv.Digest})
-		dbSession := mockstore.NewMockSession(&m)
-		manager := mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
-		err := manager.fetchAndImportFiles(charts[0].Name, charts[0].Repo, cv)
-		assert.NoErr(t, err)
-		m.AssertExpectations(t)
-	})
-
-	t.Run("file exists", func(t *testing.T) {
-		m := mock.Mock{}
-		// don't return an error when checking if files already exists
-		m.On("One", mock.Anything).Return(nil)
-		dbSession := mockstore.NewMockSession(&m)
-		manager := mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
-		err := manager.fetchAndImportFiles(charts[0].Name, charts[0].Repo, cv)
-		assert.NoErr(t, err)
-		m.AssertNotCalled(t, "UpsertId", mock.Anything, mock.Anything)
-	})
 }
 
 func Test_emptyChartRepo(t *testing.T) {

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -195,7 +195,11 @@ func (m *postgresAssetManager) updateIcon(data []byte, contentType, ID string) e
 }
 
 func (m *postgresAssetManager) filesExist(chartFilesID, digest string) bool {
-	rows, err := m.db.Query("SELECT * FROM files WHERE info -> 'ID' = $1 AND info -> 'digest' = $2", chartFilesID, digest)
+	rows, err := m.db.Query(
+		fmt.Sprintf("SELECT * FROM %s WHERE info -> 'ID' = $1 AND info -> 'digest' = $2", chartFilesTable),
+		chartFilesID,
+		digest,
+	)
 	if rows != nil {
 		defer rows.Close()
 	}

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -76,6 +76,10 @@ var syncCmd = &cobra.Command{
 			logrus.Fatalf("Can't add chart repository to database: %v", err)
 		}
 
+		// Fetch and store chart icons
+		fImporter := fileImporter{manager}
+		fImporter.fetchFiles(charts)
+
 		// Update cache in the database
 		if err = manager.UpdateLastCheck(r.Name, r.Checksum, time.Now()); err != nil {
 			logrus.Fatal(err)

--- a/cmd/asset-syncer/types.go
+++ b/cmd/asset-syncer/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"database/sql/driver"
+	"encoding/json"
 	"time"
 )
 
@@ -60,6 +62,11 @@ type chartFiles struct {
 	Schema string
 	Repo   *repo
 	Digest string
+}
+
+// Allow to convert chartFiles to a sql JSON
+func (a chartFiles) Value() (driver.Value, error) {
+	return json.Marshal(a)
 }
 
 type repoCheck struct {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

The goal of this PR is to add support for fetching chart files for the PosgreSQL driver as we do for MongoDB. For doing that:

 - I have moved common logic (logic that actually downloads files and icons from the source) to the common `utils`. For doing so I have added the struct `fileImporter` that defines the common methods.
 - The struct `fileImporter` above has, as a property, an `assetManager` which has been extended to define the methods related to the database: `updateIcon`, `filesExist` and `insertFiles`.
 - Each driver (`mongodb_utils` and `postgresql_utils`) define the methods above.

Note: I found that I was not closing the returned `rows` given by the `pq` library so I fixed that here.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #651 

