### PR TITLE
Fix chart icon size

### DIFF
--- a/dashboard/src/components/ChartIcon/ChartIcon.scss
+++ b/dashboard/src/components/ChartIcon/ChartIcon.scss
@@ -1,6 +1,10 @@
 .ChartIcon {
-  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
 }
 .ChartIcon__img {
   max-height: 64px;
+  max-width: 100%;
 }

--- a/dashboard/src/components/ChartView/ChartHeader.scss
+++ b/dashboard/src/components/ChartView/ChartHeader.scss
@@ -1,9 +1,3 @@
-.ChartHeader__icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .ChartHeader__button {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Fixes the icon size for the different charts while maintaining the current working ones:

![Screenshot from 2019-12-12 13-14-47](https://user-images.githubusercontent.com/4025665/70711473-f1501c80-1ce1-11ea-8273-6507179794dd.png)
![Screenshot from 2019-12-12 13-14-59](https://user-images.githubusercontent.com/4025665/70711474-f1e8b300-1ce1-11ea-8bec-a834aa58e72e.png)
![Screenshot from 2019-12-12 13-15-05](https://user-images.githubusercontent.com/4025665/70711476-f1e8b300-1ce1-11ea-95fc-edd1a8be1ac8.png)
![Screenshot from 2019-12-12 13-15-11](https://user-images.githubusercontent.com/4025665/70711478-f1e8b300-1ce1-11ea-9588-c52bd0430816.png)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1365
