### PR TITLE
Update GetDashToken.cmd script, token.txt should not be deleted

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -55,8 +55,8 @@ REM Get the Base64 encoded token
 kubectl get secret %ks% -o jsonpath={.data.token} > b64.txt
 
 REM Decode The Token
-DEL token.txt
 certutil -decode b64.txt token.txt
+DEL b64.txt
 ```
 
 Open a command prompt and run the `GetDashToken.cmd` Your token can be found in the `token.txt` file.


### PR DESCRIPTION
### Description of the change
Documentation update

### Benefits
Windows script to generate token is currently failing.

### Possible drawbacks
N/A

### Applicable issues
N/A

### Additional information
N/A
