### PR TITLE
Move useHelm3 switch to end until we want it so visible.

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 3.2.1
+version: 3.2.2
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -581,6 +581,7 @@ authProxy:
       cpu: 25m
       memory: 32Mi
 
-# true for Helm 3; false for Helm 2:
-useHelm3: false # DOES NOT WORK YET; will act as a feature flag later on when we have Helm 3 support.
+## The useHelm3 feature flag is currently only for developing the in-progress (and incomplete) Helm3 support.
+## If you set it to true, Kubeapps will not work at present.
+useHelm3: false
 

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -8,9 +8,6 @@
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
 
-# true for Helm 3; false for Helm 2:
-useHelm3: false # DOES NOT WORK YET; will act as a feature flag later on when we have Helm 3 support.
-
 ## The frontend service is the main reverse proxy used to access the Kubeapps UI
 ## To expose Kubeapps externally either configure the ingress object below or
 ## set frontend.service.type=LoadBalancer in the frontend configuration.
@@ -583,3 +580,7 @@ authProxy:
     requests:
       cpu: 25m
       memory: 32Mi
+
+# true for Helm 3; false for Helm 2:
+useHelm3: false # DOES NOT WORK YET; will act as a feature flag later on when we have Helm 3 support.
+


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
Just noticed this when upgrading Kubeapps itself:

![useHelm3-first-option-in-values](https://user-images.githubusercontent.com/497518/70767561-eb2b7000-1db5-11ea-98b9-af149c72d26e.png)

Not a big deal, but we probably don't want it to be the first thing a user sees until it actually works.

