### PR TITLE
Fix kubeapps CrashLoopBackOff with useHelm3

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -97,7 +97,11 @@ data:
         proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
         {{- end }}
 
+        {{- if .Values.useHelm3 }}
+        proxy_pass http://{{ template "kubeapps.kubeops.fullname" . }}:{{ .Values.kubeops.service.port }};
+        {{- else }}
         proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
+        {{- end }}
       }
 
       location / {


### PR DESCRIPTION
With `useHelm3: true`, the kubeapps pods wouldn't start properly:

    $ kubectl logs -n kubeapps kubeapps-7c6ff86b88-44tmd
     11:14:51.38
     11:14:51.38 Welcome to the Bitnami nginx container
     [...]
     11:14:51.40 INFO  ==> ** Starting NGINX **
    2019/12/13 11:14:51 [emerg] 1#0: host not found in upstream "kubeapps-internal-tiller-proxy" in /opt/bitnami/nginx/conf/server_blocks/vhost.conf:60
    nginx: [emerg] host not found in upstream "kubeapps-internal-tiller-proxy" in /opt/bitnami/nginx/conf/server_blocks/vhost.conf:60
