### PR TITLE
Remove duplicated code

### DIFF
--- a/cmd/asset-syncer/mongodb_utils_test.go
+++ b/cmd/asset-syncer/mongodb_utils_test.go
@@ -28,17 +28,21 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func getMockManager(m *mock.Mock) *mongodbAssetManager {
+	dbSession := mockstore.NewMockSession(m)
+	man := dbutils.NewMongoDBManager(datastore.Config{})
+	man.DBSession = dbSession
+	return &mongodbAssetManager{man}
+}
+
 func Test_importCharts(t *testing.T) {
 	m := &mock.Mock{}
 	// Ensure Upsert func is called with some arguments
 	m.On("Upsert", mock.Anything)
 	m.On("RemoveAll", mock.Anything)
-	dbSession := mockstore.NewMockSession(m)
 	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
 	charts := chartsFromIndex(index, &repo{Name: "test", URL: "http://testrepo.com"})
-	man := dbutils.NewMongoDBManager(datastore.Config{})
-	man.DBSession = dbSession
-	manager := &mongodbAssetManager{man}
+	manager := getMockManager(m)
 	manager.importCharts(charts)
 
 	m.AssertExpectations(t)
@@ -61,11 +65,7 @@ func Test_DeleteRepo(t *testing.T) {
 	m.On("RemoveAll", bson.M{
 		"_id": "test",
 	})
-	dbSession := mockstore.NewMockSession(m)
-
-	man := dbutils.NewMongoDBManager(datastore.Config{})
-	man.DBSession = dbSession
-	manager := &mongodbAssetManager{man}
+	manager := getMockManager(m)
 	err := manager.Delete("test")
 	if err != nil {
 		t.Errorf("failed to delete chart repo test: %v", err)
@@ -94,15 +94,12 @@ func Test_repoAlreadyProcessed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := mock.Mock{}
+			m := &mock.Mock{}
 			repo := &repoCheck{}
 			m.On("One", repo).Run(func(args mock.Arguments) {
 				*args.Get(0).(*repoCheck) = tt.mockedLastCheck
 			}).Return(nil)
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager := &mongodbAssetManager{man}
+			manager := getMockManager(m)
 			res := manager.RepoAlreadyProcessed("", tt.checksum)
 			if res != tt.processed {
 				t.Errorf("Expected alreadyProcessed to be %v got %v", tt.processed, res)
@@ -112,15 +109,12 @@ func Test_repoAlreadyProcessed(t *testing.T) {
 }
 
 func Test_updateLastCheck(t *testing.T) {
-	m := mock.Mock{}
+	m := &mock.Mock{}
 	repoName := "foo"
 	checksum := "bar"
 	now := time.Now()
 	m.On("UpsertId", repoName, bson.M{"$set": bson.M{"last_update": now, "checksum": checksum}}).Return(nil)
-	dbSession := mockstore.NewMockSession(&m)
-	man := dbutils.NewMongoDBManager(datastore.Config{})
-	man.DBSession = dbSession
-	manager := &mongodbAssetManager{man}
+	manager := getMockManager(m)
 	err := manager.UpdateLastCheck(repoName, checksum, now)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)

--- a/cmd/assetsvc/handler_test.go
+++ b/cmd/assetsvc/handler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kubeapps/common/datastore"
 	"github.com/kubeapps/common/datastore/mockstore"
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/models"
+	"github.com/kubeapps/kubeapps/pkg/dbutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -246,7 +247,9 @@ func Test_listCharts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
 				*args.Get(0).(*[]*models.Chart) = tt.charts
 			})
@@ -309,7 +312,9 @@ func Test_listRepoCharts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
 				*args.Get(0).(*[]*models.Chart) = tt.charts
@@ -376,7 +381,9 @@ func Test_getChart(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -441,7 +448,9 @@ func Test_listChartVersions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -508,7 +517,9 @@ func Test_getChartVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -579,7 +590,9 @@ func Test_getChartIcon(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -644,7 +657,9 @@ func Test_getChartVersionReadme(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -709,7 +724,9 @@ func Test_getChartVersionValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -774,7 +791,9 @@ func Test_getChartVersionSchema(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -821,7 +840,9 @@ func Test_findLatestChart(t *testing.T) {
 
 		var m mock.Mock
 		dbSession := mockstore.NewMockSession(&m)
-		manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+		man := dbutils.NewMongoDBManager(datastore.Config{})
+		man.DBSession = dbSession
+		manager = &mongodbAssetManager{man}
 		m.On("All", &chartsList).Run(func(args mock.Arguments) {
 			*args.Get(0).(*[]*models.Chart) = charts
 		})
@@ -857,7 +878,9 @@ func Test_findLatestChart(t *testing.T) {
 
 		var m mock.Mock
 		dbSession := mockstore.NewMockSession(&m)
-		manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+		man := dbutils.NewMongoDBManager(datastore.Config{})
+		man.DBSession = dbSession
+		manager = &mongodbAssetManager{man}
 		m.On("All", &chartsList).Run(func(args mock.Arguments) {
 			*args.Get(0).(*[]*models.Chart) = charts
 		})
@@ -894,7 +917,9 @@ func Test_findLatestChart(t *testing.T) {
 
 		var m mock.Mock
 		dbSession := mockstore.NewMockSession(&m)
-		manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+		man := dbutils.NewMongoDBManager(datastore.Config{})
+		man.DBSession = dbSession
+		manager = &mongodbAssetManager{man}
 		m.On("All", &chartsList).Run(func(args mock.Arguments) {
 			*args.Get(0).(*[]*models.Chart) = charts
 		})

--- a/cmd/assetsvc/handler_test.go
+++ b/cmd/assetsvc/handler_test.go
@@ -58,6 +58,13 @@ func iconBytes() []byte {
 	return b.Bytes()
 }
 
+func getMockManager(m *mock.Mock) *mongodbAssetManager {
+	dbSession := mockstore.NewMockSession(m)
+	man := dbutils.NewMongoDBManager(datastore.Config{})
+	man.DBSession = dbSession
+	return &mongodbAssetManager{man}
+}
+
 func Test_chartAttributes(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -246,10 +253,7 @@ func Test_listCharts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
 				*args.Get(0).(*[]*models.Chart) = tt.charts
 			})
@@ -311,10 +315,7 @@ func Test_listRepoCharts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
 				*args.Get(0).(*[]*models.Chart) = tt.charts
@@ -380,10 +381,7 @@ func Test_getChart(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -447,10 +445,7 @@ func Test_listChartVersions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -516,10 +511,7 @@ func Test_getChartVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -589,10 +581,7 @@ func Test_getChartIcon(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -656,10 +645,7 @@ func Test_getChartVersionReadme(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -723,10 +709,7 @@ func Test_getChartVersionValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -790,10 +773,7 @@ func Test_getChartVersionSchema(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
@@ -839,10 +819,7 @@ func Test_findLatestChart(t *testing.T) {
 		reqAppVersion := "0.1.0"
 
 		var m mock.Mock
-		dbSession := mockstore.NewMockSession(&m)
-		man := dbutils.NewMongoDBManager(datastore.Config{})
-		man.DBSession = dbSession
-		manager = &mongodbAssetManager{man}
+		manager = getMockManager(&m)
 		m.On("All", &chartsList).Run(func(args mock.Arguments) {
 			*args.Get(0).(*[]*models.Chart) = charts
 		})
@@ -877,10 +854,7 @@ func Test_findLatestChart(t *testing.T) {
 		reqAppVersion := "0.1.0"
 
 		var m mock.Mock
-		dbSession := mockstore.NewMockSession(&m)
-		man := dbutils.NewMongoDBManager(datastore.Config{})
-		man.DBSession = dbSession
-		manager = &mongodbAssetManager{man}
+		manager = getMockManager(&m)
 		m.On("All", &chartsList).Run(func(args mock.Arguments) {
 			*args.Get(0).(*[]*models.Chart) = charts
 		})
@@ -916,10 +890,7 @@ func Test_findLatestChart(t *testing.T) {
 		reqAppVersion := "0.1.0"
 
 		var m mock.Mock
-		dbSession := mockstore.NewMockSession(&m)
-		man := dbutils.NewMongoDBManager(datastore.Config{})
-		man.DBSession = dbSession
-		manager = &mongodbAssetManager{man}
+		manager = getMockManager(&m)
 		m.On("All", &chartsList).Run(func(args mock.Arguments) {
 			*args.Get(0).(*[]*models.Chart) = charts
 		})

--- a/cmd/assetsvc/main_test.go
+++ b/cmd/assetsvc/main_test.go
@@ -23,10 +23,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/kubeapps/common/datastore"
-	"github.com/kubeapps/common/datastore/mockstore"
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/models"
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -34,10 +31,7 @@ import (
 // tests the GET /live endpoint
 func Test_GetLive(t *testing.T) {
 	var m mock.Mock
-	dbSession := mockstore.NewMockSession(&m)
-	man := dbutils.NewMongoDBManager(datastore.Config{})
-	man.DBSession = dbSession
-	manager = &mongodbAssetManager{man}
+	manager = getMockManager(&m)
 
 	ts := httptest.NewServer(setupRoutes())
 	defer ts.Close()
@@ -51,10 +45,7 @@ func Test_GetLive(t *testing.T) {
 // tests the GET /ready endpoint
 func Test_GetReady(t *testing.T) {
 	var m mock.Mock
-	dbSession := mockstore.NewMockSession(&m)
-	man := dbutils.NewMongoDBManager(datastore.Config{})
-	man.DBSession = dbSession
-	manager = &mongodbAssetManager{man}
+	manager = getMockManager(&m)
 
 	ts := httptest.NewServer(setupRoutes())
 	defer ts.Close()
@@ -87,10 +78,7 @@ func Test_GetCharts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
 				*args.Get(0).(*[]*models.Chart) = tt.charts
 			})
@@ -132,10 +120,7 @@ func Test_GetChartsInRepo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
 				*args.Get(0).(*[]*models.Chart) = tt.charts
 			})
@@ -188,10 +173,7 @@ func Test_GetChartInRepo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -244,10 +226,7 @@ func Test_ListChartVersions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -300,10 +279,7 @@ func Test_GetChartVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -356,10 +332,7 @@ func Test_GetChartIcon(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -416,10 +389,7 @@ func Test_GetChartReadme(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -476,10 +446,7 @@ func Test_GetChartValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -536,10 +503,7 @@ func Test_GetChartSchema(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
-			dbSession := mockstore.NewMockSession(&m)
-			man := dbutils.NewMongoDBManager(datastore.Config{})
-			man.DBSession = dbSession
-			manager = &mongodbAssetManager{man}
+			manager = getMockManager(&m)
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {

--- a/cmd/assetsvc/main_test.go
+++ b/cmd/assetsvc/main_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubeapps/common/datastore"
 	"github.com/kubeapps/common/datastore/mockstore"
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/models"
+	"github.com/kubeapps/kubeapps/pkg/dbutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -34,7 +35,9 @@ import (
 func Test_GetLive(t *testing.T) {
 	var m mock.Mock
 	dbSession := mockstore.NewMockSession(&m)
-	manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+	man := dbutils.NewMongoDBManager(datastore.Config{})
+	man.DBSession = dbSession
+	manager = &mongodbAssetManager{man}
 
 	ts := httptest.NewServer(setupRoutes())
 	defer ts.Close()
@@ -49,7 +52,9 @@ func Test_GetLive(t *testing.T) {
 func Test_GetReady(t *testing.T) {
 	var m mock.Mock
 	dbSession := mockstore.NewMockSession(&m)
-	manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+	man := dbutils.NewMongoDBManager(datastore.Config{})
+	man.DBSession = dbSession
+	manager = &mongodbAssetManager{man}
 
 	ts := httptest.NewServer(setupRoutes())
 	defer ts.Close()
@@ -83,7 +88,9 @@ func Test_GetCharts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
 				*args.Get(0).(*[]*models.Chart) = tt.charts
 			})
@@ -126,7 +133,9 @@ func Test_GetChartsInRepo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
 				*args.Get(0).(*[]*models.Chart) = tt.charts
 			})
@@ -180,7 +189,9 @@ func Test_GetChartInRepo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -234,7 +245,9 @@ func Test_ListChartVersions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -288,7 +301,9 @@ func Test_GetChartVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -342,7 +357,9 @@ func Test_GetChartIcon(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -400,7 +417,9 @@ func Test_GetChartReadme(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -458,7 +477,9 @@ func Test_GetChartValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {
@@ -516,7 +537,9 @@ func Test_GetChartSchema(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var m mock.Mock
 			dbSession := mockstore.NewMockSession(&m)
-			manager = &mongodbAssetManager{mongoConfig: datastore.Config{}, dbSession: dbSession}
+			man := dbutils.NewMongoDBManager(datastore.Config{})
+			man.DBSession = dbSession
+			manager = &mongodbAssetManager{man}
 			if tt.err != nil {
 				m.On("One", mock.Anything).Return(tt.err)
 			} else {

--- a/cmd/assetsvc/mongodb_utils.go
+++ b/cmd/assetsvc/mongodb_utils.go
@@ -17,38 +17,25 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/kubeapps/common/datastore"
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/models"
+	"github.com/kubeapps/kubeapps/pkg/dbutils"
 )
 
 type mongodbAssetManager struct {
-	mongoConfig datastore.Config
-	dbSession   datastore.Session
+	*dbutils.MongodbAssetManager
 }
 
 func newMongoDBManager(config datastore.Config) assetManager {
-	return &mongodbAssetManager{config, nil}
-}
-
-func (m *mongodbAssetManager) Init() error {
-	dbSession, err := datastore.NewSession(m.mongoConfig)
-	if err != nil {
-		return fmt.Errorf("Can't connect to mongoDB: %v", err)
-	}
-	m.dbSession = dbSession
-	return nil
-}
-
-func (m *mongodbAssetManager) Close() error {
-	return nil
+	m := dbutils.NewMongoDBManager(config)
+	return &mongodbAssetManager{m}
 }
 
 func (m *mongodbAssetManager) getPaginatedChartList(repo string, pageNumber, pageSize int, showDuplicates bool) ([]*models.Chart, int, error) {
-	db, closer := m.dbSession.DB()
+	db, closer := m.DBSession.DB()
 	defer closer()
 	var charts []*models.Chart
 
@@ -104,7 +91,7 @@ func (m *mongodbAssetManager) getPaginatedChartList(repo string, pageNumber, pag
 }
 
 func (m *mongodbAssetManager) getChart(chartID string) (models.Chart, error) {
-	db, closer := m.dbSession.DB()
+	db, closer := m.DBSession.DB()
 	defer closer()
 	var chart models.Chart
 	err := db.C(chartCollection).FindId(chartID).One(&chart)
@@ -112,7 +99,7 @@ func (m *mongodbAssetManager) getChart(chartID string) (models.Chart, error) {
 }
 
 func (m *mongodbAssetManager) getChartVersion(chartID, version string) (models.Chart, error) {
-	db, closer := m.dbSession.DB()
+	db, closer := m.DBSession.DB()
 	defer closer()
 	var chart models.Chart
 	err := db.C(chartCollection).Find(bson.M{
@@ -126,7 +113,7 @@ func (m *mongodbAssetManager) getChartVersion(chartID, version string) (models.C
 }
 
 func (m *mongodbAssetManager) getChartFiles(filesID string) (models.ChartFiles, error) {
-	db, closer := m.dbSession.DB()
+	db, closer := m.DBSession.DB()
 	defer closer()
 	var files models.ChartFiles
 	err := db.C(filesCollection).FindId(filesID).One(&files)
@@ -134,7 +121,7 @@ func (m *mongodbAssetManager) getChartFiles(filesID string) (models.ChartFiles, 
 }
 
 func (m *mongodbAssetManager) getChartsWithFiltes(name, version, appVersion string) ([]*models.Chart, error) {
-	db, closer := m.dbSession.DB()
+	db, closer := m.DBSession.DB()
 	defer closer()
 	var charts []*models.Chart
 	err := db.C(chartCollection).Find(bson.M{
@@ -149,7 +136,7 @@ func (m *mongodbAssetManager) getChartsWithFiltes(name, version, appVersion stri
 }
 
 func (m *mongodbAssetManager) searchCharts(query, repo string) ([]*models.Chart, error) {
-	db, closer := m.dbSession.DB()
+	db, closer := m.DBSession.DB()
 	defer closer()
 	var charts []*models.Chart
 	conditions := bson.M{

--- a/go.sum
+++ b/go.sum
@@ -272,9 +272,11 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubeapps/common v0.0.0-20190508164739-10b110436c1a h1:VqeX/fehAB6FtBox0TVYcjOMXGE56INQIfbXegditX4=
 github.com/kubeapps/common v0.0.0-20190508164739-10b110436c1a/go.mod h1:TsgmjeDpbftqhwPKInJ3v+l+xbHs4goiB6DFb2WqY9c=
@@ -527,6 +529,7 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/pkg/dbutils/dbutils.go
+++ b/pkg/dbutils/dbutils.go
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2019 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dbutils
+
+// AssetManager basic manager for the different db types
+type AssetManager interface {
+	Init() error
+	Close() error
+}

--- a/pkg/dbutils/mongodb_utils.go
+++ b/pkg/dbutils/mongodb_utils.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2019 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dbutils
+
+import (
+	"fmt"
+
+	"github.com/kubeapps/common/datastore"
+)
+
+// MongodbAssetManager struct containing mongodb info
+type MongodbAssetManager struct {
+	mongoConfig datastore.Config
+	DBSession   datastore.Session
+}
+
+// NewMongoDBManager creates an asset manager for MongoDB
+func NewMongoDBManager(config datastore.Config) *MongodbAssetManager {
+	return &MongodbAssetManager{config, nil}
+}
+
+// Init creates dbsession
+func (m *MongodbAssetManager) Init() error {
+	dbSession, err := datastore.NewSession(m.mongoConfig)
+	if err != nil {
+		return fmt.Errorf("Can't connect to mongoDB: %v", err)
+	}
+	m.DBSession = dbSession
+	return nil
+}
+
+// Close (no-op)
+func (m *MongodbAssetManager) Close() error {
+	return nil
+}

--- a/pkg/dbutils/postgresql_utils.go
+++ b/pkg/dbutils/postgresql_utils.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2018 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dbutils
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/kubeapps/common/datastore"
+)
+
+type postgresDB interface {
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	Begin() (*sql.Tx, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
+	Close() error
+}
+
+// PostgresAssetManager asset manager for postgres
+type PostgresAssetManager struct {
+	connStr string
+	DB      postgresDB
+}
+
+// NewPGManager creates an asset manager for PG
+func NewPGManager(config datastore.Config) (*PostgresAssetManager, error) {
+	url := strings.Split(config.URL, ":")
+	if len(url) != 2 {
+		return nil, fmt.Errorf("Can't parse database URL: %s", config.URL)
+	}
+	connStr := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+		url[0], url[1], config.Username, config.Password, config.Database,
+	)
+	return &PostgresAssetManager{connStr, nil}, nil
+}
+
+// Init connects to PG
+func (m *PostgresAssetManager) Init() error {
+	db, err := sql.Open("postgres", m.connStr)
+	if err != nil {
+		return err
+	}
+	m.DB = db
+	return nil
+}
+
+// Close connection
+func (m *PostgresAssetManager) Close() error {
+	return m.DB.Close()
+}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of #1381

There is a bit of duplicated code shared between the `assetsvc` and the `asset-syncer` related to how the assetManager is initialized. To avoid more clutter in #1381, I have split the code related to remove that duplicated code in this PR.
