### PR TITLE
Toggle off test-tiller-proxy if useHelm3 is true

### DIFF
--- a/chart/kubeapps/templates/tests/test-tiller-proxy.yaml
+++ b/chart/kubeapps/templates/tests/test-tiller-proxy.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useHelm3 -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -20,3 +21,4 @@ spec:
         - -c
         - "curl -o /tmp/output -ik -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" $TILLER_PROXY_HOST:$TILLER_PROXY_PORT/v1/releases && cat /tmp/output && cat /tmp/output | grep $KUBEAPPS_RELEASE"
   restartPolicy: Never
+{{- end }}{{/* matches useHelm3 */}}


### PR DESCRIPTION
### Description of the change

Since the introduction of the `useHelm3` flag in `values.yaml`, we ought to check for that before running `test-tiller-proxy`. We can't assume Tiller is installed when using Helm 3.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

The test won't run when using Helm 3, which does not have the Tiller component.

<!-- What benefits will be realized by the code change? -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1380 

cc: @SimonAlling 
