### PR TITLE
DRY up proxy_pass configuration

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -144,6 +144,17 @@ Create name for the frontend config based on the fullname
 {{- end -}}
 
 {{/*
+Create proxy_pass for the frontend config based on the useHelm3 flag
+*/}}
+{{- define "kubeapps.frontend-config.proxy_pass" -}}
+{{- if .Values.useHelm3 -}}
+http://{{ template "kubeapps.kubeops.fullname" . }}:{{ .Values.kubeops.service.port }}
+{{- else -}}
+http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create name for the tiller-proxy based on the fullname
 */}}
 {{- define "kubeapps.tiller-proxy.fullname" -}}

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -62,11 +62,7 @@ data:
         proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
         {{- end }}
 
-        {{- if .Values.useHelm3 }}
-        proxy_pass http://{{ template "kubeapps.kubeops.fullname" . }}:{{ .Values.kubeops.service.port }};
-        {{- else }}
-        proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
-        {{- end }}
+        proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
       }
 
       location ~* /api/tiller-deploy {
@@ -75,11 +71,7 @@ data:
         proxy_read_timeout 10m;
         rewrite /api/tiller-deploy/(.*) /$1 break;
         rewrite /api/tiller-deploy / break;
-        {{- if .Values.useHelm3 }}
-        proxy_pass http://{{ template "kubeapps.kubeops.fullname" . }}:{{ .Values.kubeops.service.port }};
-        {{- else }}
-        proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
-        {{- end }}
+        proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
 
         {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
         # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
@@ -97,11 +89,7 @@ data:
         proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
         {{- end }}
 
-        {{- if .Values.useHelm3 }}
-        proxy_pass http://{{ template "kubeapps.kubeops.fullname" . }}:{{ .Values.kubeops.service.port }};
-        {{- else }}
-        proxy_pass http://{{ template "kubeapps.tiller-proxy.fullname" . }}:{{ .Values.tillerProxy.service.port }};
-        {{- end }}
+        proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
       }
 
       location / {


### PR DESCRIPTION
### Description of the change

It makes the `proxy_pass` configuration for Tiller Proxy or Kubeops (depending on the value of `useHelm3`) more DRY.

### Benefits

Suddenly, I couldn't get Kubeapps to start with `useHelm3: true`, making me spend several hours trying various more or less random fixes. (I thought I had messed something up with Docker or Minikube, so I didn't think of bisecting or inspecting the YAML files.) The reason turned out to be [this unconditional `proxy_pass` directive](https://github.com/kubeapps/kubeapps/pull/1347/files#diff-b0b5b871c8bf5a72f95d417c97266ae0R100) introduced in #1347 and fixed by me in #1382.

This PR is intended to prevent something similar from happening again; it's not at all obvious that the `proxy_pass` directives must be conditional.

### Additional information

Might be interesting to @lindhe and @absoludity.