### PR TITLE
Rename and move getChart to handlerutil

### DIFF
--- a/pkg/handlerutil/handlerutil.go
+++ b/pkg/handlerutil/handlerutil.go
@@ -1,11 +1,14 @@
 package handlerutil
 
 import (
+	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strings"
 
 	"github.com/gorilla/mux"
+	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
+	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
 // Params a key-value map of path params
@@ -59,4 +62,26 @@ func ErrorCodeWithDefault(err error, defaultCode int) int {
 		errCode = http.StatusUnprocessableEntity
 	}
 	return errCode
+}
+
+func ParseAndGetChart(req *http.Request, cu chartUtils.Resolver) (*chartUtils.Details, *chart.Chart, error) {
+	defer req.Body.Close()
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	chartDetails, err := cu.ParseDetails(body)
+	if err != nil {
+		return nil, nil, err
+	}
+	netClient, err := cu.InitNetClient(chartDetails)
+	if err != nil {
+		return nil, nil, err
+	}
+	requireV1Support := true
+	ch, err := cu.GetChart(chartDetails, netClient, requireV1Support)
+	if err != nil {
+		return nil, nil, err
+	}
+	return chartDetails, ch.Helm2Chart, nil
 }


### PR DESCRIPTION
I'm planning to use it in Kubeops as well.

I renamed it because I think `ParseAndGetChart` is more descriptive of what it actually does.