### PR TITLE
Make ParseAndGetChart Helm version agnostic

### DIFF
--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -29,6 +29,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const requireV1Support = true
+
 func returnForbiddenActions(forbiddenActions []auth.Action, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	body, err := json.Marshal(forbiddenActions)
@@ -59,7 +61,8 @@ func (h *TillerProxy) logStatus(name string) {
 // CreateRelease creates a new release in the namespace given as Param
 func (h *TillerProxy) CreateRelease(w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
 	log.Printf("Creating Helm Release")
-	chartDetails, ch, err := handlerutil.ParseAndGetChart(req, h.ChartClient)
+	chartDetails, chartMulti, err := handlerutil.ParseAndGetChart(req, h.ChartClient, requireV1Support)
+	ch := chartMulti.Helm2Chart
 	if err != nil {
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return
@@ -150,7 +153,8 @@ func (h *TillerProxy) RollbackRelease(w http.ResponseWriter, req *http.Request, 
 // UpgradeRelease upgrades a release in the namespace given as Param
 func (h *TillerProxy) UpgradeRelease(w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
 	log.Printf("Upgrading Helm Release")
-	chartDetails, ch, err := handlerutil.ParseAndGetChart(req, h.ChartClient)
+	chartDetails, chartMulti, err := handlerutil.ParseAndGetChart(req, h.ChartClient, requireV1Support)
+	ch := chartMulti.Helm2Chart
 	if err != nil {
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return

--- a/pkg/handlerutil/handlerutil.go
+++ b/pkg/handlerutil/handlerutil.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gorilla/mux"
 	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
-	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
 // Params a key-value map of path params
@@ -64,7 +63,7 @@ func ErrorCodeWithDefault(err error, defaultCode int) int {
 	return errCode
 }
 
-func ParseAndGetChart(req *http.Request, cu chartUtils.Resolver) (*chartUtils.Details, *chart.Chart, error) {
+func ParseAndGetChart(req *http.Request, cu chartUtils.Resolver, requireV1Support bool) (*chartUtils.Details, *chartUtils.ChartMultiVersion, error) {
 	defer req.Body.Close()
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
@@ -78,10 +77,9 @@ func ParseAndGetChart(req *http.Request, cu chartUtils.Resolver) (*chartUtils.De
 	if err != nil {
 		return nil, nil, err
 	}
-	requireV1Support := true
 	ch, err := cu.GetChart(chartDetails, netClient, requireV1Support)
 	if err != nil {
 		return nil, nil, err
 	}
-	return chartDetails, ch.Helm2Chart, nil
+	return chartDetails, ch, nil
 }


### PR DESCRIPTION
This makes it usable in Kubeops (Helm 3) as well.