### PR TITLE
Redefine Repo struct

### DIFF
--- a/cmd/asset-syncer/mongodb_utils_test.go
+++ b/cmd/asset-syncer/mongodb_utils_test.go
@@ -75,7 +75,7 @@ func Test_DeleteRepo(t *testing.T) {
 }
 
 func Test_emptyChartRepo(t *testing.T) {
-	r := &models.Repo{Name: "testRepo", URL: "https://my.examplerepo.com", Checksum: "123"}
+	r := &models.Repo{Name: "testRepo", URL: "https://my.examplerepo.com"}
 	i, err := parseRepoIndex(emptyRepoIndexYAMLBytes)
 	assert.NoErr(t, err)
 	charts := chartsFromIndex(i, r)

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -172,14 +172,14 @@ func (m *postgresAssetManager) updateIcon(data []byte, contentType, ID string) e
 
 func (m *postgresAssetManager) filesExist(chartFilesID, digest string) bool {
 	rows, err := m.DB.Query(
-		fmt.Sprintf("SELECT * FROM %s WHERE info ->> 'ID' = $1 AND info ->> 'digest' = $2", chartFilesTable),
+		fmt.Sprintf("SELECT * FROM %s WHERE chart_files_id = $1 AND info ->> 'Digest' = $2", chartFilesTable),
 		chartFilesID,
 		digest,
 	)
 	if rows != nil {
 		defer rows.Close()
 	}
-	return err == nil
+	return err == nil && rows.Next()
 }
 
 func (m *postgresAssetManager) insertFiles(chartFilesID string, files models.ChartFiles) error {

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -176,10 +176,12 @@ func (m *postgresAssetManager) filesExist(chartFilesID, digest string) bool {
 		chartFilesID,
 		digest,
 	)
+	hasEntries := false
 	if rows != nil {
 		defer rows.Close()
+		hasEntries = rows.Next()
 	}
-	return err == nil && rows.Next()
+	return err == nil && hasEntries
 }
 
 func (m *postgresAssetManager) insertFiles(chartFilesID string, files models.ChartFiles) error {

--- a/cmd/asset-syncer/postgresql_utils_test.go
+++ b/cmd/asset-syncer/postgresql_utils_test.go
@@ -124,11 +124,11 @@ func Test_PGfilesExist(t *testing.T) {
 	pgManager := &postgresAssetManager{man}
 	m.On(
 		"Query",
-		`SELECT * FROM files WHERE info ->> 'ID' = $1 AND info ->> 'digest' = $2`,
+		`SELECT * FROM files WHERE chart_files_id = $1 AND info ->> 'Digest' = $2`,
 		[]interface{}{id, digest},
 	)
 	exists := pgManager.filesExist(id, digest)
-	if exists != true {
+	if exists != false {
 		t.Errorf("Failed to check if file exists")
 	}
 	m.AssertExpectations(t)

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/kubeapps/common/datastore"
+	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -67,7 +68,7 @@ var syncCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		charts := chartsFromIndex(index, r)
+		charts := chartsFromIndex(index, &models.Repo{Name: r.Name, URL: r.URL})
 		if len(charts) == 0 {
 			logrus.Fatal("no charts in repository index")
 		}
@@ -78,7 +79,7 @@ var syncCmd = &cobra.Command{
 
 		// Fetch and store chart icons
 		fImporter := fileImporter{manager}
-		fImporter.fetchFiles(charts)
+		fImporter.fetchFiles(charts, r)
 
 		// Update cache in the database
 		if err = manager.UpdateLastCheck(r.Name, r.Checksum, time.Now()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 replace github.com/docker/docker => github.com/docker/docker v0.0.0-20190731150326-928381b2215c
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/arschles/assert v1.0.0
@@ -25,11 +26,9 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/unrolled/render v1.0.1 // indirect
 	github.com/urfave/negroni v1.0.0
-	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	google.golang.org/grpc v1.25.1
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	helm.sh/helm/v3 v3.0.0
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/api v0.0.0-20191016110408-35e52d86657a
 	k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8
 	k8s.io/client-go v0.0.0-20191016111102-bec269661e48

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e h1:eb0Pzkt15Bm7f2FFYv7sjY7NPFi3cPkS3tv1CcrFBWA=
 github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=

--- a/pkg/chart/models/chart.go
+++ b/pkg/chart/models/chart.go
@@ -25,8 +25,14 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
-// Repo holds the App repository details
+// Repo holds the App repository basic details
 type Repo struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// RepoInternal holds the App repository details including auth and checksum
+type RepoInternal struct {
 	Name                string `json:"name"`
 	URL                 string `json:"url"`
 	AuthorizationHeader string `bson:"-"`
@@ -49,9 +55,11 @@ type Chart struct {
 	ChartVersions   []ChartVersion     `json:"chartVersions"`
 }
 
+// ChartIconString is a higher-level representation of a chart package
+// TODO(andresmgot) Replace this type when the icon is stored as a binary
 type ChartIconString struct {
 	Chart
-	RawIcon string
+	RawIcon string `json:"raw_icon" bson:"raw_icon"`
 }
 
 // ChartVersion is a representation of a specific version of a chart


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

After #1386 (`models` refactor), the `Repo` struct contained auth info that was stored in the `charts` database and was being returned for each chart request. This `auth` info should not be send to the client. To fix this, the `asset-syncer` will work with the struct `RepoInternal` (which has the auth info but it's not stored in the database) and the assetsvc will continue to work with the `Repo` struct.

Apart from that this PR includes a fix that was preventing the postgres driver to properly skip files import.
