### PR TITLE
Create handler for app repositories backend API.

### DIFF
--- a/cmd/tiller-proxy/internal/handler/apprepos_handler.go
+++ b/cmd/tiller-proxy/internal/handler/apprepos_handler.go
@@ -82,8 +82,9 @@ func NewAppRepositoriesHandler(kubeappsNamespace string) (*appRepositoriesHandle
 		return nil, err
 	}
 	return &appRepositoriesHandler{
-		config:             *config,
-		kubeappsNamespace:  kubeappsNamespace,
+		config:            *config,
+		kubeappsNamespace: kubeappsNamespace,
+		// See comment in the struct defn above.
 		clientsetForConfig: clientsetForConfig,
 	}, nil
 }

--- a/cmd/tiller-proxy/internal/handler/apprepos_handler.go
+++ b/cmd/tiller-proxy/internal/handler/apprepos_handler.go
@@ -17,18 +17,148 @@ limitations under the License.
 package handler
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	clientset "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
+	"github.com/kubeapps/kubeapps/pkg/auth"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// AppRepositories handles http requests for operating on app repositories
+// appRepositories handles http requests for operating on app repositories
 // in Kubeapps, without exposing implementation details to 3rd party integrations.
-type AppRepositories struct{}
+type appRepositoriesHandler struct {
+	// The config set internally here cannot be used on its own as a valid
+	// token is required. Call-sites use ConfigForToken to obtain a valid
+	// config with a specific token.
+	config rest.Config
 
-func (a *AppRepositories) Create(w http.ResponseWriter, req *http.Request) {
-	log.Printf("Creating AppRepository")
-	// TODO: Create AppRepository using the k8s client.
+	// The namespace in which (currently) app repositories are created.
+	kubeappsNamespace string
+
+	// clientsetForConfig is a field on the struct only so it can be switched
+	// for a fake version when testing. NewAppRepositoryHandler sets it to the
+	// proper function below so that production code always has the real
+	// version (and since this is a private struct, external code cannot change
+	// the function).
+	clientsetForConfig func(*rest.Config) (clientset.Interface, error)
+}
+
+// appRepositoryRequest is used to parse the JSON request
+type appRepositoryRequest struct {
+	AppRepository appRepositoryRequestDetails `json:"appRepository"`
+}
+
+type appRepositoryRequestDetails struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+	// TODO(mnelson): Add credential support for private repositories
+	// so this can be used for the UI request also.
+}
+
+// NewAppRepositoriesHandler returns an AppRepositories handler configured with
+// the in-cluster config but overriding the token with an empty string, so that
+// ConfigForToken must be called to obtain a valid config.
+func NewAppRepositoriesHandler(kubeappsNamespace string) (*appRepositoriesHandler, error) {
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{
+			AuthInfo: clientcmdapi.AuthInfo{
+				Token:     "",
+				TokenFile: "",
+			},
+		},
+	)
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return &appRepositoriesHandler{
+		config:             *config,
+		kubeappsNamespace:  kubeappsNamespace,
+		clientsetForConfig: clientsetForConfig,
+	}, nil
+}
+
+// clientsetForConfig returns a clientset using the provided config.
+func clientsetForConfig(config *rest.Config) (clientset.Interface, error) {
+	clientset, err := clientset.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientset, nil
+}
+
+// ConfigForToken returns a new config for a given auth token.
+func (a *appRepositoriesHandler) ConfigForToken(token string) *rest.Config {
+	configCopy := a.config
+	configCopy.BearerToken = token
+	return &configCopy
+}
+
+// Create creates an AppRepository resource based on the request data
+func (a *appRepositoriesHandler) Create(w http.ResponseWriter, req *http.Request) {
+	if a.kubeappsNamespace == "" {
+		log.Errorf("attempt to use app repositories handler without kubeappsNamespace configured")
+		http.Error(w, "kubeappsNamespace must be configured to enable app repository handler", http.StatusUnauthorized)
+	}
+
+	token := auth.ExtractToken(req.Header.Get("Authorization"))
+	clientset, err := a.clientsetForConfig(a.ConfigForToken(token))
+	if err != nil {
+		log.Errorf("unable to create clientset: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	appRepo, err := appRepositoryForRequestData(req.Body)
+	if err != nil {
+		log.Infof("unable to decode: %v", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	// TODO(mnelson): validate both required data and request for index
+	// https://github.com/kubeapps/kubeapps/issues/1330
+
+	_, err = clientset.KubeappsV1alpha1().AppRepositories(a.kubeappsNamespace).Create(appRepo)
+
+	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok {
+			status := statusErr.ErrStatus
+			log.Infof("unable to create app repo: %v", status.Reason)
+			http.Error(w, status.Message, int(status.Code))
+		} else {
+			log.Errorf("unable to create app repo: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte("OK"))
+}
+
+// appRepositoryForRequestData takes care of parsing the request data into an AppRepository.
+func appRepositoryForRequestData(body io.ReadCloser) (*v1alpha1.AppRepository, error) {
+	var appRepoRequest appRepositoryRequest
+	err := json.NewDecoder(body).Decode(&appRepoRequest)
+	if err != nil {
+		return nil, err
+	}
+	return &v1alpha1.AppRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: appRepoRequest.AppRepository.Name,
+		},
+		Spec: v1alpha1.AppRepositorySpec{
+			URL: appRepoRequest.AppRepository.URL,
+		},
+	}, nil
 }

--- a/cmd/tiller-proxy/internal/handler/apprepos_handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/apprepos_handler_test.go
@@ -17,20 +17,144 @@ limitations under the License.
 package handler
 
 import (
+	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+
+	v1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	clientset "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
+	fakeclientset "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/fake"
 )
 
+func makeAppRepoObjects(repoNamesPerNamespace map[string][]string) []runtime.Object {
+	objects := []runtime.Object{}
+	for namespace, repoNames := range repoNamesPerNamespace {
+		for _, repoName := range repoNames {
+			var appRepo runtime.Object = &v1alpha1.AppRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      repoName,
+					Namespace: namespace,
+				},
+			}
+			objects = append(objects, appRepo)
+		}
+	}
+	return objects
+}
+
 func TestAppRepositoryCreate(t *testing.T) {
-	handler := AppRepositories{}
+	testCases := []struct {
+		name              string
+		kubeappsNamespace string
+		// existingRepos is a map with the namespaces as the key
+		// and a slice of repository names for that namespace as the value.
+		existingRepos map[string][]string
+		requestData   string
+		expectedCode  int
+	}{
+		{
+			name:              "it creates an app repository",
+			kubeappsNamespace: "kubeapps",
+			requestData:       `{"appRepository": {"name": "test-repo", "url": "http://example.com/test-repo"}}`,
+			expectedCode:      http.StatusCreated,
+		},
+		{
+			name:              "it errors if the repo exists in the kubeapps ns already",
+			kubeappsNamespace: "kubeapps",
+			requestData:       `{"appRepository": {"name": "bitnami"}}`,
+			existingRepos: map[string][]string{
+				"kubeapps": []string{"bitnami"},
+			},
+			expectedCode: http.StatusConflict,
+		},
+		{
+			name:              "it creates the repo even if the same repo exists in other namespaces",
+			kubeappsNamespace: "kubeapps",
+			requestData:       `{"appRepository": {"name": "bitnami"}}`,
+			existingRepos: map[string][]string{
+				"kubeapps-other-ns-1": []string{"bitnami"},
+				"kubeapps-other-ns-2": []string{"bitnami"},
+			},
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:              "it results in a bad request if the json cannot be parsed",
+			kubeappsNamespace: "kubeapps",
+			requestData:       `not a { json object`,
+			expectedCode:      http.StatusBadRequest,
+		},
+		{
+			name:              "it results in an Unauthorized response if the kubeapps namespace is not set",
+			requestData:       `{"appRepository": {"name": "bitnami"}}`,
+			kubeappsNamespace: "",
+			expectedCode:      http.StatusUnauthorized,
+		},
+	}
 
-	req := httptest.NewRequest("POST", "https://foo.bar/backend/v1/apprepositories", strings.NewReader(""))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := fakeclientset.NewSimpleClientset(makeAppRepoObjects(tc.existingRepos)...)
+			handler := appRepositoriesHandler{
+				clientsetForConfig: func(*rest.Config) (clientset.Interface, error) { return cs, nil },
+				kubeappsNamespace:  tc.kubeappsNamespace,
+			}
 
-	response := httptest.NewRecorder()
-	handler.Create(response, req)
+			req := httptest.NewRequest("POST", "https://foo.bar/backend/v1/apprepositories", strings.NewReader(tc.requestData))
 
-	if got, want := response.Code, 201; got != want {
-		t.Errorf("got: %d, want: %d", got, want)
+			response := httptest.NewRecorder()
+
+			handler.Create(response, req)
+
+			if got, want := response.Code, tc.expectedCode; got != want {
+				t.Errorf("got: %d, want: %d", got, want)
+			}
+
+			if response.Code == 201 {
+				assertRepoPresent(t, tc.kubeappsNamespace, tc.requestData, cs)
+			}
+		})
+	}
+}
+
+func assertRepoPresent(t *testing.T, namespace, requestData string, cs clientset.Interface) {
+	requestAppRepo, err := appRepositoryForRequestData(ioutil.NopCloser(strings.NewReader(requestData)))
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	requestAppRepo.ObjectMeta.Namespace = namespace
+
+	responseAppRepo, err := cs.KubeappsV1alpha1().AppRepositories(namespace).Get(requestAppRepo.ObjectMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("expected data %v not present: %+v", requestAppRepo, err)
+	}
+
+	if got, want := responseAppRepo, requestAppRepo; !cmp.Equal(want, got) {
+		t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+	}
+}
+
+func TestConfigForToken(t *testing.T) {
+	handler := appRepositoriesHandler{
+		config: rest.Config{},
+	}
+	token := "abcd"
+
+	configWithToken := handler.ConfigForToken(token)
+
+	// The returned config has the token set.
+	if got, want := configWithToken.BearerToken, token; got != want {
+		t.Errorf("got: %q, want: %q", got, want)
+	}
+
+	// The handler config's BearerToken is still blank.
+	if got, want := handler.config.BearerToken, ""; got != want {
+		t.Errorf("got: %q, want: %q", got, want)
 	}
 }

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -63,7 +63,8 @@ var (
 	tlsCertDefault   = fmt.Sprintf("%s/tls.crt", os.Getenv("HELM_HOME"))
 	tlsKeyDefault    = fmt.Sprintf("%s/tls.key", os.Getenv("HELM_HOME"))
 
-	chartsvcURL string
+	chartsvcURL       string
+	kubeappsNamespace string
 )
 
 func init() {
@@ -80,6 +81,8 @@ func init() {
 	// Default timeout from https://github.com/helm/helm/blob/b0b0accdfc84e154b3d48ec334cd5b4f9b345667/cmd/helm/install.go#L216
 	pflag.Int64Var(&timeout, "timeout", 300, "Timeout to perform release operations (install, upgrade, rollback, delete)")
 	pflag.StringVar(&chartsvcURL, "chartsvc-url", "http://kubeapps-internal-chartsvc:8080", "URL to the internal chartsvc")
+	// kubeapps-namespace is required only for the app repository handler which may move in the future.
+	pflag.StringVar(&kubeappsNamespace, "kubeapps-namespace", "", "namespace in which Kubeapps is running")
 }
 
 func main() {
@@ -183,7 +186,10 @@ func main() {
 	// Backend routes unrelated to tiller-proxy functionality.
 	// TODO(mnelson): Once the helm3 support is complete and tiller-proxy is being removed,
 	// reconsider where these endpoints live.
-	appreposHandler := handler.AppRepositories{}
+	appreposHandler, err := handler.NewAppRepositoriesHandler(kubeappsNamespace)
+	if err != nil {
+		log.Fatalf("Unable to create app repositories handler: %+v", err)
+	}
 	backendAPIv1 := r.PathPrefix("/backend/v1").Subrouter()
 	backendAPIv1.Methods("POST").Path("/apprepositories").Handler(negroni.New(
 		negroni.WrapFunc(appreposHandler.Create),

--- a/docs/architecture/design-proposals/third-party-add-repository.md
+++ b/docs/architecture/design-proposals/third-party-add-repository.md
@@ -71,6 +71,7 @@ Kubeapps provides an api endpoint for app repositories:
    - Error responses
      - 401 Unauthorized
      - 400 Bad Request
+     - 409 Conflict
      - Body of error responses to be defined.
 
 * Delete App Repository


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Fills in the stub implementation of the `Create` handler for the app repository backend API
<!-- Describe the scope of your change - i.e. what the change does. -->

Note: this handler is similar in nature to the helm3 work in the respect that it picks up the in-cluster k8s config and uses that with the user token to access the API. But note that it's structured so that:

- the k8s config, with the blanked `BearerToken` is read from the system and created once only when the handler is created,
- an actual working config with the user token is created for each request. This is a copy of the blanked k8s config with the token set.
- it is tested using the (generated) fake clientset for the resource by injecting a dummy `clientsetForConfig` function when testing which just returns the fake. This ensures that external use of this handler will always have the real `clientsetForConfig` function, and only (internal) tests can set a dummy function. In this sense, it may be useful to @SimonAlling as a way to structure the handler code to be testable (warning: client-go testing with fake clientsets is pretty verbose, but once the parts are in place, pretty easy to work with - the setup is the painful part :/)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref #1173 

### Additional information

I've added a `--kubeapps-namespace` flag which is effectively a feature flag. Without this being set, a response comes back as:
```
< HTTP/1.1 401 Unauthorized                                                                                                                                                                                                       
< Content-Length: 74                                                                                                                                                                                                              
< Content-Type: text/plain; charset=utf-8                                                                                                                                                                                         < Date: Wed, 18 Dec 2019 04:30:27 GMT                                                                                                                                                                                             < Server: nginx/1.16.1                                                                                                                                                                                                            < X-Content-Type-Options: nosniff                                                                                                                                                                                                 <                                                                                                                                                                                                                                 kubeappsNamespace must be configured to enable app repository handler                                                                                                                                                             EOF                                                                                                                                                                                                                               
```

FWIW, I need to investigate more on the use of the in-cluster config, as when I did an IRL test with the feature switched on, authing with a cookie for my `kubeapps-operator` user, I see the following unexpected result:

```
$ curl -XPOST 'http://localhost:3000/api/v1/apprepositories' -H 'User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:70.0) Gecko/20100101 Firefox/70.0' -H 'Accept: application/json, text/p
lain, */*' -H 'Accept-Language: en-US,en;q=0.5' --compressed -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Referer: http://localhost:3000/' -H 'Cookie: _oauth2_proxy=<redacted>' -vvv --data '{"appRepository": {"name": "test-repo", "url": "http://example.com/test-repo"}}'
...
> Content-Length: 79                                                                                                                                                                                                              
> Content-Type: application/x-www-form-urlencoded                                                                                                                                                                                 
>                                                                                                                                                                                                                                 
* upload completely sent off: 79 out of 79 bytes                                                                                                                                                                                  
< HTTP/1.1 403 Forbidden                                                                                                                                                                                                          
< Content-Encoding: gzip                                                                                                                                                                                                          
< Content-Type: text/plain; charset=utf-8                                                                                                                                                                                         
< Date: Wed, 18 Dec 2019 04:32:37 GMT                                                                                                                                                                                             
< Server: nginx/1.16.1                                                                                                                                                                                                            
< X-Content-Type-Options: nosniff                                                                                                                                                                                                 
< Content-Length: 156                                                                                                                                                                                                             
<                                                                                                                                                                                                                                 
apprepositories.kubeapps.com is forbidden: User "system:serviceaccount:kubeapps:kubeapps-internal-tiller-proxy" cannot create resource "apprepositories" in API group "kubeapps.com" in the namespace "kubeapps"                  
```
I don't think this should stop the PR from landing (since it's behind the extra flag which is not set in the chart yet), but tomorrow I plan to find out (a) why it assumes the user accessing is the internal-tiller-proxy service account (ie. does the in-cluster config have not only the token data, but the service account info set, which needs to be blanked out), and (b) why the token (or otherwise) is resulting in a 403.

Maybe it'll be obvious during review, but I need to run :)