### PR TITLE
Create tables before syncing content

### DIFF
--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -151,7 +151,7 @@ func (m *postgresAssetManager) removeMissingCharts(charts []models.Chart) error 
 		chartIDs = append(chartIDs, fmt.Sprintf("'%s'", chart.ID))
 	}
 	chartIDsString := strings.Join(chartIDs, ", ")
-	rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE info ->> 'ID' NOT IN (%s)", dbutils.ChartFilesTable, chartIDsString))
+	rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE info ->> 'ID' NOT IN (%s)", dbutils.ChartTable, chartIDsString))
 	if rows != nil {
 		defer rows.Close()
 	}

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -30,15 +30,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	// create table charts (ID serial NOT NULL PRIMARY KEY, info jsonb NOT NULL);
-	chartTable = "charts"
-	// create table repos (ID serial NOT NULL PRIMARY KEY, name varchar unique, checksum varchar, last_update varchar);
-	repositoryTable = "repos"
-	// create table files (ID serial NOT NULL PRIMARY KEY, chart_files_ID varchar unique, info jsonb NOT NULL);
-	chartFilesTable = "files"
-)
-
 type postgresAssetManager struct {
 	*dbutils.PostgresAssetManager
 }
@@ -61,6 +52,7 @@ func newPGManager(config datastore.Config) (assetManager, error) {
 // imported into the database as fast as possible. E.g. we want all icons for
 // charts before fetching readmes for each chart and version pair.
 func (m *postgresAssetManager) Sync(charts []models.Chart) error {
+	m.initTables()
 	err := m.importCharts(charts)
 	if err != nil {
 		return err
@@ -70,9 +62,34 @@ func (m *postgresAssetManager) Sync(charts []models.Chart) error {
 	return m.removeMissingCharts(charts)
 }
 
+func (m *postgresAssetManager) initTables() error {
+	_, err := m.DB.Exec(fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s (ID serial NOT NULL PRIMARY KEY, info jsonb NOT NULL)",
+		dbutils.ChartTable,
+	))
+	if err != nil {
+		return err
+	}
+	_, err = m.DB.Exec(fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s (ID serial NOT NULL PRIMARY KEY, name varchar unique, checksum varchar, last_update varchar)",
+		dbutils.RepositoryTable,
+	))
+	if err != nil {
+		return err
+	}
+	_, err = m.DB.Exec(fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s (ID serial NOT NULL PRIMARY KEY, chart_files_ID varchar unique, info jsonb NOT NULL)",
+		dbutils.ChartFilesTable,
+	))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *postgresAssetManager) RepoAlreadyProcessed(repoName, repoChecksum string) bool {
 	var lastChecksum string
-	row := m.DB.QueryRow(fmt.Sprintf("SELECT checksum FROM %s WHERE name = $1", repositoryTable), repoName)
+	row := m.DB.QueryRow(fmt.Sprintf("SELECT checksum FROM %s WHERE name = $1", dbutils.RepositoryTable), repoName)
 	if row != nil {
 		err := row.Scan(&lastChecksum)
 		return err == nil && lastChecksum == repoChecksum
@@ -85,7 +102,7 @@ func (m *postgresAssetManager) UpdateLastCheck(repoName, checksum string, now ti
 	VALUES ($1, $2, $3)
 	ON CONFLICT (name) 
 	DO UPDATE SET last_update = $3, checksum = $2
-	`, repositoryTable)
+	`, dbutils.RepositoryTable)
 	rows, err := m.DB.Query(query, repoName, checksum, now.String())
 	if rows != nil {
 		defer rows.Close()
@@ -99,7 +116,7 @@ func (m *postgresAssetManager) importCharts(charts []models.Chart) error {
 		log.Fatal(err)
 	}
 
-	stmt, err := txn.Prepare(pq.CopyIn(chartTable, "info"))
+	stmt, err := txn.Prepare(pq.CopyIn(dbutils.ChartTable, "info"))
 	if err != nil {
 		return err
 	}
@@ -134,7 +151,7 @@ func (m *postgresAssetManager) removeMissingCharts(charts []models.Chart) error 
 		chartIDs = append(chartIDs, fmt.Sprintf("'%s'", chart.ID))
 	}
 	chartIDsString := strings.Join(chartIDs, ", ")
-	rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE info ->> 'ID' NOT IN (%s)", chartTable, chartIDsString))
+	rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE info ->> 'ID' NOT IN (%s)", dbutils.ChartFilesTable, chartIDsString))
 	if rows != nil {
 		defer rows.Close()
 	}
@@ -142,7 +159,7 @@ func (m *postgresAssetManager) removeMissingCharts(charts []models.Chart) error 
 }
 
 func (m *postgresAssetManager) Delete(repoName string) error {
-	tables := []string{chartTable, chartFilesTable}
+	tables := []string{dbutils.ChartTable, dbutils.ChartFilesTable}
 	for _, table := range tables {
 		rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE info -> 'repo' ->> 'name' = $1", table), repoName)
 		if rows != nil {
@@ -152,7 +169,7 @@ func (m *postgresAssetManager) Delete(repoName string) error {
 			return err
 		}
 	}
-	rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE name = $1", repositoryTable), repoName)
+	rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE name = $1", dbutils.RepositoryTable), repoName)
 	if rows != nil {
 		defer rows.Close()
 	}
@@ -172,7 +189,7 @@ func (m *postgresAssetManager) updateIcon(data []byte, contentType, ID string) e
 
 func (m *postgresAssetManager) filesExist(chartFilesID, digest string) bool {
 	rows, err := m.DB.Query(
-		fmt.Sprintf("SELECT * FROM %s WHERE chart_files_id = $1 AND info ->> 'Digest' = $2", chartFilesTable),
+		fmt.Sprintf("SELECT * FROM %s WHERE chart_files_id = $1 AND info ->> 'Digest' = $2", dbutils.ChartFilesTable),
 		chartFilesID,
 		digest,
 	)
@@ -189,7 +206,7 @@ func (m *postgresAssetManager) insertFiles(chartFilesID string, files models.Cha
 	VALUES ($1, $2)
 	ON CONFLICT (chart_files_ID) 
 	DO UPDATE SET info = $2
-	`, chartFilesTable)
+	`, dbutils.ChartFilesTable)
 	rows, err := m.DB.Query(query, chartFilesID, files)
 	if rows != nil {
 		defer rows.Close()

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/kubeapps/kubeapps/pkg/dbutils"
 	"github.com/lib/pq"
+	_ "github.com/lib/pq"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -151,7 +152,7 @@ func (m *postgresAssetManager) removeMissingCharts(charts []models.Chart) error 
 		chartIDs = append(chartIDs, fmt.Sprintf("'%s'", chart.ID))
 	}
 	chartIDsString := strings.Join(chartIDs, ", ")
-	rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE info ->> 'ID' NOT IN (%s)", dbutils.ChartTable, chartIDsString))
+	rows, err := m.DB.Query(fmt.Sprintf("DELETE FROM %s WHERE info ->> 'ID' NOT IN (%s) AND info -> 'repo' ->> 'name' = $1", dbutils.ChartTable, chartIDsString), charts[0].Repo.Name)
 	if rows != nil {
 		defer rows.Close()
 	}

--- a/cmd/asset-syncer/postgresql_utils_test.go
+++ b/cmd/asset-syncer/postgresql_utils_test.go
@@ -90,12 +90,12 @@ func Test_PGUpdateLastCheck(t *testing.T) {
 }
 
 func Test_PGremoveMissingCharts(t *testing.T) {
-	charts := []models.Chart{{ID: "foo"}, {ID: "bar"}}
+	charts := []models.Chart{{ID: "foo", Repo: &models.Repo{Name: "repo"}}, {ID: "bar"}}
 	m := &mockDB{&mock.Mock{}}
 	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"})
 	man.DB = m
 	pgManager := &postgresAssetManager{man}
-	m.On("Query", "DELETE FROM charts WHERE info ->> 'ID' NOT IN ('foo', 'bar')", []interface{}(nil))
+	m.On("Query", "DELETE FROM charts WHERE info ->> 'ID' NOT IN ('foo', 'bar') AND info -> 'repo' ->> 'name' = $1", []interface{}{"repo"})
 	pgManager.removeMissingCharts(charts)
 	m.AssertExpectations(t)
 }

--- a/cmd/asset-syncer/postgresql_utils_test.go
+++ b/cmd/asset-syncer/postgresql_utils_test.go
@@ -36,10 +36,14 @@ func (d *mockDB) Close() error {
 	return nil
 }
 
+func (d *mockDB) Exec(query string, args ...interface{}) (sql.Result, error) {
+	return nil, nil
+}
+
 func Test_DeletePGRepo(t *testing.T) {
 	repoName := "test"
 	m := &mockDB{&mock.Mock{}}
-	tables := []string{chartTable, chartFilesTable}
+	tables := []string{dbutils.ChartTable, dbutils.ChartFilesTable}
 	for _, table := range tables {
 		q := fmt.Sprintf("DELETE FROM %s WHERE info -> 'repo' ->> 'name' = $1", table)
 		// Since we are not specifying any argument, Query is called with []interface{}(nil)

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -53,7 +53,6 @@ func (m *postgresAssetManager) getPaginatedChartList(repo string, pageNumber, pa
 		repoQuery = fmt.Sprintf("WHERE info -> 'repo' ->> 'name' = '%s'", repo)
 	}
 	dbQuery := fmt.Sprintf("SELECT info FROM %s %s ORDER BY info ->> 'name' ASC", dbutils.ChartTable, repoQuery)
-	fmt.Println(dbQuery)
 	charts, err := m.QueryAllCharts(dbQuery)
 	if err != nil {
 		return nil, 0, nil

--- a/pkg/dbutils/postgresql_utils.go
+++ b/pkg/dbutils/postgresql_utils.go
@@ -27,11 +27,11 @@ import (
 )
 
 const (
-	// ChartTable `create table charts (ID serial NOT NULL PRIMARY KEY, info jsonb NOT NULL);`
+	// ChartTable table containing Charts info
 	ChartTable = "charts"
-	// RepositoryTable `create table repos (ID serial NOT NULL PRIMARY KEY, name varchar unique, checksum varchar, last_update varchar);`
+	// RepositoryTable table containing repositories sync info
 	RepositoryTable = "repos"
-	// ChartFilesTable `create table files (ID serial NOT NULL PRIMARY KEY, chart_files_ID varchar unique, info jsonb NOT NULL);`
+	// ChartFilesTable table containing files related to other charts
 	ChartFilesTable = "files"
 )
 
@@ -40,6 +40,7 @@ type postgresDB interface {
 	Begin() (*sql.Tx, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
 	Close() error
+	Exec(query string, args ...interface{}) (sql.Result, error)
 }
 
 // PostgresAssetManagerIface represents the methods of the PG asset manager


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

While the goal of this PR was to create programatically the tables used (if not exist), I found several small issues while testing this IRL so I added them to this PR:

 - Use the table names defined in `dbutils`
 - Fix a bug that was deleting the chart from the repositories not being evaluated
 - Remove a debug `fmt.Print`

Note: I am not testing the new code because a test mocking the result doesn't help much and also because this is a basic functionality that will be tested in the e2e tests.

