### PR TITLE
Update apprepo create API to include appropriate secret

### DIFF
--- a/cmd/tiller-proxy/internal/handler/apprepos_handler.go
+++ b/cmd/tiller-proxy/internal/handler/apprepos_handler.go
@@ -18,20 +18,37 @@ package handler
 
 import (
 	"encoding/json"
-	"io"
+	"fmt"
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	clientset "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
+	apprepoclientset "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
+	v1alpha1typed "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/typed/apprepository/v1alpha1"
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// combinedClientsetInterface provides both the app repository clientset and the corev1 clientset.
+type combinedClientsetInterface interface {
+	KubeappsV1alpha1() v1alpha1typed.KubeappsV1alpha1Interface
+	CoreV1() corev1typed.CoreV1Interface
+}
+
+// Need to use a type alias to embed the two Clientset's without a name clash.
+type appRepoClientsetAlias = apprepoclientset.Clientset
+type combinedClientset struct {
+	*appRepoClientsetAlias
+	*kubernetes.Clientset
+}
 
 // appRepositories handles http requests for operating on app repositories
 // in Kubeapps, without exposing implementation details to 3rd party integrations.
@@ -49,7 +66,7 @@ type appRepositoriesHandler struct {
 	// proper function below so that production code always has the real
 	// version (and since this is a private struct, external code cannot change
 	// the function).
-	clientsetForConfig func(*rest.Config) (clientset.Interface, error)
+	clientsetForConfig func(*rest.Config) (combinedClientsetInterface, error)
 }
 
 // appRepositoryRequest is used to parse the JSON request
@@ -58,10 +75,12 @@ type appRepositoryRequest struct {
 }
 
 type appRepositoryRequestDetails struct {
-	Name string `json:"name"`
-	URL  string `json:"url"`
-	// TODO(mnelson): Add credential support for private repositories
-	// so this can be used for the UI request also.
+	Name               string                 `json:"name"`
+	RepoURL            string                 `json:"repoUrl"`
+	AuthHeader         string                 `json:"authHeader"`
+	CustomCA           string                 `json:"customCA"`
+	SyncJobPodTemplate corev1.PodTemplateSpec `json:"syncJobPodTemplate"`
+	ResyncRequests     uint                   `json:"resyncRequests"`
 }
 
 // NewAppRepositoriesHandler returns an AppRepositories handler configured with
@@ -72,8 +91,12 @@ func NewAppRepositoriesHandler(kubeappsNamespace string) (*appRepositoriesHandle
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{
 			AuthInfo: clientcmdapi.AuthInfo{
-				Token:     "",
-				TokenFile: "",
+				// These three override their respective file or string
+				// data.
+				ClientCertificateData: []byte{},
+				ClientKeyData:         []byte{},
+				// A non empty value is required to override, it seems.
+				TokenFile: " ",
 			},
 		},
 	)
@@ -90,12 +113,16 @@ func NewAppRepositoriesHandler(kubeappsNamespace string) (*appRepositoriesHandle
 }
 
 // clientsetForConfig returns a clientset using the provided config.
-func clientsetForConfig(config *rest.Config) (clientset.Interface, error) {
-	clientset, err := clientset.NewForConfig(config)
+func clientsetForConfig(config *rest.Config) (combinedClientsetInterface, error) {
+	arclientset, err := apprepoclientset.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}
-	return clientset, nil
+	coreclientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return &combinedClientset{arclientset, coreclientset}, nil
 }
 
 // ConfigForToken returns a new config for a given auth token.
@@ -120,16 +147,19 @@ func (a *appRepositoriesHandler) Create(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	appRepo, err := appRepositoryForRequestData(req.Body)
+	var appRepoRequest appRepositoryRequest
+	err = json.NewDecoder(req.Body).Decode(&appRepoRequest)
 	if err != nil {
 		log.Infof("unable to decode: %v", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	appRepo := appRepositoryForRequest(&appRepoRequest)
 	// TODO(mnelson): validate both required data and request for index
 	// https://github.com/kubeapps/kubeapps/issues/1330
 
-	_, err = clientset.KubeappsV1alpha1().AppRepositories(a.kubeappsNamespace).Create(appRepo)
+	appRepo, err = clientset.KubeappsV1alpha1().AppRepositories(a.kubeappsNamespace).Create(appRepo)
 
 	if err != nil {
 		if statusErr, ok := err.(*errors.StatusError); ok {
@@ -143,23 +173,98 @@ func (a *appRepositoriesHandler) Create(w http.ResponseWriter, req *http.Request
 		return
 	}
 
+	secret := secretForRequest(appRepoRequest, *appRepo)
+	if secret != nil {
+		_, err = clientset.CoreV1().Secrets(a.kubeappsNamespace).Create(secret)
+		if err != nil {
+			if statusErr, ok := err.(*errors.StatusError); ok {
+				status := statusErr.ErrStatus
+				log.Infof("unable to create app repo secret: %v", status.Reason)
+				http.Error(w, status.Message, int(status.Code))
+			} else {
+				log.Errorf("unable to create app repo secret: %v", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			return
+		}
+	}
+
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte("OK"))
 }
 
-// appRepositoryForRequestData takes care of parsing the request data into an AppRepository.
-func appRepositoryForRequestData(body io.ReadCloser) (*v1alpha1.AppRepository, error) {
-	var appRepoRequest appRepositoryRequest
-	err := json.NewDecoder(body).Decode(&appRepoRequest)
-	if err != nil {
-		return nil, err
+// appRepositoryForRequest takes care of parsing the request data into an AppRepository.
+func appRepositoryForRequest(appRepoRequest *appRepositoryRequest) *v1alpha1.AppRepository {
+	appRepo := appRepoRequest.AppRepository
+
+	var auth v1alpha1.AppRepositoryAuth
+	if appRepo.AuthHeader != "" || appRepo.CustomCA != "" {
+		secretName := fmt.Sprintf("apprepo-%s-secrets", appRepo.Name)
+		if appRepo.AuthHeader != "" {
+			auth.Header = &v1alpha1.AppRepositoryAuthHeader{
+				SecretKeyRef: corev1.SecretKeySelector{
+					Key: "authorizationHeader",
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: secretName,
+					},
+				},
+			}
+		}
+		if appRepo.CustomCA != "" {
+			auth.CustomCA = &v1alpha1.AppRepositoryCustomCA{
+				SecretKeyRef: corev1.SecretKeySelector{
+					Key: "ca.crt",
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: secretName,
+					},
+				},
+			}
+		}
 	}
+
 	return &v1alpha1.AppRepository{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: appRepoRequest.AppRepository.Name,
+			Name: appRepo.Name,
 		},
 		Spec: v1alpha1.AppRepositorySpec{
-			URL: appRepoRequest.AppRepository.URL,
+			URL:                appRepo.RepoURL,
+			Type:               "helm",
+			Auth:               auth,
+			SyncJobPodTemplate: appRepo.SyncJobPodTemplate,
+			ResyncRequests:     appRepo.ResyncRequests,
 		},
-	}, nil
+	}
+}
+
+// secretForRequest takes care of parsing the request data into a secret for an AppRepository.
+func secretForRequest(appRepoRequest appRepositoryRequest, appRepo v1alpha1.AppRepository) *corev1.Secret {
+	appRepoDetails := appRepoRequest.AppRepository
+	secrets := map[string]string{}
+	if appRepoDetails.AuthHeader != "" {
+		secrets["authorizationHeader"] = appRepoDetails.AuthHeader
+	}
+	if appRepoDetails.CustomCA != "" {
+		secrets["ca.crt"] = appRepoDetails.CustomCA
+	}
+
+	if len(secrets) == 0 {
+		return nil
+	}
+	blockOwnerDeletion := true
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("apprepo-%s-secrets", appRepoDetails.Name),
+			OwnerReferences: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					APIVersion:         appRepo.TypeMeta.APIVersion,
+					Kind:               appRepo.TypeMeta.Kind,
+					Name:               appRepo.ObjectMeta.Name,
+					UID:                appRepo.ObjectMeta.UID,
+					BlockOwnerDeletion: &blockOwnerDeletion,
+				},
+			},
+		},
+		StringData: secrets,
+	}
+	return nil
 }

--- a/cmd/tiller-proxy/internal/handler/apprepos_handler.go
+++ b/cmd/tiller-proxy/internal/handler/apprepos_handler.go
@@ -155,7 +155,7 @@ func (a *appRepositoriesHandler) Create(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	appRepo := appRepositoryForRequest(&appRepoRequest)
+	appRepo := appRepositoryForRequest(appRepoRequest)
 	// TODO(mnelson): validate both required data and request for index
 	// https://github.com/kubeapps/kubeapps/issues/1330
 
@@ -194,7 +194,7 @@ func (a *appRepositoriesHandler) Create(w http.ResponseWriter, req *http.Request
 }
 
 // appRepositoryForRequest takes care of parsing the request data into an AppRepository.
-func appRepositoryForRequest(appRepoRequest *appRepositoryRequest) *v1alpha1.AppRepository {
+func appRepositoryForRequest(appRepoRequest appRepositoryRequest) *v1alpha1.AppRepository {
 	appRepo := appRepoRequest.AppRepository
 
 	var auth v1alpha1.AppRepositoryAuth

--- a/cmd/tiller-proxy/internal/handler/apprepos_handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/apprepos_handler_test.go
@@ -161,7 +161,7 @@ func TestAppRepositoryCreate(t *testing.T) {
 
 				// When appropriate, ensure the expected secret is stored
 				if appRepoRequest.AppRepository.AuthHeader != "" {
-					requestSecret := secretForRequest(appRepoRequest, *responseAppRepo)
+					requestSecret := secretForRequest(appRepoRequest, responseAppRepo)
 					requestSecret.ObjectMeta.Namespace = tc.kubeappsNamespace
 
 					responseSecret, err := cs.CoreV1().Secrets(tc.kubeappsNamespace).Get(requestSecret.ObjectMeta.Name, metav1.GetOptions{})
@@ -403,7 +403,7 @@ func TestSecretForRequest(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got, want := secretForRequest(appRepositoryRequest{tc.request}, appRepo), tc.secret; !cmp.Equal(want, got) {
+			if got, want := secretForRequest(appRepositoryRequest{tc.request}, &appRepo), tc.secret; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}
 		})

--- a/cmd/tiller-proxy/internal/handler/apprepos_handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/apprepos_handler_test.go
@@ -147,7 +147,7 @@ func TestAppRepositoryCreate(t *testing.T) {
 				}
 
 				// Ensure the expected AppRepository is stored
-				requestAppRepo := appRepositoryForRequest(&appRepoRequest)
+				requestAppRepo := appRepositoryForRequest(appRepoRequest)
 				requestAppRepo.ObjectMeta.Namespace = tc.kubeappsNamespace
 
 				responseAppRepo, err := cs.KubeappsV1alpha1().AppRepositories(tc.kubeappsNamespace).Get(requestAppRepo.ObjectMeta.Name, metav1.GetOptions{})
@@ -321,7 +321,7 @@ func TestAppRepositoryForRequest(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got, want := appRepositoryForRequest(&appRepositoryRequest{tc.request}), &tc.appRepo; !cmp.Equal(want, got) {
+			if got, want := appRepositoryForRequest(appRepositoryRequest{tc.request}), &tc.appRepo; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}
 		})


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
Follows on from #1397

<!-- Describe the scope of your change - i.e. what the change does. -->
1. Fixes issue where clientset was still using service-account auth
2. Updates to also create and reference relevant secret for an app repo with credentials, as well as including other app repo details.

Next PR will update the UI to use this endpoint.

### Benefits

Also demonstrates testing of handlers using k8s clientsets (@SimonAlling - in case it's useful/relevant).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref #1173

