### PR TITLE
Add readiness and liveness checks for Kubeops

### DIFF
--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -36,6 +36,12 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.kubeops.service.port }}
+        {{- if .Values.kubeops.livenessProbe }}
+        livenessProbe: {{- toYaml .Values.kubeops.livenessProbe | nindent 12 }}
+        {{- end }}
+        {{- if .Values.kubeops.readinessProbe }}
+        readinessProbe: {{- toYaml .Values.kubeops.readinessProbe | nindent 12 }}
+        {{- end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -283,6 +283,21 @@ kubeops:
     requests:
       cpu: 25m
       memory: 32Mi
+  ## Kubeops containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    httpGet:
+      path: /live
+      port: 8080
+    initialDelaySeconds: 60
+    timeoutSeconds: 5
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: 8080
+    initialDelaySeconds: 0
+    timeoutSeconds: 5
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/heptiolabs/healthcheck"
 	"github.com/kubeapps/kubeapps/cmd/kubeops/internal/handler"
 	"github.com/kubeapps/kubeapps/pkg/agent"
 	"github.com/kubeapps/kubeapps/pkg/auth"
@@ -58,6 +59,11 @@ func main() {
 	}
 	withAgentConfig := handler.WithAgentConfig(storageForDriver, options)
 	r := mux.NewRouter()
+
+	// Healthcheck
+	health := healthcheck.NewHandler()
+	r.Handle("/live", health)
+	r.Handle("/ready", health)
 
 	// Routes
 	// Auth not necessary here with Helm 3 because it's done by Kubernetes.


### PR DESCRIPTION
### Description of the change

It does basically the same thing as #1348 but for Kubeops.

### Benefits

* Requests to Kubeops won't fail with `502 Bad Gateway`.

### Applicable issues

This PR is intended to be merged before #1406.