### PR TITLE
[kubeops] Add tests for CreateRelease

### DIFF
--- a/cmd/kubeops/internal/handler/handler_test.go
+++ b/cmd/kubeops/internal/handler/handler_test.go
@@ -64,7 +64,61 @@ func TestActions(t *testing.T) {
 		ResponseBody      string //optional
 	}
 
-	tests := []testScenario{}
+	tests := []testScenario{
+		{
+			// Scenario params
+			Description:      "Create a simple release without auth",
+			ExistingReleases: []release.Release{},
+			DisableAuth:      true,
+			// Request params
+			RequestBody: `{"chartName": "foo", "releaseName": "foobar",	"version": "1.0.0"}`,
+			RequestQuery: "",
+			Action:       "create",
+			Params:       map[string]string{"namespace": "default"},
+			// Expected result
+			StatusCode: 200,
+			RemainingReleases: []release.Release{
+				createRelease("foo", "foobar", "default", 1, release.StatusDeployed),
+			},
+			ResponseBody: "",
+		},
+		{
+			// Scenario params
+			Description:      "Create a simple release with auth",
+			ExistingReleases: []release.Release{},
+			DisableAuth:      true,
+			// Request params
+			RequestBody:  `{"chartName":"foo","releaseName":"foobar","version":"1.0.0"}`,
+			RequestQuery: "",
+			Action:       "create",
+			Params:       map[string]string{"namespace": "default"},
+			// Expected result
+			StatusCode: 200,
+			RemainingReleases: []release.Release{
+				createRelease("foo", "foobar", "default", 1, release.StatusDeployed),
+			},
+			ResponseBody: "",
+		},
+		{
+			// Scenario params
+			Description: "Create a conflicting release",
+			ExistingReleases: []release.Release{
+				createRelease("foo", "foobar", "default", 1, release.StatusDeployed),
+			},
+			DisableAuth: false,
+			// Request params
+			RequestBody: `{"chartName": "foo", "releaseName": "foobar",	"version": "1.0.0"}`,
+			RequestQuery: "",
+			Action:       "create",
+			Params:       map[string]string{"namespace": "default"},
+			// Expected result
+			StatusCode: 409,
+			RemainingReleases: []release.Release{
+				createRelease("foo", "foobar", "default", 1, release.StatusDeployed),
+			},
+			ResponseBody: "",
+		},
+	}
 
 	for _, test := range tests {
 		t.Run(test.Description, func(t *testing.T) {
@@ -85,6 +139,8 @@ func TestActions(t *testing.T) {
 			}
 			// Perform request
 			switch test.Action {
+			case "create":
+				CreateRelease(*cfg, response, req, test.Params)
 			default:
 				t.Errorf("Unexpected action %s", test.Action)
 			}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
Adds tests for the functionality of creating releases with Helm 3.
Tests the functionality in both the HTTP handler and `/pkg/agent` (Helm 3 library wrapper).
Analogous to the tests done for `tiller-proxy` in [`/cmd/tiller-proxy/internal/handler`](https://github.com/kubeapps/kubeapps/blob/master/cmd/tiller-proxy/internal/handler/handler_test.go) and [`/pkg/proxy`](https://github.com/kubeapps/kubeapps/blob/master/pkg/proxy/proxy_test.go)
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Covers and tests CreateRelease #1399 
<!-- What benefits will be realized by the code change? -->
<!-- Describe any known limitations with your change -->

### Applicable issues
_Should be merged after_ #1408 
