### PR TITLE
Revert to select the chart version of the current release on upgrade

### DIFF
--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -67,6 +67,17 @@ it("renders the full UpgradeForm", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it("defaults the upgrade version to the current version", () => {
+  // helm upgrade is the only way to update the values.yaml, so upgrade is
+  // often used by users to update values only, so we can't default to the
+  // latest version on the assumption that they always want to upgrade.
+  const wrapper = shallow(
+    <UpgradeForm {...defaultProps} selected={{ versions, version: versions[0] }} />,
+  );
+
+  expect(wrapper.find(DeploymentFormBody).prop("chartVersion")).toBe("1.0.0");
+});
+
 it("forwards the appValues when modified", () => {
   const wrapper = shallow(<UpgradeForm {...defaultProps} />);
   const handleValuesChange: (v: string) => void = wrapper

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -92,7 +92,7 @@ class UpgradeForm extends React.Component<IUpgradeFormProps, IUpgradeFormState> 
           <div className="col-8">
             <DeploymentFormBody
               chartID={chartID}
-              chartVersion={this.props.selected.versions[0].attributes.version}
+              chartVersion={this.props.appCurrentVersion}
               deployedValues={this.props.appCurrentValues || ""}
               namespace={this.props.namespace}
               releaseVersion={this.props.appCurrentVersion}

--- a/dashboard/src/components/UpgradeForm/__snapshots__/UpgradeForm.test.tsx.snap
+++ b/dashboard/src/components/UpgradeForm/__snapshots__/UpgradeForm.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`renders the full UpgradeForm 1`] = `
       <DeploymentFormBody
         appValues="foo: bar"
         chartID="my-repo/my-chart"
-        chartVersion="1.2.3"
+        chartVersion="1.0.0"
         deployedValues="foo: bar"
         getChartVersion={[Function]}
         goBack={[Function]}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Reverts the change which updated the default value for the chart version on upgrade to the latest available version. We'd made this decision based on the assumption that "Upgrade" is only for upgrading a chart, but it seems a common use of "Upgrade" is also to update values without upgrading a chart at all, confusingly.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Don't surprise upgrade a chart for users who are intending to only update values.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

Confuses the case for "Upgrade", but this is already confused in the helm CLI
<!-- Describe any known limitations with your change -->

### Applicable issues
#1407 
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

Sorry Andres, I think I convinced you why users, if upgrading, would want to have the most recent chart by default, without realising "Upgrade" isn't really always "upgrade". I've included a comment which would have ensured I had understood this and so not considered the change.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
