### PR TITLE
Add TODO for app-specific live/ready checks

### DIFF
--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -61,6 +61,7 @@ func main() {
 	r := mux.NewRouter()
 
 	// Healthcheck
+	// TODO: add app specific health and readiness checks as per https://github.com/heptiolabs/healthcheck
 	health := healthcheck.NewHandler()
 	r.Handle("/live", health)
 	r.Handle("/ready", health)


### PR DESCRIPTION
> It appears tiller-proxy isn't a great example here... can you add a TODO to add app specific health and readiness checks as per https://github.com/heptiolabs/healthcheck ? Thanks.

https://github.com/kubeapps/kubeapps/pull/1405#discussion_r363133504

@absoludity 