### PR TITLE
Use logrus consistently for logging

### DIFF
--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -41,7 +41,6 @@ spec:
           command:
             - /apprepository-controller
           args:
-            - --logtostderr
             - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
             - --repo-sync-image={{ template "kubeapps.image" (list .Values.apprepository.syncImage .Values.global) }}
             - --namespace={{ .Release.Namespace }}

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 
-	"github.com/golang/glog"
 	clientset "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
 	informers "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/informers/externalversions"
 	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/signals"
@@ -27,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd" // Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -49,17 +49,17 @@ func main() {
 
 	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
 	if err != nil {
-		glog.Fatalf("Error building kubeconfig: %s", err.Error())
+		log.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		glog.Fatalf("Error building kubernetes clientset: %s", err.Error())
+		log.Fatalf("Error building kubernetes clientset: %s", err.Error())
 	}
 
 	apprepoClient, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		glog.Fatalf("Error building apprepo clientset: %s", err.Error())
+		log.Fatalf("Error building apprepo clientset: %s", err.Error())
 	}
 
 	kubeInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(kubeClient, 0, namespace, nil)
@@ -71,7 +71,7 @@ func main() {
 	go apprepoInformerFactory.Start(stopCh)
 
 	if err = controller.Run(2, stopCh); err != nil {
-		glog.Fatalf("Error running controller: %s", err.Error())
+		log.Fatalf("Error running controller: %s", err.Error())
 	}
 }
 

--- a/cmd/apprepository-controller/pkg/client/clientset/versioned/clientset.go
+++ b/cmd/apprepository-controller/pkg/client/clientset/versioned/clientset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package versioned
 
 import (
-	glog "github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
 	kubeappsv1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/typed/apprepository/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -74,7 +74,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
+		log.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/docs/developer/apprepository-controller.md
+++ b/docs/developer/apprepository-controller.md
@@ -59,7 +59,7 @@ kubectl -n kubeapps scale deployment apprepository-controller --replicas=0
 You can now execute the `apprepository-controller` binary on the developer host with:
 
 ```bash
-./apprepository-controller --logtostderr --repo-sync-image=quay.io/helmpack/chart-repo:myver --kubeconfig ~/.kube/config
+./apprepository-controller --repo-sync-image=quay.io/helmpack/chart-repo:myver --kubeconfig ~/.kube/config
 ```
 
 Performing application repository actions in the Kubeapps dashboard will now trigger operations in the `apprepository-controller` binary running locally on your development host.

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,5 @@ require (
 	k8s.io/cli-runtime v0.0.0-20191016114015-74ad18325ed5
 	k8s.io/client-go v0.0.0-20191016111102-bec269661e48
 	k8s.io/helm v2.16.0+incompatible
-	k8s.io/klog v1.0.0
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/arschles/assert v1.0.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-test/deep v1.0.4
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/go-cmp v0.3.1
 	github.com/gorilla/mux v1.7.3
 	github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -6,6 +6,7 @@ import (
 
 	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
 	"github.com/kubeapps/kubeapps/pkg/proxy"
+	log "github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/kube"
@@ -15,7 +16,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
 	"sigs.k8s.io/yaml"
 )
 
@@ -25,14 +25,14 @@ type StorageForDriver func(namespace string, clientset *kubernetes.Clientset) *s
 // StorageForSecrets returns a storage using the Secret driver.
 func StorageForSecrets(namespace string, clientset *kubernetes.Clientset) *storage.Storage {
 	d := driver.NewSecrets(clientset.CoreV1().Secrets(namespace))
-	d.Log = klog.Infof
+	d.Log = log.Infof
 	return storage.Init(d)
 }
 
 // StorageForConfigMaps returns a storage using the ConfigMap driver.
 func StorageForConfigMaps(namespace string, clientset *kubernetes.Clientset) *storage.Storage {
 	d := driver.NewConfigMaps(clientset.CoreV1().ConfigMaps(namespace))
-	d.Log = klog.Infof
+	d.Log = log.Infof
 	return storage.Init(d)
 }
 
@@ -96,7 +96,7 @@ func NewActionConfig(storageForDriver StorageForDriver, config *rest.Config, cli
 	actionConfig.RESTClientGetter = restClientGetter
 	actionConfig.KubeClient = kube.New(restClientGetter)
 	actionConfig.Releases = store
-	actionConfig.Log = klog.Infof
+	actionConfig.Log = log.Infof
 	return actionConfig, nil
 }
 


### PR DESCRIPTION
### Description of the change

It replaces `github.com/golang/glog` and `k8s.io/klog` with `github.com/sirupsen/logrus`.

### Benefits

* Logging becomes more consistent.

### Possible drawbacks

* Before this PR, `V` from `glog` was sometimes used, for example like this:
  
  ```go
  glog.V(4).Info("Hello!")
  ```
  
  This PR simply replaces `glog.V(4)` with `log`, which might affect verbosity. I don't know if this matters.

### Applicable issues

* Fixes #1410.
