### PR TITLE
Switch dashboard to use backend API for creating app repos.

### DIFF
--- a/cmd/tiller-proxy/internal/handler/apprepos_handler.go
+++ b/cmd/tiller-proxy/internal/handler/apprepos_handler.go
@@ -76,7 +76,7 @@ type appRepositoryRequest struct {
 
 type appRepositoryRequestDetails struct {
 	Name               string                 `json:"name"`
-	RepoURL            string                 `json:"repoUrl"`
+	RepoURL            string                 `json:"repoURL"`
 	AuthHeader         string                 `json:"authHeader"`
 	CustomCA           string                 `json:"customCA"`
 	SyncJobPodTemplate corev1.PodTemplateSpec `json:"syncJobPodTemplate"`

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -195,24 +195,20 @@ describe("installRepo", () => {
       "",
     );
 
-    const authStruct = {
-      header: { secretKeyRef: { key: "authorizationHeader", name: "apprepo-my-repo-secrets" } },
-    };
-
     it("calls AppRepository create including a auth struct", async () => {
       await store.dispatch(installRepoCMDAuth);
       expect(AppRepository.create).toHaveBeenCalledWith(
         "my-repo",
-        "my-namespace",
         "http://foo.bar",
-        authStruct,
-        {},
+        "Bearer: abc",
+        "",
+        "",
       );
     });
 
-    it("creates the K8s secret", async () => {
+    it("does not create the K8s secret as API includes this", async () => {
       await store.dispatch(installRepoCMDAuth);
-      expect(Secret.create).toHaveBeenCalled();
+      expect(Secret.create).not.toHaveBeenCalled();
     });
 
     it("returns true", async () => {
@@ -230,24 +226,20 @@ describe("installRepo", () => {
       "",
     );
 
-    const authStruct = {
-      customCA: { secretKeyRef: { key: "ca.crt", name: "apprepo-my-repo-secrets" } },
-    };
-
     it("calls AppRepository create including a auth struct", async () => {
       await store.dispatch(installRepoCMDAuth);
       expect(AppRepository.create).toHaveBeenCalledWith(
         "my-repo",
-        "my-namespace",
         "http://foo.bar",
-        authStruct,
-        {},
+        "",
+        "This is a cert!",
+        "",
       );
     });
 
-    it("creates the K8s secret", async () => {
+    it("does not create the K8s secret as API includes this", async () => {
       await store.dispatch(installRepoCMDAuth);
-      expect(Secret.create).toHaveBeenCalled();
+      expect(Secret.create).not.toHaveBeenCalled();
     });
 
     it("returns true", async () => {
@@ -271,22 +263,11 @@ spec:
 
         expect(AppRepository.create).toHaveBeenCalledWith(
           "my-repo",
-          "my-namespace",
           "http://foo.bar",
-          {},
-          { spec: { containers: [{ env: [{ name: "FOO", value: "BAR" }] }] } },
+          "",
+          "",
+          safeYAMLTemplate,
         );
-      });
-
-      // Example from https://nealpoole.com/blog/2013/06/code-execution-via-yaml-in-js-yaml-nodejs-module/
-      const unsafeYAMLTemplate =
-        '"toString": !<tag:yaml.org,2002:js/function> "function (){very_evil_thing();}"';
-
-      it("does not call AppRepository create with an unsafe pod template", async () => {
-        await store.dispatch(
-          repoActions.installRepo("my-repo", "http://foo.bar", "", "", unsafeYAMLTemplate),
-        );
-        expect(AppRepository.create).not.toHaveBeenCalled();
       });
     });
   });
@@ -294,18 +275,7 @@ spec:
   context("when authHeader and customCA are empty", () => {
     it("calls AppRepository create without a auth struct", async () => {
       await store.dispatch(installRepoCMD);
-      expect(AppRepository.create).toHaveBeenCalledWith(
-        "my-repo",
-        "my-namespace",
-        "http://foo.bar",
-        {},
-        {},
-      );
-    });
-
-    it("does not create a K8s secret", async () => {
-      await store.dispatch(installRepoCMD);
-      expect(Secret.create).not.toHaveBeenCalled();
+      expect(AppRepository.create).toHaveBeenCalledWith("my-repo", "http://foo.bar", "", "", "");
     });
 
     it("returns true", async () => {

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -1,12 +1,10 @@
-import * as yaml from "js-yaml";
 import { ThunkAction } from "redux-thunk";
 import { ActionType, createAction } from "typesafe-actions";
 import { AppRepository } from "../shared/AppRepository";
 import Chart from "../shared/Chart";
-import Secret from "../shared/Secret";
 import { errorChart } from "./charts";
 
-import { IAppRepository, IOwnerReference, IStoreState, NotFoundError } from "../shared/types";
+import { IAppRepository, IStoreState, NotFoundError } from "../shared/types";
 
 export const addRepo = createAction("ADD_REPO");
 export const addedRepo = createAction("ADDED_REPO", resolve => {
@@ -132,68 +130,16 @@ export const installRepo = (
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     try {
-      const {
-        config: { namespace },
-      } = getState();
-      interface ISecretKeyRef {
-        key: string;
-        name: string;
-      }
-      const auth: {
-        header?: { secretKeyRef: ISecretKeyRef };
-        customCA?: { secretKeyRef: ISecretKeyRef };
-      } = {};
-      const secrets: { [s: string]: string } = {};
-      const secretName = `apprepo-${name}-secrets`;
-      if (authHeader.length || customCA.length) {
-        // ensure we can create secrets in the kubeapps namespace
-        if (authHeader.length) {
-          auth.header = {
-            secretKeyRef: {
-              key: "authorizationHeader",
-              name: secretName,
-            },
-          };
-          secrets.authorizationHeader = btoa(authHeader);
-        }
-        if (customCA.length) {
-          auth.customCA = {
-            secretKeyRef: {
-              key: "ca.crt",
-              name: secretName,
-            },
-          };
-          secrets["ca.crt"] = btoa(customCA);
-        }
-      }
-      let syncJobPodTemplateObj = {};
-      if (syncJobPodTemplate.length) {
-        syncJobPodTemplateObj = yaml.safeLoad(syncJobPodTemplate);
-      }
       dispatch(addRepo());
       const apprepo = await AppRepository.create(
         name,
-        namespace,
         repoURL,
-        auth,
-        syncJobPodTemplateObj,
+        authHeader,
+        customCA,
+        syncJobPodTemplate,
       );
       dispatch(addedRepo(apprepo));
 
-      if (authHeader.length || customCA.length) {
-        await Secret.create(
-          secretName,
-          secrets,
-          {
-            apiVersion: apprepo.apiVersion,
-            blockOwnerDeletion: true,
-            kind: apprepo.kind,
-            name: apprepo.metadata.name,
-            uid: apprepo.metadata.uid,
-          } as IOwnerReference,
-          namespace,
-        );
-      }
       return true;
     } catch (e) {
       dispatch(errorRepos(e, "create"));

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -1,6 +1,7 @@
 import { axiosWithAuth } from "./AxiosInstance";
 import { APIBase } from "./Kube";
 import { IAppRepository, IAppRepositoryList } from "./types";
+import * as url from "./url";
 
 export class AppRepository {
   public static async list(namespace: string) {
@@ -25,23 +26,19 @@ export class AppRepository {
     return data;
   }
 
+  // create uses the kubeapps backend API
+  // TODO(mnelson) Update other endpoints to similarly use the backend API, removing the need
+  // for direct k8s api access (for this resource, at least).
   public static async create(
     name: string,
-    namespace: string,
-    url: string,
-    auth: any,
+    repoURL: string,
+    authHeader: string,
+    customCA: string,
     syncJobPodTemplate: any,
   ) {
     const { data } = await axiosWithAuth.post<IAppRepository>(
-      AppRepository.getResourceLink(namespace),
-      {
-        apiVersion: "kubeapps.com/v1alpha1",
-        kind: "AppRepository",
-        metadata: {
-          name,
-        },
-        spec: { auth, type: "helm", url, syncJobPodTemplate },
-      },
+      url.backend.apprepositories.create(),
+      { appRepository: { name, repoURL, authHeader, customCA, syncJobPodTemplate } },
     );
     return data;
   }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -264,6 +264,16 @@ export interface IK8sList<I, M> extends IK8sResource {
   } & M;
 }
 
+export interface ICreateAppRepositoryRequest {
+  appRepository: {
+    name: string;
+    repoURL: string;
+    authHeader: string;
+    customCA: string;
+    syncJobPodTemplate: string;
+  };
+}
+
 export interface IAppRepository
   extends IK8sObject<
     {

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -10,6 +10,13 @@ export const app = {
   },
 };
 
+export const backend = {
+  apprepositories: {
+    base: "api/v1/apprepositories",
+    create: () => `${backend.apprepositories.base}`,
+  },
+};
+
 export const api = {
   apprepostories: {
     base: `${APIBase}/apis/kubeapps.com/v1alpha1`,

--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -2,7 +2,7 @@ frontend:
   replicaCount: 1
 tillerProxy:
   replicaCount: 1
-chartsvc:
+assetsvc:
   replicaCount: 1
 dashboard:
-  replicaCount: 1 
+  replicaCount: 1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Switches the dashboard from using the k8s API directly to create an app repository and associated secrets, to instead use the backend API to create the app repo (which creates the associated secrets).

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

This ensures that we dogfood the new API ourselves :)
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

I've tested this locally with an auth header and ca.crt to verify the correct secret is created, as well as with a sync pod template, but there could be something I've missed (I've not, for example, verified access using those with an actual private repo).

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1173 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
