### PR TITLE
Include assetsvc and asset-syncer in 'make all'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ IMG_MODIFIER ?=
 GO_PACKAGES = ./...
 # GO_FILES := $(shell find $(shell $(GO) list -f '{{.Dir}}' $(GO_PACKAGES)) -name \*.go)
 
-all: kubeapps/dashboard kubeapps/apprepository-controller kubeapps/tiller-proxy kubeapps/kubeops
+all: kubeapps/dashboard kubeapps/apprepository-controller kubeapps/tiller-proxy kubeapps/kubeops kubeapps/assetsvc kubeapps/asset-syncer
 
 # TODO(miguel) Create Makefiles per component
 kubeapps/%:


### PR DESCRIPTION
### Description of the change

It includes `assetsvc` and `asset-syncer` in the `all` make target.

### Benefits

* I think it will be easier to build and install Kubeapps locally.

### Applicable issues

* `assetsvc` and `asset-syncer` were added in #1323.

