### PR TITLE
Enable replication for PostgreSQL

### DIFF
--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - --database-secret-name={{ .Values.postgresql.existingSecret }}
             - --database-secret-key=postgresql-password
             - --database-type=postgresql
-            - --database-url={{ template "kubeapps.postgresql.fullname" . }}:5432
+            - --database-url={{ template "kubeapps.postgresql.fullname" . }}-headless:5432
             - --database-user=postgres
             - --database-name=assets
             {{- end }}

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - --database-secret-name={{ .Values.postgresql.existingSecret }}
             - --database-secret-key=postgresql-password
             - --database-type=postgresql
-            - --database-url={{ template "kubeapps.postgresql.fullname" . }}-headless:5432
+            - --database-url={{ template "kubeapps.postgresql.fullname" . }}:5432
             - --database-user=postgres
             - --database-name=assets
             {{- end }}

--- a/chart/kubeapps/templates/assetsvc-deployment.yaml
+++ b/chart/kubeapps/templates/assetsvc-deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - --database-type=postgresql
             - --database-user=postgres
             - --database-name=assets
-            - --database-url={{ template "kubeapps.postgresql.fullname" . }}:5432
+            - --database-url={{ template "kubeapps.postgresql.fullname" . }}-headless:5432
           env:
             - name: DB_PASSWORD
               valueFrom:

--- a/chart/kubeapps/templates/db-secret-bootstrap.yaml
+++ b/chart/kubeapps/templates/db-secret-bootstrap.yaml
@@ -20,5 +20,6 @@ data:
   {{- end }}
   {{- if .Values.postgresql.enabled }}
   postgresql-password: {{ randAlphaNum 10 | b64enc | quote }}
+  postgresql-replication-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
 {{- end -}}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -536,6 +536,9 @@ mongodb:
 postgresql:
   ## Whether to deploy a postgresql server to satisfy the applications database requirements.
   enabled: false
+  ## Enable replication for high availability
+  replication:
+    enabled: true
   ## Create a database for Kubeapps on the first run
   postgresqlDatabase: assets
   ## Kubeapps uses PostgreSQL as a cache and persistence is not required


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Deploy PostgreSQL (by default) with one replica. Thanks to that, if any of the two PostgreSQL pods goes down, the service will still work.

The service `kubeapps-postgresql` will reach the `master` instance only while the `kubeapps-postgresql-headless` service hits both the `master` and `slave` replicas.

### Possible drawbacks

The slave replica is read-only. This means that if the master goes down, for the time that that pod is down, the data is immutable.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1142
