### PR TITLE
Add Helm 3 DeleteRelease

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -119,3 +119,18 @@ func GetRelease(cfg agent.Config, w http.ResponseWriter, req *http.Request, para
 	}
 	response.NewDataResponse(newDashboardCompatibleRelease(*release)).Write(w)
 }
+
+func DeleteRelease(cfg agent.Config, w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
+	releaseName := params[nameParam]
+	purge := handlerutil.QueryParamIsTruthy("purge", req)
+	// Helm 3 has --purge by default; --keep-history in Helm 3 corresponds to omitting --purge in Helm 2.
+	// https://stackoverflow.com/a/59210923/2135002
+	keepHistory := !purge
+	err := agent.DeleteRelease(cfg.ActionConfig, releaseName, keepHistory)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	w.Header().Set("Status-Code", "200")
+	w.Write([]byte("OK"))
+}

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -81,6 +81,9 @@ func main() {
 	apiv1.Methods("GET").Path("/namespaces/{namespace}/releases/{releaseName}").Handler(negroni.New(
 		negroni.Wrap(withAgentConfig(handler.GetRelease)),
 	))
+	apiv1.Methods("DELETE").Path("/namespaces/{namespace}/releases/{releaseName}").Handler(negroni.New(
+		negroni.Wrap(withAgentConfig(handler.DeleteRelease)),
+	))
 
 	// assetsvc reverse proxy
 	authGate := auth.AuthGate()

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -99,6 +99,14 @@ func GetRelease(actionConfig *action.Configuration, name string) (*release.Relea
 	return release, nil
 }
 
+func DeleteRelease(actionConfig *action.Configuration, name string, keepHistory bool) error {
+	// Namespace is already known by the RESTClientGetter.
+	cmd := action.NewUninstall(actionConfig)
+	cmd.KeepHistory = keepHistory
+	_, err := cmd.Run(name)
+	return err
+}
+
 func NewActionConfig(storageForDriver StorageForDriver, config *rest.Config, clientset *kubernetes.Clientset, namespace string) (*action.Configuration, error) {
 	actionConfig := new(action.Configuration)
 	store := storageForDriver(namespace, clientset)

--- a/pkg/handlerutil/handlerutil.go
+++ b/pkg/handlerutil/handlerutil.go
@@ -83,3 +83,8 @@ func ParseAndGetChart(req *http.Request, cu chartUtils.Resolver, requireV1Suppor
 	}
 	return chartDetails, ch, nil
 }
+
+func QueryParamIsTruthy(param string, req *http.Request) bool {
+	value := req.URL.Query().Get(param)
+	return value == "1" || value == "true"
+}


### PR DESCRIPTION
### Description of the change

This PR implements `DeleteRelease` using the Helm 3 API.

As part of this, it adds the function `QueryParamIsTruthy`, which might be useful elsewhere as well.

### Benefits

* It will bring us one step closer to Helm 3 support.
* The _Purge_ option works as intended.

### Possible drawbacks

* There are no tests yet. We're having some trouble writing them, due to the namespace being known by the `RESTClientGetter` in `actionConfig`, instead of specified explicitly as an argument to `DeleteRelease`. @latiif is working on it.

### Applicable issues

* Based on discussions in #1309.
* The logical next step after #1406.

### Additional information

@lindhe likes PRs.