### PR TITLE
Add Helm 3 UpgradeRelease

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -19,7 +19,7 @@ const (
 	nameParam      = "releaseName"
 )
 
-const requireV1Support = false
+const isV1SupportRequired = false
 
 // This type represents the fact that a regular handler cannot actually be created until we have access to the request,
 // because a valid action config (and hence agent config) cannot be created until then.
@@ -93,7 +93,7 @@ func ListAllReleases(cfg agent.Config, w http.ResponseWriter, req *http.Request,
 }
 
 func CreateRelease(cfg agent.Config, w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
-	chartDetails, chartMulti, err := handlerutil.ParseAndGetChart(req, cfg.ChartClient, requireV1Support)
+	chartDetails, chartMulti, err := handlerutil.ParseAndGetChart(req, cfg.ChartClient, isV1SupportRequired)
 	if err != nil {
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return
@@ -123,7 +123,7 @@ func OperateRelease(cfg agent.Config, w http.ResponseWriter, req *http.Request, 
 
 func upgradeRelease(cfg agent.Config, w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
 	releaseName := params[nameParam]
-	chartDetails, chartMulti, err := handlerutil.ParseAndGetChart(req, cfg.ChartClient, requireV1Support)
+	chartDetails, chartMulti, err := handlerutil.ParseAndGetChart(req, cfg.ChartClient, isV1SupportRequired)
 	if err != nil {
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return

--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -115,6 +115,7 @@ func OperateRelease(cfg agent.Config, w http.ResponseWriter, req *http.Request, 
 	switch req.FormValue("action") {
 	case "upgrade":
 		upgradeRelease(cfg, w, req, params)
+	// TODO: Add "rollback" and "test" cases here.
 	default:
 		// By default, for maintaining compatibility, we call upgrade.
 		upgradeRelease(cfg, w, req, params)

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -81,6 +81,9 @@ func main() {
 	apiv1.Methods("GET").Path("/namespaces/{namespace}/releases/{releaseName}").Handler(negroni.New(
 		negroni.Wrap(withAgentConfig(handler.GetRelease)),
 	))
+	apiv1.Methods("PUT").Path("/namespaces/{namespace}/releases/{releaseName}").Handler(negroni.New(
+		negroni.Wrap(withAgentConfig(handler.OperateRelease)),
+	))
 
 	// assetsvc reverse proxy
 	authGate := auth.AuthGate()


### PR DESCRIPTION
### Description of the change

This PR implements `UpgradeRelease` using the Helm 3 API.

### Benefits

* It will bring us one step closer to Helm 3 support.

### Possible drawbacks

* There are no tests yet.
* `OperateRelease` only supports upgrading at the moment (but it will support testing and rolling back later).

### Applicable issues

* Based on discussions in #1309.
* The logical next step after #1420.

### Additional information

The `switch` statement in `handler.OperateRelease` is currently redundant, but it will make sense when support for testing and rolling back is added (see [its Tiller Proxy counterpart](https://github.com/kubeapps/kubeapps/blob/4b4b14bff89e552506aea7170ec51a4aa32719e5/cmd/tiller-proxy/internal/handler/handler.go#L97:L110)).