### PR TITLE
Set unique chart ID column

### DIFF
--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -65,7 +65,7 @@ func (m *postgresAssetManager) Sync(charts []models.Chart) error {
 
 func (m *postgresAssetManager) initTables() error {
 	_, err := m.DB.Exec(fmt.Sprintf(
-		"CREATE TABLE IF NOT EXISTS %s (ID serial NOT NULL PRIMARY KEY, info jsonb NOT NULL)",
+		"CREATE TABLE IF NOT EXISTS %s (ID serial NOT NULL PRIMARY KEY, chart_id varchar unique, info jsonb NOT NULL)",
 		dbutils.ChartTable,
 	))
 	if err != nil {
@@ -117,7 +117,7 @@ func (m *postgresAssetManager) importCharts(charts []models.Chart) error {
 		log.Fatal(err)
 	}
 
-	stmt, err := txn.Prepare(pq.CopyIn(dbutils.ChartTable, "info"))
+	stmt, err := txn.Prepare(pq.CopyIn(dbutils.ChartTable, "chart_id", "info"))
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (m *postgresAssetManager) importCharts(charts []models.Chart) error {
 		if err != nil {
 			return err
 		}
-		_, err = stmt.Exec(string(d))
+		_, err = stmt.Exec(chart.ID, string(d))
 		if err != nil {
 			return err
 		}

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -75,7 +75,7 @@ func (m *postgresAssetManager) getPaginatedChartList(repo string, pageNumber, pa
 
 func (m *postgresAssetManager) getChart(chartID string) (models.Chart, error) {
 	var chart models.ChartIconString
-	err := m.QueryOne(&chart, fmt.Sprintf("SELECT info FROM %s WHERE info ->> 'ID' = $1", dbutils.ChartTable), chartID)
+	err := m.QueryOne(&chart, fmt.Sprintf("SELECT info FROM %s WHERE chart_id = $1", dbutils.ChartTable), chartID)
 	if err != nil {
 		return models.Chart{}, err
 	}
@@ -103,7 +103,7 @@ func (m *postgresAssetManager) getChart(chartID string) (models.Chart, error) {
 
 func (m *postgresAssetManager) getChartVersion(chartID, version string) (models.Chart, error) {
 	var chart models.Chart
-	err := m.QueryOne(&chart, fmt.Sprintf("SELECT info FROM %s WHERE info ->> 'ID' = $1", dbutils.ChartTable), chartID)
+	err := m.QueryOne(&chart, fmt.Sprintf("SELECT info FROM %s WHERE chart_id = $1", dbutils.ChartTable), chartID)
 	if err != nil {
 		return models.Chart{}, err
 	}

--- a/cmd/assetsvc/postgresql_utils_test.go
+++ b/cmd/assetsvc/postgresql_utils_test.go
@@ -71,7 +71,7 @@ func Test_PGgetChart(t *testing.T) {
 		Chart:   models.Chart{ID: "foo"},
 		RawIcon: iconB64,
 	}
-	m.On("QueryOne", &models.ChartIconString{}, "SELECT info FROM charts WHERE info ->> 'ID' = $1", []interface{}{"foo"}).Run(func(args mock.Arguments) {
+	m.On("QueryOne", &models.ChartIconString{}, "SELECT info FROM charts WHERE chart_id = $1", []interface{}{"foo"}).Run(func(args mock.Arguments) {
 		*args.Get(0).(*models.ChartIconString) = dbChart
 	})
 
@@ -100,7 +100,7 @@ func Test_PGgetChartVersion(t *testing.T) {
 			{Version: "2.0.0"},
 		},
 	}
-	m.On("QueryOne", &models.Chart{}, "SELECT info FROM charts WHERE info ->> 'ID' = $1", []interface{}{"foo"}).Run(func(args mock.Arguments) {
+	m.On("QueryOne", &models.Chart{}, "SELECT info FROM charts WHERE chart_id = $1", []interface{}{"foo"}).Run(func(args mock.Arguments) {
 		*args.Get(0).(*models.Chart) = dbChart
 	})
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Not setting a unique varchar column with PostgreSQL was causing the application to show duplicates instead of updating the existing chart. Now the chart ID (e.g. `bitnami/apache`) is used as that unique column.

### Possible drawbacks

It requires deleting the existing table (or restarting postgres pods) but the feature has not been released yet.
