### PR TITLE
[PG] Return latest chart version

### DIFF
--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -142,8 +142,6 @@ func (m *postgresAssetManager) getChartsWithFilters(name, version, appVersion st
 	result := []*models.Chart{}
 	for _, c := range charts {
 		if _, found := containsVersionAndAppVersion(c.ChartVersions, version, appVersion); found {
-			// Return only the latest ChartVersion
-			c.ChartVersions = []models.ChartVersion{c.ChartVersions[0]}
 			result = append(result, c)
 		}
 	}

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -141,9 +141,9 @@ func (m *postgresAssetManager) getChartsWithFilters(name, version, appVersion st
 	}
 	result := []*models.Chart{}
 	for _, c := range charts {
-		if cv, found := containsVersionAndAppVersion(c.ChartVersions, version, appVersion); found {
-			// Return only the interesting ChartVersion
-			c.ChartVersions = []models.ChartVersion{cv}
+		if _, found := containsVersionAndAppVersion(c.ChartVersions, version, appVersion); found {
+			// Return only the latest ChartVersion
+			c.ChartVersions = []models.ChartVersion{c.ChartVersions[0]}
 			result = append(result, c)
 		}
 	}

--- a/cmd/assetsvc/postgresql_utils_test.go
+++ b/cmd/assetsvc/postgresql_utils_test.go
@@ -161,6 +161,7 @@ func Test_getChartWithFilters(t *testing.T) {
 		Name: "foo",
 		ChartVersions: []models.ChartVersion{
 			{Version: "2.0.0", AppVersion: "2.0.2"},
+			{Version: "1.0.0", AppVersion: "1.0.1"},
 		},
 	}}
 	if !cmp.Equal(charts, expectedCharts) {

--- a/cmd/assetsvc/postgresql_utils_test.go
+++ b/cmd/assetsvc/postgresql_utils_test.go
@@ -146,8 +146,8 @@ func Test_getChartWithFilters(t *testing.T) {
 	dbChart := models.Chart{
 		Name: "foo",
 		ChartVersions: []models.ChartVersion{
-			{Version: "1.0.0", AppVersion: "1.0.1"},
 			{Version: "2.0.0", AppVersion: "2.0.2"},
+			{Version: "1.0.0", AppVersion: "1.0.1"},
 		},
 	}
 	chartsResponse = []*models.Chart{&dbChart}
@@ -160,7 +160,7 @@ func Test_getChartWithFilters(t *testing.T) {
 	expectedCharts := []*models.Chart{&models.Chart{
 		Name: "foo",
 		ChartVersions: []models.ChartVersion{
-			{Version: "1.0.0", AppVersion: "1.0.1"},
+			{Version: "2.0.0", AppVersion: "2.0.2"},
 		},
 	}}
 	if !cmp.Equal(charts, expectedCharts) {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

It's not explicit but the `chartVersion` returned by `getChartsWithFilters` should be the latest version in order to return it to the client. That's is later used by the dashboard to determine if there are updates available. Since the charts are ordered, it should return the first one of the array.

