### PR TITLE
[kubeops] Add tests for GetRelease

### DIFF
--- a/cmd/kubeops/internal/handler/dashboardcompat_test.go
+++ b/cmd/kubeops/internal/handler/dashboardcompat_test.go
@@ -1,0 +1,200 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"runtime/debug"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kubeapps/common/response"
+	h3chart "helm.sh/helm/v3/pkg/chart"
+	h3 "helm.sh/helm/v3/pkg/release"
+	h2chart "k8s.io/helm/pkg/proto/hapi/chart"
+	h2 "k8s.io/helm/pkg/proto/hapi/release"
+
+	"testing"
+)
+
+func TestNewDashboardCompatibleRelease(t *testing.T) {
+	type testScenario struct {
+		// Scenario params
+		Description         string
+		Helm3Release        h3.Release
+		Helm2Release        h2.Release
+		MarshallingFunction func(h2.Release) string
+		ShouldFail          bool
+	}
+	tests := []testScenario{
+		{
+			Description:         "Two equivalent releases",
+			MarshallingFunction: asResponse,
+			Helm3Release: h3.Release{
+				Name:      "Foo",
+				Namespace: "default",
+				Chart: &h3chart.Chart{
+					Metadata: &h3chart.Metadata{},
+					Values: map[string]interface{}{
+						"port": 8080,
+					},
+				},
+				Info: &h3.Info{
+					Status: h3.StatusDeployed,
+				},
+				Version: 1,
+				Config: map[string]interface{}{
+					"port": 3000,
+					"user": map[string]interface{}{
+						"name":     "user1",
+						"password": "123456",
+					},
+				},
+			},
+			Helm2Release: h2.Release{
+				Name:      "Foo",
+				Namespace: "default",
+				Info: &h2.Info{
+					Status: &h2.Status{
+						Code: h2.Status_DEPLOYED,
+					},
+				},
+				Chart: &h2chart.Chart{
+					Metadata: &h2chart.Metadata{},
+					Values: &h2chart.Config{
+						Raw: "port: 8080\n",
+					},
+				},
+				Version: 1,
+				Config: &h2chart.Config{
+					Raw: "port: 3000\nuser:\n  name: user1\n  password: \"123456\"\n",
+				},
+			},
+		},
+		{
+			Description:         "Two equivalent releases with switched order of values",
+			MarshallingFunction: asResponse,
+			Helm3Release: h3.Release{
+				Name:      "Foo",
+				Namespace: "default",
+				Chart: &h3chart.Chart{
+					Metadata: &h3chart.Metadata{},
+					Values:   map[string]interface{}{},
+				},
+				Info: &h3.Info{
+					Status: h3.StatusDeployed,
+				},
+				Version: 1,
+				Config: map[string]interface{}{
+					"user": map[string]interface{}{
+						"password": "123456",
+						"name":     "user1",
+					},
+					"port": 3000,
+				},
+			},
+			Helm2Release: h2.Release{
+				Name:      "Foo",
+				Namespace: "default",
+				Info: &h2.Info{
+					Status: &h2.Status{
+						Code: h2.Status_DEPLOYED,
+					},
+				},
+				Chart: &h2chart.Chart{
+					Metadata: &h2chart.Metadata{},
+					Values: &h2chart.Config{
+						Raw: "{}\n",
+					},
+				},
+				Version: 1,
+				Config: &h2chart.Config{
+					Raw: "port: 3000\nuser:\n  name: user1\n  password: \"123456\"\n",
+				},
+			},
+		},
+		{
+			Description:         "Two equivalent releases with different versions",
+			ShouldFail:          true,
+			MarshallingFunction: asResponse,
+			Helm3Release: h3.Release{
+				Name:      "Foo",
+				Namespace: "default",
+				Chart: &h3chart.Chart{
+					Metadata: &h3chart.Metadata{},
+					Values: map[string]interface{}{
+						"port": 8080,
+					},
+				},
+				Info: &h3.Info{
+					Status: h3.StatusDeployed,
+				},
+				Version: 1,
+				Config: map[string]interface{}{
+					"port": 3000,
+					"user": map[string]interface{}{
+						"name":     "user1",
+						"password": "123456",
+					},
+				},
+			},
+			Helm2Release: h2.Release{
+				Name:      "Foo",
+				Namespace: "default",
+				Info: &h2.Info{
+					Status: &h2.Status{
+						Code: h2.Status_DEPLOYED,
+					},
+				},
+				Chart: &h2chart.Chart{
+					Metadata: &h2chart.Metadata{},
+					Values: &h2chart.Config{
+						Raw: "port: 8080\n",
+					},
+				},
+				Version: 5,
+				Config: &h2chart.Config{
+					Raw: "port: 3000\nuser:\n  name: user1\n  password: \"123456\"\n",
+				},
+			},
+		},
+		{
+			Description:         "Incomplete Helm 3 Release",
+			ShouldFail:          true,
+			MarshallingFunction: asResponse,
+			Helm3Release:        h3.Release{Name: "Incomplete"},
+			Helm2Release:        h2.Release{Name: "Incomplete"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Description, func(t *testing.T) {
+			// A panic is a failure for the test
+			defer func() {
+				if r := recover(); r != nil {
+					if !test.ShouldFail {
+						t.Errorf("Not expected to fail, yet got a panic: %v. \nStacktrace: \n%s", r, string(debug.Stack()))
+					}
+				}
+			}()
+			// Perform conversion
+			compatibleH3rls := newDashboardCompatibleRelease(test.Helm3Release)
+			// Marshall both: Compatible H3Release and H2Release
+			h3Marshalled := test.MarshallingFunction(compatibleH3rls)
+			t.Logf("Marshalled Helm 3 Release %s", h3Marshalled)
+			h2Marshalled := test.MarshallingFunction(test.Helm2Release)
+			t.Logf("Marshalled Helm 2 Release %s", h2Marshalled)
+			// Check result
+			areEqual := h2Marshalled == h3Marshalled
+			if test.ShouldFail && areEqual {
+				t.Errorf("Expected to fail, but are equal %v", cmp.Diff(h3Marshalled, h2Marshalled))
+			}
+			if !test.ShouldFail && !areEqual {
+				t.Errorf("Not equal: %s", cmp.Diff(h3Marshalled, h2Marshalled))
+			}
+		})
+	}
+}
+
+func asResponse(data h2.Release) string {
+	w := httptest.NewRecorder()
+	response.NewDataResponse(data).Write(w)
+	return w.Body.String()
+}

--- a/cmd/kubeops/internal/handler/dashboardcompat_test.go
+++ b/cmd/kubeops/internal/handler/dashboardcompat_test.go
@@ -17,9 +17,13 @@ import (
 func TestNewDashboardCompatibleRelease(t *testing.T) {
 	type testScenario struct {
 		// Scenario params
-		Description         string
-		Helm3Release        h3.Release
-		Helm2Release        h2.Release
+		Description  string
+		Helm3Release h3.Release
+		Helm2Release h2.Release
+		// MarshallingFunction defines what it means to
+		// parse a Helm 2 Release to a string i.e. which fields are relevant/redundant,
+		// and how to format the fields of a Helm 2 release.
+		// E.g. spew.Dumps is a valid marhsalling function.
 		MarshallingFunction func(h2.Release) string
 	}
 	tests := []testScenario{
@@ -134,6 +138,8 @@ func TestNewDashboardCompatibleRelease(t *testing.T) {
 	}
 }
 
+// asResponse is one of many possible Marshalling functions
+// However, it's the one most relevant for the current usage of 'dashboardcompat.go'
 func asResponse(data h2.Release) string {
 	w := httptest.NewRecorder()
 	response.NewDataResponse(data).Write(w)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -70,6 +70,64 @@ func makeReleases(t *testing.T, actionConfig *action.Configuration, rels []relea
 	}
 }
 
+func TestGetRelease(t *testing.T) {
+	fooApp := releaseStub{"foo", "my_ns", 1, release.StatusDeployed}
+	barApp := releaseStub{"bar", "other_ns", 1, release.StatusDeployed}
+	testCases := []struct {
+		description      string
+		existingReleases []releaseStub
+		targetApp        string
+		targetNamespace  string
+		expectedResult   string
+		shouldFail       bool
+	}{
+		{
+			description:      "Get an existing release",
+			existingReleases: []releaseStub{fooApp, barApp},
+			targetApp:        "foo",
+			targetNamespace:  "my_ns",
+			expectedResult:   "foo",
+		},
+		{
+			description:      "Get an existing release with default namespace",
+			existingReleases: []releaseStub{fooApp, barApp},
+			targetApp:        "foo",
+			targetNamespace:  "",
+			expectedResult:   "foo",
+		},
+		{
+			description:      "Get an non-existing release",
+			existingReleases: []releaseStub{barApp},
+			targetApp:        "foo",
+			targetNamespace:  "my_ns",
+			expectedResult:   "",
+			shouldFail:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := newActionConfigFixture(t)
+			makeReleases(t, cfg, tc.existingReleases)
+			rls, err := GetRelease(cfg, tc.targetApp)
+			if tc.shouldFail && err == nil {
+				t.Errorf("Get %s/%s should fail", tc.targetNamespace, tc.targetApp)
+			}
+			if !tc.shouldFail {
+				if err != nil {
+					t.Errorf("Unexpected error %v", err)
+				}
+				if rls == nil {
+					t.Fatalf("Release is nil: %v", rls)
+				}
+				if rls.Name != tc.expectedResult {
+					t.Errorf("Expecting app %s, received %s", tc.expectedResult, rls.Name)
+				}
+			}
+		})
+	}
+}
+
 func TestCreateReleases(t *testing.T) {
 	testCases := []struct {
 		desc             string


### PR DESCRIPTION





<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
Tests new functionality introduced by #1406 . 

### Benefits
<!-- Describe the scope of your change - i.e. what the change does. -->
- Adds test for GetRelease in `/pkg/agent`
- Adds `action="get"` tests for `/kubeops/handler`
- Adds tests for `dashboardcompat.go` in `/kubeops/internal/handler`

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
Skip tests blocked by memory driver bug
<!-- Describe any known limitations with your change -->

### Applicable issues
Tests #1406 
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information
Contains a `TODO` in `/cmd/kubeops/internal/handler/handler_test.go` with instructions on what to do when the [memory driver bug](https://github.com/helm/helm/pull/7372) is fixed.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
Signed-off-by: Latiif <abdullatif.alshriaf@combitech.se>