### PR TITLE
Move Config and Options from agent to handler

### DIFF
--- a/cmd/kubeops/internal/handler/handler_test.go
+++ b/cmd/kubeops/internal/handler/handler_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/pkg/agent"
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	authFake "github.com/kubeapps/kubeapps/pkg/auth/fake"
 	chartFake "github.com/kubeapps/kubeapps/pkg/chart/fake"
@@ -25,12 +24,12 @@ import (
 
 const defaultListLimit = 256
 
-// newConfigFixture returns an agent.Config with fake clients
+// newConfigFixture returns a Config with fake clients
 // and memory storage.
-func newConfigFixture(t *testing.T) *agent.Config {
+func newConfigFixture(t *testing.T) *Config {
 	t.Helper()
 
-	return &agent.Config{
+	return &Config{
 		ActionConfig: &action.Configuration{
 			Releases:     storage.Init(driver.NewMemory()),
 			KubeClient:   &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}},
@@ -41,7 +40,7 @@ func newConfigFixture(t *testing.T) *agent.Config {
 			},
 		},
 		ChartClient: &chartFake.FakeChart{},
-		AgentOptions: agent.Options{
+		Options: Options{
 			ListLimit: defaultListLimit,
 		},
 	}

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -44,7 +44,7 @@ func main() {
 	pflag.Parse()
 	settings.Init(pflag.CommandLine)
 
-	options := agent.Options{
+	options := handler.Options{
 		ListLimit: listLimit,
 		Timeout:   timeout,
 	}
@@ -57,7 +57,7 @@ func main() {
 			panic(err)
 		}
 	}
-	withAgentConfig := handler.WithAgentConfig(storageForDriver, options)
+	withHandlerConfig := handler.WithHandlerConfig(storageForDriver, options)
 	r := mux.NewRouter()
 
 	// Healthcheck
@@ -68,7 +68,7 @@ func main() {
 
 	// Routes
 	// Auth not necessary here with Helm 3 because it's done by Kubernetes.
-	addRoute := handler.AddRouteWith(r.PathPrefix("/v1").Subrouter(), withAgentConfig)
+	addRoute := handler.AddRouteWith(r.PathPrefix("/v1").Subrouter(), withHandlerConfig)
 	addRoute("GET", "/releases", handler.ListAllReleases)
 	addRoute("GET", "/namespaces/{namespace}/releases", handler.ListReleases)
 	addRoute("POST", "/namespaces/{namespace}/releases", handler.CreateRelease)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 
-	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
 	"github.com/kubeapps/kubeapps/pkg/proxy"
 	log "github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/action"
@@ -44,18 +43,6 @@ func StorageForMemory(_ string, _ *kubernetes.Clientset) *storage.Storage {
 	return storage.Init(d)
 }
 
-type Options struct {
-	ListLimit int
-	Timeout   int64
-	UserAgent string
-}
-
-type Config struct {
-	ActionConfig *action.Configuration
-	AgentOptions Options
-	ChartClient  chartUtils.Resolver
-}
-
 func ListReleases(actionConfig *action.Configuration, namespace string, listLimit int, status string) ([]proxy.AppOverview, error) {
 	allNamespaces := namespace == ""
 	cmd := action.NewList(actionConfig)
@@ -79,8 +66,8 @@ func ListReleases(actionConfig *action.Configuration, namespace string, listLimi
 	return appOverviews, nil
 }
 
-func CreateRelease(config Config, name, namespace, valueString string, ch *chart.Chart) (*release.Release, error) {
-	cmd := action.NewInstall(config.ActionConfig)
+func CreateRelease(actionConfig *action.Configuration, name, namespace, valueString string, ch *chart.Chart) (*release.Release, error) {
+	cmd := action.NewInstall(actionConfig)
 	cmd.ReleaseName = name
 	cmd.Namespace = namespace
 	values, err := getValues([]byte(valueString))


### PR DESCRIPTION
### Description of the change

It moves the types `Config` and `Options` from the `agent` package to the `handler` package and updates all depending code accordingly.

### Benefits

* The types in question will be more reasonably located. They are not actually used in `agent.go` (except by mistake in `CreateRelease`; fixed in this commit); the functions there only need an `action.Configuration`.