### PR TITLE
Add tests for DeleteRelease

### DIFF
--- a/cmd/kubeops/internal/handler/handler_test.go
+++ b/cmd/kubeops/internal/handler/handler_test.go
@@ -192,6 +192,7 @@ func TestActions(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Description, func(t *testing.T) {
 			// TODO Remove this `if` statement after the memory driver bug is fixed
+			// Memory Driver Bug: https://github.com/helm/helm/pull/7372
 			if test.Skip {
 				t.SkipNow()
 			}

--- a/cmd/kubeops/internal/handler/handler_test.go
+++ b/cmd/kubeops/internal/handler/handler_test.go
@@ -52,6 +52,7 @@ func TestActions(t *testing.T) {
 		Description      string
 		ExistingReleases []release.Release
 		DisableAuth      bool
+		Skip             bool //TODO: Remove this when the memory bug is fixed
 		// Request params
 		RequestBody  string
 		RequestQuery string
@@ -117,10 +118,83 @@ func TestActions(t *testing.T) {
 			},
 			ResponseBody: "",
 		},
+		{
+			// Scenario params
+			Description: "Delete a simple release",
+			ExistingReleases: []release.Release{
+				createRelease("foobarchart", "foobar", "default", 1, release.StatusDeployed),
+			},
+			DisableAuth: true,
+			// Request params
+			RequestBody:  "",
+			RequestQuery: "",
+			Action:       "delete",
+			Params:       map[string]string{"namespace": "default", "releaseName": "foobar"},
+			// Expected result
+			StatusCode: 200,
+			RemainingReleases: []release.Release{
+				createRelease("foobarchart", "foobar", "default", 1, release.StatusUninstalled),
+			},
+			ResponseBody: "",
+		},
+		{
+			// Scenario params
+			Description: "Delete and purge a simple release with purge=true",
+			ExistingReleases: []release.Release{
+				createRelease("foobarchart", "foobar", "default", 1, release.StatusDeployed),
+			},
+			DisableAuth: true,
+			// Request params
+			RequestBody:  "",
+			RequestQuery: "?purge=true",
+			Action:       "delete",
+			Params:       map[string]string{"namespace": "default", "releaseName": "foobar"},
+			// Expected result
+			StatusCode:        200,
+			RemainingReleases: []release.Release{},
+			ResponseBody:      "",
+		},
+		{
+			// Scenario params
+			Description: "Delete and purge a simple release with purge=1",
+			ExistingReleases: []release.Release{
+				createRelease("foobarchart", "foobar", "default", 1, release.StatusDeployed),
+			},
+			DisableAuth: true,
+			// Request params
+			RequestBody:  "",
+			RequestQuery: "?purge=1",
+			Action:       "delete",
+			Params:       map[string]string{"namespace": "default", "releaseName": "foobar"},
+			// Expected result
+			StatusCode:        200,
+			RemainingReleases: []release.Release{},
+			ResponseBody:      "",
+		},
+		{
+			// Scenario params
+			Description:      "Delete a missing release",
+			ExistingReleases: []release.Release{},
+			DisableAuth:      true,
+			Skip:             true,
+			// Request params
+			RequestBody:  "",
+			RequestQuery: "",
+			Action:       "delete",
+			Params:       map[string]string{"namespace": "default", "releaseName": "foobar"},
+			// Expected result
+			StatusCode:        404,
+			RemainingReleases: []release.Release{},
+			ResponseBody:      "",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.Description, func(t *testing.T) {
+			// TODO Remove this `if` statement after the memory driver bug is fixed
+			if test.Skip {
+				t.SkipNow()
+			}
 			// Initialize environment for test
 			req := httptest.NewRequest("GET", fmt.Sprintf("http://foo.bar%s", test.RequestQuery), strings.NewReader(test.RequestBody))
 			if !test.DisableAuth {
@@ -140,6 +214,8 @@ func TestActions(t *testing.T) {
 			switch test.Action {
 			case "create":
 				CreateRelease(*cfg, response, req, test.Params)
+			case "delete":
+				DeleteRelease(*cfg, response, req, test.Params)
 			default:
 				t.Errorf("Unexpected action %s", test.Action)
 			}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -324,6 +324,52 @@ func TestListReleases(t *testing.T) {
 	}
 }
 
+func TestDeleteRelease(t *testing.T) {
+	testCases := []struct {
+		description     string
+		releases        []releaseStub
+		releaseToDelete string
+		namespace       string
+		shouldFail      bool
+	}{
+		{
+			description: "Delete a release",
+			releases: []releaseStub{
+				releaseStub{"airwatch", "default", 1, release.StatusDeployed},
+			},
+			releaseToDelete: "airwatch",
+		},
+		{
+			description: "Delete a non-existing release",
+			releases: []releaseStub{
+				releaseStub{"airwatch", "default", 1, release.StatusDeployed},
+			},
+			releaseToDelete: "apache",
+			shouldFail:      true,
+		},
+		{
+			description: "Delete a release in different namespace",
+			releases: []releaseStub{
+				releaseStub{"airwatch", "default", 1, release.StatusDeployed},
+				releaseStub{"apache", "dev", 1, release.StatusDeployed},
+			},
+			releaseToDelete: "apache",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			cfg := newActionConfigFixture(t)
+			makeReleases(t, cfg, tc.releases)
+			err := DeleteRelease(cfg, tc.releaseToDelete, true)
+			t.Logf("error: %v", err)
+			if isOk := err != nil == tc.shouldFail; !isOk {
+				t.Errorf("wanted fail = %v, got fail = %v", tc.shouldFail, err != nil)
+			}
+		})
+	}
+}
+
 func TestParseDriverType(t *testing.T) {
 	validTestCases := []struct {
 		input      string

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -363,7 +363,7 @@ func TestDeleteRelease(t *testing.T) {
 			makeReleases(t, cfg, tc.releases)
 			err := DeleteRelease(cfg, tc.releaseToDelete, true)
 			t.Logf("error: %v", err)
-			if isOk := err != nil == tc.shouldFail; !isOk {
+			if didFail := err != nil; didFail != tc.shouldFail {
 				t.Errorf("wanted fail = %v, got fail = %v", tc.shouldFail, err != nil)
 			}
 		})


### PR DESCRIPTION


### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Tests new functionality introduced by #1420 

### Benefits

- Adds test for DeleteRelease in /pkg/agent
- Adds action="delete" tests for /kubeops/handler

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
Skip tests blocked by memory driver bug

<!-- Describe any known limitations with your change -->

### Applicable issues

- Tests #1420 
- Related to #1434 
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
### Additional information

Contains a `TODO` in `/cmd/kubeops/internal/handler/handler_test.go` with instructions on what to do when the [memory driver bug](https://github.com/helm/helm/pull/7372) is fixed.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
