### PR TITLE
Update to test with gke 1.13 and 1.14 rather than 1.12 and 1.13, since 1.12 master no longer available.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,14 +63,14 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_12_MASTER:
+      - GKE_1_14_MASTER:
           <<: *build_on_master
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_12_LATEST_RELEASE:
+      - GKE_1_14_LATEST_RELEASE:
           <<: *build_on_master
           requires:
             - test_go
@@ -84,8 +84,8 @@ workflows:
             - local_e2e_tests_mongodb
             - GKE_1_13_MASTER
             - GKE_1_13_LATEST_RELEASE
-            - GKE_1_12_MASTER
-            - GKE_1_12_LATEST_RELEASE
+            - GKE_1_14_MASTER
+            - GKE_1_14_LATEST_RELEASE
       - push_images:
           <<: *build_on_master
           requires:
@@ -93,8 +93,8 @@ workflows:
             - local_e2e_tests_mongodb
             - GKE_1_13_MASTER
             - GKE_1_13_LATEST_RELEASE
-            - GKE_1_12_MASTER
-            - GKE_1_12_LATEST_RELEASE
+            - GKE_1_14_MASTER
+            - GKE_1_14_LATEST_RELEASE
       - release:
           <<: *build_on_tag
           requires:
@@ -102,8 +102,8 @@ workflows:
             - local_e2e_tests_mongodb
             - GKE_1_13_MASTER
             - GKE_1_13_LATEST_RELEASE
-            - GKE_1_12_MASTER
-            - GKE_1_12_LATEST_RELEASE
+            - GKE_1_14_MASTER
+            - GKE_1_14_LATEST_RELEASE
 
 ## Definitions
 install_gcloud_sdk: &install_gcloud_sdk
@@ -157,7 +157,7 @@ build_images: &build_images
           - "*"
 install_kubectl: &install_kubectl
   run: |
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl
     chmod +x ./kubectl
     sudo mv ./kubectl /usr/local/bin/kubectl
 run_e2e_tests: &run_e2e_tests
@@ -311,14 +311,14 @@ jobs:
     environment:
       GKE_BRANCH: "1.13"
       TEST_LATEST_RELEASE: 1
-  GKE_1_12_MASTER:
+  GKE_1_14_MASTER:
     <<: *gke_test
     environment:
-      GKE_BRANCH: "1.12"
-  GKE_1_12_LATEST_RELEASE:
+      GKE_BRANCH: "1.14"
+  GKE_1_14_LATEST_RELEASE:
     <<: *gke_test
     environment:
-      GKE_BRANCH: "1.12"
+      GKE_BRANCH: "1.14"
       TEST_LATEST_RELEASE: 1
   sync_chart:
     docker:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Updates to test against GKE 1.13 and 1.14 rather than 1.12 and 1.13.

Update kubectl version from 1.12 to 1.13.

### Benefits

CircleCI began failing today when testing GKE_1_12_MASTER with the error:
```
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=No valid versions with the prefix "1.12" found.

```
It's not clear to my why this errored while GKE_1_12_LATEST_RELEASE did not (though they both use the same `GKE_BRANCH="1.12"` env var, but nonetheless I saw in the [release notes from a week ago](https://cloud.google.com/kubernetes-engine/docs/release-notes) that certain 1.12 cluster versions would no longer be available. 

