### PR TITLE
Enable apprepositoriess endpoint for kubeops

### DIFF
--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/heptiolabs/healthcheck"
 	"github.com/kubeapps/kubeapps/cmd/kubeops/internal/handler"
 	"github.com/kubeapps/kubeapps/pkg/agent"
+	appRepoHandler "github.com/kubeapps/kubeapps/pkg/apprepo"
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -75,6 +76,18 @@ func main() {
 	addRoute("GET", "/namespaces/{namespace}/releases/{releaseName}", handler.GetRelease)
 	addRoute("PUT", "/namespaces/{namespace}/releases/{releaseName}", handler.OperateRelease)
 	addRoute("DELETE", "/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
+
+	// Backend routes unrelated to tiller-proxy functionality.
+	// TODO(mnelson): Once the helm3 support is complete and tiller-proxy is being removed,
+	// reconsider where these endpoints live.
+	appreposHandler, err := appRepoHandler.NewAppRepositoriesHandler(os.Getenv("POD_NAMESPACE"))
+	if err != nil {
+		log.Fatalf("Unable to create app repositories handler: %+v", err)
+	}
+	backendAPIv1 := r.PathPrefix("/backend/v1").Subrouter()
+	backendAPIv1.Methods("POST").Path("/apprepositories").Handler(negroni.New(
+		negroni.WrapFunc(appreposHandler.Create),
+	))
 
 	// assetsvc reverse proxy
 	authGate := auth.AuthGate()

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -78,8 +78,6 @@ func main() {
 	addRoute("DELETE", "/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
 
 	// Backend routes unrelated to kubeops functionality.
-	// TODO(mnelson): Once the helm3 support is complete and tiller-proxy is being removed,
-	// reconsider where these endpoints live.
 	appreposHandler, err := appRepoHandler.NewAppRepositoriesHandler(os.Getenv("POD_NAMESPACE"))
 	if err != nil {
 		log.Fatalf("Unable to create app repositories handler: %+v", err)

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -77,7 +77,7 @@ func main() {
 	addRoute("PUT", "/namespaces/{namespace}/releases/{releaseName}", handler.OperateRelease)
 	addRoute("DELETE", "/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
 
-	// Backend routes unrelated to tiller-proxy functionality.
+	// Backend routes unrelated to kubeops functionality.
 	// TODO(mnelson): Once the helm3 support is complete and tiller-proxy is being removed,
 	// reconsider where these endpoints live.
 	appreposHandler, err := appRepoHandler.NewAppRepositoriesHandler(os.Getenv("POD_NAMESPACE"))

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/heptiolabs/healthcheck"
 	appRepo "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
 	"github.com/kubeapps/kubeapps/cmd/tiller-proxy/internal/handler"
+	appRepoHandler "github.com/kubeapps/kubeapps/pkg/apprepo"
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
 	"github.com/kubeapps/kubeapps/pkg/handlerutil"
@@ -183,7 +184,7 @@ func main() {
 	// Backend routes unrelated to tiller-proxy functionality.
 	// TODO(mnelson): Once the helm3 support is complete and tiller-proxy is being removed,
 	// reconsider where these endpoints live.
-	appreposHandler, err := handler.NewAppRepositoriesHandler(os.Getenv("POD_NAMESPACE"))
+	appreposHandler, err := appRepoHandler.NewAppRepositoriesHandler(os.Getenv("POD_NAMESPACE"))
 	if err != nil {
 		log.Fatalf("Unable to create app repositories handler: %+v", err)
 	}

--- a/pkg/apprepo/apprepos_handler.go
+++ b/pkg/apprepo/apprepos_handler.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package handler
+package apprepo
 
 import (
 	"encoding/json"

--- a/pkg/apprepo/apprepos_handler_test.go
+++ b/pkg/apprepo/apprepos_handler_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package handler
+package apprepo
 
 import (
 	"encoding/json"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

In order to be able to create apprepositories when using kubeops (Helm 3), it's necessary to use the same code and endpoint than with tiller-proxy.

