### PR TITLE
Use kubeops serviceaccount to retrieve charts

### DIFF
--- a/chart/kubeapps/templates/kubeops-rbac.yaml
+++ b/chart/kubeapps/templates/kubeops-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.useHelm3 -}}
+{{- if .Values.useHelm3 -}}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/chart/kubeapps/templates/kubeops-rbac.yaml
+++ b/chart/kubeapps/templates/kubeops-rbac.yaml
@@ -1,0 +1,44 @@
+{{- if not .Values.useHelm3 -}}
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "kubeapps.kubeops.fullname" . }}
+  labels:
+    app: {{ template "kubeapps.kubeops.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - "kubeapps.com"
+    resources:
+      - apprepositories
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "kubeapps.kubeops.fullname" . }}
+  labels:
+    app: {{ template "kubeapps.kubeops.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kubeapps.kubeops.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubeapps.kubeops.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end }}{{/* matches useHelm3 */}}

--- a/go.sum
+++ b/go.sum
@@ -570,6 +570,7 @@ k8s.io/cli-runtime v0.0.0-20191016114015-74ad18325ed5 h1:8ZfMjkMBzcXEawLsYHg9lDM
 k8s.io/cli-runtime v0.0.0-20191016114015-74ad18325ed5/go.mod h1:sDl6WKSQkDM6zS1u9F49a0VooQ3ycYFBFLqd2jf2Xfo=
 k8s.io/client-go v0.0.0-20191016111102-bec269661e48 h1:C2XVy2z0dV94q9hSSoCuTPp1KOG7IegvbdXuz9VGxoU=
 k8s.io/client-go v0.0.0-20191016111102-bec269661e48/go.mod h1:hrwktSwYGI4JK+TJA3dMaFyyvHVi/aLarVHpbs8bgCU=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/code-generator v0.0.0-20191004115455-8e001e5d1894/go.mod h1:mJUgkl06XV4kstAnLHAIzJPVCOzVR+ZcfPIv4fUsFCY=
 k8s.io/component-base v0.0.0-20191016111319-039242c015a9/go.mod h1:SuWowIgd/dtU/m/iv8OD9eOxp3QZBBhTIiWMsBQvKjI=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Kubeops is in charge of downloading the chart info and deploy it. For doing so, it needs to retrieve apprepositories and secrets in the `kubeapps` namespace. We are not using the user token for this task so the user doesn't need to have permissions for the above (context at: #1110).

cc/ @SimonAlling @latiif 
