### PR TITLE
Show forbidden errors for Helm 3

### DIFF
--- a/dashboard/src/components/Config/ServiceBrokerList/__snapshots__/ServiceBrokerList.test.tsx.snap
+++ b/dashboard/src/components/Config/ServiceBrokerList/__snapshots__/ServiceBrokerList.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`when all the brokers are loaded shows a forbiden (resync) error if it e
                 >
                   <div>
                     <p>
-                      Ask your administrator for the following permissions:
+                      Ask your administrator for the following RBAC roles:
                     </p>
                     <ul
                       className="error__permisions-list"

--- a/dashboard/src/components/Config/ServiceBrokerList/__snapshots__/ServiceBrokerList.test.tsx.snap
+++ b/dashboard/src/components/Config/ServiceBrokerList/__snapshots__/ServiceBrokerList.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`when all the brokers are loaded shows a forbiden (resync) error if it e
           <PermissionsErrorPage
             action="resync Service Brokers"
             namespace=""
+            rawMessage=""
             roles={
               Array [
                 Object {
@@ -234,7 +235,7 @@ exports[`when all the brokers are loaded shows a forbiden (resync) error if it e
                 >
                   <div>
                     <p>
-                      Ask your administrator for the following RBAC roles:
+                      Ask your administrator for the following permissions:
                     </p>
                     <ul
                       className="error__permisions-list"

--- a/dashboard/src/components/ErrorAlert/ErrorSelector.tsx
+++ b/dashboard/src/components/ErrorAlert/ErrorSelector.tsx
@@ -52,6 +52,7 @@ const ErrorSelector: React.SFC<IErrorSelectorProps> = props => {
         <PermissionsErrorAlert
           namespace={namespace || ""}
           roles={roles}
+          rawMessage={message}
           action={`${action} ${resource || ""}`}
         />
       );

--- a/dashboard/src/components/ErrorAlert/PermissionsErrorAlert.test.tsx
+++ b/dashboard/src/components/ErrorAlert/PermissionsErrorAlert.test.tsx
@@ -20,7 +20,7 @@ it("renders an error message for the action", () => {
     .find(ErrorAlertHeader);
   expect(header).toExist();
   expect(header.shallow().text()).toContain(`You don't have sufficient permissions to ${action}`);
-  expect(wrapper.html()).toContain("Ask your administrator for the following permissions:");
+  expect(wrapper.html()).toContain("The following error was returned:");
   expect(wrapper).toMatchSnapshot();
 });
 
@@ -41,6 +41,7 @@ it("renders PermissionsListItem for each RBAC role", () => {
   const wrapper = shallow(
     <PermissionsErrorAlert roles={roles} action="test" namespace="test" rawMessage="" />,
   );
+  expect(wrapper.html()).toContain("Ask your administrator for the following RBAC roles:");
   expect(wrapper.find(PermissionsListItem)).toHaveLength(2);
 });
 

--- a/dashboard/src/components/ErrorAlert/PermissionsErrorAlert.test.tsx
+++ b/dashboard/src/components/ErrorAlert/PermissionsErrorAlert.test.tsx
@@ -11,14 +11,16 @@ import { genericMessage } from "./UnexpectedErrorAlert";
 it("renders an error message for the action", () => {
   const roles: IRBACRole[] = [];
   const action = "unit-test";
-  const wrapper = shallow(<PermissionsErrorAlert roles={roles} action={action} namespace="test" />);
+  const wrapper = shallow(
+    <PermissionsErrorAlert roles={roles} action={action} namespace="test" rawMessage="" />,
+  );
   const header = wrapper
     .find(UnexpectedErrorAlert)
     .shallow()
     .find(ErrorAlertHeader);
   expect(header).toExist();
   expect(header.shallow().text()).toContain(`You don't have sufficient permissions to ${action}`);
-  expect(wrapper.html()).toContain("Ask your administrator for the following RBAC roles:");
+  expect(wrapper.html()).toContain("Ask your administrator for the following permissions:");
   expect(wrapper).toMatchSnapshot();
 });
 
@@ -36,18 +38,31 @@ it("renders PermissionsListItem for each RBAC role", () => {
       verbs: ["list", "watch"],
     },
   ];
-  const wrapper = shallow(<PermissionsErrorAlert roles={roles} action="test" namespace="test" />);
+  const wrapper = shallow(
+    <PermissionsErrorAlert roles={roles} action="test" namespace="test" rawMessage="" />,
+  );
   expect(wrapper.find(PermissionsListItem)).toHaveLength(2);
 });
 
 it("renders a link to access control documentation", () => {
   const roles: IRBACRole[] = [];
-  const wrapper = shallow(<PermissionsErrorAlert roles={roles} action="test" namespace="test" />);
+  const wrapper = shallow(
+    <PermissionsErrorAlert roles={roles} action="test" namespace="test" rawMessage="" />,
+  );
   expect(wrapper.html()).toMatch(
     /See the documentation for more info on.*access control in Kubeapps./,
   );
   expect(wrapper.html()).toContain(
     '<a href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md" target="_blank">',
   );
+  expect(wrapper.html()).not.toContain(shallow(genericMessage).html());
+});
+
+it("renders the raw message if there are no roles defined", () => {
+  const roles: IRBACRole[] = [];
+  const wrapper = shallow(
+    <PermissionsErrorAlert roles={roles} action="test" namespace="test" rawMessage="boom!" />,
+  );
+  expect(wrapper.html()).toMatch(/boom!/);
   expect(wrapper.html()).not.toContain(shallow(genericMessage).html());
 });

--- a/dashboard/src/components/ErrorAlert/PermissionsErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/PermissionsErrorAlert.tsx
@@ -9,12 +9,13 @@ import PermissionsListItem from "./PermissionsListItem";
 interface IPermissionsErrorPage {
   action: string;
   roles: IRBACRole[];
+  rawMessage: string;
   namespace: string;
 }
 
 class PermissionsErrorPage extends React.Component<IPermissionsErrorPage> {
   public render() {
-    const { action, namespace, roles } = this.props;
+    const { action, namespace, roles, rawMessage } = this.props;
     return (
       <UnexpectedErrorAlert
         title={
@@ -26,12 +27,20 @@ class PermissionsErrorPage extends React.Component<IPermissionsErrorPage> {
         showGenericMessage={false}
       >
         <div>
-          <p>Ask your administrator for the following RBAC roles:</p>
-          <ul className="error__permisions-list">
-            {roles.map((r, i) => (
-              <PermissionsListItem key={i} namespace={namespace} role={r} />
-            ))}
-          </ul>
+          <p>Ask your administrator for the following permissions:</p>
+          {roles.length > 0 ? (
+            <ul className="error__permisions-list">
+              {roles.map((r, i) => (
+                <PermissionsListItem key={i} namespace={namespace} role={r} />
+              ))}
+            </ul>
+          ) : (
+            <div className="error__content">
+              <section className="Terminal terminal__error elevation-1 type-color-white error__text">
+                {rawMessage}
+              </section>
+            </div>
+          )}
           <p>
             See the documentation for more info on{" "}
             <a

--- a/dashboard/src/components/ErrorAlert/PermissionsErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/PermissionsErrorAlert.tsx
@@ -27,19 +27,24 @@ class PermissionsErrorPage extends React.Component<IPermissionsErrorPage> {
         showGenericMessage={false}
       >
         <div>
-          <p>Ask your administrator for the following permissions:</p>
           {roles.length > 0 ? (
-            <ul className="error__permisions-list">
-              {roles.map((r, i) => (
-                <PermissionsListItem key={i} namespace={namespace} role={r} />
-              ))}
-            </ul>
+            <>
+              <p>Ask your administrator for the following RBAC roles:</p>
+              <ul className="error__permisions-list">
+                {roles.map((r, i) => (
+                  <PermissionsListItem key={i} namespace={namespace} role={r} />
+                ))}
+              </ul>
+            </>
           ) : (
-            <div className="error__content">
-              <section className="Terminal terminal__error elevation-1 type-color-white error__text">
-                {rawMessage}
-              </section>
-            </div>
+            <>
+              <p>The following error was returned:</p>
+              <div className="error__content">
+                <section className="Terminal terminal__error elevation-1 type-color-white error__text">
+                  {rawMessage}
+                </section>
+              </div>
+            </>
           )}
           <p>
             See the documentation for more info on{" "}

--- a/dashboard/src/components/ErrorAlert/__snapshots__/ErrorSelector.test.tsx.snap
+++ b/dashboard/src/components/ErrorAlert/__snapshots__/ErrorSelector.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`ForbiddenError should show an error message with the default RBAC roles
 <PermissionsErrorPage
   action="view my app"
   namespace="my-ns"
+  rawMessage=""
   roles={
     Array [
       Object {

--- a/dashboard/src/components/ErrorAlert/__snapshots__/PermissionsErrorAlert.test.tsx.snap
+++ b/dashboard/src/components/ErrorAlert/__snapshots__/PermissionsErrorAlert.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders an error message for the action 1`] = `
 >
   <div>
     <p>
-      Ask your administrator for the following permissions:
+      The following error was returned:
     </p>
     <div
       className="error__content"

--- a/dashboard/src/components/ErrorAlert/__snapshots__/PermissionsErrorAlert.test.tsx.snap
+++ b/dashboard/src/components/ErrorAlert/__snapshots__/PermissionsErrorAlert.test.tsx.snap
@@ -21,11 +21,15 @@ exports[`renders an error message for the action 1`] = `
 >
   <div>
     <p>
-      Ask your administrator for the following RBAC roles:
+      Ask your administrator for the following permissions:
     </p>
-    <ul
-      className="error__permisions-list"
-    />
+    <div
+      className="error__content"
+    >
+      <section
+        className="Terminal terminal__error elevation-1 type-color-white error__text"
+      />
+    </div>
     <p>
       See the documentation for more info on
        

--- a/pkg/handlerutil/handlerutil.go
+++ b/pkg/handlerutil/handlerutil.go
@@ -39,7 +39,7 @@ func isAlreadyExists(err error) bool {
 }
 
 func isForbidden(err error) bool {
-	return strings.Contains(err.Error(), "Unauthorized")
+	return strings.Contains(err.Error(), "Unauthorized") || strings.Contains(err.Error(), "forbidden")
 }
 
 func isUnprocessable(err error) bool {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

With Helm 3, we are not pre-processing the chart to return the forbidden actions, we are leaving that to Helm. Then we are just returning the error given by Helm if it exists. We need to adapt the dashboard code and the response a bit in order to give an appropriated response.

### Benefits

Now forbidden errors are easier to debug with Helm 3:

![Screenshot from 2020-01-14 17-52-13](https://user-images.githubusercontent.com/4025665/72364905-943bf200-36f7-11ea-8ef8-2a5573178ae8.png)

### Possible drawbacks

If we compare this solution to the one in tiller-proxy (Helm 2) we have two drawbacks due to just forwarding the error given by Helm:

 - The error message is more confusing (e.g. `create: failed to create: secrets is forbidden ...`
 - Only one forbidden action is returned (the first one to fail I guess) instead of all the forbidden action.

This is the same error for Helm 2 for the sake of comparison:

![Screenshot from 2020-01-14 18-00-39](https://user-images.githubusercontent.com/4025665/72365228-1a583880-36f8-11ea-9657-86f128de9007.png)

To mitigate this a bit, we could parse the error returned by Helm but that would be prone to errors if they change the format in the future.

