### PR TITLE
Use error wrapping to test without string comparison.

### DIFF
--- a/pkg/chart/helm3to2/dashboardcompat.go
+++ b/pkg/chart/helm3to2/dashboardcompat.go
@@ -37,7 +37,7 @@ func Convert(h3r h3.Release) (h2.Release, error) {
 		var err error
 		deleted, err = ptypes.TimestampProto(h3r.Info.Deleted.Time)
 		if err != nil {
-			return h2.Release{}, ErrFailedToParseDeletionTime
+			return h2.Release{}, fmt.Errorf("%w: %v", ErrFailedToParseDeletionTime, err)
 		}
 	}
 	return h2.Release{

--- a/pkg/chart/helm3to2/dashboardcompat_test.go
+++ b/pkg/chart/helm3to2/dashboardcompat_test.go
@@ -1,6 +1,7 @@
 package helm3to2
 
 import (
+	"errors"
 	"net/http/httptest"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -206,7 +207,7 @@ func TestConvert(t *testing.T) {
 		t.Run(test.Description, func(t *testing.T) {
 			// Perform conversion
 			compatibleH3rls, err := Convert(test.Helm3Release)
-			if got, want := err, test.ExpectedError; got != want {
+			if got, want := err, test.ExpectedError; !errors.Is(got, want) {
 				t.Errorf("got: %v, want: %v", got, want)
 			}
 			if err != nil {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

In #1445 I removed some detail from an error because I couldn't figure out a good way to test the situation (without resorting to string comparisons). I had tried to use the new error wrapping ability, but since the underlying error (from `ptypes.timestamp`) doesn't return or expose a standard error, I was unable to use `errors.Is()` to identify it.

With a fresh mind this morning, I realised that `fmt.Errorf` intentionally allows you to wrap either error while still maintaining the same error string in the result. That allows this simple change to work. See what you think
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Allows handling errors and identifying our own errors using `errors.Is` as is done here in a test (but not restricted to tests).


### Additional information

This is an alternative to #1447 