### PR TITLE
Consistent ordering in TestListReleases

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -214,8 +214,8 @@ func TestListReleases(t *testing.T) {
 			listLimit: defaultListLimit,
 			releases: []releaseStub{
 				releaseStub{"airwatch", "default", 1, "1.0.0", release.StatusDeployed},
-				releaseStub{"wordpress", "default", 1, "1.0.0", release.StatusDeployed},
-				releaseStub{"not-in-default-namespace", "other", 1, "1.0.0", release.StatusDeployed},
+				releaseStub{"wordpress", "default", 1, "1.0.1", release.StatusDeployed},
+				releaseStub{"not-in-default-namespace", "other", 1, "1.0.2", release.StatusDeployed},
 			},
 			expectedApps: []proxy.AppOverview{
 				proxy.AppOverview{
@@ -231,25 +231,25 @@ func TestListReleases(t *testing.T) {
 					},
 				},
 				proxy.AppOverview{
-					ReleaseName: "not-in-default-namespace",
-					Namespace:   "other",
-					Version:     "1.0.0",
+					ReleaseName: "wordpress",
+					Namespace:   "default",
+					Version:     "1.0.1",
 					Status:      "deployed",
 					Icon:        "https://example.com/icon.png",
 					ChartMetadata: chartv1.Metadata{
-						Version:     "1.0.0",
+						Version:     "1.0.1",
 						Icon:        "https://example.com/icon.png",
 						Maintainers: []*chartv1.Maintainer{},
 					},
 				},
 				proxy.AppOverview{
-					ReleaseName: "wordpress",
-					Namespace:   "default",
-					Version:     "1.0.0",
+					ReleaseName: "not-in-default-namespace",
+					Namespace:   "other",
+					Version:     "1.0.2",
 					Status:      "deployed",
 					Icon:        "https://example.com/icon.png",
 					ChartMetadata: chartv1.Metadata{
-						Version:     "1.0.0",
+						Version:     "1.0.2",
 						Icon:        "https://example.com/icon.png",
 						Maintainers: []*chartv1.Maintainer{},
 					},
@@ -262,8 +262,8 @@ func TestListReleases(t *testing.T) {
 			listLimit: defaultListLimit,
 			releases: []releaseStub{
 				releaseStub{"airwatch", "default", 1, "1.0.0", release.StatusDeployed},
-				releaseStub{"wordpress", "default", 1, "1.0.0", release.StatusDeployed},
-				releaseStub{"not-in-namespace", "other", 1, "1.0.0", release.StatusDeployed},
+				releaseStub{"wordpress", "default", 1, "1.0.1", release.StatusDeployed},
+				releaseStub{"not-in-namespace", "other", 1, "1.0.2", release.StatusDeployed},
 			},
 			expectedApps: []proxy.AppOverview{
 				proxy.AppOverview{
@@ -281,11 +281,11 @@ func TestListReleases(t *testing.T) {
 				proxy.AppOverview{
 					ReleaseName: "wordpress",
 					Namespace:   "default",
-					Version:     "1.0.0",
+					Version:     "1.0.1",
 					Status:      "deployed",
 					Icon:        "https://example.com/icon.png",
 					ChartMetadata: chartv1.Metadata{
-						Version:     "1.0.0",
+						Version:     "1.0.1",
 						Icon:        "https://example.com/icon.png",
 						Maintainers: []*chartv1.Maintainer{},
 					},
@@ -298,8 +298,8 @@ func TestListReleases(t *testing.T) {
 			listLimit: 1,
 			releases: []releaseStub{
 				releaseStub{"airwatch", "default", 1, "1.0.0", release.StatusDeployed},
-				releaseStub{"wordpress", "default", 1, "1.0.0", release.StatusDeployed},
-				releaseStub{"not-in-namespace", "other", 1, "1.0.0", release.StatusDeployed},
+				releaseStub{"wordpress", "default", 1, "1.0.1", release.StatusDeployed},
+				releaseStub{"not-in-namespace", "other", 1, "1.0.2", release.StatusDeployed},
 			},
 			expectedApps: []proxy.AppOverview{
 				proxy.AppOverview{
@@ -381,7 +381,7 @@ func TestListReleases(t *testing.T) {
 			listLimit: defaultListLimit,
 			releases: []releaseStub{
 				releaseStub{"wordpress", "default", 1, "1.0.0", release.StatusDeployed},
-				releaseStub{"wordpress", "dev", 2, "1.0.0", release.StatusUninstalled},
+				releaseStub{"wordpress", "dev", 2, "1.0.1", release.StatusUninstalled},
 			},
 			expectedApps: []proxy.AppOverview{
 				proxy.AppOverview{
@@ -399,11 +399,11 @@ func TestListReleases(t *testing.T) {
 				proxy.AppOverview{
 					ReleaseName: "wordpress",
 					Namespace:   "dev",
-					Version:     "1.0.0",
+					Version:     "1.0.1",
 					Status:      "uninstalled",
 					Icon:        "https://example.com/icon.png",
 					ChartMetadata: chartv1.Metadata{
-						Version:     "1.0.0",
+						Version:     "1.0.1",
 						Icon:        "https://example.com/icon.png",
 						Maintainers: []*chartv1.Maintainer{},
 					},


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

In 9c2df183d the Helm3 `AppOverview.Version` was explicitly changed from representing the release revision (`strconv.Itoa(r.Version)`) to the chart version (`Chart.Metadata.Version`), as it should to match the response from tiller proxy.

But the tests in `TestListReleases` was relying on the version to sort the results for consistent ordering (due to an issue with Helm's memory driver https://github.com/helm/helm/issues/7263). Since the new values used to sort in the test were identical, we get inconsistent ordering resulting in occasional test failures like:

https://circleci.com/gh/kubeapps/kubeapps/15198

```
--- FAIL: TestListReleases (0.00s)
    --- FAIL: TestListReleases/include_uninstalled_apps_when_requesting_all_statuses (0.00s)
        agent_test.go:437:   []proxy.AppOverview{
              	{
              		ReleaseName:   "wordpress",
              		Version:       "1.0.0",
            - 		Namespace:     "dev",
            + 		Namespace:     "default",
              		Icon:          "https://example.com/icon.png",
            - 		Status:        "uninstalled",
            + 		Status:        "deployed",
              		Chart:         "",
              		ChartMetadata: chart.Metadata{Version: "1.0.0", Maintainers: []*chart.Maintainer{}, Icon: "https://example.com/icon.png"},
              	},
              	{
              		ReleaseName:   "wordpress",
              		Version:       "1.0.0",
            - 		Namespace:     "default",
            + 		Namespace:     "dev",
              		Icon:          "https://example.com/icon.png",
            - 		Status:        "deployed",
            + 		Status:        "uninstalled",
              		Chart:         "",
              		ChartMetadata: chart.Metadata{Version: "1.0.0", Maintainers: []*chart.Maintainer{}, Icon: "https://example.com/icon.png"},
              	},
              }
time="2020-01-14T23:43:22Z" level=info msg="Rolling back airwatch to revision 1."
time="2020-01-14T23:43:22Z" level=info msg="Rolling back airwatch to revision 1."
time="2020-01-14T23:43:22Z" level=info msg="Rolling back airwatch to revision 1."
FAIL
FAIL	github.com/kubeapps/kubeapps/pkg/agent	0.055s
```

This change just ensures the data to sort the results is differentiable.
 
