### PR TITLE
Request chart when both repo and app are populated

### DIFF
--- a/dashboard/src/components/AppUpgrade/AppUpgrade.test.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.test.tsx
@@ -268,6 +268,25 @@ describe("when receiving new props", () => {
     expect(getDeployedChartVersion).toHaveBeenCalledWith("stable/bar", "1.0.0");
   });
 
+  it("should request the deployed chart when the repo is populated later", () => {
+    const repo = { metadata: { name: "stable" } };
+    const app = {
+      chart: {
+        metadata: {
+          name: "bar",
+          version: "1.0.0",
+        },
+      },
+    } as IRelease;
+    const getDeployedChartVersion = jest.fn();
+    const wrapper = shallow(
+      <AppUpgrade {...defaultProps} app={app} getDeployedChartVersion={getDeployedChartVersion} />,
+    );
+    expect(getDeployedChartVersion).not.toHaveBeenCalled();
+    wrapper.setProps({ repo });
+    expect(getDeployedChartVersion).toHaveBeenCalledWith("stable/bar", "1.0.0");
+  });
+
   it("a new app should re-trigger the deployed chart retrieval", () => {
     const repo = { metadata: { name: "stable" } };
     const app = {

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -93,7 +93,7 @@ class AppUpgrade extends React.Component<IAppUpgradeProps, IAppUpgradeState> {
         repo &&
         repo.metadata &&
         repo.metadata.name &&
-        prevProps.app !== app
+        (prevProps.app !== app || prevProps.repo !== repo)
       ) {
         const chartID = `${repo.metadata.name}/${chart.metadata.name}`;
         this.props.getDeployedChartVersion(chartID, chart.metadata.version);


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

I've found a bug when upgrading an application that is not possible to resolve it's source registry. In that case, we ask the user to introduce the chart registry and then we internally populate the `repo` info. The problem was that we were only tracking changes in the `app` info in order to retrieve the deployed chart data causing the app to show the default values in the upgrade form (without the user modifications).
