### PR TITLE
Remove duplicated ingress in chart

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -77,15 +77,15 @@ ingress:
   ## The list of hostnames to be covered with this ingress record.
   ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
   ##
-  hosts:
-    - name: kubeapps.local
-      path: /
-      ## Set this to true in order to enable TLS on the ingress record
-      ##
-      tls: false
-      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-      ##
-      tlsSecret: kubeapps.local-tls
+  # hosts:
+  #   - name: kubeapps.local
+  #     path: /
+  #     ## Set this to true in order to enable TLS on the ingress record
+  #     ##
+  #     tls: false
+  #     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+  #     ##
+  #     tlsSecret: kubeapps.local-tls
 
 ## Frontend paramters
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

When enabling the ingress setup, two hosts with identical information are generated. One because the `hostname` is set and another one because the section `hosts` is also configured (the legacy mechanism to set ingresses).

cc/ @juan131 