### PR TITLE
Enable atomic installations for Helm 3

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -72,6 +72,7 @@ func CreateRelease(actionConfig *action.Configuration, name, namespace, valueStr
 	cmd := action.NewInstall(actionConfig)
 	cmd.ReleaseName = name
 	cmd.Namespace = namespace
+	cmd.Atomic = true
 	values, err := getValues([]byte(valueString))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

When installing a chart, if the installation fails, it's useful to cleanup the release so the same name can be reused. This was already implemented for Helm 2 (#1163) but was missing for Helm 3.

