### PR TITLE
Remove RawIcon from chart versions

### DIFF
--- a/cmd/assetsvc/handler.go
+++ b/cmd/assetsvc/handler.go
@@ -303,7 +303,7 @@ func newChartResponse(c *models.Chart) *apiResponse {
 	return &apiResponse{
 		Type:       "chart",
 		ID:         c.ID,
-		Attributes: chartAttributes(*c),
+		Attributes: blankRawIcon(chartAttributes(*c)),
 		Links:      selfLink{pathPrefix + "/charts/" + c.ID},
 		Relationships: relMap{
 			"latestChartVersion": rel{
@@ -312,6 +312,14 @@ func newChartResponse(c *models.Chart) *apiResponse {
 			},
 		},
 	}
+}
+
+// blankRawIcon returns the same chart data but with a blank raw icon field.
+// TODO(mnelson): The raw icon data should be stored in a separate postgresql column
+// rather than the json field so that this isn't necessary.
+func blankRawIcon(c models.Chart) models.Chart {
+	c.RawIcon = nil
+	return c
 }
 
 func newChartListResponse(charts []*models.Chart) apiListResponse {
@@ -346,7 +354,7 @@ func newChartVersionResponse(c *models.Chart, cv models.ChartVersion) *apiRespon
 		Links:      selfLink{pathPrefix + "/charts/" + c.ID + "/versions/" + cv.Version},
 		Relationships: relMap{
 			"chart": rel{
-				Data:  chartAttributes(*c),
+				Data:  blankRawIcon(chartAttributes(*c)),
 				Links: selfLink{pathPrefix + "/charts/" + c.ID},
 			},
 		},


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
Removes the `RawIcon` field from the json/bson responses.

I noticed while testing today that listing the (default) catalog is a 6M payload:
![catalog-6MB](https://user-images.githubusercontent.com/497518/72495886-148b6000-387c-11ea-8f9f-09712c6d501d.png)

and looking at a specific wordpress chart is as 14M payload:
![wordpress-versions-14MB](https://user-images.githubusercontent.com/497518/72495909-23721280-387c-11ea-8803-20b6e64816fa.png)

A large part of this is because we are now including the `RawIcon` data as part of the responses (for each chart, or for each version of a chart).

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

The request for the list of charts (default repos) goes down from 6M to 3M. The request for a chart's versions goes down from 14M to 4M.

### Other info
I think this issue (of the huge payloads) appears to have begun with the switch away from the monocular repo, as I notice there that the chart model is explicitly defined to *not* serialize certain fields to (and from) json, including the RawIcon and ChartVersions:

https://github.com/helm/monocular/blob/master/cmd/chartsvc/models/chart.go#L42

It appears that the postgres version is dependent on these being serialized - interested to know the background here.

I think a better solution than what I've tested here would be, as per the TODO, to store the raw icon not in the json column, but a separate column, so it's easy to pull out for serving, but is *not* included in the normal payload.

Thoughts?