### PR TITLE
Enable CI builds for Helm 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ jobs:
     working_directory: /go/src/github.com/kubeapps/kubeapps
     environment:
       GOPATH: /home/circleci/.go_workspace
-      IMAGES: "apprepository-controller tiller-proxy asset-syncer assetsvc kubeops"
+      IMAGES: "kubeops apprepository-controller tiller-proxy asset-syncer assetsvc"
     <<: *build_images
   build_dashboard:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,19 +338,23 @@ jobs:
   GKE_1_13_MASTER:
     <<: *gke_test
     environment:
+      HELM_VERSION: "v2.14.0"
       GKE_BRANCH: "1.13"
   GKE_1_13_LATEST_RELEASE:
     <<: *gke_test
     environment:
+      HELM_VERSION: "v2.14.0"
       GKE_BRANCH: "1.13"
       TEST_LATEST_RELEASE: 1
   GKE_1_14_MASTER:
     <<: *gke_test
     environment:
+      HELM_VERSION: "v2.14.0"
       GKE_BRANCH: "1.14"
   GKE_1_14_LATEST_RELEASE:
     <<: *gke_test
     environment:
+      HELM_VERSION: "v2.14.0"
       GKE_BRANCH: "1.14"
       TEST_LATEST_RELEASE: 1
   sync_chart:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,14 +35,28 @@ workflows:
           <<: *build_always
       - build_dashboard:
           <<: *build_always
-      - local_e2e_tests_mongodb:
+      - local_e2e_tests_mongodb_helm2:
           <<: *build_always
           requires:
             - test_go
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - local_e2e_tests_postgresql:
+      - local_e2e_tests_postgresql_helm2:
+          <<: *build_always
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - local_e2e_tests_mongodb_helm3:
+          <<: *build_always
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
+      - local_e2e_tests_postgresql_helm3:
           <<: *build_always
           requires:
             - test_go
@@ -80,8 +94,10 @@ workflows:
       - sync_chart:
           <<: *build_on_master
           requires:
-            - local_e2e_tests_postgresql
-            - local_e2e_tests_mongodb
+            - local_e2e_tests_postgresql_helm2
+            - local_e2e_tests_postgresql_helm3
+            - local_e2e_tests_mongodb_helm2
+            - local_e2e_tests_mongodb_helm3
             - GKE_1_13_MASTER
             - GKE_1_13_LATEST_RELEASE
             - GKE_1_14_MASTER
@@ -89,8 +105,10 @@ workflows:
       - push_images:
           <<: *build_on_master
           requires:
-            - local_e2e_tests_postgresql
-            - local_e2e_tests_mongodb
+            - local_e2e_tests_postgresql_helm2
+            - local_e2e_tests_postgresql_helm3
+            - local_e2e_tests_mongodb_helm2
+            - local_e2e_tests_mongodb_helm3
             - GKE_1_13_MASTER
             - GKE_1_13_LATEST_RELEASE
             - GKE_1_14_MASTER
@@ -98,8 +116,10 @@ workflows:
       - release:
           <<: *build_on_tag
           requires:
-            - local_e2e_tests_postgresql
-            - local_e2e_tests_mongodb
+            - local_e2e_tests_postgresql_helm2
+            - local_e2e_tests_postgresql_helm3
+            - local_e2e_tests_mongodb_helm2
+            - local_e2e_tests_mongodb_helm3
             - GKE_1_13_MASTER
             - GKE_1_13_LATEST_RELEASE
             - GKE_1_14_MASTER
@@ -116,7 +136,7 @@ install_gcloud_sdk: &install_gcloud_sdk
     fi
 install_helm_cli: &install_helm_cli
   run: |
-    wget https://storage.googleapis.com/kubernetes-helm/helm-$HELM_VERSION-linux-amd64.tar.gz
+    wget https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz
     tar zxf helm-$HELM_VERSION-linux-amd64.tar.gz
     sudo mv linux-amd64/helm /usr/local/bin/
 exports: &exports
@@ -129,8 +149,6 @@ exports: &exports
     # Apart from using a DEV_TAG we use a different image ID to avoid polluting the tag
     # history of the production tag
     echo "export IMG_MODIFIER=-ci" >> $BASH_ENV
-    # Helm version (should be +2.10)
-    echo "export HELM_VERSION=v2.14.0" >> $BASH_ENV
 build_images: &build_images
   steps:
     - setup_remote_docker:
@@ -264,13 +282,14 @@ jobs:
       - run: yarn --cwd=dashboard run lint
       - run: yarn --cwd=dashboard run test --maxWorkers=4 --coverage
   test_chart_render:
+    environment:
+      HELM_VERSION: "v3.0.2"
     docker:
       - image: circleci/golang:1.13
     steps:
       - <<: *exports
       - checkout
       - <<: *install_helm_cli
-      - run: helm init --client-only
       - run: ./script/chart-template-test.sh
   build_go_images:
     docker:
@@ -278,7 +297,7 @@ jobs:
     working_directory: /go/src/github.com/kubeapps/kubeapps
     environment:
       GOPATH: /home/circleci/.go_workspace
-      IMAGES: "apprepository-controller tiller-proxy asset-syncer assetsvc"
+      IMAGES: "apprepository-controller tiller-proxy asset-syncer assetsvc kubeops"
     <<: *build_images
   build_dashboard:
     docker:
@@ -292,14 +311,28 @@ jobs:
     steps:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
-  local_e2e_tests_mongodb:
+  local_e2e_tests_mongodb_helm2:
     machine: true
     environment:
       KUBEAPPS_DB: "mongodb"
+      HELM_VERSION: "v2.14.0"
     <<: *local_e2e_steps
-  local_e2e_tests_postgresql:
+  local_e2e_tests_postgresql_helm2:
     machine: true
     environment:
+      HELM_VERSION: "v2.14.0"
+      KUBEAPPS_DB: "postgresql"
+    <<: *local_e2e_steps
+  local_e2e_tests_mongodb_helm3:
+    machine: true
+    environment:
+      HELM_VERSION: "v3.0.2"
+      KUBEAPPS_DB: "mongodb"
+    <<: *local_e2e_steps
+  local_e2e_tests_postgresql_helm3:
+    machine: true
+    environment:
+      HELM_VERSION: "v3.0.2"
       KUBEAPPS_DB: "postgresql"
     <<: *local_e2e_steps
   GKE_1_13_MASTER:
@@ -344,7 +377,7 @@ jobs:
       - run: |
           if [[ -z "$CIRCLE_PULL_REQUEST" && -n "$DOCKER_USERNAME" && -n "$DOCKER_PASSWORD" ]]; then
             docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-            for IMAGE in kubeapps/apprepository-controller kubeapps/dashboard kubeapps/tiller-proxy kubeapps/asset-syncer kubeapps/assetsvc; do
+            for IMAGE in kubeapps/apprepository-controller kubeapps/dashboard kubeapps/tiller-proxy kubeapps/asset-syncer kubeapps/assetsvc kubeapps/kubeops; do
               docker pull ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
               docker tag ${IMAGE}${IMG_MODIFIER}:${DEV_TAG} ${IMAGE}:${PROD_TAG}
               docker push ${IMAGE}:${PROD_TAG}

--- a/cmd/kubeops/Dockerfile
+++ b/cmd/kubeops/Dockerfile
@@ -10,8 +10,8 @@ ARG VERSION
 # With the trick below, Go's build cache is kept between builds.
 # https://github.com/golang/go/issues/27719#issuecomment-514747274
 RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X main.version=$VERSION" ./cmd/kubeops
+  --mount=type=cache,target=/root/.cache/go-build \
+  CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X main.version=$VERSION" ./cmd/kubeops
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -139,6 +139,12 @@ for dep in ${deployments[@]}; do
   k8s_wait_for_deployment kubeapps ${dep}
   echo "Deployment ${dep} ready"
 done
+if [[ "$HELM_VERSION" =~ "v2" ]]; then
+  k8s_wait_for_deployment kubeapps kubeapps-ci-internal-tiller-proxy
+else
+  k8s_wait_for_deployment kubeapps kubeapps-ci-internal-kubeops
+fi
+
 
 # Wait for Kubeapps Jobs
 k8s_wait_for_job_completed kubeapps apprepositories.kubeapps.com/repo-name=stable

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -73,8 +73,6 @@ imgFlags=(
   --set kubeops.image.repository=${kubeopsImage}${IMG_MODIFIER}
 )
 
-# Install Kubeapps
-kubectl create ns kubeapps
 if [[ "$HELM_VERSION" =~ "v2" ]]; then
   # Install Tiller with TLS support
   kubectl -n kube-system create sa tiller
@@ -110,6 +108,7 @@ if [[ "$HELM_VERSION" =~ "v2" ]]; then
     ${dbFlags}
 else
   # Install Kubeapps
+  kubectl create ns kubeapps
   helm dep up $ROOT_DIR/chart/kubeapps/
   helm install kubeapps-ci --namespace kubeapps $ROOT_DIR/chart/kubeapps \
     `# Image flags` \

--- a/script/libtest.sh
+++ b/script/libtest.sh
@@ -14,7 +14,7 @@
 
 set -e
 
-export TEST_MAX_WAIT_SEC=300
+export TEST_MAX_WAIT_SEC=600
 
 ## k8s specific Helper functions
 k8s_wait_for_deployment() {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Enable two more builds to run end-to-end tests using Helm 3 (both using MongoDB and PostgreSQL as database back-ends). 
