### PR TITLE
Parse forbidden errors to return forbidden actions

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -154,7 +154,7 @@ func returnErrMessage(err error, w http.ResponseWriter) {
 			response.NewErrorResponse(code, errMessage).Write(w)
 		}
 	} else {
-		returnErrMessage(err, w)
+		response.NewErrorResponse(code, errMessage).Write(w)
 	}
 }
 

--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -131,11 +132,37 @@ func AddRouteWith(
 	}
 }
 
+func returnForbiddenActions(forbiddenActions []auth.Action, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	body, err := json.Marshal(forbiddenActions)
+	if err != nil {
+		returnErrMessage(err, w)
+		return
+	}
+	response.NewErrorResponse(http.StatusForbidden, string(body)).Write(w)
+}
+
+func returnErrMessage(err error, w http.ResponseWriter) {
+	code := handlerutil.ErrorCode(err)
+	errMessage := err.Error()
+	if code == http.StatusForbidden {
+		forbiddenActions := auth.ParseForbiddenActions(errMessage)
+		if len(forbiddenActions) > 0 {
+			returnForbiddenActions(forbiddenActions, w)
+		} else {
+			// Unable to parse forbidden actions, return the raw message
+			response.NewErrorResponse(code, errMessage).Write(w)
+		}
+	} else {
+		returnErrMessage(err, w)
+	}
+}
+
 // ListReleases list existing releases.
 func ListReleases(cfg Config, w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
 	apps, err := agent.ListReleases(cfg.ActionConfig, params[namespaceParam], cfg.Options.ListLimit, req.URL.Query().Get("statuses"))
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	response.NewDataResponse(apps).Write(w)
@@ -150,7 +177,7 @@ func ListAllReleases(cfg Config, w http.ResponseWriter, req *http.Request, _ han
 func CreateRelease(cfg Config, w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
 	chartDetails, chartMulti, err := handlerutil.ParseAndGetChart(req, cfg.ChartClient, isV1SupportRequired)
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	ch := chartMulti.Helm3Chart
@@ -159,7 +186,7 @@ func CreateRelease(cfg Config, w http.ResponseWriter, req *http.Request, params 
 	valuesString := chartDetails.Values
 	release, err := agent.CreateRelease(cfg.ActionConfig, releaseName, namespace, valuesString, ch)
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	response.NewDataResponse(release).Write(w)
@@ -183,18 +210,18 @@ func upgradeRelease(cfg Config, w http.ResponseWriter, req *http.Request, params
 	releaseName := params[nameParam]
 	chartDetails, chartMulti, err := handlerutil.ParseAndGetChart(req, cfg.ChartClient, isV1SupportRequired)
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	ch := chartMulti.Helm3Chart
 	rel, err := agent.UpgradeRelease(cfg.ActionConfig, releaseName, chartDetails.Values, ch)
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	compatRelease, err := helm3to2.Convert(*rel)
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	response.NewDataResponse(compatRelease).Write(w)
@@ -209,17 +236,17 @@ func rollbackRelease(cfg Config, w http.ResponseWriter, req *http.Request, param
 	}
 	revisionInt, err := strconv.ParseInt(revision, 10, 32)
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	rel, err := agent.RollbackRelease(cfg.ActionConfig, releaseName, int(revisionInt))
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	compatRelease, err := helm3to2.Convert(*rel)
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	response.NewDataResponse(compatRelease).Write(w)
@@ -231,12 +258,12 @@ func GetRelease(cfg Config, w http.ResponseWriter, req *http.Request, params han
 	releaseName := params[nameParam]
 	release, err := agent.GetRelease(cfg.ActionConfig, releaseName)
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	compatRelease, err := helm3to2.Convert(*release)
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	response.NewDataResponse(compatRelease).Write(w)
@@ -251,7 +278,7 @@ func DeleteRelease(cfg Config, w http.ResponseWriter, req *http.Request, params 
 	keepHistory := !purge
 	err := agent.DeleteRelease(cfg.ActionConfig, releaseName, keepHistory)
 	if err != nil {
-		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		returnErrMessage(err, w)
 		return
 	}
 	w.Header().Set("Status-Code", "200")

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -551,6 +552,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+helm.sh/helm v2.16.1+incompatible h1:np11uYeEtlYcFIFRya8Xs5ZweV1z6MvaWQqJAW+1SZQ=
 helm.sh/helm/v3 v3.0.0 h1:or/9cs1GgfcTQeEnR2CVJNw893/rmqIG1KsNHmUiSFw=
 helm.sh/helm/v3 v3.0.0/go.mod h1:sI7B9yfvMgxtTPMWdk1jSKJ2aa59UyP9qhPydqW6mgo=
 helm.sh/helm/v3 v3.0.2 h1:BggvLisIMrAc+Is5oAHVrlVxgwOOrMN8nddfQbm5gKo=

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -222,13 +222,14 @@ func uniqVerbs(current []string, new []string) []string {
 			resMap[v] = true
 		}
 	}
+	res := append([]string{}, current...)
 	for _, v := range new {
 		if !resMap[v] {
 			resMap[v] = true
-			current = append(current, v)
+			res = append(res, v)
 		}
 	}
-	return current
+	return res
 }
 
 func reduceActionsByVerb(actions []Action) []Action {
@@ -286,6 +287,9 @@ func (u *UserAuth) GetForbiddenActions(namespace, action, manifest string) ([]Ac
 
 // ParseForbiddenActions parses a forbidden error returned by the Kubernetes API and return the list of forbidden actions
 func ParseForbiddenActions(message string) []Action {
+	// TODO(andresmgot): Helm may not return all the required permissions in the same message. At the moment of writing this
+	// the only supported format is an error string so we can only parse the message with a regex
+	// More info: https://github.com/helm/helm/issues/7453
 	re := regexp.MustCompile(`User "(.*?)" cannot (.*?) resource "(.*?)" in API group "(.*?)"(?: in the namespace "(.*?)")?`)
 	match := re.FindAllStringSubmatch(message, -1)
 	forbiddenActions := []Action{}

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package auth
 
 import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"reflect"
 	"strings"
 	"testing"
@@ -209,5 +211,56 @@ kind: FooBar
 		if !reflect.DeepEqual(res, tt.ExpectedActions) {
 			t.Errorf("Expecting %v, received %v", tt.ExpectedActions, res)
 		}
+	}
+}
+
+func TestParseForbiddenActions(t *testing.T) {
+	testSuite := []struct {
+		Description     string
+		Error           string
+		ExpectedActions []Action
+	}{
+		{
+			"parses an error with a single resource",
+			`User "foo" cannot create resource "secrets" in API group "" in the namespace "default"`,
+			[]Action{
+				{APIVersion: "", Resource: "secrets", Namespace: "default", Verbs: []string{"create"}},
+			},
+		},
+		{
+			"parses an error with a cluster-wide resource",
+			`User "foo" cannot create resource "clusterroles" in API group "v1"`,
+			[]Action{
+				{APIVersion: "v1", Resource: "clusterroles", Namespace: "", Verbs: []string{"create"}, ClusterWide: true},
+			},
+		},
+		{
+			"parses several resources",
+			`User "foo" cannot create resource "secrets" in API group "" in the namespace "default";
+			User "foo" cannot create resource "pods" in API group "" in the namespace "default"`,
+			[]Action{
+				{APIVersion: "", Resource: "secrets", Namespace: "default", Verbs: []string{"create"}},
+				{APIVersion: "", Resource: "pods", Namespace: "default", Verbs: []string{"create"}},
+			},
+		},
+		{
+			"includes different verbs and remove duplicates",
+			`User "foo" cannot create resource "secrets" in API group "" in the namespace "default";
+			User "foo" cannot create resource "secrets" in API group "" in the namespace "default";
+			User "foo" cannot delete resource "secrets" in API group "" in the namespace "default"`,
+			[]Action{
+				{APIVersion: "", Resource: "secrets", Namespace: "default", Verbs: []string{"create", "delete"}},
+			},
+		},
+	}
+	for _, test := range testSuite {
+		t.Run(test.Description, func(t *testing.T) {
+			actions := ParseForbiddenActions(test.Error)
+			// order actions by resource
+			less := func(x, y Action) bool { return strings.Compare(x.Resource, y.Resource) < 0 }
+			if !cmp.Equal(actions, test.ExpectedActions, cmpopts.SortSlices(less)) {
+				t.Errorf("Unexpected forbidden actions: %v", cmp.Diff(actions, test.ExpectedActions))
+			}
+		})
 	}
 }

--- a/pkg/handlerutil/handlerutil.go
+++ b/pkg/handlerutil/handlerutil.go
@@ -47,24 +47,27 @@ func isUnprocessable(err error) bool {
 	return re.MatchString(err.Error())
 }
 
+// ErrorCode returns the int representing an error.
 func ErrorCode(err error) int {
 	return ErrorCodeWithDefault(err, http.StatusInternalServerError)
 }
 
+// ErrorCodeWithDefault returns the int representing an error with a default value.
 func ErrorCodeWithDefault(err error, defaultCode int) int {
 	errCode := defaultCode
 	if isAlreadyExists(err) {
 		errCode = http.StatusConflict
-	} else if isNotFound(err) {
-		errCode = http.StatusNotFound
 	} else if isForbidden(err) {
 		errCode = http.StatusForbidden
+	} else if isNotFound(err) {
+		errCode = http.StatusNotFound
 	} else if isUnprocessable(err) {
 		errCode = http.StatusUnprocessableEntity
 	}
 	return errCode
 }
 
+// ParseAndGetChart request and parse a chart.
 func ParseAndGetChart(req *http.Request, cu chartUtils.Resolver, requireV1Support bool) (*chartUtils.Details, *chartUtils.ChartMultiVersion, error) {
 	defer req.Body.Close()
 	body, err := ioutil.ReadAll(req.Body)


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of https://github.com/kubeapps/kubeapps/pull/1450

With Helm 3, we are currently not doing the pre-validation to check if the user has enough permissions. Because of that, we are currently returning the raw error to the user. That's a regression in the UX since with Helm 2 we give a detailed list of roles needed to perform the requested action.

What this PR proposes is to parse the error returned by Helm and give an user-friendly error (like we do in Helm 2) with the permissions needed.

### Benefits

When trying to do an operation over an application, we are parsing the error returned by the Helm client, returning all the information that we have:

![Screenshot from 2020-01-16 18-01-16](https://user-images.githubusercontent.com/4025665/72545977-3e4b8380-388a-11ea-8b29-dd227b2285da.png)

The good thing about this approach is that we are not assuming anything. We are just leaving Helm do its work and forward its response.

### Possible drawbacks

From the screenshot above, you can notice that we are returning that the user needs permission to `create` PVCs and to `delete` a bunch of things. This is because `helm` stops processing the chart once one element fails to be installed but then it tries to delete everything (even if it has not been created). This can be an issue with Helm because the error message is a bit misleading (and because we are using atomic installations).

In any case, since we are not pre-checking that the user has permissions to do everything that the chart contains, the user may need to iterate several times over the error page (if the admin gives permissions one by one).
