### PR TITLE
Remove chartVersions when listing versions

### DIFF
--- a/cmd/assetsvc/handler.go
+++ b/cmd/assetsvc/handler.go
@@ -303,7 +303,7 @@ func newChartResponse(c *models.Chart) *apiResponse {
 	return &apiResponse{
 		Type:       "chart",
 		ID:         c.ID,
-		Attributes: blankRawIconAndChartVersions(chartAttributes(c)),
+		Attributes: blankRawIconAndChartVersions(chartAttributes(*c)),
 		Links:      selfLink{pathPrefix + "/charts/" + c.ID},
 		Relationships: relMap{
 			"latestChartVersion": rel{
@@ -317,7 +317,7 @@ func newChartResponse(c *models.Chart) *apiResponse {
 // blankRawIconAndChartVersions returns the same chart data but with a blank raw icon field and no chartversions.
 // TODO(mnelson): The raw icon data should be stored in a separate postgresql column
 // rather than the json field so that this isn't necessary.
-func blankRawIconAndChartVersions(c *models.Chart) *models.Chart {
+func blankRawIconAndChartVersions(c models.Chart) models.Chart {
 	c.RawIcon = nil
 	c.ChartVersions = []models.ChartVersion{}
 	return c
@@ -337,7 +337,7 @@ func chartVersionAttributes(cid string, cv models.ChartVersion) models.ChartVers
 	return cv
 }
 
-func chartAttributes(c *models.Chart) *models.Chart {
+func chartAttributes(c models.Chart) models.Chart {
 	if c.RawIcon != nil {
 		c.Icon = pathPrefix + "/assets/" + c.ID + "/logo"
 	} else {
@@ -355,7 +355,7 @@ func newChartVersionResponse(c *models.Chart, cv models.ChartVersion) *apiRespon
 		Links:      selfLink{pathPrefix + "/charts/" + c.ID + "/versions/" + cv.Version},
 		Relationships: relMap{
 			"chart": rel{
-				Data:  blankRawIconAndChartVersions(chartAttributes(c)),
+				Data:  blankRawIconAndChartVersions(chartAttributes(*c)),
 				Links: selfLink{pathPrefix + "/charts/" + c.ID},
 			},
 		},

--- a/cmd/assetsvc/handler.go
+++ b/cmd/assetsvc/handler.go
@@ -303,7 +303,7 @@ func newChartResponse(c *models.Chart) *apiResponse {
 	return &apiResponse{
 		Type:       "chart",
 		ID:         c.ID,
-		Attributes: blankRawIcon(chartAttributes(*c)),
+		Attributes: blankRawIconAndChartVersions(chartAttributes(c)),
 		Links:      selfLink{pathPrefix + "/charts/" + c.ID},
 		Relationships: relMap{
 			"latestChartVersion": rel{
@@ -314,11 +314,12 @@ func newChartResponse(c *models.Chart) *apiResponse {
 	}
 }
 
-// blankRawIcon returns the same chart data but with a blank raw icon field.
+// blankRawIconAndChartVersions returns the same chart data but with a blank raw icon field and no chartversions.
 // TODO(mnelson): The raw icon data should be stored in a separate postgresql column
 // rather than the json field so that this isn't necessary.
-func blankRawIcon(c models.Chart) models.Chart {
+func blankRawIconAndChartVersions(c *models.Chart) *models.Chart {
 	c.RawIcon = nil
+	c.ChartVersions = []models.ChartVersion{}
 	return c
 }
 
@@ -336,7 +337,7 @@ func chartVersionAttributes(cid string, cv models.ChartVersion) models.ChartVers
 	return cv
 }
 
-func chartAttributes(c models.Chart) models.Chart {
+func chartAttributes(c *models.Chart) *models.Chart {
 	if c.RawIcon != nil {
 		c.Icon = pathPrefix + "/assets/" + c.ID + "/logo"
 	} else {
@@ -354,7 +355,7 @@ func newChartVersionResponse(c *models.Chart, cv models.ChartVersion) *apiRespon
 		Links:      selfLink{pathPrefix + "/charts/" + c.ID + "/versions/" + cv.Version},
 		Relationships: relMap{
 			"chart": rel{
-				Data:  blankRawIcon(chartAttributes(*c)),
+				Data:  blankRawIconAndChartVersions(chartAttributes(c)),
 				Links: selfLink{pathPrefix + "/charts/" + c.ID},
 			},
 		},

--- a/cmd/assetsvc/handler_test.go
+++ b/cmd/assetsvc/handler_test.go
@@ -134,7 +134,6 @@ func Test_newChartResponse(t *testing.T) {
 			assert.Equal(t, cResponse.ID, tt.chart.ID, "chart ID should be the same")
 			assert.Equal(t, cResponse.Relationships["latestChartVersion"].Data.(models.ChartVersion).Version, tt.chart.ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 			assert.Equal(t, cResponse.Links.(selfLink).Self, pathPrefix+"/charts/"+tt.chart.ID, "self link should be the same")
-			assert.Equal(t, len(cResponse.Attributes.(models.Chart).ChartVersions), len(tt.chart.ChartVersions), "number of chart versions in the response should be the same")
 			// We don't send the raw icon down the wire.
 			assert.Nil(t, cResponse.Attributes.(models.Chart).RawIcon)
 		})
@@ -171,7 +170,6 @@ func Test_newChartListResponse(t *testing.T) {
 				assert.Equal(t, clResponse[i].ID, tt.result[i].ID, "chart ID should be the same")
 				assert.Equal(t, clResponse[i].Relationships["latestChartVersion"].Data.(models.ChartVersion).Version, tt.result[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 				assert.Equal(t, clResponse[i].Links.(selfLink).Self, pathPrefix+"/charts/"+tt.result[i].ID, "self link should be the same")
-				assert.Equal(t, len(clResponse[i].Attributes.(models.Chart).ChartVersions), len(tt.result[i].ChartVersions), "number of chart versions in the response should be the same")
 			}
 		})
 	}
@@ -211,6 +209,7 @@ func Test_newChartVersionResponse(t *testing.T) {
 				expectedChart := tt.chart
 				expectedChart.RawIcon = nil
 				expectedChart.Icon = tt.expectedIcon
+				expectedChart.ChartVersions = []models.ChartVersion{}
 				assert.Equal(t, cvResponse.Relationships["chart"].Data.(interface{}).(models.Chart), expectedChart, "chart in relatioship matches")
 			}
 		})


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of https://github.com/kubeapps/kubeapps/pull/1460

Remove the ChartVersion list from the requests: `/charts/{repo}/{chartName}/versions` and `/charts/{repo}/{chartName}/versions/{version}` as the `chartsvc` does. This reduces the sice of the requests from several MBs to less than 500KB.
