### PR TITLE
Check repo state instead of props when upgrading

### DIFF
--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -93,7 +93,7 @@ class AppUpgrade extends React.Component<IAppUpgradeProps, IAppUpgradeState> {
         repo &&
         repo.metadata &&
         repo.metadata.name &&
-        (prevProps.app !== app || prevProps.repo !== repo)
+        (prevProps.app !== app || this.state.repo !== repo)
       ) {
         const chartID = `${repo.metadata.name}/${chart.metadata.name}`;
         this.props.getDeployedChartVersion(chartID, chart.metadata.version);

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -61,6 +61,7 @@ class AppUpgrade extends React.Component<IAppUpgradeProps, IAppUpgradeState> {
 
   public componentDidUpdate(prevProps: IAppUpgradeProps) {
     const { repos, app } = this.props;
+    const prevRepo = this.state.repo;
     let repo = this.state.repo;
     // Retrieve the current repo
     if (!repo) {
@@ -93,7 +94,7 @@ class AppUpgrade extends React.Component<IAppUpgradeProps, IAppUpgradeState> {
         repo &&
         repo.metadata &&
         repo.metadata.name &&
-        (prevProps.app !== app || this.state.repo !== repo)
+        (prevProps.app !== app || prevRepo !== repo)
       ) {
         const chartID = `${repo.metadata.name}/${chart.metadata.name}`;
         this.props.getDeployedChartVersion(chartID, chart.metadata.version);


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

After https://github.com/kubeapps/kubeapps/pull/1455/ I introduced a regression. When upgrading, if the repository can be auto-resolved, the properties of `AppUpgrade` are not being updated and the condition I introduced was always `true`, causing an infinity loop.

