### PR TITLE
Disable atomic installations

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -72,7 +72,9 @@ func CreateRelease(actionConfig *action.Configuration, name, namespace, valueStr
 	cmd := action.NewInstall(actionConfig)
 	cmd.ReleaseName = name
 	cmd.Namespace = namespace
-	cmd.Atomic = true
+	// TODO(andresmgot): Enable Atomic installations once this issue is fixed in Helm
+	// https://github.com/helm/helm/issues/7426
+	// cmd.Atomic = true
 	values, err := getValues([]byte(valueString))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

When adding the atomic flag, I only checked wrong builds so it worked as expected but it seems that when the build should be successful, the connection just hangs. I have opened an issue in Helm (link in the code) but in the meantime, I am disabling the feature.
