### PR TITLE
Allow to upgrade an application without RBAC permissions to read apprepositories

### DIFF
--- a/dashboard/src/components/AppUpgrade/__snapshots__/AppUpgrade.test.tsx.snap
+++ b/dashboard/src/components/AppUpgrade/__snapshots__/AppUpgrade.test.tsx.snap
@@ -8,95 +8,41 @@ exports[`loading spinner matches the snapshot 1`] = `
 `;
 
 exports[`renders the repo selection form if not introduced 1`] = `
-<div>
-  <SelectRepoForm
-    app={
+<SelectRepoForm
+  chartName="bar"
+  checkChart={[Function]}
+  fetchRepositories={[Function]}
+  isFetching={false}
+  kubeappsNamespace="kubeapps"
+  repo={Object {}}
+  repos={
+    Array [
       Object {
-        "chart": Object {
-          "metadata": Object {
-            "name": "bar",
-            "version": "1.0.0",
-          },
+        "metadata": Object {
+          "name": "stable",
         },
-        "name": "foo",
-      }
-    }
-    chartName="bar"
-    checkChart={[Function]}
-    clearRepo={[Function]}
-    deployed={Object {}}
-    fetchChartVersions={[Function]}
-    fetchRepositories={[Function]}
-    getAppWithUpdateInfo={[Function]}
-    getChartVersion={[Function]}
-    getDeployedChartVersion={[Function]}
-    goBack={[Function]}
-    isFetching={false}
-    kubeappsNamespace="kubeapps"
-    namespace="default"
-    push={[Function]}
-    releaseName="foo"
-    repo={Object {}}
-    repos={
-      Array [
-        Object {
-          "metadata": Object {
-            "name": "stable",
-          },
-        },
-      ]
-    }
-    selected={Object {}}
-    upgradeApp={[Function]}
-    version="1.0.0"
-  />
-</div>
+      },
+    ]
+  }
+/>
 `;
 
 exports[`renders the upgrade form when the repo is available 1`] = `
 <div>
   <UpgradeForm
-    app={
-      Object {
-        "chart": Object {
-          "metadata": Object {
-            "name": "bar",
-            "version": "1.0.0",
-          },
-        },
-        "name": "foo",
-      }
-    }
     appCurrentValues=""
     appCurrentVersion="1.0.0"
     chartName="bar"
-    checkChart={[Function]}
-    clearRepo={[Function]}
     deployed={Object {}}
     fetchChartVersions={[Function]}
-    fetchRepositories={[Function]}
-    getAppWithUpdateInfo={[Function]}
     getChartVersion={[Function]}
-    getDeployedChartVersion={[Function]}
     goBack={[Function]}
-    isFetching={false}
-    kubeappsNamespace="kubeapps"
     namespace="default"
     push={[Function]}
     releaseName="foo"
-    repo="stable"
-    repos={
-      Array [
-        Object {
-          "metadata": Object {
-            "name": "stable",
-          },
-        },
-      ]
-    }
+    repo="foobar"
     selected={Object {}}
     upgradeApp={[Function]}
-    version="1.0.0"
   />
 </div>
 `;
@@ -104,56 +50,19 @@ exports[`renders the upgrade form when the repo is available 1`] = `
 exports[`skips the repo selection form if the app contains upgrade info 1`] = `
 <div>
   <UpgradeForm
-    app={
-      Object {
-        "chart": Object {
-          "metadata": Object {
-            "name": "bar",
-            "version": "1.0.0",
-          },
-        },
-        "name": "foo",
-        "updateInfo": Object {
-          "appLatestVersion": "1.1.0",
-          "chartLatestVersion": "1.1.0",
-          "repository": Object {
-            "name": "stable",
-            "url": "",
-          },
-          "upToDate": true,
-        },
-      }
-    }
     appCurrentValues=""
     appCurrentVersion="1.0.0"
     chartName="bar"
-    checkChart={[Function]}
-    clearRepo={[Function]}
     deployed={Object {}}
     fetchChartVersions={[Function]}
-    fetchRepositories={[Function]}
-    getAppWithUpdateInfo={[Function]}
     getChartVersion={[Function]}
-    getDeployedChartVersion={[Function]}
     goBack={[Function]}
-    isFetching={false}
-    kubeappsNamespace="kubeapps"
     namespace="default"
     push={[Function]}
     releaseName="foo"
     repo="stable"
-    repos={
-      Array [
-        Object {
-          "metadata": Object {
-            "name": "stable",
-          },
-        },
-      ]
-    }
     selected={Object {}}
     upgradeApp={[Function]}
-    version="1.0.0"
   />
 </div>
 `;
@@ -161,20 +70,6 @@ exports[`skips the repo selection form if the app contains upgrade info 1`] = `
 exports[`when an error exists renders a generic error message 1`] = `
 <ErrorSelector
   action="update"
-  defaultRequiredRBACRoles={
-    Object {
-      "update": Array [
-        Object {
-          "apiGroup": "kubeapps.com",
-          "namespace": "kubeapps",
-          "resource": "apprepositories",
-          "verbs": Array [
-            "get",
-          ],
-        },
-      ],
-    }
-  }
   error={[Error: foo doesn't exists]}
   namespace="default"
   resource="foo"

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
@@ -49,7 +49,7 @@ class SelectRepoForm extends React.Component<ISelectRepoFormProps, ISelectRepoFo
         />
       );
     }
-    if (this.props.repos?.length === 0) {
+    if (this.props.repos.length === 0) {
       return (
         <MessageAlert
           level={"warning"}
@@ -112,7 +112,7 @@ class SelectRepoForm extends React.Component<ISelectRepoFormProps, ISelectRepoFo
 
   private getRepoURL = (name: string) => {
     let res = "";
-    this.props.repos!.forEach(r => {
+    this.props.repos.forEach(r => {
       if (r.metadata.name === name && r.spec) {
         res = r.spec.url;
       }

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
@@ -1,17 +1,21 @@
 import * as React from "react";
+import { Link } from "react-router-dom";
 
-import { IAppRepository } from "../../shared/types";
+import { IAppRepository, IRBACRole } from "../../shared/types";
 import LoadingWrapper from "../LoadingWrapper";
 
-import { ErrorSelector } from "../ErrorAlert";
+import { ErrorSelector, MessageAlert } from "../ErrorAlert";
 
 interface ISelectRepoFormProps {
+  isFetching: boolean;
   kubeappsNamespace: string;
-  error: Error | undefined;
+  repoError?: Error;
+  error?: Error;
   repo: IAppRepository;
   repos: IAppRepository[];
   chartName: string;
   checkChart: (repo: string, chartName: string) => any;
+  fetchRepositories: () => void;
 }
 
 interface ISelectRepoFormState {
@@ -26,7 +30,39 @@ class SelectRepoForm extends React.Component<ISelectRepoFormProps, ISelectRepoFo
         : "",
   };
 
+  public componentDidMount() {
+    this.props.fetchRepositories();
+  }
+
   public render() {
+    if (this.props.isFetching) {
+      return <LoadingWrapper />;
+    }
+    if (this.props.repoError) {
+      return (
+        <ErrorSelector
+          error={this.props.repoError}
+          namespace={this.props.kubeappsNamespace}
+          action="view"
+          defaultRequiredRBACRoles={{ view: this.requiredRBACRoles() }}
+          resource="App Repositories"
+        />
+      );
+    }
+    if (this.props.repos?.length === 0) {
+      return (
+        <MessageAlert
+          level={"warning"}
+          children={
+            <div>
+              <h5>Chart repositories not found.</h5>
+              Manage your Helm chart repositories in Kubeapps by visiting the{" "}
+              <Link to={"/config/repos"}>App repositories configuration</Link> page.
+            </div>
+          }
+        />
+      );
+    }
     return (
       <LoadingWrapper loaded={this.props.repos.length > 0}>
         <div className="container margin-normal">
@@ -76,13 +112,24 @@ class SelectRepoForm extends React.Component<ISelectRepoFormProps, ISelectRepoFo
 
   private getRepoURL = (name: string) => {
     let res = "";
-    this.props.repos.forEach(r => {
+    this.props.repos!.forEach(r => {
       if (r.metadata.name === name && r.spec) {
         res = r.spec.url;
       }
     });
     return res;
   };
+
+  private requiredRBACRoles(): IRBACRole[] {
+    return [
+      {
+        apiGroup: "kubeapps.com",
+        namespace: this.props.kubeappsNamespace,
+        resource: "apprepositories",
+        verbs: ["get"],
+      },
+    ];
+  }
 }
 
 export default SelectRepoForm;

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -17,7 +17,7 @@ export interface IUpgradeFormProps {
   namespace: string;
   releaseName: string;
   repo: string;
-  error: Error | undefined;
+  error?: Error;
   selected: IChartState["selected"];
   deployed: IChartState["deployed"];
   upgradeApp: (

--- a/dashboard/src/containers/AppUpgradeContainer/AppUpgradeContainer.tsx
+++ b/dashboard/src/containers/AppUpgradeContainer/AppUpgradeContainer.tsx
@@ -24,8 +24,10 @@ function mapStateToProps(
 ) {
   return {
     app: apps.selected,
-    isFetching: apps.isFetching || repos.isFetching,
-    error: apps.error || charts.selected.error,
+    appIsFetching: apps.isFetching,
+    reposIsFetching: repos.isFetching,
+    appsError: apps.error,
+    chartsError: charts.selected.error,
     kubeappsNamespace: config.namespace,
     namespace: params.namespace,
     releaseName: params.releaseName,
@@ -34,6 +36,7 @@ function mapStateToProps(
     repos: repos.repos,
     selected: charts.selected,
     deployed: charts.deployed,
+    repoName: repos.repo.metadata && repos.repo.metadata.name,
   };
 }
 

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -70,11 +70,6 @@ const reposReducer = (
       return { ...state, redirectTo: action.payload };
     case getType(actions.repos.redirected):
       return { ...state, redirectTo: undefined };
-    case getType(actions.charts.errorChart):
-      return {
-        ...state,
-        errors: { fetch: action.payload },
-      };
     case getType(actions.repos.errorRepos):
       return {
         ...state,

--- a/integration/use-cases/upgrade.js
+++ b/integration/use-cases/upgrade.js
@@ -1,0 +1,40 @@
+test("Upgrades an application", async () => {
+  await page.goto(getUrl("/#/login"));
+
+  await expect(page).toFillForm("form", {
+    token: process.env.EDIT_TOKEN
+  });
+
+  await expect(page).toClick("button", { text: "Login" });
+
+  await expect(page).toClick("a", { text: "Catalog" });
+
+  await expect(page).toClick("a", { text: "apache", timeout: 60000 });
+
+  await expect(page).toClick("button", { text: "Deploy" });
+
+  const chartVersionElement = await expect(page).toMatchElement(
+    "#chartVersion"
+  );
+  const chartVersionElementContent = await chartVersionElement.getProperty(
+    "textContent"
+  );
+  const chartVersionValue = await chartVersionElementContent.jsonValue();
+  const latestChartVersion = chartVersionValue.split(" ")[0];
+
+  await expect(page).toSelect("#chartVersion", "7.3.2", { delay: 1000 });
+
+  await expect(page).toClick("button", { text: "Submit", delay: 1000 });
+
+  await expect(page).toMatch("Update Available", { timeout: 60000 });
+
+  await expect(page).toClick("button", { text: "Upgrade" });
+
+  await expect(page).toSelect("#chartVersion", latestChartVersion, {
+    delay: 1000
+  });
+
+  await expect(page).toClick("button", { text: "Submit", delay: 1000 });
+
+  await expect(page).toMatch("Up to date", { timeout: 60000 });
+});

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -215,9 +215,13 @@ admin_token=`kubectl get -n kubeapps secret $(kubectl get -n kubeapps serviceacc
 kubectl create serviceaccount kubeapps-view -n kubeapps
 kubectl create clusterrolebinding kubeapps-view --clusterrole=view --serviceaccount kubeapps:kubeapps-view
 view_token=`kubectl get -n kubeapps secret $(kubectl get -n kubeapps serviceaccount kubeapps-view -o jsonpath='{.secrets[].name}') -o go-template='{{.data.token | base64decode}}' && echo`
+## Create edit user
+kubectl create serviceaccount kubeapps-edit -n kubeapps
+kubectl create rolebinding kubeapps-edit -n kubeapps --clusterrole=edit --serviceaccount kubeapps:kubeapps-edit
+edit_token=`kubectl get -n kubeapps secret $(kubectl get -n kubeapps serviceaccount kubeapps-edit -o jsonpath='{.secrets[].name}') -o go-template='{{.data.token | base64decode}}' && echo`
 ## Run tests
 set +e
-kubectl exec -it ${pod} -- /bin/sh -c "INTEGRATION_ENTRYPOINT=http://kubeapps-ci.kubeapps ADMIN_TOKEN=${admin_token} VIEW_TOKEN=${view_token} yarn start"
+kubectl exec -it ${pod} -- /bin/sh -c "INTEGRATION_ENTRYPOINT=http://kubeapps-ci.kubeapps ADMIN_TOKEN=${admin_token} VIEW_TOKEN=${view_token} EDIT_TOKEN=${edit_token} yarn start"
 code=$?
 set -e
 if [[ "$code" != 0 ]]; then


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

I found an issue when doing some testing with a serviceaccount that didn't have permissions to interact with apprepositories (but has write permissions in the namespace). The `AppUpgrade` form was requesting the existing repositories regardless if it was necessary or not (it's only necessaary when the source repository cannot be auto-detected).

This PR refactors the `AppUpgrade` component so the `SelectRepoForm` is the one requesting apprepositories and it's only mounted if it's not possible to auto-resolve the source repository. I am also refactoring quite a bit the `AppUpgrade` component since the logic and error handling is quite messy.

### Possible drawbacks

For the sake of simplicity, I have removed a case in which the chart information is present but it doesn't have metadata (which is not a real situation).
