### PR TITLE
Add scroll bars to prevent content jumping

### DIFF
--- a/dashboard/src/index.scss
+++ b/dashboard/src/index.scss
@@ -4,6 +4,8 @@
 body {
   margin: 0;
   padding: 0;
+  overflow-y: scroll;
+  overflow-x: scroll;
 }
 
 .container-fluid > .row > div {


### PR DESCRIPTION
### Description of the change

It forces scrollbars to always appear, even if they're not necessary.

### Benefits

Without this addition, page content often jumps around when the user navigates between "pages" or when stuff loads dynamically. Forcing scrollbars at all times removes said annoying behavior.

### Additional information

I'm currently unable to run Kubeapps locally, but I think this should work as intended. Just let me know otherwise, and/or suggest a change.