### PR TITLE
Creates a namespace when typing a new one in the namespace selector

### DIFF
--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -2,7 +2,14 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { getType } from "typesafe-actions";
 import Namespace from "../shared/Namespace";
-import { errorNamespaces, fetchNamespaces, receiveNamespaces, setNamespace } from "./namespace";
+import {
+  createNamespace,
+  errorNamespaces,
+  fetchNamespaces,
+  postNamespace,
+  receiveNamespaces,
+  setNamespace,
+} from "./namespace";
 
 const mockStore = configureMockStore([thunk]);
 
@@ -72,6 +79,45 @@ describe("fetchNamespaces", () => {
     ];
 
     await store.dispatch(fetchNamespaces());
+
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe("createNamespace", () => {
+  it("dispatches the new namespace and re-fetch namespaces", async () => {
+    Namespace.create = jest.fn();
+    Namespace.list = jest.fn().mockImplementationOnce(() => {
+      return {
+        items: [{ metadata: { name: "overlook-hotel" } }, { metadata: { name: "room-217" } }],
+      };
+    });
+    const expectedActions = [
+      {
+        type: getType(postNamespace),
+        payload: "overlook-hotel",
+      },
+      {
+        type: getType(receiveNamespaces),
+        payload: ["overlook-hotel", "room-217"],
+      },
+    ];
+
+    await store.dispatch(createNamespace("overlook-hotel"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches errorNamespace if error creating a namespace", async () => {
+    const err = new Error("Bang!");
+    Namespace.create = jest.fn().mockImplementationOnce(() => Promise.reject(err));
+    const expectedActions = [
+      {
+        type: getType(errorNamespaces),
+        payload: { err, op: "create" },
+      },
+    ];
+
+    await store.dispatch(createNamespace("foo"));
 
     expect(store.getActions()).toEqual(expectedActions);
   });

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -9,17 +9,27 @@ export const setNamespace = createAction("SET_NAMESPACE", resolve => {
   return (namespace: string) => resolve(namespace);
 });
 
+export const postNamespace = createAction("CREATE_NAMESPACE", resolve => {
+  return (namespace: string) => resolve(namespace);
+});
+
 export const receiveNamespaces = createAction("RECEIVE_NAMESPACES", resolve => {
   return (namespaces: string[]) => resolve(namespaces);
 });
 
 export const errorNamespaces = createAction("ERROR_NAMESPACES", resolve => {
-  return (err: Error, op: "list") => resolve({ err, op });
+  return (err: Error, op: string) => resolve({ err, op });
 });
 
 export const clearNamespaces = createAction("CLEAR_NAMESPACES");
 
-const allActions = [setNamespace, receiveNamespaces, errorNamespaces, clearNamespaces];
+const allActions = [
+  setNamespace,
+  receiveNamespaces,
+  errorNamespaces,
+  clearNamespaces,
+  postNamespace,
+];
 export type NamespaceAction = ActionType<typeof allActions[number]>;
 
 export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
@@ -30,6 +40,21 @@ export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null,
       dispatch(receiveNamespaces(namespaceStrings));
     } catch (e) {
       dispatch(errorNamespaces(e, "list"));
+      return;
+    }
+  };
+}
+
+export function createNamespace(
+  ns: string,
+): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
+  return async dispatch => {
+    try {
+      await Namespace.create(ns);
+      dispatch(postNamespace(ns));
+      dispatch(fetchNamespaces());
+    } catch (e) {
+      dispatch(errorNamespaces(e, "create"));
       return;
     }
   };

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -16,6 +16,7 @@ const defaultProps = {
   pathname: "",
   push: jest.fn(),
   setNamespace: jest.fn(),
+  createNamespace: jest.fn(),
 };
 it("renders the header links and titles", () => {
   const wrapper = shallow(<Header {...defaultProps} />);
@@ -51,4 +52,55 @@ it("renders the namespace switcher", () => {
       namespace: defaultProps.namespace,
     }),
   );
+});
+
+it("call setNamespace when selecting a namespace", () => {
+  const setNamespace = jest.fn();
+  const createNamespace = jest.fn();
+  const namespace = {
+    current: "foo",
+    namespaces: ["foo", "bar"],
+  };
+  const wrapper = shallow(
+    <Header
+      {...defaultProps}
+      setNamespace={setNamespace}
+      namespace={namespace}
+      createNamespace={createNamespace}
+    />,
+  );
+
+  const namespaceSelector = wrapper.find("NamespaceSelector");
+  expect(namespaceSelector).toExist();
+  const onChange = namespaceSelector.prop("onChange") as (ns: any) => void;
+  onChange("bar");
+
+  expect(setNamespace).toHaveBeenCalledWith("bar");
+  expect(createNamespace).not.toHaveBeenCalled();
+});
+
+it("call setNamespace and createNamespace when selecting a new namespace", () => {
+  const setNamespace = jest.fn();
+  const createNamespace = jest.fn();
+  const namespace = {
+    current: "foo",
+    namespaces: ["foo", "bar"],
+  };
+  const wrapper = shallow(
+    <Header
+      {...defaultProps}
+      setNamespace={setNamespace}
+      namespace={namespace}
+      createNamespace={createNamespace}
+      pathname="/ns/foo"
+    />,
+  );
+
+  const namespaceSelector = wrapper.find("NamespaceSelector");
+  expect(namespaceSelector).toExist();
+  const onChange = namespaceSelector.prop("onChange") as (ns: any) => void;
+  onChange("foobar");
+
+  expect(setNamespace).toHaveBeenCalledWith("foobar");
+  expect(createNamespace).toHaveBeenCalledWith("foobar");
 });

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -104,3 +104,29 @@ it("call setNamespace and createNamespace when selecting a new namespace", () =>
   expect(setNamespace).toHaveBeenCalledWith("foobar");
   expect(createNamespace).toHaveBeenCalledWith("foobar");
 });
+
+it("do not try to create a namespace if it's setting the default or all", () => {
+  const setNamespace = jest.fn();
+  const createNamespace = jest.fn();
+  const wrapper = shallow(
+    <Header
+      {...defaultProps}
+      setNamespace={setNamespace}
+      createNamespace={createNamespace}
+      pathname="/ns/foo"
+      defaultNamespace="default"
+    />,
+  );
+
+  const namespaceSelector = wrapper.find("NamespaceSelector");
+  expect(namespaceSelector).toExist();
+  const onChange = namespaceSelector.prop("onChange") as (ns: any) => void;
+
+  onChange("default");
+  expect(setNamespace).toHaveBeenCalledWith("default");
+  expect(createNamespace).not.toHaveBeenCalled();
+
+  onChange("_all");
+  expect(setNamespace).toHaveBeenCalledWith("_all");
+  expect(createNamespace).not.toHaveBeenCalled();
+});

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -175,11 +175,18 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   };
 
   private handleNamespaceChange = (ns: string) => {
-    const { pathname, push, setNamespace, createNamespace, namespace } = this.props;
+    const {
+      pathname,
+      push,
+      setNamespace,
+      createNamespace,
+      namespace,
+      defaultNamespace,
+    } = this.props;
     const to = pathname.replace(/\/ns\/[^/]*/, `/ns/${ns}`);
     setNamespace(ns);
     if (to !== pathname) {
-      if (!namespace.namespaces.includes(ns)) {
+      if (!namespace.namespaces.includes(ns) && ns !== defaultNamespace && ns !== "_all") {
         createNamespace(ns);
       }
       push(to);

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -21,6 +21,7 @@ interface IHeaderProps {
   pathname: string;
   push: (path: string) => void;
   setNamespace: (ns: string) => void;
+  createNamespace: (ns: string) => void;
 }
 
 interface IHeaderState {
@@ -174,11 +175,13 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   };
 
   private handleNamespaceChange = (ns: string) => {
-    const { pathname, push, setNamespace } = this.props;
+    const { pathname, push, setNamespace, createNamespace, namespace } = this.props;
     const to = pathname.replace(/\/ns\/[^/]*/, `/ns/${ns}`);
-    if (to === pathname) {
-      setNamespace(ns);
-    } else {
+    setNamespace(ns);
+    if (to !== pathname) {
+      if (!namespace.namespaces.includes(ns)) {
+        createNamespace(ns);
+      }
       push(to);
     }
   };

--- a/dashboard/src/components/Header/NamespaceSelector.scss
+++ b/dashboard/src/components/Header/NamespaceSelector.scss
@@ -18,3 +18,10 @@
 .NamespaceSelector .Select-clear {
   line-height: inherit;
 }
+
+.NamespaceSelectorError {
+  position: relative;
+  left: 0.3em;
+  bottom: -0.3em;
+  width: 20px;
+}

--- a/dashboard/src/components/Header/NamespaceSelector.test.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.test.tsx
@@ -1,6 +1,7 @@
 import { shallow } from "enzyme";
 import * as React from "react";
 
+import { AlertCircle } from "react-feather";
 import { INamespaceState } from "../../reducers/namespace";
 import NamespaceSelector from "./NamespaceSelector";
 
@@ -71,4 +72,18 @@ it("renders the default namespace option if no namespaces provided", () => {
       ],
     }),
   );
+});
+
+it("renders the a creation error if exists", () => {
+  const error = {
+    action: "create",
+    errorMsg: "Unable to create that namespace",
+  };
+  const ns = {
+    ...defaultProps.namespace,
+    error,
+  };
+  const wrapper = shallow(<NamespaceSelector {...defaultProps} namespace={ns} />);
+
+  expect(wrapper.find(AlertCircle)).toExist();
 });

--- a/dashboard/src/components/Header/NamespaceSelector.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import * as Select from "react-select";
+import * as ReactTooltip from "react-tooltip";
 
+import { AlertCircle } from "react-feather";
 import { INamespaceState } from "../../reducers/namespace";
 import { definedNamespaces } from "../../shared/Namespace";
 
@@ -20,7 +22,7 @@ class NamespaceSelector extends React.Component<INamespaceSelectorProps> {
 
   public render() {
     const {
-      namespace: { current, namespaces },
+      namespace: { current, namespaces, error },
       defaultNamespace,
     } = this.props;
     const options =
@@ -35,6 +37,7 @@ class NamespaceSelector extends React.Component<INamespaceSelectorProps> {
     return (
       <div className="NamespaceSelector margin-r-normal">
         <label className="NamespaceSelector__label type-tiny">NAMESPACE</label>
+        {error && error.action === "create" && this.renderError(error.errorMsg)}
         <Select.Creatable
           className="NamespaceSelector__select type-small"
           value={value}
@@ -55,7 +58,20 @@ class NamespaceSelector extends React.Component<INamespaceSelectorProps> {
   };
 
   private promptTextCreator = (text: string) => {
-    return `Use namespace "${text}"`;
+    return `Create namespace "${text}"`;
+  };
+
+  private renderError = (errMsg: string) => {
+    return (
+      <>
+        <a data-tip={true} data-for="ns-error">
+          <AlertCircle className="NamespaceSelectorError" color="white" fill="red" />
+        </a>
+        <ReactTooltip id="ns-error" className="extraClass" effect="solid">
+          {errMsg}
+        </ReactTooltip>
+      </>
+    );
   };
 }
 

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -30,6 +30,7 @@ function mapStateToProps({
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
     fetchNamespaces: () => dispatch(actions.namespace.fetchNamespaces()),
+    createNamespace: (ns: string) => dispatch(actions.namespace.createNamespace(ns)),
     logout: () => dispatch(actions.auth.logout()),
     push: (path: string) => dispatch(push(path)),
     setNamespace: (ns: string) => dispatch(actions.namespace.setNamespace(ns)),

--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -48,7 +48,7 @@ describe("namespaceReducer", () => {
           type: getType(actions.namespace.errorNamespaces),
           payload: { err, op: "list" },
         }),
-      ).toEqual({ ...initialState, errorMsg: err.message });
+      ).toEqual({ ...initialState, error: { action: "list", errorMsg: err.message } });
     });
   });
 
@@ -77,6 +77,20 @@ describe("namespaceReducer", () => {
           },
         ),
       ).toEqual({ current: "foo-bar", namespaces: [] });
+    });
+  });
+
+  context("when SET_NAMESPACE", () => {
+    it("sets the current namespace and clears error", () => {
+      expect(
+        namespaceReducer(
+          { current: "error", namespaces: [], error: { action: "create", errorMsg: "boom" } },
+          {
+            type: getType(actions.namespace.setNamespace),
+            payload: "default",
+          },
+        ),
+      ).toEqual({ current: "default", namespaces: [], error: undefined });
     });
   });
 });

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -9,7 +9,7 @@ import { Auth } from "../shared/Auth";
 export interface INamespaceState {
   current: string;
   namespaces: string[];
-  errorMsg?: string;
+  error?: { action: string; errorMsg: string };
 }
 
 const getInitialState: () => INamespaceState = (): INamespaceState => {
@@ -29,9 +29,12 @@ const namespaceReducer = (
     case getType(actions.namespace.receiveNamespaces):
       return { ...state, namespaces: action.payload };
     case getType(actions.namespace.setNamespace):
-      return { ...state, current: action.payload };
+      return { ...state, current: action.payload, error: undefined };
     case getType(actions.namespace.errorNamespaces):
-      return { ...state, errorMsg: action.payload.err.message };
+      return {
+        ...state,
+        error: { action: action.payload.op, errorMsg: action.payload.err.message },
+      };
     case getType(actions.namespace.clearNamespaces):
       return { ...initialState };
     case LOCATION_CHANGE:

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -9,6 +9,17 @@ export default class Namespace {
     return data;
   }
 
+  public static async create(name: string) {
+    const { data } = await axiosWithAuth.post<IResource>(Namespace.APIEndpoint, {
+      apiVersion: "v1",
+      kind: "Namespace",
+      metadata: {
+        name,
+      },
+    });
+    return data;
+  }
+
   private static APIBase: string = APIBase;
   private static APIEndpoint: string = `${Namespace.APIBase}/api/v1/namespaces/`;
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Since Helm 3, the namespace is not being created when deploying an application in a new namespace. This PR adapts kubeapps so it creates the namespace when submitting it from the namespace selector so the installation doesn't fail.

It also re-request the list of namespaces after creating one so this fixes #1364

If a user doesn't have permissions to create a namespace, instead that silently fail, it renders a warning icon with a tooltip text with the content of the error:

![Screenshot from 2020-01-27 13-02-47](https://user-images.githubusercontent.com/4025665/73175383-546b0680-410a-11ea-991c-c5ed8cbf2624.png)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1364

