### PR TITLE
Return a valid error when using non-existing namespaces

### DIFF
--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -6,8 +6,11 @@ import {
   createNamespace,
   errorNamespaces,
   fetchNamespaces,
+  getNamespace,
   postNamespace,
+  receiveNamespace,
   receiveNamespaces,
+  requestNamespace,
   setNamespace,
 } from "./namespace";
 
@@ -120,6 +123,42 @@ describe("createNamespace", () => {
 
     const res = await store.dispatch(createNamespace("foo"));
     expect(res).toBe(false);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe("createNamespace", () => {
+  it("dispatches requested namespace", async () => {
+    const ns = { metadata: { name: "default" } };
+    Namespace.get = jest.fn(() => ns);
+    const expectedActions = [
+      {
+        type: getType(requestNamespace),
+        payload: "default",
+      },
+      {
+        type: getType(receiveNamespace),
+        payload: ns,
+      },
+    ];
+    await store.dispatch(getNamespace("default"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches errorNamespace if error creating a namespace", async () => {
+    const err = new Error("Bang!");
+    Namespace.get = jest.fn().mockImplementationOnce(() => Promise.reject(err));
+    const expectedActions = [
+      {
+        type: getType(requestNamespace),
+        payload: "default",
+      },
+      {
+        type: getType(errorNamespaces),
+        payload: { err, op: "get" },
+      },
+    ];
+    await store.dispatch(getNamespace("default"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -127,7 +127,7 @@ describe("createNamespace", () => {
   });
 });
 
-describe("createNamespace", () => {
+describe("getNamespace", () => {
   it("dispatches requested namespace", async () => {
     const ns = { metadata: { name: "default" } };
     Namespace.get = jest.fn(() => ns);
@@ -141,7 +141,8 @@ describe("createNamespace", () => {
         payload: ns,
       },
     ];
-    await store.dispatch(getNamespace("default"));
+    const r = await store.dispatch(getNamespace("default"));
+    expect(r).toBe(true);
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -158,7 +159,8 @@ describe("createNamespace", () => {
         payload: { err, op: "get" },
       },
     ];
-    await store.dispatch(getNamespace("default"));
+    const r = await store.dispatch(getNamespace("default"));
+    expect(r).toBe(false);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -111,7 +111,7 @@ describe("createNamespace", () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
-  it("dispatches errorNamespace if error creating a namespace", async () => {
+  it("dispatches errorNamespace if error getting a namespace", async () => {
     const err = new Error("Bang!");
     Namespace.create = jest.fn().mockImplementationOnce(() => Promise.reject(err));
     const expectedActions = [

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -72,15 +72,16 @@ export function createNamespace(
 
 export function getNamespace(
   ns: string,
-): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
+): ThunkAction<Promise<boolean>, IStoreState, null, NamespaceAction> {
   return async dispatch => {
     try {
       dispatch(requestNamespace(ns));
       const namespace = await Namespace.get(ns);
       dispatch(receiveNamespace(namespace));
+      return true;
     } catch (e) {
       dispatch(errorNamespaces(e, "get"));
-      return;
+      return false;
     }
   };
 }

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -5,6 +5,13 @@ import { ActionType, createAction } from "typesafe-actions";
 import Namespace from "../shared/Namespace";
 import { IResource, IStoreState } from "../shared/types";
 
+export const requestNamespace = createAction("REQUEST_NAMESPACE", resolve => {
+  return (namespace: string) => resolve(namespace);
+});
+export const receiveNamespace = createAction("RECEIVE_NAMESPACE", resolve => {
+  return (namespace: IResource) => resolve(namespace);
+});
+
 export const setNamespace = createAction("SET_NAMESPACE", resolve => {
   return (namespace: string) => resolve(namespace);
 });
@@ -24,6 +31,8 @@ export const errorNamespaces = createAction("ERROR_NAMESPACES", resolve => {
 export const clearNamespaces = createAction("CLEAR_NAMESPACES");
 
 const allActions = [
+  requestNamespace,
+  receiveNamespace,
   setNamespace,
   receiveNamespaces,
   errorNamespaces,
@@ -57,6 +66,21 @@ export function createNamespace(
     } catch (e) {
       dispatch(errorNamespaces(e, "create"));
       return false;
+    }
+  };
+}
+
+export function getNamespace(
+  ns: string,
+): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
+  return async dispatch => {
+    try {
+      dispatch(requestNamespace(ns));
+      const namespace = await Namespace.get(ns);
+      dispatch(receiveNamespace(namespace));
+    } catch (e) {
+      dispatch(errorNamespaces(e, "get"));
+      return;
     }
   };
 }

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -2,7 +2,7 @@ import { mount, shallow } from "enzyme";
 import * as Moniker from "moniker-native";
 import * as React from "react";
 
-import { IChartState, IChartVersion, UnprocessableEntity } from "../../shared/types";
+import { IChartState, IChartVersion, NotFoundError, UnprocessableEntity } from "../../shared/types";
 import DeploymentFormBody from "../DeploymentFormBody/DeploymentFormBody";
 import { ErrorSelector } from "../ErrorAlert";
 import DeploymentForm from "./DeploymentForm";
@@ -19,6 +19,7 @@ const defaultProps = {
   fetchChartVersions: jest.fn(),
   getChartVersion: jest.fn(),
   namespace: "default",
+  getNamespace: jest.fn(),
 };
 const versions = [{ id: "foo", attributes: { version: "1.2.3" } }] as IChartVersion[];
 let monikerChooseMock: jest.Mock;
@@ -82,6 +83,16 @@ describe("renders an error", () => {
     wrapper.setState({ releaseName: "another-app" });
     expect(wrapper.find(ErrorSelector).html()).toContain(expectedErrorMsg);
   });
+
+  it("renders a custom error if the namespace is missing", () => {
+    const wrapper = shallow(
+      <DeploymentForm
+        {...defaultProps}
+        error={new NotFoundError(`namespaces ${defaultProps.namespace} not found`)}
+      />,
+    );
+    expect(wrapper.html()).toContain(`Namespace <code>${defaultProps.namespace}</code> is missing`);
+  });
 });
 
 it("renders the full DeploymentForm", () => {
@@ -135,6 +146,7 @@ it("triggers a deployment when submitting the form", done => {
   const schema = { properties: { foo: { type: "string", form: true } } };
   const deployChart = jest.fn(() => true);
   const push = jest.fn();
+  const getNamespace = jest.fn();
   const wrapper = mount(
     <DeploymentForm
       {...defaultProps}
@@ -142,6 +154,7 @@ it("triggers a deployment when submitting the form", done => {
       deployChart={deployChart}
       push={push}
       namespace={namespace}
+      getNamespace={getNamespace}
     />,
   );
   wrapper.setState({ appValues });
@@ -149,6 +162,7 @@ it("triggers a deployment when submitting the form", done => {
   expect(deployChart).toHaveBeenCalledWith(versions[0], releaseName, namespace, appValues, schema);
   setTimeout(() => {
     expect(push).toHaveBeenCalledWith("/apps/ns/default/my-release");
+    expect(getNamespace).toHaveBeenCalledWith(namespace);
     done();
   }, 1);
 });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -2,7 +2,7 @@ import { mount, shallow } from "enzyme";
 import * as Moniker from "moniker-native";
 import * as React from "react";
 
-import { IChartState, IChartVersion, NotFoundError, UnprocessableEntity } from "../../shared/types";
+import { IChartState, IChartVersion, UnprocessableEntity } from "../../shared/types";
 import DeploymentFormBody from "../DeploymentFormBody/DeploymentFormBody";
 import { ErrorSelector } from "../ErrorAlert";
 import DeploymentForm from "./DeploymentForm";
@@ -19,7 +19,6 @@ const defaultProps = {
   fetchChartVersions: jest.fn(),
   getChartVersion: jest.fn(),
   namespace: "default",
-  getNamespace: jest.fn(),
 };
 const versions = [{ id: "foo", attributes: { version: "1.2.3" } }] as IChartVersion[];
 let monikerChooseMock: jest.Mock;
@@ -83,16 +82,6 @@ describe("renders an error", () => {
     wrapper.setState({ releaseName: "another-app" });
     expect(wrapper.find(ErrorSelector).html()).toContain(expectedErrorMsg);
   });
-
-  it("renders a custom error if the namespace is missing", () => {
-    const wrapper = shallow(
-      <DeploymentForm
-        {...defaultProps}
-        error={new NotFoundError(`namespaces ${defaultProps.namespace} not found`)}
-      />,
-    );
-    expect(wrapper.html()).toContain(`Namespace <code>${defaultProps.namespace}</code> is missing`);
-  });
 });
 
 it("renders the full DeploymentForm", () => {
@@ -146,7 +135,6 @@ it("triggers a deployment when submitting the form", done => {
   const schema = { properties: { foo: { type: "string", form: true } } };
   const deployChart = jest.fn(() => true);
   const push = jest.fn();
-  const getNamespace = jest.fn();
   const wrapper = mount(
     <DeploymentForm
       {...defaultProps}
@@ -154,7 +142,6 @@ it("triggers a deployment when submitting the form", done => {
       deployChart={deployChart}
       push={push}
       namespace={namespace}
-      getNamespace={getNamespace}
     />,
   );
   wrapper.setState({ appValues });
@@ -162,7 +149,6 @@ it("triggers a deployment when submitting the form", done => {
   expect(deployChart).toHaveBeenCalledWith(versions[0], releaseName, namespace, appValues, schema);
   setTimeout(() => {
     expect(push).toHaveBeenCalledWith("/apps/ns/default/my-release");
-    expect(getNamespace).toHaveBeenCalledWith(namespace);
     done();
   }, 1);
 });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -3,9 +3,9 @@ import * as Moniker from "moniker-native";
 import * as React from "react";
 
 import { JSONSchema4 } from "json-schema";
-import { IChartState, IChartVersion, NotFoundError } from "../../shared/types";
+import { IChartState, IChartVersion } from "../../shared/types";
 import DeploymentFormBody from "../DeploymentFormBody/DeploymentFormBody";
-import { ErrorSelector, NotFoundErrorAlert } from "../ErrorAlert";
+import { ErrorSelector } from "../ErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
 
 import "react-tabs/style/react-tabs.css";
@@ -27,7 +27,6 @@ export interface IDeploymentFormProps {
   fetchChartVersions: (id: string) => void;
   getChartVersion: (id: string, chartVersion: string) => void;
   namespace: string;
-  getNamespace: (ns: string) => void;
 }
 
 export interface IDeploymentFormState {
@@ -63,20 +62,6 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   public render() {
     const { namespace, error } = this.props;
     if (error) {
-      // Helm 3 returns a NotFound error if the namespace doesn't exist
-      if (error.constructor === NotFoundError && error.message.match(/namespaces.*not found/)) {
-        return (
-          <NotFoundErrorAlert
-            header={
-              <span>
-                Namespace <code>{namespace}</code> is missing
-              </span>
-            }
-          >
-            <span>Please create it in advance.</span>
-          </NotFoundErrorAlert>
-        );
-      }
       return (
         <ErrorSelector
           error={error}
@@ -134,7 +119,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
 
   public handleDeploy = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const { selected, deployChart, push, namespace, getNamespace } = this.props;
+    const { selected, deployChart, push, namespace } = this.props;
     const { releaseName, appValues } = this.state;
 
     this.setState({ isDeploying: true, latestSubmittedReleaseName: releaseName });
@@ -148,8 +133,6 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
       );
       this.setState({ isDeploying: false });
       if (deployed) {
-        // Helm 2 may have created a new namespace, re-fetch the ns just in case
-        getNamespace(namespace);
         push(`/apps/ns/${namespace}/${releaseName}`);
       }
     }

--- a/dashboard/src/components/ErrorAlert/NotFoundErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/NotFoundErrorAlert.tsx
@@ -9,7 +9,7 @@ import ErrorPageHeader from "./ErrorAlertHeader";
 import { namespaceText } from "./helpers";
 
 interface INotFoundErrorPageProps {
-  header?: string;
+  header?: string | JSX.Element;
   children?: JSX.Element;
   resource?: string;
   namespace?: string;

--- a/dashboard/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/dashboard/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme";
 import * as React from "react";
 import ErrorBoundary from ".";
+import UnexpectedErrorPage from "../../components/ErrorAlert/UnexpectedErrorAlert";
 import { UnexpectedErrorAlert } from "../ErrorAlert";
 
 // tslint:disable:no-console
@@ -65,4 +66,9 @@ describe("ErrorBoundary around a component", () => {
     // console.error is not called
     expect(console.error).not.toHaveBeenCalled();
   });
+});
+
+it("renders an error if it exists as a property", () => {
+  const wrapper = mount(<ErrorBoundary error={new Error("boom!")} children={<></>} />);
+  expect(wrapper.find(UnexpectedErrorPage).text()).toContain("boom!");
 });

--- a/dashboard/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/dashboard/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
+
+import UnexpectedErrorPage from "../../components/ErrorAlert/UnexpectedErrorAlert";
 import { UnexpectedErrorAlert } from "../ErrorAlert";
 
 interface IErrorBoundaryProps {
+  error?: Error;
   children: React.ReactChildren | React.ReactNode | string;
 }
 
@@ -15,6 +18,15 @@ class ErrorBoundary extends React.Component<IErrorBoundaryProps, IErrorBoundaryS
 
   public render() {
     const { error } = this.state;
+    if (this.props.error) {
+      return (
+        <UnexpectedErrorPage
+          raw={true}
+          showGenericMessage={false}
+          text={this.props.error.message}
+        />
+      );
+    }
     return <React.Fragment>{error ? this.renderError() : this.props.children}</React.Fragment>;
   }
 

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -82,3 +82,28 @@ it("call setNamespace and getNamespace when selecting a namespace", () => {
   expect(getNamespace).toHaveBeenCalledWith("bar");
   expect(createNamespace).not.toHaveBeenCalled();
 });
+
+it("doesn't call getNamespace when selecting all namespaces", () => {
+  const setNamespace = jest.fn();
+  const getNamespace = jest.fn();
+  const namespace = {
+    current: "foo",
+    namespaces: ["foo", "bar"],
+  };
+  const wrapper = shallow(
+    <Header
+      {...defaultProps}
+      setNamespace={setNamespace}
+      namespace={namespace}
+      getNamespace={getNamespace}
+    />,
+  );
+
+  const namespaceSelector = wrapper.find("NamespaceSelector");
+  expect(namespaceSelector).toExist();
+  const onChange = namespaceSelector.prop("onChange") as (ns: any) => void;
+  onChange("_all");
+
+  expect(setNamespace).toHaveBeenCalledWith("_all");
+  expect(getNamespace).not.toHaveBeenCalled();
+});

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -17,6 +17,7 @@ const defaultProps = {
   push: jest.fn(),
   setNamespace: jest.fn(),
   createNamespace: jest.fn(),
+  getNamespace: jest.fn(),
 };
 it("renders the header links and titles", () => {
   const wrapper = shallow(<Header {...defaultProps} />);
@@ -54,9 +55,10 @@ it("renders the namespace switcher", () => {
   );
 });
 
-it("call setNamespace when selecting a namespace", () => {
+it("call setNamespace and getNamespace when selecting a namespace", () => {
   const setNamespace = jest.fn();
   const createNamespace = jest.fn();
+  const getNamespace = jest.fn();
   const namespace = {
     current: "foo",
     namespaces: ["foo", "bar"],
@@ -67,6 +69,7 @@ it("call setNamespace when selecting a namespace", () => {
       setNamespace={setNamespace}
       namespace={namespace}
       createNamespace={createNamespace}
+      getNamespace={getNamespace}
     />,
   );
 
@@ -76,5 +79,6 @@ it("call setNamespace when selecting a namespace", () => {
   onChange("bar");
 
   expect(setNamespace).toHaveBeenCalledWith("bar");
+  expect(getNamespace).toHaveBeenCalledWith("bar");
   expect(createNamespace).not.toHaveBeenCalled();
 });

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -22,6 +22,7 @@ interface IHeaderProps {
   push: (path: string) => void;
   setNamespace: (ns: string) => void;
   createNamespace: (ns: string) => Promise<boolean>;
+  getNamespace: (ns: string) => void;
 }
 
 interface IHeaderState {
@@ -74,6 +75,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
       defaultNamespace,
       authenticated: showNav,
       createNamespace,
+      getNamespace,
     } = this.props;
     const header = `header ${this.state.mobileOpen ? "header-open" : ""}`;
     const submenu = `header__nav__submenu ${
@@ -119,6 +121,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                   onChange={this.handleNamespaceChange}
                   fetchNamespaces={fetchNamespaces}
                   createNamespace={createNamespace}
+                  getNamespace={getNamespace}
                 />
                 <ul className="header__nav__menu" role="menubar">
                   <li
@@ -182,9 +185,10 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   };
 
   private handleNamespaceChange = (ns: string) => {
-    const { pathname, push, setNamespace } = this.props;
+    const { pathname, push, setNamespace, getNamespace } = this.props;
     const to = pathname.replace(/\/ns\/[^/]*/, `/ns/${ns}`);
     setNamespace(ns);
+    getNamespace(ns);
     if (to !== pathname) {
       push(to);
     }

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -3,6 +3,7 @@ import { NavLink } from "react-router-dom";
 import logo from "../../logo.svg";
 
 import { INamespaceState } from "../../reducers/namespace";
+import { definedNamespaces } from "../../shared/Namespace";
 import HeaderLink, { IHeaderLinkProps } from "./HeaderLink";
 import NamespaceSelector from "./NamespaceSelector";
 
@@ -188,7 +189,9 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
     const { pathname, push, setNamespace, getNamespace } = this.props;
     const to = pathname.replace(/\/ns\/[^/]*/, `/ns/${ns}`);
     setNamespace(ns);
-    getNamespace(ns);
+    if (ns !== definedNamespaces.all) {
+      getNamespace(ns);
+    }
     if (to !== pathname) {
       push(to);
     }

--- a/dashboard/src/components/Header/NamespaceSelector.scss
+++ b/dashboard/src/components/Header/NamespaceSelector.scss
@@ -25,3 +25,11 @@
   bottom: -0.3em;
   width: 20px;
 }
+
+.NamespaceTooltipError {
+  pointer-events: auto;
+  &:hover {
+    visibility: visible;
+    opacity: 1;
+  }
+}

--- a/dashboard/src/components/Header/NamespaceSelector.test.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.test.tsx
@@ -117,6 +117,21 @@ it("fetches namespaces and retrive the current namespace", () => {
   expect(getNamespace).toHaveBeenCalledWith("foo");
 });
 
+it("doesnt' get the current namespace if all namespaces is selected", () => {
+  const fetchNamespaces = jest.fn();
+  const getNamespace = jest.fn();
+  shallow(
+    <NamespaceSelector
+      {...defaultProps}
+      fetchNamespaces={fetchNamespaces}
+      getNamespace={getNamespace}
+      namespace={{ current: "_all", namespaces: [] }}
+    />,
+  );
+  expect(fetchNamespaces).toHaveBeenCalled();
+  expect(getNamespace).not.toHaveBeenCalled();
+});
+
 it("renders an error warning", () => {
   const wrapper = shallow(
     <NamespaceSelector

--- a/dashboard/src/components/Header/NamespaceSelector.test.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.test.tsx
@@ -2,10 +2,8 @@ import { mount, shallow } from "enzyme";
 import * as React from "react";
 import * as ReactModal from "react-modal";
 import * as Select from "react-select";
-import * as ReactTooltip from "react-tooltip";
 
 import { INamespaceState } from "../../reducers/namespace";
-import { ForbiddenError } from "../../shared/types";
 import NamespaceSelector from "./NamespaceSelector";
 import NewNamespace from "./NewNamespace";
 
@@ -130,22 +128,4 @@ it("doesnt' get the current namespace if all namespaces is selected", () => {
   );
   expect(fetchNamespaces).toHaveBeenCalled();
   expect(getNamespace).not.toHaveBeenCalled();
-});
-
-it("renders an error warning", () => {
-  const wrapper = shallow(
-    <NamespaceSelector
-      {...defaultProps}
-      namespace={{
-        error: { action: "get", error: new ForbiddenError() },
-        current: "foo",
-        namespaces: [],
-      }}
-    />,
-  );
-  const err = wrapper.find(ReactTooltip);
-  expect(err).toExist();
-  expect(err.children().text()).toContain(
-    "You don't have sufficient permissions to use the namespace foo",
-  );
 });

--- a/dashboard/src/components/Header/NamespaceSelector.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.tsx
@@ -1,11 +1,8 @@
 import * as React from "react";
-import { AlertCircle } from "react-feather";
 import * as Select from "react-select";
-import * as ReactTooltip from "react-tooltip";
 
 import { INamespaceState } from "../../reducers/namespace";
 import { definedNamespaces } from "../../shared/Namespace";
-import { ForbiddenError, NotFoundError } from "../../shared/types";
 
 import "./NamespaceSelector.css";
 import NewNamespace from "./NewNamespace";
@@ -61,7 +58,6 @@ class NamespaceSelector extends React.Component<INamespaceSelectorProps, INamesp
     return (
       <div className="NamespaceSelector margin-r-normal">
         <label className="NamespaceSelector__label type-tiny">NAMESPACE</label>
-        {error && this.renderError(error.error)}
         <Select.Creatable
           className="NamespaceSelector__select type-small"
           value={value}
@@ -113,36 +109,6 @@ class NamespaceSelector extends React.Component<INamespaceSelectorProps, INamesp
     this.setState({
       modalIsOpen: false,
     });
-  };
-
-  private errorText = (err: Error) => {
-    switch (err.constructor) {
-      case ForbiddenError:
-        return `You don't have sufficient permissions to use the namespace ${this.selected}`;
-      case NotFoundError:
-        return `Namespace ${this.selected} not found. Create it before using it.`;
-      default:
-        return err.message;
-    }
-  };
-
-  private renderError = (err: Error) => {
-    return (
-      <>
-        <a data-tip={true} data-for="ns-error">
-          <AlertCircle className="NamespaceSelectorError" color="white" fill="red" />
-        </a>
-        <ReactTooltip
-          className="NamespaceTooltipError"
-          delayHide={1000}
-          id="ns-error"
-          effect="solid"
-          place="bottom"
-        >
-          {this.errorText(err)}
-        </ReactTooltip>
-      </>
-    );
   };
 }
 

--- a/dashboard/src/components/Header/NamespaceSelector.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.tsx
@@ -36,7 +36,9 @@ class NamespaceSelector extends React.Component<INamespaceSelectorProps, INamesp
 
   public componentDidMount() {
     this.props.fetchNamespaces();
-    this.props.getNamespace(this.selected);
+    if (this.selected !== definedNamespaces.all) {
+      this.props.getNamespace(this.selected);
+    }
   }
 
   public render() {

--- a/dashboard/src/components/Layout/Layout.tsx
+++ b/dashboard/src/components/Layout/Layout.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import ErrorBoundaryContainer from "containers/ErrorBoundaryContainer";
 import Footer from "../../containers/FooterContainer";
-import ErrorBoundary from "../ErrorBoundary";
 
 import "./Layout.css";
 
@@ -17,7 +17,7 @@ class Layout extends React.Component<ILayoutProps> {
         <HeaderComponent />
         <main>
           <div className="container">
-            <ErrorBoundary>{this.props.children}</ErrorBoundary>
+            <ErrorBoundaryContainer>{this.props.children}</ErrorBoundaryContainer>
           </div>
         </main>
         <Footer />

--- a/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -45,6 +45,7 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     getChartVersion: (id: string, version: string) =>
       dispatch(actions.charts.getChartVersion(id, version)),
     push: (location: string) => dispatch(push(location)),
+    getNamespace: (ns: string) => dispatch(actions.namespace.getNamespace(ns)),
   };
 }
 

--- a/dashboard/src/containers/ErrorBoundaryContainer/ErrorBoundaryContainer.test.tsx
+++ b/dashboard/src/containers/ErrorBoundaryContainer/ErrorBoundaryContainer.test.tsx
@@ -1,0 +1,25 @@
+import { mount } from "enzyme";
+import * as React from "react";
+import { INamespaceState } from "reducers/namespace";
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+import ErrorBoundaryContainer from ".";
+import UnexpectedErrorPage from "../../components/ErrorAlert/UnexpectedErrorAlert";
+
+const mockStore = configureMockStore([thunk]);
+const makeStore = (error?: { action: string; error: Error }) => {
+  const state: INamespaceState = {
+    current: "default",
+    namespaces: ["default"],
+    error,
+  };
+  return mockStore({ namespace: state });
+};
+
+describe("LoginFormContainer props", () => {
+  it("maps namespace redux state to props", () => {
+    const store = makeStore({ action: "get", error: new Error("boom!") });
+    const wrapper = mount(<ErrorBoundaryContainer store={store} children={<></>} />);
+    expect(wrapper.find(UnexpectedErrorPage).text()).toContain("boom!");
+  });
+});

--- a/dashboard/src/containers/ErrorBoundaryContainer/ErrorBoundaryContainer.ts
+++ b/dashboard/src/containers/ErrorBoundaryContainer/ErrorBoundaryContainer.ts
@@ -1,0 +1,17 @@
+import { connect } from "react-redux";
+
+import ErrorBoundary from "../../components/ErrorBoundary";
+import { IStoreState } from "../../shared/types";
+
+interface IErrorBoundaryProps {
+  children: React.ReactChildren | React.ReactNode | string;
+}
+
+function mapStateToProps({ namespace }: IStoreState, { children }: IErrorBoundaryProps) {
+  return {
+    error: namespace.error && namespace.error.error,
+    children,
+  };
+}
+
+export default connect(mapStateToProps)(ErrorBoundary);

--- a/dashboard/src/containers/ErrorBoundaryContainer/index.ts
+++ b/dashboard/src/containers/ErrorBoundaryContainer/index.ts
@@ -1,0 +1,3 @@
+import ErrorBoundaryContainer from "./ErrorBoundaryContainer";
+
+export default ErrorBoundaryContainer;

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -34,6 +34,7 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     logout: () => dispatch(actions.auth.logout()),
     push: (path: string) => dispatch(push(path)),
     setNamespace: (ns: string) => dispatch(actions.namespace.setNamespace(ns)),
+    getNamespace: (ns: string) => dispatch(actions.namespace.getNamespace(ns)),
   };
 }
 

--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -114,15 +114,15 @@ describe("namespaceReducer", () => {
         namespaceReducer(
           {
             current: "",
-            namespaces: [],
+            namespaces: ["default"],
             error: { action: "create", error: new Error("boom") },
           },
           {
             type: getType(actions.namespace.receiveNamespace),
-            payload: { metadata: { name: "default" } } as IResource,
+            payload: { metadata: { name: "bar" } } as IResource,
           },
         ),
-      ).toEqual({ current: "", namespaces: ["default"], error: undefined });
+      ).toEqual({ current: "", namespaces: ["bar", "default"], error: undefined });
     });
   });
 });

--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -3,6 +3,7 @@ import context from "jest-plugin-context";
 import { getType } from "typesafe-actions";
 
 import actions from "../actions";
+import { IResource } from "../shared/types";
 import namespaceReducer from "./namespace";
 
 describe("namespaceReducer", () => {
@@ -42,13 +43,22 @@ describe("namespaceReducer", () => {
   context("when ERROR_NAMESPACE", () => {
     const err = new Error("Bang!");
 
-    it("leaves namespaces intact and sets error", () => {
+    it("when listing leaves namespaces intact and but ignores the error", () => {
       expect(
         namespaceReducer(initialState, {
           type: getType(actions.namespace.errorNamespaces),
           payload: { err, op: "list" },
         }),
-      ).toEqual({ ...initialState, error: { action: "list", error: err } });
+      ).toEqual({ ...initialState, error: undefined });
+    });
+
+    it("leaves namespaces intact and sets the error", () => {
+      expect(
+        namespaceReducer(initialState, {
+          type: getType(actions.namespace.errorNamespaces),
+          payload: { err, op: "create" },
+        }),
+      ).toEqual({ ...initialState, error: { action: "create", error: err } });
     });
   });
 
@@ -95,6 +105,24 @@ describe("namespaceReducer", () => {
           },
         ),
       ).toEqual({ current: "default", namespaces: [], error: undefined });
+    });
+  });
+
+  context("when RECEIVE_NAMESPACE", () => {
+    it("adds the namespace to the list and clears error", () => {
+      expect(
+        namespaceReducer(
+          {
+            current: "",
+            namespaces: [],
+            error: { action: "create", error: new Error("boom") },
+          },
+          {
+            type: getType(actions.namespace.receiveNamespace),
+            payload: { metadata: { name: "default" } } as IResource,
+          },
+        ),
+      ).toEqual({ current: "", namespaces: ["default"], error: undefined });
     });
   });
 });

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -30,7 +30,7 @@ const namespaceReducer = (
       if (!state.namespaces.includes(action.payload.metadata.name)) {
         return {
           ...state,
-          namespaces: state.namespaces.concat(action.payload.metadata.name),
+          namespaces: state.namespaces.concat(action.payload.metadata.name).sort(),
           error: undefined,
         };
       }

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -26,11 +26,24 @@ const namespaceReducer = (
   action: NamespaceAction | LocationChangeAction | AuthAction,
 ): INamespaceState => {
   switch (action.type) {
+    case getType(actions.namespace.receiveNamespace):
+      if (!state.namespaces.includes(action.payload.metadata.name)) {
+        return {
+          ...state,
+          namespaces: state.namespaces.concat(action.payload.metadata.name),
+          error: undefined,
+        };
+      }
+      return state;
     case getType(actions.namespace.receiveNamespaces):
       return { ...state, namespaces: action.payload };
     case getType(actions.namespace.setNamespace):
       return { ...state, current: action.payload, error: undefined };
     case getType(actions.namespace.errorNamespaces):
+      // Ignore error listing namespaces since those are expected
+      if (action.payload.op === "list") {
+        return state;
+      }
       return {
         ...state,
         error: { action: action.payload.op, error: action.payload.err },

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -20,6 +20,11 @@ export default class Namespace {
     return data;
   }
 
+  public static async get(name: string) {
+    const { data } = await axiosWithAuth.get<IResource>(`${Namespace.APIEndpoint}/${name}`);
+    return data;
+  }
+
   private static APIBase: string = APIBase;
   private static APIEndpoint: string = `${Namespace.APIBase}/api/v1/namespaces/`;
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of #1489 to fix #1364

When selecting a namespace that doesn't exists, shows an error so the namespace is created in advance:

![Screenshot from 2020-02-03 11-55-46](https://user-images.githubusercontent.com/4025665/73647650-3ce8cc00-467c-11ea-85f3-bf868ff9f73a.png)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1364

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
cc/ @fabianschwarzfritz 