### PR TITLE
Fix flaky test

### DIFF
--- a/integration/use-cases/create-registry.js
+++ b/integration/use-cases/create-registry.js
@@ -8,6 +8,10 @@ test("Creates a registry", async () => {
   await expect(page).toClick("button", { text: "Login" });
 
   await expect(page).toClick("button", { text: "Add App Repository" });
+  // Sometimes, the test fails because the modal doesn't get rendered
+  // Clicking again, just in case, to avoid issues
+  // https://circleci.com/gh/kubeapps/kubeapps/16306
+  await expect(page).toClick("button", { text: "Add App Repository" });
 
   await page.type("#kubeapps-repo-name", "my-repo");
 

--- a/integration/use-cases/create-registry.js
+++ b/integration/use-cases/create-registry.js
@@ -8,10 +8,8 @@ test("Creates a registry", async () => {
   await expect(page).toClick("button", { text: "Login" });
 
   await expect(page).toClick("button", { text: "Add App Repository" });
-  // Sometimes, the test fails because the modal doesn't get rendered
-  // Clicking again, just in case, to avoid issues
-  // https://circleci.com/gh/kubeapps/kubeapps/16306
-  await expect(page).toClick("button", { text: "Add App Repository" });
+
+  await expect(page).toMatch("Install Repo");
 
   await page.type("#kubeapps-repo-name", "my-repo");
 

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -185,7 +185,7 @@ done
 
 # Run helm tests
 # Retry once if tests fail to avoid temporary issue
-if ! retry_while testHelm "1" "1"; then
+if ! retry_while testHelm "2" "1"; then
   warn "PODS status on failure"
   kubectl get pods -n kubeapps
   for pod in $(kubectl get po -l release=kubeapps-ci -oname -n kubeapps); do


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

The end to end test to create a registry is quite flaky:

https://circleci.com/gh/kubeapps/kubeapps/16306
https://circleci.com/gh/kubeapps/kubeapps/16279

Checking the screenshot, the modal that renders the form is not being shown. My guess is that the click in the button is not behaving as expected in the browser so I have added a second click to ensure that the modal is opened. If this doesn't fix the issue I will investigate further.

