### PR TITLE
[Helm 3] Re-enable atomic installations

### DIFF
--- a/cmd/kubeops/internal/handler/handler_test.go
+++ b/cmd/kubeops/internal/handler/handler_test.go
@@ -257,11 +257,9 @@ func TestActions(t *testing.T) {
 			Action:       "create",
 			Params:       map[string]string{"namespace": "default"},
 			// Expected result
-			StatusCode: 403,
-			RemainingReleases: []*release.Release{
-				createRelease("foo", "foobar", "default", 1, release.StatusFailed),
-			},
-			ResponseBody: `{"code":403,"message":"[{\"apiGroup\":\"\",\"resource\":\"secrets\",\"namespace\":\"default\",\"clusterWide\":false,\"verbs\":[\"create\"]}]"}`,
+			StatusCode:        403,
+			RemainingReleases: nil,
+			ResponseBody:      `{"code":403,"message":"[{\"apiGroup\":\"\",\"resource\":\"secrets\",\"namespace\":\"default\",\"clusterWide\":false,\"verbs\":[\"create\"]}]"}`,
 		},
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -557,6 +557,7 @@ helm.sh/helm/v3 v3.0.0 h1:or/9cs1GgfcTQeEnR2CVJNw893/rmqIG1KsNHmUiSFw=
 helm.sh/helm/v3 v3.0.0/go.mod h1:sI7B9yfvMgxtTPMWdk1jSKJ2aa59UyP9qhPydqW6mgo=
 helm.sh/helm/v3 v3.0.2 h1:BggvLisIMrAc+Is5oAHVrlVxgwOOrMN8nddfQbm5gKo=
 helm.sh/helm/v3 v3.0.2/go.mod h1:KBxE6XWO57XSNA1PA9CvVLYRY0zWqYQTad84bNXp1lw=
+helm.sh/helm/v3 v3.0.3 h1:FwoMFwq6evEuljmP9s08WPScb/QzVLB6ZXR2P/MZP6c=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -133,14 +133,15 @@ func TestGetRelease(t *testing.T) {
 
 func TestCreateReleases(t *testing.T) {
 	testCases := []struct {
-		desc             string
-		releaseName      string
-		namespace        string
-		chartName        string
-		values           string
-		version          int
-		existingReleases []releaseStub
-		shouldFail       bool
+		desc              string
+		releaseName       string
+		namespace         string
+		chartName         string
+		values            string
+		version           int
+		existingReleases  []releaseStub
+		remainingReleases int
+		shouldFail        bool
 	}{
 		{
 			desc:      "install new release",
@@ -151,7 +152,8 @@ func TestCreateReleases(t *testing.T) {
 			existingReleases: []releaseStub{
 				releaseStub{"otherchart", "default", 1, "1.0.0", release.StatusDeployed},
 			},
-			shouldFail: false,
+			remainingReleases: 2,
+			shouldFail:        false,
 		},
 		{
 			desc:      "install with an existing name",
@@ -162,7 +164,8 @@ func TestCreateReleases(t *testing.T) {
 			existingReleases: []releaseStub{
 				releaseStub{"mychart", "default", 1, "1.0.0", release.StatusDeployed},
 			},
-			shouldFail: true,
+			remainingReleases: 1,
+			shouldFail:        true,
 		},
 		{
 			desc:      "install with same name different version",
@@ -173,7 +176,8 @@ func TestCreateReleases(t *testing.T) {
 			existingReleases: []releaseStub{
 				releaseStub{"mychart", "dev", 2, "1.0.0", release.StatusDeployed},
 			},
-			shouldFail: true,
+			remainingReleases: 1,
+			shouldFail:        true,
 		},
 	}
 
@@ -194,6 +198,13 @@ func TestCreateReleases(t *testing.T) {
 			}
 			if !tc.shouldFail && rls == nil {
 				t.Errorf("Should succeed with %v; instead got error %v", tc.desc, err)
+			}
+			rlss, err := actionConfig.Releases.ListReleases()
+			if err != nil {
+				t.Errorf("Unexpected err %v", err)
+			}
+			if len(rlss) != tc.remainingReleases {
+				t.Errorf("Expecting %d remaining releases, got %d", tc.remainingReleases, len(rlss))
 			}
 		})
 	}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

From https://github.com/helm/helm/issues/7426 I noticed that the atomic flag requires to use the wait flag as well which doesn't fit our use case.

This PR mimics what we had in tiller-proxy: check if the release already exists, if not and the installation fails, clean it up.

