### PR TITLE
Switch rbac api version to v1 (GA from k8s 1.8)

### DIFF
--- a/chart/kubeapps/templates/apprepository-jobs-cleanup-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-cleanup-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "kubeapps.apprepository-jobs-cleanup.fullname" . }}
@@ -28,7 +28,7 @@ rules:
       - list
       - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.apprepository-jobs-cleanup.fullname" . }}

--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "kubeapps.apprepository.fullname" . }}
@@ -43,7 +43,7 @@ rules:
       - update
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.apprepository.fullname" . }}
@@ -62,7 +62,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 # Define role, but no binding, so users can be bound to this role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}-repositories-read
@@ -76,7 +76,7 @@ rules:
       - get
 ---
 # Define role, but no binding, so users can be bound to this role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}-repositories-write

--- a/chart/kubeapps/templates/db-secret-cleanup-rbac.yaml
+++ b/chart/kubeapps/templates/db-secret-cleanup-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "kubeapps.db-secret-jobs-cleanup.fullname" . }}
@@ -20,7 +20,7 @@ rules:
     verbs:
       - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.db-secret-jobs-cleanup.fullname" . }}

--- a/chart/kubeapps/templates/kubeops-rbac.yaml
+++ b/chart/kubeapps/templates/kubeops-rbac.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.useHelm3 -}}
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "kubeapps.kubeops.fullname" . }}
@@ -23,7 +23,7 @@ rules:
     verbs:
       - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.kubeops.fullname" . }}

--- a/chart/kubeapps/templates/tiller-proxy-rbac.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-rbac.yaml
@@ -1,6 +1,6 @@
 {{- if not .Values.useHelm3 -}}
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "kubeapps.tiller-proxy.fullname" . }}
@@ -23,7 +23,7 @@ rules:
     verbs:
       - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.tiller-proxy.fullname" . }}


### PR DESCRIPTION
# Description of the change

Update k8s api version for rbac. v1 has been GA since k8s 1.8 which is our minimum supported k8s version [according to our docs](https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md).

Ref: #1495 