### PR TITLE
Fix accidentally merged clusterrolebindings

### DIFF
--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -32,18 +32,6 @@ rules:
       - jobs
     verbs:
       - create
----
-# Kubeapps can read and watch its own AppRepository resources cluster-wide.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: "kubeapps:controller:apprepository-reader-{{ .Release.Namespace }}"
-  labels:
-    app: {{ template "kubeapps.apprepository.fullname" . }}
-    chart: {{ template "kubeapps.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-rules:
   - apiGroups:
       - kubeapps.com
     resources:
@@ -68,24 +56,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ template "kubeapps.apprepository.fullname" . }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "kubeapps.apprepository.fullname" . }}
-    namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: "kubeapps:controller:apprepository-reader-{{ .Release.Namespace }}"
-  labels:
-    app: {{ template "kubeapps.apprepository.fullname" . }}
-    chart: {{ template "kubeapps.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: "kubeapps:controller:apprepository-reader-{{ .Release.Namespace }}"
 subjects:
   - kind: ServiceAccount
     name: {{ template "kubeapps.apprepository.fullname" . }}


### PR DESCRIPTION
Accidentally merged master rather than rebasing before landing this, which meant it had an older commit adding the ClusterRole unconditionally.