### PR TITLE
1495 5 app repos for namespace only

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -13,9 +13,10 @@ const mockStore = configureMockStore([thunk]);
 
 let store: any;
 const appRepo = { spec: { resyncRequests: 10000 } };
+const kubeappsNamespace = "kubeapps-namespace";
 
 beforeEach(() => {
-  store = mockStore({ config: { namespace: "my-namespace" } });
+  store = mockStore({ config: { namespace: kubeappsNamespace } });
   AppRepository.list = jest.fn().mockImplementationOnce(() => {
     return { items: { foo: "bar" } };
   });
@@ -85,6 +86,7 @@ describe("deleteRepo", () => {
     const expectedActions = [
       {
         type: getType(repoActions.requestRepos),
+        payload: kubeappsNamespace,
       },
       {
         type: getType(repoActions.receiveRepos),
@@ -148,10 +150,28 @@ describe("resyncRepo", () => {
 });
 
 describe("fetchRepos", () => {
+  const namespace = "default";
   it("dispatches requestRepos and receivedRepos if no error", async () => {
     const expectedActions = [
       {
         type: getType(repoActions.requestRepos),
+        payload: namespace,
+      },
+      {
+        type: getType(repoActions.receiveRepos),
+        payload: { foo: "bar" },
+      },
+    ];
+
+    await store.dispatch(repoActions.fetchRepos(namespace));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("defaults to apprepos in kubeapps own namespace if none specified", async () => {
+    const expectedActions = [
+      {
+        type: getType(repoActions.requestRepos),
+        payload: kubeappsNamespace,
       },
       {
         type: getType(repoActions.receiveRepos),
@@ -171,6 +191,7 @@ describe("fetchRepos", () => {
     const expectedActions = [
       {
         type: getType(repoActions.requestRepos),
+        payload: namespace,
       },
       {
         type: getType(repoActions.errorRepos),
@@ -178,7 +199,7 @@ describe("fetchRepos", () => {
       },
     ];
 
-    await store.dispatch(repoActions.fetchRepos());
+    await store.dispatch(repoActions.fetchRepos(namespace));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.test.tsx
@@ -8,7 +8,7 @@ import { AppRepoForm } from "./AppRepoForm";
 
 const defaultProps = {
   install: jest.fn(),
-  kubeappsNamespace: "kubeapps",
+  namespace: "kubeapps",
 };
 
 it("should open a modal with the repository form", () => {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -30,7 +30,7 @@ interface IAppRepoAddButtonProps {
     syncJobPodTemplate: string,
   ) => Promise<boolean>;
   redirectTo?: string;
-  kubeappsNamespace: string;
+  namespace: string;
 }
 interface IAppRepoAddButtonState {
   lastSubmittedName: string;
@@ -63,7 +63,7 @@ export class AppRepoAddButton extends React.Component<
               error={this.props.error}
               defaultRequiredRBACRoles={{ create: RequiredRBACRoles }}
               action="create"
-              namespace={this.props.kubeappsNamespace}
+              namespace={this.props.namespace}
               resource={`App Repository ${this.state.lastSubmittedName}`}
             />
           )}

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -14,6 +14,7 @@ const defaultProps = {
   resyncAllRepos: jest.fn(),
   install: jest.fn(),
   namespace: defaultNamespace,
+  displayReposPerNamespaceMsg: false,
 };
 
 describe("AppRepoList", () => {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -28,7 +28,7 @@ describe("AppRepoList", () => {
     expect(props.fetchRepos).toHaveBeenCalledWith(defaultNamespace);
   });
 
-  it("fetches repos when updating after a fetch error is cleared", () => {
+  it("refetches repos when updating after a fetch error is cleared", () => {
     const props = {
       ...defaultProps,
       errors: { fetch: new Error("Bang!") },
@@ -43,5 +43,37 @@ describe("AppRepoList", () => {
 
     expect(props.fetchRepos).toHaveBeenCalledTimes(2);
     expect(props.fetchRepos).toHaveBeenLastCalledWith(defaultNamespace);
+  });
+
+  it("refetches repos when the namespace changes", () => {
+    const props = {
+      ...defaultProps,
+      fetchRepos: jest.fn(),
+    };
+    const differentNamespace = "different-namespace";
+
+    const wrapper = shallow(<AppRepoList {...props} />);
+    wrapper.setProps({
+      ...props,
+      namespace: differentNamespace,
+    });
+
+    expect(props.fetchRepos).toHaveBeenCalledTimes(2);
+    expect(props.fetchRepos).toHaveBeenLastCalledWith(differentNamespace);
+  });
+
+  it("does not refetch otherwise", () => {
+    const props = {
+      ...defaultProps,
+      fetchRepos: jest.fn(),
+    };
+
+    const wrapper = shallow(<AppRepoList {...props} />);
+    wrapper.setProps({
+      ...props,
+      errors: { fetch: new Error("Bang!") },
+    });
+
+    expect(props.fetchRepos).toHaveBeenCalledTimes(1);
   });
 });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -1,0 +1,47 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+
+import AppRepoList from "./AppRepoList";
+
+const defaultNamespace = "default-namespace";
+
+const defaultProps = {
+  errors: {},
+  repos: [],
+  fetchRepos: jest.fn(),
+  deleteRepo: jest.fn(),
+  resyncRepo: jest.fn(),
+  resyncAllRepos: jest.fn(),
+  install: jest.fn(),
+  namespace: defaultNamespace,
+};
+
+describe("AppRepoList", () => {
+  it("fetches repos for a namespace when mounted", () => {
+    const props = {
+      ...defaultProps,
+      fetchRepos: jest.fn(),
+    };
+
+    shallow(<AppRepoList {...props} />);
+
+    expect(props.fetchRepos).toHaveBeenCalledWith(defaultNamespace);
+  });
+
+  it("fetches repos when updating after a fetch error is cleared", () => {
+    const props = {
+      ...defaultProps,
+      errors: { fetch: new Error("Bang!") },
+      fetchRepos: jest.fn(),
+    };
+
+    const wrapper = shallow(<AppRepoList {...props} />);
+    wrapper.setProps({
+      ...props,
+      errors: {},
+    });
+
+    expect(props.fetchRepos).toHaveBeenCalledTimes(2);
+    expect(props.fetchRepos).toHaveBeenLastCalledWith(defaultNamespace);
+  });
+});

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { definedNamespaces } from "../../../shared/Namespace";
 import { IAppRepository, IRBACRole } from "../../../shared/types";
 import { ErrorSelector, MessageAlert } from "../../ErrorAlert";
 import { AppRepoAddButton } from "./AppRepoButton";
@@ -81,6 +82,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
       namespace,
       displayReposPerNamespaceMsg,
     } = this.props;
+    const renderNamespace = namespace === definedNamespaces.all;
     return (
       <div className="app-repo-list">
         <h1>App Repositories</h1>
@@ -91,6 +93,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
           <thead>
             <tr>
               <th>Repo</th>
+              {renderNamespace && <th>Namespace</th>}
               <th>URL</th>
               <th>Actions</th>
             </tr>
@@ -102,6 +105,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
                 deleteRepo={deleteRepo}
                 resyncRepo={resyncRepo}
                 repo={repo}
+                renderNamespace={renderNamespace}
               />
             ))}
           </tbody>
@@ -113,15 +117,18 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
           namespace={namespace}
         />
         {displayReposPerNamespaceMsg && (
-          <MessageAlert header="Looking for site-wide app repositories?">
+          <MessageAlert header="Looking for other app repositories?">
             <div>
               <p className="margin-v-normal">
-                You can view site-wide App Repositories by selecting "All Namespaces" above, if you
-                have permission to view or edit App Repositories available to all namespaces.
+                You can view App Repositories across all namespaces by selecting "All Namespaces"
+                above, if you have permission to view App Repositories cluster-wide. We will also
+                add information on the current page indicating App Repositories in other namespaces
+                which can be used in the current namespace.
               </p>
               <p className="margin-v-normal">
-                Kubeapps now enables you to create App Repositories in your own namespace. You can
-                read more information in the{" "}
+                Kubeapps now enables you to create App Repositories in your own namespace that will
+                be available in your own namespace and optionally other namespaces to which you have
+                access. You can read more information in the{" "}
                 <a href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/private-app-repository.md#per-namespace-app-repositories">
                   Private App Repository docs
                 </a>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -14,7 +14,7 @@ export interface IAppRepoListProps {
     update?: Error;
   };
   repos: IAppRepository[];
-  fetchRepos: () => void;
+  fetchRepos: (namespace: string) => void;
   deleteRepo: (name: string) => Promise<boolean>;
   resyncRepo: (name: string) => void;
   resyncAllRepos: (names: string[]) => void;
@@ -25,7 +25,7 @@ export interface IAppRepoListProps {
     customCA: string,
     syncJobPodTemplate: string,
   ) => Promise<boolean>;
-  kubeappsNamespace: string;
+  namespace: string;
 }
 
 const RequiredRBACRoles: { [s: string]: IRBACRole[] } = {
@@ -54,17 +54,18 @@ const RequiredRBACRoles: { [s: string]: IRBACRole[] } = {
 
 class AppRepoList extends React.Component<IAppRepoListProps> {
   public componentDidMount() {
-    this.props.fetchRepos();
+    this.props.fetchRepos(this.props.namespace);
   }
 
   public componentDidUpdate(prevProps: IAppRepoListProps) {
     const {
       errors: { fetch },
       fetchRepos,
+      namespace,
     } = this.props;
     // refetch if error removed due to location change
     if (prevProps.errors.fetch && !fetch) {
-      fetchRepos();
+      fetchRepos(namespace);
     }
   }
 
@@ -76,7 +77,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
       deleteRepo,
       resyncRepo,
       resyncAllRepos,
-      kubeappsNamespace,
+      namespace,
     } = this.props;
     return (
       <div className="app-repo-list">
@@ -103,15 +104,11 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
             ))}
           </tbody>
         </table>
-        <AppRepoAddButton
-          error={errors.create}
-          install={install}
-          kubeappsNamespace={kubeappsNamespace}
-        />
+        <AppRepoAddButton error={errors.create} install={install} namespace={namespace} />
         <AppRepoRefreshAllButton
           resyncAllRepos={resyncAllRepos}
           repos={repos}
-          kubeappsNamespace={kubeappsNamespace}
+          namespace={namespace}
         />
       </div>
     );
@@ -123,7 +120,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
         error={this.props.errors[action]}
         defaultRequiredRBACRoles={RequiredRBACRoles}
         action={action}
-        namespace={this.props.kubeappsNamespace}
+        namespace={this.props.namespace}
         resource="App Repositories"
       />
     );

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -63,8 +63,8 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
       fetchRepos,
       namespace,
     } = this.props;
-    // refetch if error removed due to location change
-    if (prevProps.errors.fetch && !fetch) {
+    // refetch if namespace changes or if error removed due to location change
+    if (prevProps.namespace !== namespace || (prevProps.errors.fetch && !fetch)) {
       fetchRepos(namespace);
     }
   }

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { IAppRepository, IRBACRole } from "../../../shared/types";
-import ErrorSelector from "../../ErrorAlert/ErrorSelector";
+import { ErrorSelector, MessageAlert } from "../../ErrorAlert";
 import { AppRepoAddButton } from "./AppRepoButton";
 import { AppRepoListItem } from "./AppRepoListItem";
 import { AppRepoRefreshAllButton } from "./AppRepoRefreshAllButton";
@@ -26,6 +26,7 @@ export interface IAppRepoListProps {
     syncJobPodTemplate: string,
   ) => Promise<boolean>;
   namespace: string;
+  displayReposPerNamespaceMsg: boolean;
 }
 
 const RequiredRBACRoles: { [s: string]: IRBACRole[] } = {
@@ -78,6 +79,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
       resyncRepo,
       resyncAllRepos,
       namespace,
+      displayReposPerNamespaceMsg,
     } = this.props;
     return (
       <div className="app-repo-list">
@@ -110,6 +112,24 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
           repos={repos}
           namespace={namespace}
         />
+        {displayReposPerNamespaceMsg && (
+          <MessageAlert header="Looking for site-wide app repositories?">
+            <div>
+              <p className="margin-v-normal">
+                You can view site-wide App Repositories by selecting "All Namespaces" above, if you
+                have permission to view or edit App Repositories available to all namespaces.
+              </p>
+              <p className="margin-v-normal">
+                Kubeapps now enables you to create App Repositories in your own namespace. You can
+                read more information in the{" "}
+                <a href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/private-app-repository.md#per-namespace-app-repositories">
+                  Private App Repository docs
+                </a>
+                .
+              </p>
+            </div>
+          </MessageAlert>
+        )}
       </div>
     );
   }

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -121,14 +121,12 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
             <div>
               <p className="margin-v-normal">
                 You can view App Repositories across all namespaces by selecting "All Namespaces"
-                above, if you have permission to view App Repositories cluster-wide. We will also
-                add information on the current page indicating App Repositories in other namespaces
-                which can be used in the current namespace.
+                above, if you have permission to view App Repositories cluster-wide.
               </p>
               <p className="margin-v-normal">
                 Kubeapps now enables you to create App Repositories in your own namespace that will
-                be available in your own namespace and optionally other namespaces to which you have
-                access. You can read more information in the{" "}
+                be available in your own namespace and, in the future, optionally available in other
+                namespaces to which you have access. You can read more information in the{" "}
                 <a href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/private-app-repository.md#per-namespace-app-repositories">
                   Private App Repository docs
                 </a>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
@@ -6,6 +6,7 @@ import ConfirmDialog from "../../ConfirmDialog";
 
 interface IAppRepoListItemProps {
   repo: IAppRepository;
+  renderNamespace: boolean;
   deleteRepo: (name: string) => Promise<boolean>;
   resyncRepo: (name: string) => void;
 }
@@ -20,12 +21,13 @@ export class AppRepoListItem extends React.Component<IAppRepoListItemProps, IApp
   };
 
   public render() {
-    const { repo } = this.props;
+    const { renderNamespace, repo } = this.props;
     return (
       <tr key={repo.metadata.name}>
         <td>
           <Link to={`/catalog/${repo.metadata.name}`}>{repo.metadata.name}</Link>
         </td>
+        {renderNamespace && <td>{repo.metadata.namespace}</td>}
         <td>{repo.spec && repo.spec.url}</td>
         <td>
           <ConfirmDialog

--- a/dashboard/src/components/Config/AppRepoList/AppRepoRefreshAllButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoRefreshAllButton.tsx
@@ -6,7 +6,7 @@ import "./AppRepo.css";
 interface IAppRepoRefreshAllButtonProps {
   resyncAllRepos: (names: string[]) => void;
   repos: IAppRepository[];
-  kubeappsNamespace: string;
+  namespace: string;
 }
 
 export class AppRepoRefreshAllButton extends React.Component<IAppRepoRefreshAllButtonProps> {

--- a/dashboard/src/components/Config/AppRepoList/__snapshots__/AppRepoButton.test.tsx.snap
+++ b/dashboard/src/components/Config/AppRepoList/__snapshots__/AppRepoButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`should open a modal with the repository form 1`] = `
 <AppRepoAddButton
   install={[Function]}
-  kubeappsNamespace="kubeapps"
+  namespace="kubeapps"
 >
   <button
     className="button button-primary"

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.test.tsx
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.test.tsx
@@ -1,0 +1,48 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+
+import RepoListContainer from ".";
+
+const mockStore = configureMockStore([thunk]);
+const currentNamespace = "current-namespace";
+const kubeappsNamespace = "kubeapps-namespace";
+
+const defaultState = {
+  config: {
+    featureFlags: { reposPerNamespace: false },
+    namespace: kubeappsNamespace,
+  },
+  namespace: { current: currentNamespace },
+  repos: {},
+};
+
+describe("RepoListContainer props", () => {
+  it("uses kubeapps namespace when reposPerNamespace false", () => {
+    const store = mockStore(defaultState);
+    const wrapper = shallow(<RepoListContainer store={store} />);
+
+    const component = wrapper.find("AppRepoList");
+
+    expect(component).toHaveProp({
+      namespace: kubeappsNamespace,
+    });
+  });
+
+  it("uses the current namespace when reposPerNamespace is true", () => {
+    const store = mockStore({
+      ...defaultState,
+      config: {
+        featureFlags: { reposPerNamespace: true },
+      },
+    });
+    const wrapper = shallow(<RepoListContainer store={store} />);
+
+    const component = wrapper.find("AppRepoList");
+
+    expect(component).toHaveProp({
+      namespace: currentNamespace,
+    });
+  });
+});

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.test.tsx
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.test.tsx
@@ -50,7 +50,7 @@ describe("RepoListContainer props", () => {
     });
   });
 
-  it("uses kubeapps namespace when reposPerNamespace is true and _all namespaces selected", () => {
+  it("passes _all through as a normal namespace when reposPerNamespaces is true, to be handled by the component", () => {
     const store = mockStore({
       ...defaultState,
       config: {
@@ -64,7 +64,7 @@ describe("RepoListContainer props", () => {
     const component = wrapper.find("AppRepoList");
 
     expect(component).toHaveProp({
-      namespace: kubeappsNamespace,
+      namespace: definedNamespaces.all,
       displayReposPerNamespaceMsg: false,
     });
   });

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.test.tsx
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.test.tsx
@@ -17,6 +17,7 @@ const defaultState = {
   },
   namespace: { current: currentNamespace },
   repos: {},
+  displayReposPerNamespaceMsg: false,
 };
 
 describe("RepoListContainer props", () => {
@@ -28,6 +29,7 @@ describe("RepoListContainer props", () => {
 
     expect(component).toHaveProp({
       namespace: kubeappsNamespace,
+      displayReposPerNamespaceMsg: false,
     });
   });
 
@@ -44,6 +46,7 @@ describe("RepoListContainer props", () => {
 
     expect(component).toHaveProp({
       namespace: currentNamespace,
+      displayReposPerNamespaceMsg: true,
     });
   });
 
@@ -62,6 +65,7 @@ describe("RepoListContainer props", () => {
 
     expect(component).toHaveProp({
       namespace: kubeappsNamespace,
+      displayReposPerNamespaceMsg: false,
     });
   });
 });

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.test.tsx
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.test.tsx
@@ -4,6 +4,7 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 
 import RepoListContainer from ".";
+import { definedNamespaces } from "../../shared/Namespace";
 
 const mockStore = configureMockStore([thunk]);
 const currentNamespace = "current-namespace";
@@ -43,6 +44,24 @@ describe("RepoListContainer props", () => {
 
     expect(component).toHaveProp({
       namespace: currentNamespace,
+    });
+  });
+
+  it("uses kubeapps namespace when reposPerNamespace is true and _all namespaces selected", () => {
+    const store = mockStore({
+      ...defaultState,
+      config: {
+        featureFlags: { reposPerNamespace: true },
+        namespace: kubeappsNamespace,
+      },
+      namespace: { current: definedNamespaces.all },
+    });
+    const wrapper = shallow(<RepoListContainer store={store} />);
+
+    const component = wrapper.find("AppRepoList");
+
+    expect(component).toHaveProp({
+      namespace: kubeappsNamespace,
     });
   });
 });

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -10,9 +10,11 @@ import { IStoreState } from "../../shared/types";
 function mapStateToProps({ config, namespace, repos }: IStoreState) {
   let repoNamespace = config.namespace;
   let displayReposPerNamespaceMsg = false;
-  if (config.featureFlags.reposPerNamespace && namespace.current !== definedNamespaces.all) {
+  if (config.featureFlags.reposPerNamespace) {
     repoNamespace = namespace.current;
-    displayReposPerNamespaceMsg = true;
+    if (repoNamespace !== definedNamespaces.all) {
+      displayReposPerNamespaceMsg = true;
+    }
   }
   return {
     errors: repos.errors,

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -4,11 +4,12 @@ import { ThunkDispatch } from "redux-thunk";
 
 import actions from "../../actions";
 import AppRepoList from "../../components/Config/AppRepoList";
+import { definedNamespaces } from "../../shared/Namespace";
 import { IStoreState } from "../../shared/types";
 
 function mapStateToProps({ config, namespace, repos }: IStoreState) {
   let repoNamespace = config.namespace;
-  if (config.featureFlags.reposPerNamespace) {
+  if (config.featureFlags.reposPerNamespace && namespace.current !== definedNamespaces.all) {
     repoNamespace = namespace.current;
   }
   return {

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -6,10 +6,14 @@ import actions from "../../actions";
 import AppRepoList from "../../components/Config/AppRepoList";
 import { IStoreState } from "../../shared/types";
 
-function mapStateToProps({ repos, config }: IStoreState) {
+function mapStateToProps({ config, namespace, repos }: IStoreState) {
+  let repoNamespace = config.namespace;
+  if (config.featureFlags.reposPerNamespace) {
+    repoNamespace = namespace.current;
+  }
   return {
     errors: repos.errors,
-    kubeappsNamespace: config.namespace,
+    namespace: repoNamespace,
     repos: repos.repos,
   };
 }
@@ -19,8 +23,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     deleteRepo: async (name: string) => {
       return dispatch(actions.repos.deleteRepo(name));
     },
-    fetchRepos: async () => {
-      return dispatch(actions.repos.fetchRepos());
+    fetchRepos: async (namespace: string) => {
+      return dispatch(actions.repos.fetchRepos(namespace));
     },
     install: async (
       name: string,

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -9,13 +9,16 @@ import { IStoreState } from "../../shared/types";
 
 function mapStateToProps({ config, namespace, repos }: IStoreState) {
   let repoNamespace = config.namespace;
+  let displayReposPerNamespaceMsg = false;
   if (config.featureFlags.reposPerNamespace && namespace.current !== definedNamespaces.all) {
     repoNamespace = namespace.current;
+    displayReposPerNamespaceMsg = true;
   }
   return {
     errors: repos.errors,
     namespace: repoNamespace,
     repos: repos.repos,
+    displayReposPerNamespaceMsg,
   };
 }
 

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -1,5 +1,6 @@
 import { axiosWithAuth } from "./AxiosInstance";
 import { APIBase } from "./Kube";
+import { definedNamespaces } from "./Namespace";
 import { IAppRepository, IAppRepositoryList, ICreateAppRepositoryResponse } from "./types";
 import * as url from "./url";
 
@@ -47,7 +48,7 @@ export class AppRepository {
   private static APIEndpoint: string = `${AppRepository.APIBase}/apis/kubeapps.com/v1alpha1`;
   private static getResourceLink(namespace?: string): string {
     return `${AppRepository.APIEndpoint}/${
-      namespace ? `namespaces/${namespace}/` : ""
+      !namespace || namespace === definedNamespaces.all ? "" : `namespaces/${namespace}/`
     }apprepositories`;
   }
   private static getSelfLink(name: string, namespace: string): string {

--- a/docs/user/private-app-repository.md
+++ b/docs/user/private-app-repository.md
@@ -199,3 +199,9 @@ spec:
 ```
 
 The above will generate a Pod with the label `my-repo: isPrivate` and the environment variable `FOO=BAR`.
+
+## Per Namespace App Repositories
+
+There is work in progress to support AppRepositories per namespace in Kubeapps, rather than sharing access to AppRepositories in Kubeapps' own namespace. Details about the design can be read on the [design document](https://docs.google.com/document/d/1YEeKC6nPLoq4oaxs9v8_UsmxrRfWxB6KCyqrh2-Q8x0/edit?ts=5e2adf87).
+
+More information will be added once it is available for general use.


### PR DESCRIPTION
Ref: #1495 . Updates so that AppRepositories are display per namespace (when the FeatureFlag is enabled).

I've also added a helper which can remain for a release or two after we remove the feature flag, which only displays if you're viewing app repos for a specific namespace.

In the next PR I plan to:

- Get rid of the jump that you see when changing namespace (by removing app repos from state immediately when the namespace changes, rather than when the new list is loaded). Perhaps we want a spinner here now too?
- Update the installRepo so that a new repo is created in the current namespace.

Quick example:
![app-repos-per-namespace1](https://user-images.githubusercontent.com/497518/73900788-f0ec9000-48e4-11ea-9919-d26b16a6cbc0.gif)
