### PR TITLE
1495 6 app repos created in namespace

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -205,11 +205,19 @@ describe("fetchRepos", () => {
 });
 
 describe("installRepo", () => {
-  const installRepoCMD = repoActions.installRepo("my-repo", "http://foo.bar", "", "", "");
+  const installRepoCMD = repoActions.installRepo(
+    "my-repo",
+    "my-namespace",
+    "http://foo.bar",
+    "",
+    "",
+    "",
+  );
 
   context("when authHeader provided", () => {
     const installRepoCMDAuth = repoActions.installRepo(
       "my-repo",
+      "my-namespace",
       "http://foo.bar",
       "Bearer: abc",
       "",
@@ -220,6 +228,7 @@ describe("installRepo", () => {
       await store.dispatch(installRepoCMDAuth);
       expect(AppRepository.create).toHaveBeenCalledWith(
         "my-repo",
+        "my-namespace",
         "http://foo.bar",
         "Bearer: abc",
         "",
@@ -241,6 +250,7 @@ describe("installRepo", () => {
   context("when a customCA is provided", () => {
     const installRepoCMDAuth = repoActions.installRepo(
       "my-repo",
+      "my-namespace",
       "http://foo.bar",
       "",
       "This is a cert!",
@@ -251,6 +261,7 @@ describe("installRepo", () => {
       await store.dispatch(installRepoCMDAuth);
       expect(AppRepository.create).toHaveBeenCalledWith(
         "my-repo",
+        "my-namespace",
         "http://foo.bar",
         "",
         "This is a cert!",
@@ -279,12 +290,26 @@ spec:
 
       it("calls AppRepository create including pod template", async () => {
         await store.dispatch(
-          repoActions.installRepo("my-repo", "http://foo.bar", "", "", safeYAMLTemplate),
+          repoActions.installRepo(
+            "my-repo",
+            "my-namespace",
+            "http://foo.bar",
+            "",
+            "",
+            safeYAMLTemplate,
+          ),
         );
 
-        expect(AppRepository.create).toHaveBeenCalledWith("my-repo", "http://foo.bar", "", "", {
-          spec: { containers: [{ env: [{ name: "FOO", value: "BAR" }] }] },
-        });
+        expect(AppRepository.create).toHaveBeenCalledWith(
+          "my-repo",
+          "my-namespace",
+          "http://foo.bar",
+          "",
+          "",
+          {
+            spec: { containers: [{ env: [{ name: "FOO", value: "BAR" }] }] },
+          },
+        );
       });
 
       // Example from https://nealpoole.com/blog/2013/06/code-execution-via-yaml-in-js-yaml-nodejs-module/
@@ -293,7 +318,14 @@ spec:
 
       it("does not call AppRepository create with an unsafe pod template", async () => {
         await store.dispatch(
-          repoActions.installRepo("my-repo", "http://foo.bar", "", "", unsafeYAMLTemplate),
+          repoActions.installRepo(
+            "my-repo",
+            "my-namespace",
+            "http://foo.bar",
+            "",
+            "",
+            unsafeYAMLTemplate,
+          ),
         );
         expect(AppRepository.create).not.toHaveBeenCalled();
       });
@@ -303,7 +335,14 @@ spec:
   context("when authHeader and customCA are empty", () => {
     it("calls AppRepository create without a auth struct", async () => {
       await store.dispatch(installRepoCMD);
-      expect(AppRepository.create).toHaveBeenCalledWith("my-repo", "http://foo.bar", "", "", {});
+      expect(AppRepository.create).toHaveBeenCalledWith(
+        "my-repo",
+        "my-namespace",
+        "http://foo.bar",
+        "",
+        "",
+        {},
+      );
     });
 
     it("returns true", async () => {

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -393,6 +393,19 @@ spec:
     await store.dispatch(installRepoCMD);
     expect(store.getActions()).toEqual(expectedActions);
   });
+
+  it("uses kubeapps own namespace if namespace is _all", async () => {
+    await store.dispatch(repoActions.installRepo("my-repo", "_all", "http://foo.bar", "", "", ""));
+
+    expect(AppRepository.create).toHaveBeenCalledWith(
+      "my-repo",
+      "kubeapps-namespace",
+      "http://foo.bar",
+      "",
+      "",
+      {},
+    );
+  });
 });
 
 describe("checkChart", () => {

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -134,6 +134,7 @@ export const fetchRepos = (
 
 export const installRepo = (
   name: string,
+  namespace: string,
   repoURL: string,
   authHeader: string,
   customCA: string,
@@ -148,6 +149,7 @@ export const installRepo = (
       dispatch(addRepo());
       const data = await AppRepository.create(
         name,
+        namespace,
         repoURL,
         authHeader,
         customCA,

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -3,6 +3,7 @@ import { ThunkAction } from "redux-thunk";
 import { ActionType, createAction } from "typesafe-actions";
 import { AppRepository } from "../shared/AppRepository";
 import Chart from "../shared/Chart";
+import { definedNamespaces } from "../shared/Namespace";
 import { errorChart } from "./charts";
 
 import { IAppRepository, IStoreState, NotFoundError } from "../shared/types";
@@ -145,6 +146,12 @@ export const installRepo = (
     try {
       if (syncJobPodTemplate.length) {
         syncJobPodTemplateObj = yaml.safeLoad(syncJobPodTemplate);
+      }
+      const {
+        config: { namespace: kubeappsNamespace },
+      } = getState();
+      if (namespace === definedNamespaces.all) {
+        namespace = kubeappsNamespace;
       }
       dispatch(addRepo());
       const data = await AppRepository.create(

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.test.tsx
@@ -36,7 +36,7 @@ it("should install a repository with a custom auth header", done => {
   const button = wrapper.find(AppRepoForm).find(".button");
   button.simulate("submit");
 
-  expect(install).toBeCalledWith("my-repo", "http://foo.bar", "foo", "bar", "");
+  expect(install).toBeCalledWith("my-repo", "kubeapps", "http://foo.bar", "foo", "bar", "");
   // Wait for the Modal to be closed
   setTimeout(() => {
     expect(wrapper.state("modalIsOpen")).toBe(false);
@@ -62,7 +62,14 @@ it("should install a repository with basic auth", done => {
   const button = wrapper.find(AppRepoForm).find(".button");
   button.simulate("submit");
 
-  expect(install).toBeCalledWith("my-repo", "http://foo.bar", "Basic Zm9vOmJhcg==", "", "");
+  expect(install).toBeCalledWith(
+    "my-repo",
+    "kubeapps",
+    "http://foo.bar",
+    "Basic Zm9vOmJhcg==",
+    "",
+    "",
+  );
   // Wait for the Modal to be closed
   setTimeout(() => {
     expect(wrapper.state("modalIsOpen")).toBe(false);
@@ -87,7 +94,7 @@ it("should install a repository with a bearer token", done => {
   const button = wrapper.find(AppRepoForm).find(".button");
   button.simulate("submit");
 
-  expect(install).toBeCalledWith("my-repo", "http://foo.bar", "Bearer foobar", "", "");
+  expect(install).toBeCalledWith("my-repo", "kubeapps", "http://foo.bar", "Bearer foobar", "", "");
   // Wait for the Modal to be closed
   setTimeout(() => {
     expect(wrapper.state("modalIsOpen")).toBe(false);
@@ -112,7 +119,14 @@ it("should install a repository with a podSpecTemplate", done => {
   const button = wrapper.find(AppRepoForm).find(".button");
   button.simulate("submit");
 
-  expect(install).toBeCalledWith("my-repo", "http://foo.bar", "Bearer ", "", "foo: bar");
+  expect(install).toBeCalledWith(
+    "my-repo",
+    "kubeapps",
+    "http://foo.bar",
+    "Bearer ",
+    "",
+    "foo: bar",
+  );
   // Wait for the Modal to be closed
   setTimeout(() => {
     expect(wrapper.state("modalIsOpen")).toBe(false);

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -24,6 +24,7 @@ interface IAppRepoAddButtonProps {
   error?: Error;
   install: (
     name: string,
+    namespace: string,
     url: string,
     authHeader: string,
     customCA: string,
@@ -84,7 +85,14 @@ export class AppRepoAddButton extends React.Component<
   ) => {
     // Store last submitted name to show it in an error if needed
     this.setState({ lastSubmittedName: name });
-    return this.props.install(name, url, authHeader, customCA, syncJobPodTemplate);
+    return this.props.install(
+      name,
+      this.props.namespace,
+      url,
+      authHeader,
+      customCA,
+      syncJobPodTemplate,
+    );
   };
   private openModal = async () => this.setState({ modalIsOpen: true });
 }

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -15,6 +15,7 @@ const defaultProps = {
   install: jest.fn(),
   namespace: defaultNamespace,
   displayReposPerNamespaceMsg: false,
+  isFetching: false,
 };
 
 describe("AppRepoList", () => {
@@ -76,5 +77,20 @@ describe("AppRepoList", () => {
     });
 
     expect(props.fetchRepos).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays LoadingWrapper when fetching", () => {
+    const props = {
+      ...defaultProps,
+      isFetching: true,
+    };
+
+    const wrapper = shallow(<AppRepoList {...props} />);
+
+    const loading = wrapper.find("LoadingWrapper");
+    expect(loading.length).toBe(1);
+    expect(loading).toHaveProp({
+      loaded: false,
+    });
   });
 });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -110,6 +110,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
                   deleteRepo={deleteRepo}
                   resyncRepo={resyncRepo}
                   repo={repo}
+                  renderNamespace={renderNamespace}
                 />
               ))}
             </tbody>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { definedNamespaces } from "../../../shared/Namespace";
 import { IAppRepository, IRBACRole } from "../../../shared/types";
 import { ErrorSelector, MessageAlert } from "../../ErrorAlert";
+import LoadingWrapper from "../../LoadingWrapper";
 import { AppRepoAddButton } from "./AppRepoButton";
 import { AppRepoListItem } from "./AppRepoListItem";
 import { AppRepoRefreshAllButton } from "./AppRepoRefreshAllButton";
@@ -28,6 +29,7 @@ export interface IAppRepoListProps {
   ) => Promise<boolean>;
   namespace: string;
   displayReposPerNamespaceMsg: boolean;
+  isFetching: boolean;
 }
 
 const RequiredRBACRoles: { [s: string]: IRBACRole[] } = {
@@ -81,6 +83,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
       resyncAllRepos,
       namespace,
       displayReposPerNamespaceMsg,
+      isFetching,
     } = this.props;
     const renderNamespace = namespace === definedNamespaces.all;
     return (
@@ -89,27 +92,28 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
         {errors.fetch && this.renderError("fetch")}
         {errors.delete && this.renderError("delete")}
         {errors.update && this.renderError("update")}
-        <table>
-          <thead>
-            <tr>
-              <th>Repo</th>
-              {renderNamespace && <th>Namespace</th>}
-              <th>URL</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {repos.map(repo => (
-              <AppRepoListItem
-                key={repo.metadata.uid}
-                deleteRepo={deleteRepo}
-                resyncRepo={resyncRepo}
-                repo={repo}
-                renderNamespace={renderNamespace}
-              />
-            ))}
-          </tbody>
-        </table>
+        <LoadingWrapper loaded={!isFetching}>
+          <table>
+            <thead>
+              <tr>
+                <th>Repo</th>
+                {renderNamespace && <th>Namespace</th>}
+                <th>URL</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {repos.map(repo => (
+                <AppRepoListItem
+                  key={repo.metadata.uid}
+                  deleteRepo={deleteRepo}
+                  resyncRepo={resyncRepo}
+                  repo={repo}
+                />
+              ))}
+            </tbody>
+          </table>
+        </LoadingWrapper>
         <AppRepoAddButton error={errors.create} install={install} namespace={namespace} />
         <AppRepoRefreshAllButton
           resyncAllRepos={resyncAllRepos}

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -22,6 +22,7 @@ export interface IAppRepoListProps {
   resyncAllRepos: (names: string[]) => void;
   install: (
     name: string,
+    namespace: string,
     url: string,
     authHeader: string,
     customCA: string,

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -35,13 +35,14 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     },
     install: async (
       name: string,
+      namespace: string,
       url: string,
       authHeader: string,
       customCA: string,
       syncJobPodTemplate: string,
     ) => {
       return dispatch(
-        actions.repos.installRepo(name, url, authHeader, customCA, syncJobPodTemplate),
+        actions.repos.installRepo(name, namespace, url, authHeader, customCA, syncJobPodTemplate),
       );
     },
     resyncRepo: async (name: string) => {

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -21,6 +21,7 @@ function mapStateToProps({ config, namespace, repos }: IStoreState) {
     namespace: repoNamespace,
     repos: repos.repos,
     displayReposPerNamespaceMsg,
+    isFetching: repos.isFetching,
   };
 }
 

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -32,6 +32,7 @@ export class AppRepository {
   // for direct k8s api access (for this resource, at least).
   public static async create(
     name: string,
+    namespace: string,
     repoURL: string,
     authHeader: string,
     customCA: string,
@@ -39,7 +40,7 @@ export class AppRepository {
   ) {
     const { data } = await axiosWithAuth.post<ICreateAppRepositoryResponse>(
       url.backend.apprepositories.create(),
-      { appRepository: { name, repoURL, authHeader, customCA, syncJobPodTemplate } },
+      { appRepository: { name, namespace, repoURL, authHeader, customCA, syncJobPodTemplate } },
     );
     return data;
   }


### PR DESCRIPTION
Follows #1503. Ref #1495 .

As planned in the previous PR, this one:

- Adds the `LoadingWrapper` so that stale data doesn't flash when changing namespaces.
- Updates the installRepo action to pass the namespace with the request (the backend already supports this, from #1499)

The next PR will update the delete and refresh actions to work with per-namespace app repositories.