### PR TITLE
Enable deleting, resynching and resync all across namespaces.

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -16,7 +16,10 @@ const appRepo = { spec: { resyncRequests: 10000 } };
 const kubeappsNamespace = "kubeapps-namespace";
 
 beforeEach(() => {
-  store = mockStore({ config: { namespace: kubeappsNamespace } });
+  store = mockStore({
+    config: { namespace: kubeappsNamespace },
+    namespace: { current: kubeappsNamespace },
+  });
   AppRepository.list = jest.fn().mockImplementationOnce(() => {
     return { items: { foo: "bar" } };
   });
@@ -94,7 +97,7 @@ describe("deleteRepo", () => {
       },
     ];
 
-    await store.dispatch(repoActions.deleteRepo("foo"));
+    await store.dispatch(repoActions.deleteRepo("foo", "my-namespace"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -110,7 +113,7 @@ describe("deleteRepo", () => {
       },
     ];
 
-    await store.dispatch(repoActions.deleteRepo("foo"));
+    await store.dispatch(repoActions.deleteRepo("foo", "my-namespace"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -128,7 +131,7 @@ describe("resyncRepo", () => {
       },
     ];
 
-    await store.dispatch(repoActions.resyncRepo("foo"));
+    await store.dispatch(repoActions.resyncRepo("foo", "my-namespace"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -144,8 +147,31 @@ describe("resyncRepo", () => {
       },
     ];
 
-    await store.dispatch(repoActions.resyncRepo("foo"));
+    await store.dispatch(repoActions.resyncRepo("foo", "my-namespace"));
     expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe("resyncAllRepos", () => {
+  it("resyncs each repo using its namespace", async () => {
+    const appRepoGetMock = jest.fn();
+    AppRepository.get = appRepoGetMock;
+    await store.dispatch(
+      repoActions.resyncAllRepos([
+        {
+          name: "foo",
+          namespace: "namespace-1",
+        },
+        {
+          name: "bar",
+          namespace: "namespace-2",
+        },
+      ]),
+    );
+
+    expect(appRepoGetMock).toHaveBeenCalledTimes(2);
+    expect(appRepoGetMock.mock.calls[0]).toEqual(["foo", "namespace-1"]);
+    expect(appRepoGetMock.mock.calls[1]).toEqual(["bar", "namespace-2"]);
   });
 });
 

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { definedNamespaces } from "../../../shared/Namespace";
-import { IAppRepository, IRBACRole } from "../../../shared/types";
+import { IAppRepository, IAppRepositoryKey, IRBACRole } from "../../../shared/types";
 import { ErrorSelector, MessageAlert } from "../../ErrorAlert";
 import LoadingWrapper from "../../LoadingWrapper";
 import { AppRepoAddButton } from "./AppRepoButton";
@@ -17,9 +17,9 @@ export interface IAppRepoListProps {
   };
   repos: IAppRepository[];
   fetchRepos: (namespace: string) => void;
-  deleteRepo: (name: string) => Promise<boolean>;
-  resyncRepo: (name: string) => void;
-  resyncAllRepos: (names: string[]) => void;
+  deleteRepo: (name: string, namespace: string) => Promise<boolean>;
+  resyncRepo: (name: string, namespace: string) => void;
+  resyncAllRepos: (repos: IAppRepositoryKey[]) => void;
   install: (
     name: string,
     namespace: string,
@@ -79,12 +79,12 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
       errors,
       repos,
       install,
-      deleteRepo,
-      resyncRepo,
-      resyncAllRepos,
       namespace,
       displayReposPerNamespaceMsg,
       isFetching,
+      deleteRepo,
+      resyncRepo,
+      resyncAllRepos,
     } = this.props;
     const renderNamespace = namespace === definedNamespaces.all;
     return (
@@ -117,11 +117,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
           </table>
         </LoadingWrapper>
         <AppRepoAddButton error={errors.create} install={install} namespace={namespace} />
-        <AppRepoRefreshAllButton
-          resyncAllRepos={resyncAllRepos}
-          repos={repos}
-          namespace={namespace}
-        />
+        <AppRepoRefreshAllButton resyncAllRepos={resyncAllRepos} repos={repos} />
         {displayReposPerNamespaceMsg && (
           <MessageAlert header="Looking for other app repositories?">
             <div>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
@@ -7,8 +7,8 @@ import ConfirmDialog from "../../ConfirmDialog";
 interface IAppRepoListItemProps {
   repo: IAppRepository;
   renderNamespace: boolean;
-  deleteRepo: (name: string) => Promise<boolean>;
-  resyncRepo: (name: string) => void;
+  deleteRepo: (name: string, namespace: string) => Promise<boolean>;
+  resyncRepo: (name: string, namespace: string) => void;
 }
 
 interface IAppRepoListItemState {
@@ -31,7 +31,7 @@ export class AppRepoListItem extends React.Component<IAppRepoListItemProps, IApp
         <td>{repo.spec && repo.spec.url}</td>
         <td>
           <ConfirmDialog
-            onConfirm={this.handleDeleteClick(repo.metadata.name)}
+            onConfirm={this.handleDeleteClick(repo.metadata.name, repo.metadata.namespace)}
             modalIsOpen={this.state.modalIsOpen}
             loading={false}
             closeModal={this.closeModal}
@@ -43,7 +43,7 @@ export class AppRepoListItem extends React.Component<IAppRepoListItemProps, IApp
 
           <button
             className="button button-secondary"
-            onClick={this.handleResyncClick(repo.metadata.name)}
+            onClick={this.handleResyncClick(repo.metadata.name, repo.metadata.namespace)}
           >
             Refresh
           </button>
@@ -64,16 +64,16 @@ export class AppRepoListItem extends React.Component<IAppRepoListItemProps, IApp
     });
   };
 
-  private handleDeleteClick(repoName: string) {
+  private handleDeleteClick(repoName: string, namespace: string) {
     return async () => {
-      this.props.deleteRepo(repoName);
+      this.props.deleteRepo(repoName, namespace);
       this.setState({ modalIsOpen: false });
     };
   }
 
-  private handleResyncClick(repoName: string) {
+  private handleResyncClick(repoName: string, namespace: string) {
     return () => {
-      this.props.resyncRepo(repoName);
+      this.props.resyncRepo(repoName, namespace);
     };
   }
 }

--- a/dashboard/src/components/Config/AppRepoList/AppRepoRefreshAllButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoRefreshAllButton.tsx
@@ -1,12 +1,11 @@
 import * as React from "react";
 
-import { IAppRepository } from "shared/types";
+import { IAppRepository, IAppRepositoryKey } from "shared/types";
 import "./AppRepo.css";
 
 interface IAppRepoRefreshAllButtonProps {
-  resyncAllRepos: (names: string[]) => void;
+  resyncAllRepos: (repos: IAppRepositoryKey[]) => void;
   repos: IAppRepository[];
-  namespace: string;
 }
 
 export class AppRepoRefreshAllButton extends React.Component<IAppRepoRefreshAllButtonProps> {
@@ -24,10 +23,13 @@ export class AppRepoRefreshAllButton extends React.Component<IAppRepoRefreshAllB
 
   private handleResyncAllClick = async () => {
     if (this.props.repos) {
-      const repoNames = this.props.repos.map(repo => {
-        return repo.metadata.name;
+      const repos = this.props.repos.map(repo => {
+        return {
+          name: repo.metadata.name,
+          namespace: repo.metadata.namespace,
+        };
       });
-      this.props.resyncAllRepos(repoNames);
+      this.props.resyncAllRepos(repos);
     }
   };
 }

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -5,7 +5,7 @@ import { ThunkDispatch } from "redux-thunk";
 import actions from "../../actions";
 import AppRepoList from "../../components/Config/AppRepoList";
 import { definedNamespaces } from "../../shared/Namespace";
-import { IStoreState } from "../../shared/types";
+import { IAppRepositoryKey, IStoreState } from "../../shared/types";
 
 function mapStateToProps({ config, namespace, repos }: IStoreState) {
   let repoNamespace = config.namespace;
@@ -27,8 +27,8 @@ function mapStateToProps({ config, namespace, repos }: IStoreState) {
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    deleteRepo: async (name: string) => {
-      return dispatch(actions.repos.deleteRepo(name));
+    deleteRepo: async (name: string, namespace: string) => {
+      return dispatch(actions.repos.deleteRepo(name, namespace));
     },
     fetchRepos: async (namespace: string) => {
       return dispatch(actions.repos.fetchRepos(namespace));
@@ -45,11 +45,12 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
         actions.repos.installRepo(name, namespace, url, authHeader, customCA, syncJobPodTemplate),
       );
     },
-    resyncRepo: async (name: string) => {
-      return dispatch(actions.repos.resyncRepo(name));
+    resyncRepo: async (name: string, namespace: string) => {
+      return dispatch(actions.repos.resyncRepo(name, namespace));
     },
-    resyncAllRepos: async (names: string[]) => {
-      return dispatch(actions.repos.resyncAllRepos(names));
+    // Update here after actions
+    resyncAllRepos: async (repos: IAppRepositoryKey[]) => {
+      return dispatch(actions.repos.resyncAllRepos(repos));
     },
   };
 }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -304,6 +304,11 @@ export interface IAppRepositoryList
     }
   > {}
 
+export interface IAppRepositoryKey {
+  name: string;
+  namespace: string;
+}
+
 /** @see https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#response-status-kind */
 export interface IStatus extends IK8sResource {
   kind: "Status";


### PR DESCRIPTION
Follows #1504, Ref: #1495 

Enables delete, resync and resync all for repos using each repos own namespace (so each works fine on the All Namespaces view also).