### PR TITLE
Allow to discover namespaces

### DIFF
--- a/chart/kubeapps/templates/kubeops-rbac.yaml
+++ b/chart/kubeapps/templates/kubeops-rbac.yaml
@@ -40,5 +40,42 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kubeapps.kubeops.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- if .Values.allowNamespaceDiscovery }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "kubeapps.kubeops.fullname" . }}-ns-discovery
+  labels:
+    app: {{ template "kubeapps.kubeops.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "kubeapps.kubeops.fullname" . }}-ns-discovery
+  labels:
+    app: {{ template "kubeapps.kubeops.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kubeapps.kubeops.fullname" . }}-ns-discovery
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubeapps.kubeops.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
 {{- end -}}
 {{- end }}{{/* matches useHelm3 */}}

--- a/chart/kubeapps/templates/tiller-proxy-rbac.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-rbac.yaml
@@ -40,5 +40,42 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kubeapps.tiller-proxy.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- if .Values.allowNamespaceDiscovery }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "kubeapps.tiller-proxy.fullname" . }}-ns-discovery
+  labels:
+    app: {{ template "kubeapps.tiller-proxy.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - namespaces
+  verbs:
+    - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "kubeapps.tiller-proxy.fullname" . }}-ns-discovery
+  labels:
+    app: {{ template "kubeapps.tiller-proxy.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kubeapps.tiller-proxy.fullname" . }}-ns-discovery
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubeapps.tiller-proxy.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
 {{- end -}}
 {{- end }}{{/* matches useHelm3 */}}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -12,6 +12,10 @@
 ## If you set it to true, Kubeapps will not work with releases installed with Helm 2.
 useHelm3: false
 
+## Enable this feature flag to allow users to discover available namespaces (only the ones they have access).
+## If you set it to true, Kubeapps create a ClusterRole to be able to list namespaces.
+allowNamespaceDiscovery: false
+
 ## The frontend service is the main reverse proxy used to access the Kubeapps UI
 ## To expose Kubeapps externally either configure the ingress object below or
 ## set frontend.service.type=LoadBalancer in the frontend configuration.

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -86,6 +86,9 @@ func main() {
 	backendAPIv1.Methods("POST").Path("/apprepositories").Handler(negroni.New(
 		negroni.WrapFunc(appreposHandler.Create),
 	))
+	backendAPIv1.Methods("GET").Path("/namespaces").Handler(negroni.New(
+		negroni.WrapFunc(appreposHandler.GetNamespaces),
+	))
 
 	// assetsvc reverse proxy
 	authGate := auth.AuthGate()

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -192,6 +192,9 @@ func main() {
 	backendAPIv1.Methods("POST").Path("/apprepositories").Handler(negroni.New(
 		negroni.WrapFunc(appreposHandler.Create),
 	))
+	backendAPIv1.Methods("GET").Path("/namespaces").Handler(negroni.New(
+		negroni.WrapFunc(appreposHandler.GetNamespaces),
+	))
 
 	// assetsvc reverse proxy
 	parsedAssetsvcURL, err := url.Parse(assetsvcURL)

--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -56,9 +56,7 @@ actionTestCases.forEach(tc => {
 describe("fetchNamespaces", () => {
   it("dispatches the list of namespace names if no error", async () => {
     Namespace.list = jest.fn().mockImplementationOnce(() => {
-      return {
-        items: [{ metadata: { name: "overlook-hotel" } }, { metadata: { name: "room-217" } }],
-      };
+      return [{ metadata: { name: "overlook-hotel" } }, { metadata: { name: "room-217" } }];
     });
     const expectedActions = [
       {
@@ -91,9 +89,7 @@ describe("createNamespace", () => {
   it("dispatches the new namespace and re-fetch namespaces", async () => {
     Namespace.create = jest.fn();
     Namespace.list = jest.fn().mockImplementationOnce(() => {
-      return {
-        items: [{ metadata: { name: "overlook-hotel" } }, { metadata: { name: "room-217" } }],
-      };
+      return [{ metadata: { name: "overlook-hotel" } }, { metadata: { name: "room-217" } }];
     });
     const expectedActions = [
       {

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -45,7 +45,7 @@ export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null,
   return async dispatch => {
     try {
       const namespaces = await Namespace.list();
-      const namespaceStrings = namespaces.items.map((n: IResource) => n.metadata.name);
+      const namespaceStrings = namespaces.map((n: IResource) => n.metadata.name);
       dispatch(receiveNamespaces(namespaceStrings));
     } catch (e) {
       dispatch(errorNamespaces(e, "list"));

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -1,11 +1,12 @@
 import { axiosWithAuth } from "./AxiosInstance";
 import { APIBase } from "./Kube";
+import * as url from "./url";
 
-import { ForbiddenError, IK8sList, IResource, NotFoundError } from "./types";
+import { ForbiddenError, IResource, NotFoundError } from "./types";
 
 export default class Namespace {
   public static async list() {
-    const { data } = await axiosWithAuth.get<IK8sList<IResource, {}>>(`${Namespace.APIEndpoint}`);
+    const { data } = await axiosWithAuth.get<IResource[]>(url.backend.namespaces.list());
     return data;
   }
 

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -15,6 +15,10 @@ export const backend = {
     base: "api/v1/apprepositories",
     create: () => `${backend.apprepositories.base}`,
   },
+  namespaces: {
+    base: "api/v1/namespaces",
+    list: () => `${backend.namespaces.base}`,
+  },
 };
 
 export const api = {

--- a/go.sum
+++ b/go.sum
@@ -568,6 +568,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65 h1:kThoiqgMsSw
 k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65/go.mod h1:5BINdGqggRXXKnDgpwoJ7PyQH8f+Ypp02fvVNcIFy9s=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8 h1:Iieh/ZEgT3BWwbLD5qEKcY06jKuPEl6zC7gPSehoLw4=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
+k8s.io/apimachinery v0.17.2 h1:hwDQQFbdRlpnnsR64Asdi55GyCaIP/3WQpMmbNBeWr4=
 k8s.io/apiserver v0.0.0-20191016112112-5190913f932d/go.mod h1:7OqfAolfWxUM/jJ/HBLyE+cdaWFBUoo5Q5pHgJVj2ws=
 k8s.io/cli-runtime v0.0.0-20191016114015-74ad18325ed5 h1:8ZfMjkMBzcXEawLsYHg9lDM7aLEVso3NiVKfUTnN56A=
 k8s.io/cli-runtime v0.0.0-20191016114015-74ad18325ed5/go.mod h1:sDl6WKSQkDM6zS1u9F49a0VooQ3ycYFBFLqd2jf2Xfo=

--- a/pkg/apprepo/apprepos_handler.go
+++ b/pkg/apprepo/apprepos_handler.go
@@ -333,7 +333,10 @@ func filterAllowedNamespaces(userClientset combinedClientsetInterface, namespace
 	return allowedNamespaces, nil
 }
 
-// GetNamespaces return namespaces
+// GetNamespaces return the list of namespaces that the user has permission to access
+// TODO(andresmgot): I am adding this method in this package for simplicity
+// (since it already allows to impersonate the user)
+// We should refactor this code to make it more generic (not apprepository-specific)
 func (a *appRepositoriesHandler) GetNamespaces(w http.ResponseWriter, req *http.Request) {
 	token := auth.ExtractToken(req.Header.Get("Authorization"))
 	userClientset, err := a.clientsetForConfig(a.ConfigForToken(token))


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

The goal of this PR is to allow users that don't have permission to list namespaces to discover the namespaces they have access to.

Now the dashboard, instead than hitting the k8s API to list namespaces, it contacts the "backend" service (either kubeops or tiller-proxy). This service first tries to list namespaces using the user serviceaccount (just like we do today). If the user doesn't have permissions to list namespaces, it uses the backed serviceaccount to do so. If the chart is installed with the flag `allowNamespaceDiscovery`, the backend will have permission to list those.

After that, for each one of the namespaces, the backend determines if the user has permission to access that namespace checking if they have permission to get secrets. Then it return the list of allowed namespaces to the user.

### Possible drawbacks

To be able to use this feature, the chart needs to be installed with the flag above. This require a ClusterRole so it's disabled by default.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1471

### Additional information

I have implemented the method `GetNamespaces` in the `appreposHandler` library because there, there is already logic to use the requester service account. I was planning to refactor this library but since it can conflict with @absoludity work I didn't continue. My plan was to:

 - Rename `appreposHandler` for something generic like `kubeHandler`
 - Remove references to the HTTP writer in that package. We are just using those because we extracted the logic from the service handler (`cmd/tiller-proxy/handler`).  This should be a normal library that perform the required actions and returns errors if needed.
 - Reuse this package in the `pkg/chart` package since the logic is currently duplicated to obtain AppRepositories and secrets there.

I will leave this as a TODO.
