### PR TITLE
Store a copy of the repo secret in Kubeapps' namespace

### DIFF
--- a/pkg/apprepo/apprepos_handler.go
+++ b/pkg/apprepo/apprepos_handler.go
@@ -39,11 +39,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// coreClientsetInterface provides just the core client
-type coreClientsetInterface interface {
-	CoreV1() corev1typed.CoreV1Interface
-}
-
 // combinedClientsetInterface provides both the app repository clientset and the corev1 clientset.
 type combinedClientsetInterface interface {
 	KubeappsV1alpha1() v1alpha1typed.KubeappsV1alpha1Interface
@@ -70,7 +65,7 @@ type appRepositoriesHandler struct {
 	kubeappsNamespace string
 
 	// The Kubernetes client using the pod serviceaccount
-	svcKubeClient coreClientsetInterface
+	svcKubeClient kubernetes.Interface
 
 	// clientsetForConfig is a field on the struct only so it can be switched
 	// for a fake version when testing. NewAppRepositoryHandler sets it to the

--- a/pkg/apprepo/apprepos_handler.go
+++ b/pkg/apprepo/apprepos_handler.go
@@ -39,6 +39,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// coreClientsetInterface provides just the core client
+type coreClientsetInterface interface {
+	CoreV1() corev1typed.CoreV1Interface
+}
+
 // combinedClientsetInterface provides both the app repository clientset and the corev1 clientset.
 type combinedClientsetInterface interface {
 	KubeappsV1alpha1() v1alpha1typed.KubeappsV1alpha1Interface
@@ -65,7 +70,7 @@ type appRepositoriesHandler struct {
 	kubeappsNamespace string
 
 	// The Kubernetes client using the pod serviceaccount
-	svcKubeClient *kubernetes.Clientset
+	svcKubeClient coreClientsetInterface
 
 	// clientsetForConfig is a field on the struct only so it can be switched
 	// for a fake version when testing. NewAppRepositoryHandler sets it to the
@@ -179,10 +184,11 @@ func (a *appRepositoriesHandler) Create(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	appRepo := appRepositoryForRequest(appRepoRequest)
-	if appRepo.ObjectMeta.Namespace == "" {
-		appRepo.ObjectMeta.Namespace = a.kubeappsNamespace
+	// Remove once dashboard always sends namespace.
+	if appRepoRequest.AppRepository.Namespace == "" {
+		appRepoRequest.AppRepository.Namespace = a.kubeappsNamespace
 	}
+	appRepo := appRepositoryForRequest(appRepoRequest)
 
 	// TODO(mnelson): validate both required data and request for index
 	// https://github.com/kubeapps/kubeapps/issues/1330
@@ -201,9 +207,9 @@ func (a *appRepositoriesHandler) Create(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	secret := secretForRequest(appRepoRequest, appRepo)
-	if secret != nil {
-		_, err = clientset.CoreV1().Secrets(a.kubeappsNamespace).Create(secret)
+	repoSecret := secretForRequest(appRepoRequest, appRepo)
+	if repoSecret != nil {
+		_, err = clientset.CoreV1().Secrets(repoSecret.ObjectMeta.Namespace).Create(repoSecret)
 		if err != nil {
 			if statusErr, ok := err.(*errors.StatusError); ok {
 				status := statusErr.ErrStatus
@@ -214,6 +220,31 @@ func (a *appRepositoriesHandler) Create(w http.ResponseWriter, req *http.Request
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 			return
+		}
+		// If the namespace isn't kubeapps (ie. this is a per-namespace
+		// AppRepository), save a copy of the repository secret in kubeapps
+		// namespace using the service account clientset. This enables the
+		// existing assetsync service to be able to sync private
+		// AppRepositories in other namespaces. It is not ideal and is a
+		// temporary work-around until the asset-sync is updated to run
+		// cronjobs in other namespaces with the assetsvc receiving the data.
+		// See the relevant section of the design doc for details:
+		// https://docs.google.com/document/d/1YEeKC6nPLoq4oaxs9v8_UsmxrRfWxB6KCyqrh2-Q8x0/edit?ts=5e2adf87#heading=h.kilvd2vii0w
+		if repoSecret.ObjectMeta.Namespace != a.kubeappsNamespace {
+			repoSecret.ObjectMeta.Namespace = a.kubeappsNamespace
+			repoSecret.ObjectMeta.Name = kubeappsSecretNameForRepo(appRepo.ObjectMeta.Name, appRepo.ObjectMeta.Namespace)
+			_, err = a.svcKubeClient.CoreV1().Secrets(repoSecret.ObjectMeta.Namespace).Create(repoSecret)
+			if err != nil {
+				if statusErr, ok := err.(*errors.StatusError); ok {
+					status := statusErr.ErrStatus
+					log.Infof("unable to create app repo secret in Kubeapps' namespace: %v", status.Reason)
+					http.Error(w, status.Message, int(status.Code))
+				} else {
+					log.Errorf("unable to create app repo secret in Kubeapps' namespace: %v", err)
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+				return
+			}
 		}
 	}
 
@@ -308,6 +339,12 @@ func secretForRequest(appRepoRequest appRepositoryRequest, appRepo *v1alpha1.App
 
 func secretNameForRepo(repoName string) string {
 	return fmt.Sprintf("apprepo-%s-secrets", repoName)
+}
+
+// kubeappsSecretNameForRepo returns a name suitable for recording a copy of
+// a per-namespace repository secret in the kubeapps namespace.
+func kubeappsSecretNameForRepo(repoName, namespace string) string {
+	return fmt.Sprintf("%s-%s", namespace, secretNameForRepo(repoName))
 }
 
 func filterAllowedNamespaces(userClientset combinedClientsetInterface, namespaces *corev1.NamespaceList) ([]corev1.Namespace, error) {

--- a/pkg/apprepo/apprepos_handler_test.go
+++ b/pkg/apprepo/apprepos_handler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
@@ -130,6 +131,12 @@ func TestAppRepositoryCreate(t *testing.T) {
 			requestData:       `{"appRepository": {"name": "test-repo", "url": "http://example.com/test-repo", "authHeader": "test-me"}}`,
 			expectedCode:      http.StatusCreated,
 		},
+		{
+			name:              "it creates a copy of the namespaced repo secret in the kubeapps namespace",
+			kubeappsNamespace: "kubeapps",
+			requestData:       `{"appRepository": {"name": "test-repo", "namespace": "test-namespace", "url": "http://example.com/test-repo", "authHeader": "test-me"}}`,
+			expectedCode:      http.StatusCreated,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -141,6 +148,7 @@ func TestAppRepositoryCreate(t *testing.T) {
 			handler := appRepositoriesHandler{
 				clientsetForConfig: func(*rest.Config) (combinedClientsetInterface, error) { return cs, nil },
 				kubeappsNamespace:  tc.kubeappsNamespace,
+				svcKubeClient:      fakecoreclientset.NewSimpleClientset(),
 			}
 
 			req := httptest.NewRequest("POST", "https://foo.bar/backend/v1/apprepositories", strings.NewReader(tc.requestData))
@@ -160,13 +168,13 @@ func TestAppRepositoryCreate(t *testing.T) {
 					t.Fatalf("%+v", err)
 				}
 
-				// Ensure the expected AppRepository is stored
-				requestAppRepo := appRepositoryForRequest(appRepoRequest)
 				// Default to the kubeapps namespace if not included in request.
 				// TODO(mnelson, #1256): remove once frontend always sends namespace.
-				if requestAppRepo.ObjectMeta.Namespace == "" {
-					requestAppRepo.ObjectMeta.Namespace = tc.kubeappsNamespace
+				if appRepoRequest.AppRepository.Namespace == "" {
+					appRepoRequest.AppRepository.Namespace = tc.kubeappsNamespace
 				}
+				// Ensure the expected AppRepository is stored
+				requestAppRepo := appRepositoryForRequest(appRepoRequest)
 
 				responseAppRepo, err := cs.KubeappsV1alpha1().AppRepositories(requestAppRepo.ObjectMeta.Namespace).Get(requestAppRepo.ObjectMeta.Name, metav1.GetOptions{})
 				if err != nil {
@@ -188,18 +196,44 @@ func TestAppRepositoryCreate(t *testing.T) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 				}
 
-				// When appropriate, ensure the expected secret is stored
+				// When appropriate, ensure the expected secret is stored.
 				if appRepoRequest.AppRepository.AuthHeader != "" {
-					requestSecret := secretForRequest(appRepoRequest, responseAppRepo)
-					requestSecret.ObjectMeta.Namespace = tc.kubeappsNamespace
+					expectedSecret := secretForRequest(appRepoRequest, responseAppRepo)
+					responseSecret, err := cs.CoreV1().Secrets(appRepoRequest.AppRepository.Namespace).Get(expectedSecret.ObjectMeta.Name, metav1.GetOptions{})
 
-					responseSecret, err := cs.CoreV1().Secrets(tc.kubeappsNamespace).Get(requestSecret.ObjectMeta.Name, metav1.GetOptions{})
 					if err != nil {
-						t.Errorf("expected data %v not present: %+v", requestSecret, err)
+						t.Errorf("expected data %v not present: %+v", expectedSecret, err)
 					}
 
-					if got, want := responseSecret, requestSecret; !cmp.Equal(want, got) {
+					if got, want := responseSecret, expectedSecret; !cmp.Equal(want, got) {
 						t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+					}
+
+					// Verify the copy of the repo secret in in kubeapps is
+					// also stored if this is a per-namespace app repository.
+					kubeappsSecretName := kubeappsSecretNameForRepo(requestAppRepo.ObjectMeta.Name, requestAppRepo.ObjectMeta.Namespace)
+					expectedSecret.ObjectMeta.Name = kubeappsSecretName
+					expectedSecret.ObjectMeta.Namespace = tc.kubeappsNamespace
+
+					if requestAppRepo.ObjectMeta.Namespace != tc.kubeappsNamespace {
+						responseSecret, err = handler.svcKubeClient.CoreV1().Secrets(tc.kubeappsNamespace).Get(kubeappsSecretName, metav1.GetOptions{})
+						if err != nil {
+							t.Errorf("expected data %v not present: %+v", expectedSecret, err)
+						}
+
+						if got, want := responseSecret, expectedSecret; !cmp.Equal(want, got) {
+							t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+						}
+					} else {
+						_, err = handler.svcKubeClient.CoreV1().Secrets(tc.kubeappsNamespace).Get(kubeappsSecretName, metav1.GetOptions{})
+						if statusErr, ok := err.(*errors.StatusError); ok {
+							status := statusErr.ErrStatus
+							if got, want := status.Code, int32(404); got != want {
+								t.Errorf("got: %d, want: %d", got, want)
+							}
+						} else {
+							t.Errorf("Unable to convert err to StatusError: %+v", err)
+						}
 					}
 				}
 			}
@@ -383,8 +417,9 @@ func TestSecretForRequest(t *testing.T) {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-repo",
-			UID:  "abcd1234",
+			Name:      "test-repo",
+			UID:       "abcd1234",
+			Namespace: "repo-namespace",
 		},
 	}
 	// And the same owner references expectation.
@@ -405,7 +440,7 @@ func TestSecretForRequest(t *testing.T) {
 		secret  *corev1.Secret
 	}{
 		{
-			name: "it creates a nil secret without auth",
+			name: "it does not create a secret without auth",
 			request: appRepositoryRequestDetails{
 				Name:    "test-repo",
 				RepoURL: "http://example.com/test-repo",


### PR DESCRIPTION
Ref: #1496 
Updates the apprepo handler so that a copy of an app repository credential is recorded in Kubeapps' own namespace.