### PR TITLE
Show meaningful error when creating a release

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 import { IChartState, IChartVersion, UnprocessableEntity } from "../../shared/types";
 import DeploymentFormBody from "../DeploymentFormBody/DeploymentFormBody";
-import { ErrorSelector } from "../ErrorAlert";
+import { UnexpectedErrorAlert } from "../ErrorAlert";
 import DeploymentForm from "./DeploymentForm";
 
 const releaseName = "my-release";
@@ -53,15 +53,15 @@ describe("renders an error", () => {
       />,
     );
     wrapper.setState({ latestSubmittedReleaseName: "my-app" });
-    expect(wrapper.find(ErrorSelector).exists()).toBe(true);
-    expect(wrapper.find(ErrorSelector).html()).toContain(
-      "Sorry! Something went wrong processing my-app",
+    expect(wrapper.find(UnexpectedErrorAlert).exists()).toBe(true);
+    expect(wrapper.find(UnexpectedErrorAlert).html()).toContain(
+      "Sorry! The installation of my-app failed",
     );
-    expect(wrapper.find(ErrorSelector).html()).toContain("wrong format!");
+    expect(wrapper.find(UnexpectedErrorAlert).html()).toContain("wrong format!");
   });
 
   it("the error does not change if the release name changes", () => {
-    const expectedErrorMsg = "Sorry! Something went wrong processing my-app";
+    const expectedErrorMsg = "Sorry! The installation of my-app failed";
 
     const wrapper = shallow(
       <DeploymentForm
@@ -77,10 +77,10 @@ describe("renders an error", () => {
     );
 
     wrapper.setState({ latestSubmittedReleaseName: "my-app" });
-    expect(wrapper.find(ErrorSelector).exists()).toBe(true);
-    expect(wrapper.find(ErrorSelector).html()).toContain(expectedErrorMsg);
+    expect(wrapper.find(UnexpectedErrorAlert).exists()).toBe(true);
+    expect(wrapper.find(UnexpectedErrorAlert).html()).toContain(expectedErrorMsg);
     wrapper.setState({ releaseName: "another-app" });
-    expect(wrapper.find(ErrorSelector).html()).toContain(expectedErrorMsg);
+    expect(wrapper.find(UnexpectedErrorAlert).html()).toContain(expectedErrorMsg);
   });
 });
 

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -3,9 +3,9 @@ import * as Moniker from "moniker-native";
 import * as React from "react";
 
 import { JSONSchema4 } from "json-schema";
-import { IChartState, IChartVersion } from "../../shared/types";
+import { IChartState, IChartVersion, InternalServerError } from "../../shared/types";
 import DeploymentFormBody from "../DeploymentFormBody/DeploymentFormBody";
-import { ErrorSelector } from "../ErrorAlert";
+import { UnexpectedErrorAlert } from "../ErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
 
 import "react-tabs/style/react-tabs.css";
@@ -60,15 +60,31 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   }
 
   public render() {
-    const { namespace, error } = this.props;
+    const { error } = this.props;
     if (error) {
       return (
-        <ErrorSelector
-          error={error}
-          namespace={namespace}
-          action="create"
-          resource={this.state.latestSubmittedReleaseName}
-        />
+        <UnexpectedErrorAlert
+          title={`Sorry! The installation of ${this.state.latestSubmittedReleaseName} failed`}
+          text={error.message}
+          raw={true}
+          showGenericMessage={error.constructor === InternalServerError}
+        >
+          {error.constructor === InternalServerError ? (
+            <span>
+              The server returned an internal error. If the problem persists, please contant
+              Kubeapps maintainers.
+            </span>
+          ) : (
+            <span>
+              If you are unable to install the application, contact the chart maintainers or if you
+              think the issue is related to Kubeapps, please open an{" "}
+              <a href="https://github.com/kubeapps/kubeapps/issues/new" target="_blank">
+                issue in GitHub
+              </a>
+              .
+            </span>
+          )}
+        </UnexpectedErrorAlert>
       );
     }
     if (this.state.isDeploying) {

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -3,9 +3,14 @@ import * as Moniker from "moniker-native";
 import * as React from "react";
 
 import { JSONSchema4 } from "json-schema";
-import { IChartState, IChartVersion, InternalServerError } from "../../shared/types";
+import {
+  ForbiddenError,
+  IChartState,
+  IChartVersion,
+  InternalServerError,
+} from "../../shared/types";
 import DeploymentFormBody from "../DeploymentFormBody/DeploymentFormBody";
-import { UnexpectedErrorAlert } from "../ErrorAlert";
+import { ErrorSelector, UnexpectedErrorAlert } from "../ErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
 
 import "react-tabs/style/react-tabs.css";
@@ -60,8 +65,20 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
   }
 
   public render() {
-    const { error } = this.props;
+    const { namespace, error } = this.props;
     if (error) {
+      if (error.constructor === ForbiddenError) {
+        // Only if the error is a ForbiddenError use the error selector
+        // to parse the required roles
+        return (
+          <ErrorSelector
+            error={error}
+            namespace={namespace}
+            action="create"
+            resource={this.state.latestSubmittedReleaseName}
+          />
+        );
+      }
       return (
         <UnexpectedErrorAlert
           title={`Sorry! The installation of ${this.state.latestSubmittedReleaseName} failed`}

--- a/dashboard/src/shared/AxiosInstance.test.ts
+++ b/dashboard/src/shared/AxiosInstance.test.ts
@@ -7,6 +7,7 @@ import { Auth } from "./Auth";
 import {
   ConflictError,
   ForbiddenError,
+  InternalServerError,
   NotFoundError,
   UnauthorizedError,
   UnprocessableEntity,
@@ -70,6 +71,7 @@ describe("createAxiosInterceptorWithAuth", () => {
     { code: 404, errorClass: NotFoundError },
     { code: 409, errorClass: ConflictError },
     { code: 422, errorClass: UnprocessableEntity },
+    { code: 500, errorClass: InternalServerError },
   ];
 
   testCases.forEach(t => {

--- a/dashboard/src/shared/AxiosInstance.ts
+++ b/dashboard/src/shared/AxiosInstance.ts
@@ -7,6 +7,7 @@ import { Auth } from "./Auth";
 import {
   ConflictError,
   ForbiddenError,
+  InternalServerError,
   IStoreState,
   NotFoundError,
   UnauthorizedError,
@@ -67,6 +68,8 @@ export function addErrorHandling(axiosInstance: AxiosInstance, store: Store<ISto
           return Promise.reject(new ConflictError(message));
         case 422:
           return Promise.reject(new UnprocessableEntity(message));
+        case 500:
+          return Promise.reject(new InternalServerError(message));
         default:
           return Promise.reject(new Error(message));
       }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -27,6 +27,8 @@ export class ConflictError extends CustomError {}
 
 export class UnprocessableEntity extends CustomError {}
 
+export class InternalServerError extends CustomError {}
+
 export interface IRepo {
   name: string;
   url: string;

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/kubeapps/kubeapps/pkg/chart/helm3to2"
 	"github.com/kubeapps/kubeapps/pkg/proxy"
@@ -85,7 +86,7 @@ func CreateRelease(actionConfig *action.Configuration, name, namespace, valueStr
 	if err != nil {
 		// Simulate the Atomic flag and delete the release if failed
 		errDelete := DeleteRelease(actionConfig, name, false)
-		if errDelete != nil {
+		if errDelete != nil && !strings.Contains(errDelete.Error(), "release: not found") {
 			return nil, fmt.Errorf("Release %q failed: %v. Unable to delete failed release: %v", name, err, errDelete)
 		}
 		return nil, fmt.Errorf("Release %q failed and has been uninstalled: %v", name, err)

--- a/pkg/handlerutil/handlerutil.go
+++ b/pkg/handlerutil/handlerutil.go
@@ -43,7 +43,7 @@ func isForbidden(err error) bool {
 }
 
 func isUnprocessable(err error) bool {
-	re := regexp.MustCompile(`release.*failed`)
+	re := regexp.MustCompile(`[rR]elease.*failed`)
 	return re.MatchString(err.Error())
 }
 

--- a/pkg/handlerutil/handlerutil_test.go
+++ b/pkg/handlerutil/handlerutil_test.go
@@ -17,6 +17,7 @@ func TestErrorCodeWithDefault(t *testing.T) {
 		{fmt.Errorf("release foo not found"), http.StatusInternalServerError, http.StatusNotFound},
 		{fmt.Errorf("Unauthorized to get release foo"), http.StatusInternalServerError, http.StatusForbidden},
 		{fmt.Errorf("release \"Foo \" failed"), http.StatusInternalServerError, http.StatusUnprocessableEntity},
+		{fmt.Errorf("Release \"Foo \" failed"), http.StatusInternalServerError, http.StatusUnprocessableEntity},
 		{fmt.Errorf("This is an unexpected error"), http.StatusInternalServerError, http.StatusInternalServerError},
 		{fmt.Errorf("This is an unexpected error"), http.StatusUnprocessableEntity, http.StatusUnprocessableEntity},
 	}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

The goal of this PR is to show an error that really represents the installation status when creating a new release. It gather fixes for #1464, #1508 and #1440.

Now, when there is an error when creating a release, instead of assuming the error, it shows it to the user.

Apart from showing the error, we display a message that changes depending if the error is Kubeapps related (a 500 error) or something else to help people to look for support in the right place.

These are some examples:

Wrong manifest:
![Screenshot from 2020-02-11 11-52-58](https://user-images.githubusercontent.com/4025665/74245108-cdf61d80-4ce2-11ea-86b2-d6609257a1a1.png)

Masked forbidden error:
![Screenshot from 2020-02-11 11-52-19](https://user-images.githubusercontent.com/4025665/74245111-ce8eb400-4ce2-11ea-825c-12c7fd10b7ab.png)

Invalid manifest:
![Screenshot from 2020-02-11 11-47-15](https://user-images.githubusercontent.com/4025665/74245113-cf274a80-4ce2-11ea-8040-656c099a9a64.png)

Missing repository:
![Screenshot from 2020-02-11 11-54-44](https://user-images.githubusercontent.com/4025665/74245106-cd5d8700-4ce2-11ea-99fb-8b4b314e56f4.png)

Only when it's a forbidden error, we keep doing some additional parsing:

![Screenshot from 2020-02-11 15-54-44](https://user-images.githubusercontent.com/4025665/74247749-d9e3de80-4ce6-11ea-96cc-78cc8adfaf72.png)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1464 
  - fixes #1508
  - fixes #1440

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
