### PR TITLE
Add DeleteAppRepository handler and use that from frontend.

### DIFF
--- a/chart/kubeapps/templates/kubeops-rbac.yaml
+++ b/chart/kubeapps/templates/kubeops-rbac.yaml
@@ -16,6 +16,8 @@ rules:
       - secrets
     verbs:
       - get
+      - create
+      - delete
   - apiGroups:
       - "kubeapps.com"
     resources:

--- a/chart/kubeapps/templates/tiller-proxy-rbac.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-rbac.yaml
@@ -16,6 +16,8 @@ rules:
       - secrets
     verbs:
       - get
+      - create
+      - delete
   - apiGroups:
       - "kubeapps.com"
     resources:

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -23,7 +23,9 @@ export class AppRepository {
   }
 
   public static async delete(name: string, namespace: string) {
-    const { data } = await axiosWithAuth.delete(AppRepository.getSelfLink(name, namespace));
+    const { data } = await axiosWithAuth.delete(
+      url.backend.apprepositories.delete(name, namespace),
+    );
     return data;
   }
 

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -13,6 +13,8 @@ export const backend = {
   apprepositories: {
     base: (namespace: string) => `api/v1/namespaces/${namespace}/apprepositories`,
     create: (namespace: string) => backend.apprepositories.base(namespace),
+    delete: (name: string, namespace: string) =>
+      `${backend.apprepositories.base(namespace)}/${name}`,
   },
   namespaces: {
     base: "api/v1/namespaces",


### PR DESCRIPTION
Ref #1496 . Adds a delete handler in the backend and switches the dashboard to use that. Following PR will ensure a repo secret is deleted from the Kubeapps namespace when appropriate.

While there, I've moved the use of `mux` back out to the http-handler. We'll still want to pull out the use of `http.Request` I assume.