### PR TITLE
Delete kubeapps copy of secret if app repo has creds.

### DIFF
--- a/chart/kubeapps/templates/kubeops-rbac.yaml
+++ b/chart/kubeapps/templates/kubeops-rbac.yaml
@@ -16,6 +16,8 @@ rules:
       - secrets
     verbs:
       - get
+      - create
+      - delete
   - apiGroups:
       - "kubeapps.com"
     resources:

--- a/chart/kubeapps/templates/tiller-proxy-rbac.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-rbac.yaml
@@ -16,6 +16,8 @@ rules:
       - secrets
     verbs:
       - get
+      - create
+      - delete
   - apiGroups:
       - "kubeapps.com"
     resources:

--- a/pkg/apprepo/apprepos_handler.go
+++ b/pkg/apprepo/apprepos_handler.go
@@ -212,6 +212,7 @@ func (a *AppRepositoriesHandler) CreateAppRepository(req *http.Request, requestN
 		// https://docs.google.com/document/d/1YEeKC6nPLoq4oaxs9v8_UsmxrRfWxB6KCyqrh2-Q8x0/edit?ts=5e2adf87#heading=h.kilvd2vii0w
 		if requestNamespace != a.kubeappsNamespace {
 			repoSecret.ObjectMeta.Name = kubeappsSecretNameForRepo(appRepo.ObjectMeta.Name, appRepo.ObjectMeta.Namespace)
+			repoSecret.ObjectMeta.OwnerReferences = nil
 			_, err = a.svcKubeClient.CoreV1().Secrets(a.kubeappsNamespace).Create(repoSecret)
 			if err != nil {
 				return nil, err
@@ -227,8 +228,28 @@ func (a *AppRepositoriesHandler) DeleteAppRepository(req *http.Request, repoName
 	if err != nil {
 		return err
 	}
+	appRepo, err := clientset.KubeappsV1alpha1().AppRepositories(repoNamespace).Get(repoName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	hasCredentials := appRepo.Spec.Auth.Header != nil || appRepo.Spec.Auth.CustomCA != nil
+	var propagationPolicy metav1.DeletionPropagation = "Foreground"
+	err = clientset.KubeappsV1alpha1().AppRepositories(repoNamespace).Delete(repoName, &metav1.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	})
+	if err != nil {
+		return err
+	}
 
-	return clientset.KubeappsV1alpha1().AppRepositories(repoNamespace).Delete(repoName, &metav1.DeleteOptions{})
+	// If the app repo was in a namespace other than the kubeapps one, we also delete the copy of
+	// the repository credentials kept in the kubeapps namespace (the repo credentials in the actual
+	// namespace should be deleted when the owning app repo is deleted).
+	// TODO(mnelson) Ensure secret in the app repo namespace is created with owner references so it is
+	// deleted with the AppRepo.
+	if hasCredentials && repoNamespace != a.kubeappsNamespace {
+		err = clientset.CoreV1().Secrets(a.kubeappsNamespace).Delete(kubeappsSecretNameForRepo(repoName, repoNamespace), &metav1.DeleteOptions{})
+	}
+	return err
 }
 
 // appRepositoryForRequest takes care of parsing the request data into an AppRepository.
@@ -307,7 +328,7 @@ func secretForRequest(appRepoRequest appRepositoryRequest, appRepo *v1alpha1.App
 }
 
 func secretNameForRepo(repoName string) string {
-	return fmt.Sprintf("apprepo-%s-secrets", repoName)
+	return fmt.Sprintf("apprepo-%s", repoName)
 }
 
 // kubeappsSecretNameForRepo returns a name suitable for recording a copy of

--- a/pkg/apprepo/apprepos_handler.go
+++ b/pkg/apprepo/apprepos_handler.go
@@ -244,8 +244,6 @@ func (a *AppRepositoriesHandler) DeleteAppRepository(req *http.Request, repoName
 	// If the app repo was in a namespace other than the kubeapps one, we also delete the copy of
 	// the repository credentials kept in the kubeapps namespace (the repo credentials in the actual
 	// namespace should be deleted when the owning app repo is deleted).
-	// TODO(mnelson) Ensure secret in the app repo namespace is created with owner references so it is
-	// deleted with the AppRepo.
 	if hasCredentials && repoNamespace != a.kubeappsNamespace {
 		err = clientset.CoreV1().Secrets(a.kubeappsNamespace).Delete(kubeappsSecretNameForRepo(repoName, repoNamespace), &metav1.DeleteOptions{})
 	}

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -73,6 +73,7 @@ func DeleteAppRepository(appRepo apprepo.Handler) func(w http.ResponseWriter, re
 	return func(w http.ResponseWriter, req *http.Request) {
 		repoNamespace := mux.Vars(req)["namespace"]
 		repoName := mux.Vars(req)["name"]
+
 		err := appRepo.DeleteAppRepository(req, repoName, repoNamespace)
 
 		if err != nil {

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -73,7 +73,6 @@ func DeleteAppRepository(appRepo apprepo.Handler) func(w http.ResponseWriter, re
 	return func(w http.ResponseWriter, req *http.Request) {
 		repoNamespace := mux.Vars(req)["namespace"]
 		repoName := mux.Vars(req)["name"]
-
 		err := appRepo.DeleteAppRepository(req, repoName, repoNamespace)
 
 		if err != nil {


### PR DESCRIPTION
Explicitly delete kubeapps copy of secret when app repo with creds is deleted. Ensure normal secret deleted by propagation (tried to test, but as per comment, k8s fake client doesn't do finalizers/propagation, so tested IRL).

Fixed a couple of other things that I found with IRL testing: missing RBAC for service to create/delete secrets in its own namespace, as well as the name of created secrets: removed useless suffix of `-secret`.

Ref: #1496. Follows #1514 
