### PR TITLE
Remove HTTP references from pkg/apprepo

### DIFF
--- a/pkg/http-handler/http-handler_test.go
+++ b/pkg/http-handler/http-handler_test.go
@@ -19,7 +19,7 @@ package httphandler
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -40,15 +40,15 @@ type FakeHandler struct {
 	err        error
 }
 
-func (c *FakeHandler) CreateAppRepository(req *http.Request, namespace string) (*v1alpha1.AppRepository, error) {
+func (c *FakeHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace, token string) (*v1alpha1.AppRepository, error) {
 	return c.appRepo, c.err
 }
 
-func (c *FakeHandler) DeleteAppRepository(req *http.Request, name, namespace string) error {
+func (c *FakeHandler) DeleteAppRepository(name, namespace, token string) error {
 	return c.err
 }
 
-func (c *FakeHandler) GetNamespaces(req *http.Request) ([]corev1.Namespace, error) {
+func (c *FakeHandler) GetNamespaces(token string) ([]corev1.Namespace, error) {
 	return c.namespaces, c.err
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Requires #1516

Finally remove all references to the HTTP request from the `pkg/apprepo`. This allow us to to be able to use the package from `pkg/chart`.

