### PR TITLE
Move all k8s resources operations to pkg/apprepo

### DIFF
--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -45,9 +45,15 @@ func main() {
 	pflag.Parse()
 	settings.Init(pflag.CommandLine)
 
+	kubeappsNamespace := os.Getenv("POD_NAMESPACE")
+	if kubeappsNamespace == "" {
+		log.Fatal("POD_NAMESPACE should be defined")
+	}
+
 	options := handler.Options{
-		ListLimit: listLimit,
-		Timeout:   timeout,
+		ListLimit:         listLimit,
+		Timeout:           timeout,
+		KubeappsNamespace: kubeappsNamespace,
 	}
 
 	storageForDriver := agent.StorageForSecrets

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -131,6 +131,10 @@ func main() {
 
 	proxy = tillerProxy.NewProxy(kubeClient, helmClient, timeout)
 	kubeappsNamespace := os.Getenv("POD_NAMESPACE")
+	if kubeappsNamespace == "" {
+		log.Fatalf("POD_NAMESPACE should be defined")
+	}
+
 	appRepoHandler, err := apprepo.NewAppRepositoriesHandler(kubeappsNamespace)
 	if err != nil {
 		log.Fatalf("Failed to create handler: %v", err)

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/heptiolabs/healthcheck"
-	appRepo "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
 	"github.com/kubeapps/kubeapps/cmd/tiller-proxy/internal/handler"
+	"github.com/kubeapps/kubeapps/pkg/apprepo"
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
 	"github.com/kubeapps/kubeapps/pkg/handlerutil"
@@ -99,11 +99,6 @@ func main() {
 		log.Fatalf("Unable to create a kubernetes client: %v", err)
 	}
 
-	appRepoClient, err := appRepo.NewForConfig(config)
-	if err != nil {
-		log.Fatalf("Unable to create an app repository client: %v", err)
-	}
-
 	log.Printf("Using tiller host: %s", settings.TillerHost)
 	helmOptions := []helm.Option{helm.Host(settings.TillerHost)}
 	if tlsVerify || tlsEnable {
@@ -135,7 +130,13 @@ func main() {
 	}
 
 	proxy = tillerProxy.NewProxy(kubeClient, helmClient, timeout)
-	chartClient := chartUtils.NewChartClient(kubeClient, appRepoClient, userAgent())
+	kubeappsNamespace := os.Getenv("POD_NAMESPACE")
+	appRepoHandler, err := apprepo.NewAppRepositoriesHandler(kubeappsNamespace)
+	if err != nil {
+		log.Fatalf("Failed to create handler: %v", err)
+	}
+
+	chartClient := chartUtils.NewChartClient(appRepoHandler, kubeappsNamespace, userAgent())
 
 	r := mux.NewRouter()
 

--- a/go.sum
+++ b/go.sum
@@ -582,6 +582,7 @@ k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/helm v2.16.0+incompatible h1:btXM7zx8MHBmnuO8KQH07rkw65tH2gYU+IMqz1xC++M=
 k8s.io/helm v2.16.0+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
+k8s.io/helm v2.16.3+incompatible h1:MGUcXcG1uAXWZmxu4vzzgRjZOnfFUsSJbHgqM+kyqzM=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=

--- a/pkg/apprepo/apprepos_handler.go
+++ b/pkg/apprepo/apprepos_handler.go
@@ -52,35 +52,56 @@ type combinedClientset struct {
 	*kubernetes.Clientset
 }
 
-// AppRepositoriesHandler handles http requests for operating on app repositories
+// appRepositoriesHandler handles http requests for operating on app repositories
 // in Kubeapps, without exposing implementation details to 3rd party integrations.
-type AppRepositoriesHandler struct {
+type appRepositoriesHandler struct {
 	// The config set internally here cannot be used on its own as a valid
-	// token is required. Call-sites use ConfigForToken to obtain a valid
+	// token is required. Call-sites use configForToken to obtain a valid
 	// config with a specific token.
 	config rest.Config
 
 	// The namespace in which (currently) app repositories are created.
 	kubeappsNamespace string
 
-	// The Kubernetes client using the pod serviceaccount
-	svcKubeClient kubernetes.Interface
+	// clientset using the pod serviceaccount
+	svcClientset combinedClientsetInterface
 
 	// clientsetForConfig is a field on the struct only so it can be switched
-	// for a fake version when testing. NewAppRepositoryHandler sets it to the
+	// for a fake version when testing. NewAppRepositoryhandler sets it to the
 	// proper function below so that production code always has the real
 	// version (and since this is a private struct, external code cannot change
 	// the function).
 	clientsetForConfig func(*rest.Config) (combinedClientsetInterface, error)
+
+	clientset combinedClientsetInterface
 }
 
-// Handler exposes the handler method for testing purposes
-type Handler interface {
-	CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace, token string) (*v1alpha1.AppRepository, error)
-	DeleteAppRepository(name, namespace, token string) error
-	GetNamespaces(token string) ([]corev1.Namespace, error)
-	GetSecret(name, namespace, token string) (*corev1.Secret, error)
-	GetAppRepository(repoName, repoNamespace, token string) (*v1alpha1.AppRepository, error)
+type handler interface {
+	CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error)
+	DeleteAppRepository(name, namespace string) error
+	GetNamespaces() ([]corev1.Namespace, error)
+	GetSecret(name, namespace string) (*corev1.Secret, error)
+	GetAppRepository(repoName, repoNamespace string) (*v1alpha1.AppRepository, error)
+}
+
+// AuthHandler exposes handler functionality as a user or the current serviceaccount
+type AuthHandler interface {
+	AsUser(token string) handler
+	AsSVC() handler
+}
+
+func (a *appRepositoriesHandler) AsUser(token string) handler {
+	clientset, err := a.clientsetForConfig(a.configForToken(token))
+	if err != nil {
+		log.Errorf("unable to create clientset: %v", err)
+	}
+	a.clientset = clientset
+	return a
+}
+
+func (a *appRepositoriesHandler) AsSVC() handler {
+	a.clientset = a.svcClientset
+	return a
 }
 
 // appRepositoryRequest is used to parse the JSON request
@@ -99,8 +120,8 @@ type appRepositoryRequestDetails struct {
 
 // NewAppRepositoriesHandler returns an AppRepositories and Kubernetes handler configured with
 // the in-cluster config but overriding the token with an empty string, so that
-// ConfigForToken must be called to obtain a valid config.
-func NewAppRepositoriesHandler(kubeappsNamespace string) (*AppRepositoriesHandler, error) {
+// configForToken must be called to obtain a valid config.
+func NewAppRepositoriesHandler(kubeappsNamespace string) (AuthHandler, error) {
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{
@@ -127,13 +148,17 @@ func NewAppRepositoriesHandler(kubeappsNamespace string) (*AppRepositoriesHandle
 	if err != nil {
 		return nil, err
 	}
+	svcAppRepoClient, err := apprepoclientset.NewForConfig(svcRestConfig)
+	if err != nil {
+		return nil, err
+	}
 
-	return &AppRepositoriesHandler{
+	return &appRepositoriesHandler{
 		config:            *config,
 		kubeappsNamespace: kubeappsNamespace,
 		// See comment in the struct defn above.
 		clientsetForConfig: clientsetForConfig,
-		svcKubeClient:      svcKubeClient,
+		svcClientset:       &combinedClientset{svcAppRepoClient, svcKubeClient},
 	}, nil
 }
 
@@ -150,17 +175,15 @@ func clientsetForConfig(config *rest.Config) (combinedClientsetInterface, error)
 	return &combinedClientset{arclientset, coreclientset}, nil
 }
 
-// ConfigForToken returns a new config for a given auth token.
-func (a *AppRepositoriesHandler) ConfigForToken(token string) *rest.Config {
+// configForToken returns a new config for a given auth token.
+func (a *appRepositoriesHandler) configForToken(token string) *rest.Config {
 	configCopy := a.config
-	if token != "" {
-		configCopy.BearerToken = token
-	}
+	configCopy.BearerToken = token
 	return &configCopy
 }
 
-func (a *AppRepositoriesHandler) clientsetForRequest(token string) (combinedClientsetInterface, error) {
-	clientset, err := a.clientsetForConfig(a.ConfigForToken(token))
+func (a *appRepositoriesHandler) clientsetForRequest(token string) (combinedClientsetInterface, error) {
+	clientset, err := a.clientsetForConfig(a.configForToken(token))
 	if err != nil {
 		log.Errorf("unable to create clientset: %v", err)
 	}
@@ -168,20 +191,14 @@ func (a *AppRepositoriesHandler) clientsetForRequest(token string) (combinedClie
 }
 
 // CreateAppRepository creates an AppRepository resource based on the request data
-func (a *AppRepositoriesHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace, token string) (*v1alpha1.AppRepository, error) {
+func (a *appRepositoriesHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error) {
 	if a.kubeappsNamespace == "" {
 		log.Errorf("attempt to use app repositories handler without kubeappsNamespace configured")
 		return nil, fmt.Errorf("kubeappsNamespace must be configured to enable app repository handler")
 	}
 
-	clientset, err := a.clientsetForRequest(token)
-	if err != nil {
-		log.Errorf("unable to create clientset: %v", err)
-		return nil, err
-	}
-
 	var appRepoRequest appRepositoryRequest
-	err = json.NewDecoder(appRepoBody).Decode(&appRepoRequest)
+	err := json.NewDecoder(appRepoBody).Decode(&appRepoRequest)
 	if err != nil {
 		log.Infof("unable to decode: %v", err)
 		return nil, err
@@ -191,7 +208,7 @@ func (a *AppRepositoriesHandler) CreateAppRepository(appRepoBody io.ReadCloser, 
 
 	// TODO(mnelson): validate both required data and request for index
 	// https://github.com/kubeapps/kubeapps/issues/1330
-	appRepo, err = clientset.KubeappsV1alpha1().AppRepositories(requestNamespace).Create(appRepo)
+	appRepo, err = a.clientset.KubeappsV1alpha1().AppRepositories(requestNamespace).Create(appRepo)
 
 	if err != nil {
 		return nil, err
@@ -199,7 +216,7 @@ func (a *AppRepositoriesHandler) CreateAppRepository(appRepoBody io.ReadCloser, 
 
 	repoSecret := secretForRequest(appRepoRequest, appRepo)
 	if repoSecret != nil {
-		_, err = clientset.CoreV1().Secrets(requestNamespace).Create(repoSecret)
+		_, err = a.clientset.CoreV1().Secrets(requestNamespace).Create(repoSecret)
 		if err != nil {
 			return nil, err
 		}
@@ -215,7 +232,7 @@ func (a *AppRepositoriesHandler) CreateAppRepository(appRepoBody io.ReadCloser, 
 		if requestNamespace != a.kubeappsNamespace {
 			repoSecret.ObjectMeta.Name = kubeappsSecretNameForRepo(appRepo.ObjectMeta.Name, appRepo.ObjectMeta.Namespace)
 			repoSecret.ObjectMeta.OwnerReferences = nil
-			_, err = a.svcKubeClient.CoreV1().Secrets(a.kubeappsNamespace).Create(repoSecret)
+			_, err = a.svcClientset.CoreV1().Secrets(a.kubeappsNamespace).Create(repoSecret)
 			if err != nil {
 				return nil, err
 			}
@@ -225,18 +242,14 @@ func (a *AppRepositoriesHandler) CreateAppRepository(appRepoBody io.ReadCloser, 
 }
 
 // DeleteAppRepository deletes an AppRepository resource from a namespace.
-func (a *AppRepositoriesHandler) DeleteAppRepository(repoName, repoNamespace, token string) error {
-	clientset, err := a.clientsetForRequest(token)
-	if err != nil {
-		return err
-	}
-	appRepo, err := clientset.KubeappsV1alpha1().AppRepositories(repoNamespace).Get(repoName, metav1.GetOptions{})
+func (a *appRepositoriesHandler) DeleteAppRepository(repoName, repoNamespace string) error {
+	appRepo, err := a.clientset.KubeappsV1alpha1().AppRepositories(repoNamespace).Get(repoName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 	hasCredentials := appRepo.Spec.Auth.Header != nil || appRepo.Spec.Auth.CustomCA != nil
 	var propagationPolicy metav1.DeletionPropagation = "Foreground"
-	err = clientset.KubeappsV1alpha1().AppRepositories(repoNamespace).Delete(repoName, &metav1.DeleteOptions{
+	err = a.clientset.KubeappsV1alpha1().AppRepositories(repoNamespace).Delete(repoName, &metav1.DeleteOptions{
 		PropagationPolicy: &propagationPolicy,
 	})
 	if err != nil {
@@ -247,19 +260,15 @@ func (a *AppRepositoriesHandler) DeleteAppRepository(repoName, repoNamespace, to
 	// the repository credentials kept in the kubeapps namespace (the repo credentials in the actual
 	// namespace should be deleted when the owning app repo is deleted).
 	if hasCredentials && repoNamespace != a.kubeappsNamespace {
-		err = clientset.CoreV1().Secrets(a.kubeappsNamespace).Delete(kubeappsSecretNameForRepo(repoName, repoNamespace), &metav1.DeleteOptions{})
+		err = a.clientset.CoreV1().Secrets(a.kubeappsNamespace).Delete(kubeappsSecretNameForRepo(repoName, repoNamespace), &metav1.DeleteOptions{})
 	}
 	return err
 }
 
 // GetAppRepository returns an AppRepository resource from a namespace.
 // Optionally set a token to get the AppRepository using a custom serviceaccount
-func (a *AppRepositoriesHandler) GetAppRepository(repoName, repoNamespace, token string) (*v1alpha1.AppRepository, error) {
-	clientset, err := a.clientsetForRequest(token)
-	if err != nil {
-		return nil, err
-	}
-	return clientset.KubeappsV1alpha1().AppRepositories(repoNamespace).Get(repoName, metav1.GetOptions{})
+func (a *appRepositoriesHandler) GetAppRepository(repoName, repoNamespace string) (*v1alpha1.AppRepository, error) {
+	return a.clientset.KubeappsV1alpha1().AppRepositories(repoNamespace).Get(repoName, metav1.GetOptions{})
 }
 
 // appRepositoryForRequest takes care of parsing the request data into an AppRepository.
@@ -374,25 +383,20 @@ func filterAllowedNamespaces(userClientset combinedClientsetInterface, namespace
 // TODO(andresmgot): I am adding this method in this package for simplicity
 // (since it already allows to impersonate the user)
 // We should refactor this code to make it more generic (not apprepository-specific)
-func (a *AppRepositoriesHandler) GetNamespaces(token string) ([]corev1.Namespace, error) {
-	userClientset, err := a.clientsetForRequest(token)
-	if err != nil {
-		return nil, err
-	}
-
+func (a *appRepositoriesHandler) GetNamespaces() ([]corev1.Namespace, error) {
 	// Try to list namespaces with the user token, for backward compatibility
-	namespaces, err := userClientset.CoreV1().Namespaces().List(metav1.ListOptions{})
+	namespaces, err := a.clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		if k8sErrors.IsForbidden(err) {
 			// The user doesn't have permissions to list namespaces, use the current serviceaccount
-			namespaces, err = a.svcKubeClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+			namespaces, err = a.svcClientset.CoreV1().Namespaces().List(metav1.ListOptions{})
 		}
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	allowedNamespaces, err := filterAllowedNamespaces(userClientset, namespaces)
+	allowedNamespaces, err := filterAllowedNamespaces(a.clientset, namespaces)
 	if err != nil {
 		return nil, err
 	}
@@ -401,11 +405,6 @@ func (a *AppRepositoriesHandler) GetNamespaces(token string) ([]corev1.Namespace
 }
 
 // GetSecret return the a secret from a namespace using a token if given
-func (a *AppRepositoriesHandler) GetSecret(name, namespace, token string) (*corev1.Secret, error) {
-	userClientset, err := a.clientsetForRequest(token)
-	if err != nil {
-		return nil, err
-	}
-
-	return userClientset.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+func (a *appRepositoriesHandler) GetSecret(name, namespace string) (*corev1.Secret, error) {
+	return a.clientset.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
 }

--- a/pkg/apprepo/apprepos_handler_test.go
+++ b/pkg/apprepo/apprepos_handler_test.go
@@ -182,11 +182,10 @@ func TestAppRepositoryCreate(t *testing.T) {
 				fakeapprepoclientset.NewSimpleClientset(makeAppRepoObjects(tc.existingRepos)...),
 				fakecoreclientset.NewSimpleClientset(),
 			}
-			handler := appRepositoriesHandler{
-				clientsetForConfig: func(*rest.Config) (combinedClientsetInterface, error) { return cs, nil },
-				kubeappsNamespace:  tc.kubeappsNamespace,
-				svcClientset:       cs,
-				clientset:          cs,
+			handler := userHandler{
+				kubeappsNamespace: tc.kubeappsNamespace,
+				svcClientset:      cs,
+				clientset:         cs,
 			}
 
 			apprepo, err := handler.CreateAppRepository(ioutil.NopCloser(strings.NewReader(tc.requestData)), tc.requestNamespace)
@@ -313,10 +312,10 @@ func TestDeleteAppRepository(t *testing.T) {
 			handler := appRepositoriesHandler{
 				clientsetForConfig: func(*rest.Config) (combinedClientsetInterface, error) { return cs, nil },
 				kubeappsNamespace:  kubeappsNamespace,
-				clientset:          cs,
+				svcClientset:       cs,
 			}
 
-			err := handler.DeleteAppRepository(tc.repoName, tc.requestNamespace)
+			err := handler.AsSVC().DeleteAppRepository(tc.repoName, tc.requestNamespace)
 
 			if got, want := errorCodeForK8sError(t, err), tc.expectedErrorCode; got != want {
 				t.Errorf("got: %d, want: %d", got, want)
@@ -644,10 +643,10 @@ func TestGetNamespaces(t *testing.T) {
 			handler := appRepositoriesHandler{
 				clientsetForConfig: func(*rest.Config) (combinedClientsetInterface, error) { return cs, nil },
 				kubeappsNamespace:  "kubeapps",
-				clientset:          cs,
+				svcClientset:       cs,
 			}
 
-			namespaces, err := handler.GetNamespaces()
+			namespaces, err := handler.AsSVC().GetNamespaces()
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}

--- a/pkg/apprepo/fake.go
+++ b/pkg/apprepo/fake.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fake
+package apprepo
 
 import (
 	"fmt"
@@ -24,8 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// Handler represents a fake Handler for testing purposes
-type Handler struct {
+// FakeHandler represents a fake Handler for testing purposes
+type FakeHandler struct {
 	AppRepos    []*v1alpha1.AppRepository
 	CreatedRepo *v1alpha1.AppRepository
 	Namespaces  []corev1.Namespace
@@ -33,19 +33,29 @@ type Handler struct {
 	Err         error
 }
 
+// AsUser fakes user auth
+func (c *FakeHandler) AsUser(token string) handler {
+	return c
+}
+
+// AsSVC fakes using current svcaccount
+func (c *FakeHandler) AsSVC() handler {
+	return c
+}
+
 // CreateAppRepository fake
-func (c *Handler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace, token string) (*v1alpha1.AppRepository, error) {
+func (c *FakeHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error) {
 	c.AppRepos = append(c.AppRepos, c.CreatedRepo)
 	return c.CreatedRepo, c.Err
 }
 
 // DeleteAppRepository fake
-func (c *Handler) DeleteAppRepository(name, namespace, token string) error {
+func (c *FakeHandler) DeleteAppRepository(name, namespace string) error {
 	return c.Err
 }
 
 // GetAppRepository fake
-func (c *Handler) GetAppRepository(name, namespace, token string) (*v1alpha1.AppRepository, error) {
+func (c *FakeHandler) GetAppRepository(name, namespace string) (*v1alpha1.AppRepository, error) {
 	for _, r := range c.AppRepos {
 		if r.Name == name && r.Namespace == namespace {
 			return r, nil
@@ -55,12 +65,12 @@ func (c *Handler) GetAppRepository(name, namespace, token string) (*v1alpha1.App
 }
 
 // GetNamespaces fake
-func (c *Handler) GetNamespaces(token string) ([]corev1.Namespace, error) {
+func (c *FakeHandler) GetNamespaces() ([]corev1.Namespace, error) {
 	return c.Namespaces, c.Err
 }
 
 // GetSecret fake
-func (c *Handler) GetSecret(name, namespace, token string) (*corev1.Secret, error) {
+func (c *FakeHandler) GetSecret(name, namespace string) (*corev1.Secret, error) {
 	for _, r := range c.Secrets {
 		if r.Name == name && r.Namespace == namespace {
 			return r, nil

--- a/pkg/apprepo/fake/apprepo-fake.go
+++ b/pkg/apprepo/fake/apprepo-fake.go
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2019 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+	"io"
+
+	v1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Handler represents a fake Handler for testing purposes
+type Handler struct {
+	AppRepos    []*v1alpha1.AppRepository
+	CreatedRepo *v1alpha1.AppRepository
+	Namespaces  []corev1.Namespace
+	Secrets     []*corev1.Secret
+	Err         error
+}
+
+// CreateAppRepository fake
+func (c *Handler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace, token string) (*v1alpha1.AppRepository, error) {
+	c.AppRepos = append(c.AppRepos, c.CreatedRepo)
+	return c.CreatedRepo, c.Err
+}
+
+// DeleteAppRepository fake
+func (c *Handler) DeleteAppRepository(name, namespace, token string) error {
+	return c.Err
+}
+
+// GetAppRepository fake
+func (c *Handler) GetAppRepository(name, namespace, token string) (*v1alpha1.AppRepository, error) {
+	for _, r := range c.AppRepos {
+		if r.Name == name && r.Namespace == namespace {
+			return r, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+// GetNamespaces fake
+func (c *Handler) GetNamespaces(token string) ([]corev1.Namespace, error) {
+	return c.Namespaces, c.Err
+}
+
+// GetSecret fake
+func (c *Handler) GetSecret(name, namespace, token string) (*corev1.Secret, error) {
+	for _, r := range c.Secrets {
+		if r.Name == name && r.Namespace == namespace {
+			return r, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -35,10 +35,8 @@ import (
 
 	"github.com/ghodss/yaml"
 	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	// appRepoClientSet "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
 	helm3chart "helm.sh/helm/v3/pkg/chart"
 	helm3loader "helm.sh/helm/v3/pkg/chart/loader"
-	// "k8s.io/client-go/kubernetes"
 	helm2loader "k8s.io/helm/pkg/chartutil"
 	helm2chart "k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/repo"

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -364,7 +364,6 @@ func TestInitNetClient(t *testing.T) {
 				"custom-secret-key": []byte(authHeaderSecretData),
 			},
 		}}
-		fmt.Println(tc.name)
 
 		apprepos := []*appRepov1.AppRepository{&appRepov1.AppRepository{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/arschles/assert"
 	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	fakeAppRepo "github.com/kubeapps/kubeapps/pkg/apprepo/fake"
+	"github.com/kubeapps/kubeapps/pkg/apprepo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	chartv2 "k8s.io/helm/pkg/proto/hapi/chart"
@@ -374,7 +374,7 @@ func TestInitNetClient(t *testing.T) {
 		}}
 
 		chUtils := ChartClient{
-			appRepoHandler:    &fakeAppRepo.Handler{Secrets: secrets, AppRepos: apprepos},
+			appRepoHandler:    &apprepo.FakeHandler{Secrets: secrets, AppRepos: apprepos},
 			kubeappsNamespace: metav1.NamespaceSystem,
 		}
 

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -52,11 +52,11 @@ func returnK8sError(err error, w http.ResponseWriter) {
 }
 
 // CreateAppRepository creates App Repository
-func CreateAppRepository(appRepo apprepo.Handler) func(w http.ResponseWriter, req *http.Request) {
+func CreateAppRepository(handler apprepo.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		requestNamespace := mux.Vars(req)["namespace"]
 		token := auth.ExtractToken(req.Header.Get("Authorization"))
-		appRepo, err := appRepo.CreateAppRepository(req.Body, requestNamespace, token)
+		appRepo, err := handler.AsUser(token).CreateAppRepository(req.Body, requestNamespace)
 		if err != nil {
 			returnK8sError(err, w)
 			return
@@ -75,13 +75,13 @@ func CreateAppRepository(appRepo apprepo.Handler) func(w http.ResponseWriter, re
 }
 
 // DeleteAppRepository deletes an App Repository
-func DeleteAppRepository(appRepo apprepo.Handler) func(w http.ResponseWriter, req *http.Request) {
+func DeleteAppRepository(appRepo apprepo.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		repoNamespace := mux.Vars(req)["namespace"]
 		repoName := mux.Vars(req)["name"]
 		token := auth.ExtractToken(req.Header.Get("Authorization"))
 
-		err := appRepo.DeleteAppRepository(repoName, repoNamespace, token)
+		err := appRepo.AsUser(token).DeleteAppRepository(repoName, repoNamespace)
 
 		if err != nil {
 			returnK8sError(err, w)
@@ -90,10 +90,10 @@ func DeleteAppRepository(appRepo apprepo.Handler) func(w http.ResponseWriter, re
 }
 
 // GetNamespaces return the list of namespaces
-func GetNamespaces(appRepo apprepo.Handler) func(w http.ResponseWriter, req *http.Request) {
+func GetNamespaces(appRepo apprepo.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		token := auth.ExtractToken(req.Header.Get("Authorization"))
-		namespaces, err := appRepo.GetNamespaces(token)
+		namespaces, err := appRepo.AsUser(token).GetNamespaces()
 		if err != nil {
 			returnK8sError(err, w)
 		}

--- a/pkg/http-handler/http-handler_test.go
+++ b/pkg/http-handler/http-handler_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
-	"github.com/kubeapps/kubeapps/pkg/apprepo/fake"
+	"github.com/kubeapps/kubeapps/pkg/apprepo"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,7 +59,7 @@ func TestCreateAppRepository(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			createAppFunc := CreateAppRepository(&fake.Handler{CreatedRepo: tc.appRepo, Err: tc.err})
+			createAppFunc := CreateAppRepository(&apprepo.FakeHandler{CreatedRepo: tc.appRepo, Err: tc.err})
 			req := httptest.NewRequest("POST", "https://foo.bar/backend/v1/namespaces/kubeapps/apprepositories", strings.NewReader("data"))
 			req = mux.SetURLVars(req, map[string]string{"namespace": "kubeapps"})
 
@@ -108,7 +108,7 @@ func TestDeleteAppRepository(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			deleteAppFunc := DeleteAppRepository(&fake.Handler{Err: tc.err})
+			deleteAppFunc := DeleteAppRepository(&apprepo.FakeHandler{Err: tc.err})
 			req := httptest.NewRequest("POST", "https://foo.bar/backend/v1/namespaces/kubeapps/apprepositories", strings.NewReader("data"))
 			req = mux.SetURLVars(req, map[string]string{"namespace": "kubeapps"})
 
@@ -142,7 +142,7 @@ func TestGetNamespaces(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			getNSFunc := GetNamespaces(&fake.Handler{Namespaces: tc.namespaces, Err: tc.err})
+			getNSFunc := GetNamespaces(&apprepo.FakeHandler{Namespaces: tc.namespaces, Err: tc.err})
 			req := httptest.NewRequest("GET", "https://foo.bar/backend/v1/namespaces", nil)
 
 			response := httptest.NewRecorder()

--- a/pkg/http-handler/http-handler_test.go
+++ b/pkg/http-handler/http-handler_test.go
@@ -19,13 +19,13 @@ package httphandler
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
+	"github.com/kubeapps/kubeapps/pkg/apprepo/fake"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,24 +33,6 @@ import (
 
 	v1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 )
-
-type FakeHandler struct {
-	appRepo    *v1alpha1.AppRepository
-	namespaces []corev1.Namespace
-	err        error
-}
-
-func (c *FakeHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace, token string) (*v1alpha1.AppRepository, error) {
-	return c.appRepo, c.err
-}
-
-func (c *FakeHandler) DeleteAppRepository(name, namespace, token string) error {
-	return c.err
-}
-
-func (c *FakeHandler) GetNamespaces(token string) ([]corev1.Namespace, error) {
-	return c.namespaces, c.err
-}
 
 func TestCreateAppRepository(t *testing.T) {
 	testCases := []struct {
@@ -77,7 +59,7 @@ func TestCreateAppRepository(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			createAppFunc := CreateAppRepository(&FakeHandler{appRepo: tc.appRepo, namespaces: []corev1.Namespace{}, err: tc.err})
+			createAppFunc := CreateAppRepository(&fake.Handler{CreatedRepo: tc.appRepo, Err: tc.err})
 			req := httptest.NewRequest("POST", "https://foo.bar/backend/v1/namespaces/kubeapps/apprepositories", strings.NewReader("data"))
 			req = mux.SetURLVars(req, map[string]string{"namespace": "kubeapps"})
 
@@ -126,7 +108,7 @@ func TestDeleteAppRepository(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			deleteAppFunc := DeleteAppRepository(&FakeHandler{appRepo: nil, namespaces: []corev1.Namespace{}, err: tc.err})
+			deleteAppFunc := DeleteAppRepository(&fake.Handler{Err: tc.err})
 			req := httptest.NewRequest("POST", "https://foo.bar/backend/v1/namespaces/kubeapps/apprepositories", strings.NewReader("data"))
 			req = mux.SetURLVars(req, map[string]string{"namespace": "kubeapps"})
 
@@ -160,7 +142,7 @@ func TestGetNamespaces(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			getNSFunc := GetNamespaces(&FakeHandler{appRepo: nil, namespaces: tc.namespaces, err: tc.err})
+			getNSFunc := GetNamespaces(&fake.Handler{Namespaces: tc.namespaces, Err: tc.err})
 			req := httptest.NewRequest("GET", "https://foo.bar/backend/v1/namespaces", nil)
 
 			response := httptest.NewRecorder()


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Requires #1517

The goal of this PR is to complete the migration to the existing operations over k8s resources to the package `pkg/apprepo` (the name of the package is to be changed). The advantage of this package is that it allow callers to set a `token`. If set, it uses that token to do requests, if not it uses the backend serviceaccount.

Now the package `pkg/chart` uses this package thanks to the implementation of the methods `GetAppRepository` and `GetSecret` that use the same approach for the `token`.

The fake Handler has been moved to its own package so it can be reused.
