### PR TITLE
1496 asset sync namespaces

### DIFF
--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -64,6 +64,9 @@ spec:
             {{- if .Values.apprepository.crontab }}
             - --crontab={{ .Values.apprepository.crontab }}
             {{- end }}
+            {{- if .Values.featureFlags.reposPerNamespace }}
+            - --repos-per-namespace
+            {{- end }}
           {{- if .Values.apprepository.resources }}
           resources: {{- toYaml .Values.apprepository.resources | nindent 12 }}
           {{- end }}

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -55,6 +55,9 @@ const (
 	// existing.
 	ErrResourceExists = "ErrResourceExists"
 
+	LabelRepoName      = "apprepositories.kubeapps.com/repo-name"
+	LabelRepoNamespace = "apprepositories.kubeapps.com/repo-namespace"
+
 	// MessageResourceExists is the message used for Events when a resource
 	// fails to sync due to a CronJob already existing
 	MessageResourceExists = "Resource %q already exists and is not managed by AppRepository"
@@ -84,6 +87,8 @@ type Controller struct {
 	// recorder is an event recorder for recording Event resources to the
 	// Kubernetes API.
 	recorder record.EventRecorder
+
+	kubeappsNamespace string
 }
 
 // NewController returns a new sample controller
@@ -91,7 +96,8 @@ func NewController(
 	kubeclientset kubernetes.Interface,
 	apprepoclientset clientset.Interface,
 	kubeInformerFactory kubeinformers.SharedInformerFactory,
-	apprepoInformerFactory informers.SharedInformerFactory) *Controller {
+	apprepoInformerFactory informers.SharedInformerFactory,
+	kubeappsNamespace string) *Controller {
 
 	// obtain references to shared index informers for the CronJob and
 	// AppRepository types.
@@ -109,14 +115,15 @@ func NewController(
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 
 	controller := &Controller{
-		kubeclientset:    kubeclientset,
-		apprepoclientset: apprepoclientset,
-		cronjobsLister:   cronjobInformer.Lister(),
-		cronjobsSynced:   cronjobInformer.Informer().HasSynced,
-		appreposLister:   apprepoInformer.Lister(),
-		appreposSynced:   apprepoInformer.Informer().HasSynced,
-		workqueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AppRepositories"),
-		recorder:         recorder,
+		kubeclientset:     kubeclientset,
+		apprepoclientset:  apprepoclientset,
+		cronjobsLister:    cronjobInformer.Lister(),
+		cronjobsSynced:    cronjobInformer.Informer().HasSynced,
+		appreposLister:    apprepoInformer.Lister(),
+		appreposSynced:    apprepoInformer.Informer().HasSynced,
+		workqueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AppRepositories"),
+		recorder:          recorder,
+		kubeappsNamespace: kubeappsNamespace,
 	}
 
 	log.Info("Setting up event handlers")
@@ -262,7 +269,7 @@ func (c *Controller) syncHandler(key string) error {
 		if errors.IsNotFound(err) {
 			log.Infof("AppRepository '%s' no longer exists so performing cleanup of charts from the DB", key)
 			// Trigger a Job to perfrom the cleanup of the charts in the DB corresponding to deleted AppRepository
-			_, err = c.kubeclientset.BatchV1().Jobs(namespace).Create(newCleanupJob(name, namespace))
+			_, err = c.kubeclientset.BatchV1().Jobs(namespace).Create(newCleanupJob(name, namespace, c.kubeappsNamespace))
 			return nil
 		}
 		return fmt.Errorf("Error fetching object with key %s from store: %v", key, err)
@@ -270,27 +277,27 @@ func (c *Controller) syncHandler(key string) error {
 
 	// Get the cronjob with the same name as AppRepository
 	cronjobName := cronJobName(apprepo)
-	cronjob, err := c.cronjobsLister.CronJobs(apprepo.Namespace).Get(cronjobName)
+	cronjob, err := c.cronjobsLister.CronJobs(c.kubeappsNamespace).Get(cronjobName)
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {
 		log.Infof("Creating CronJob %q for AppRepository %q", cronjobName, apprepo.GetName())
-		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(apprepo.Namespace).Create(newCronJob(apprepo))
+		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(c.kubeappsNamespace).Create(newCronJob(apprepo, c.kubeappsNamespace))
 		if err != nil {
 			return err
 		}
 
 		// Trigger a manual Job for the initial sync
-		_, err = c.kubeclientset.BatchV1().Jobs(apprepo.Namespace).Create(newSyncJob(apprepo))
+		_, err = c.kubeclientset.BatchV1().Jobs(c.kubeappsNamespace).Create(newSyncJob(apprepo, c.kubeappsNamespace))
 	} else if err == nil {
 		// If the resource already exists, we'll update it
-		log.Infof("Updating CronJob %q for AppRepository %q", cronjobName, apprepo.GetName())
-		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(apprepo.Namespace).Update(newCronJob(apprepo))
+		log.Infof("Updating CronJob %q in namespace %q for AppRepository %q in namespace %q", cronjobName, c.kubeappsNamespace, apprepo.GetName(), apprepo.GetNamespace())
+		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(c.kubeappsNamespace).Update(newCronJob(apprepo, c.kubeappsNamespace))
 		if err != nil {
 			return err
 		}
 
 		// The AppRepository has changed, launch a manual Job
-		_, err = c.kubeclientset.BatchV1().Jobs(apprepo.Namespace).Create(newSyncJob(apprepo))
+		_, err = c.kubeclientset.BatchV1().Jobs(c.kubeappsNamespace).Create(newSyncJob(apprepo, c.kubeappsNamespace))
 	}
 
 	// If an error occurs during Get/Create, we'll requeue the item so we can
@@ -300,9 +307,11 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	// If the CronJob is not controlled by this AppRepository resource, we should
-	// log a warning to the event recorder and ret
-	if !metav1.IsControlledBy(cronjob, apprepo) {
+	// If the CronJob is not controlled by this AppRepository resource and it is not a
+	// cronjob for an app repo in another namespace, then we should
+	// log a warning to the event recorder and return it.
+	if !metav1.IsControlledBy(cronjob, apprepo) && !objectBelongsTo(cronjob, apprepo) {
+		log.Errorf("Cronjob: %+v\nAppRepo: %+v", cronjob.ObjectMeta, apprepo.ObjectMeta)
 		msg := fmt.Sprintf(MessageResourceExists, cronjob.Name)
 		c.recorder.Event(apprepo, corev1.EventTypeWarning, ErrResourceExists, msg)
 		return fmt.Errorf(msg)
@@ -315,8 +324,17 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	c.recorder.Event(apprepo, corev1.EventTypeNormal, SuccessSynced, MessageResourceSynced)
+	if apprepo.GetNamespace() == c.kubeappsNamespace {
+		c.recorder.Event(apprepo, corev1.EventTypeNormal, SuccessSynced, MessageResourceSynced)
+	}
 	return nil
+}
+
+// belongsTo is similar to IsControlledBy, but enables us to establish a relationship
+// between cronjobs and app repositories in different namespaces.
+func objectBelongsTo(object, parent metav1.Object) bool {
+	labels := object.GetLabels()
+	return labels[LabelRepoName] == parent.GetName() && labels[LabelRepoNamespace] == parent.GetNamespace()
 }
 
 // enqueueAppRepo takes a AppRepository resource and converts it into a namespace/name
@@ -367,26 +385,40 @@ func (c *Controller) handleObject(obj interface{}) {
 			return
 		}
 
+		if apprepo.ObjectMeta.DeletionTimestamp != nil {
+			log.Infof("ignoring object %q of AppRepository %q with deletion timestamp %q", object.GetSelfLink(), ownerRef.Name, apprepo.ObjectMeta.DeletionTimestamp)
+			return
+		}
+
 		c.enqueueAppRepo(apprepo)
 		return
 	}
 }
 
+// ownerReferencesForAppRepo returns populated owner references for app repos in the same namespace
+// as the cronjob and nil otherwise.
+func ownerReferencesForAppRepo(apprepo *apprepov1alpha1.AppRepository, childNamespace string) []metav1.OwnerReference {
+	if apprepo.GetNamespace() == childNamespace {
+		return []metav1.OwnerReference{
+			*metav1.NewControllerRef(apprepo, schema.GroupVersionKind{
+				Group:   apprepov1alpha1.SchemeGroupVersion.Group,
+				Version: apprepov1alpha1.SchemeGroupVersion.Version,
+				Kind:    "AppRepository",
+			}),
+		}
+	}
+	return nil
+}
+
 // newCronJob creates a new CronJob for a AppRepository resource. It also sets
 // the appropriate OwnerReferences on the resource so handleObject can discover
 // the AppRepository resource that 'owns' it.
-func newCronJob(apprepo *apprepov1alpha1.AppRepository) *batchv1beta1.CronJob {
+func newCronJob(apprepo *apprepov1alpha1.AppRepository, kubeappsNamespace string) *batchv1beta1.CronJob {
 	return &batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cronJobName(apprepo),
-			Namespace: apprepo.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(apprepo, schema.GroupVersionKind{
-					Group:   apprepov1alpha1.SchemeGroupVersion.Group,
-					Version: apprepov1alpha1.SchemeGroupVersion.Version,
-					Kind:    "AppRepository",
-				}),
-			},
+			Name:            cronJobName(apprepo),
+			OwnerReferences: ownerReferencesForAppRepo(apprepo, kubeappsNamespace),
+			Labels:          jobLabels(apprepo),
 		},
 		Spec: batchv1beta1.CronJobSpec{
 			Schedule: crontab,
@@ -403,18 +435,11 @@ func newCronJob(apprepo *apprepov1alpha1.AppRepository) *batchv1beta1.CronJob {
 
 // newSyncJob triggers a job for the AppRepository resource. It also sets the
 // appropriate OwnerReferences on the resource
-func newSyncJob(apprepo *apprepov1alpha1.AppRepository) *batchv1.Job {
+func newSyncJob(apprepo *apprepov1alpha1.AppRepository, kubeappsNamespace string) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: cronJobName(apprepo) + "-",
-			Namespace:    apprepo.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(apprepo, schema.GroupVersionKind{
-					Group:   apprepov1alpha1.SchemeGroupVersion.Group,
-					Version: apprepov1alpha1.SchemeGroupVersion.Version,
-					Kind:    "AppRepository",
-				}),
-			},
+			GenerateName:    cronJobName(apprepo) + "-",
+			OwnerReferences: ownerReferencesForAppRepo(apprepo, kubeappsNamespace),
 		},
 		Spec: syncJobSpec(apprepo),
 	}
@@ -475,11 +500,11 @@ func syncJobSpec(apprepo *apprepov1alpha1.AppRepository) batchv1.JobSpec {
 
 // newCleanupJob triggers a job for the AppRepository resource. It also sets the
 // appropriate OwnerReferences on the resource
-func newCleanupJob(reponame, namespace string) *batchv1.Job {
+func newCleanupJob(reponame, namespace, kubeappsNamespace string) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: deleteJobName(reponame) + "-",
-			Namespace:    namespace,
+			GenerateName: deleteJobName(reponame, namespace) + "-",
+			Namespace:    kubeappsNamespace,
 		},
 		Spec: cleanupJobSpec(reponame),
 	}
@@ -519,18 +544,19 @@ func cleanupJobSpec(repoName string) batchv1.JobSpec {
 // jobLabels returns the labels for the job and cronjob resources
 func jobLabels(apprepo *apprepov1alpha1.AppRepository) map[string]string {
 	return map[string]string{
-		"apprepositories.kubeapps.com/repo-name": apprepo.Name,
+		LabelRepoName:      apprepo.GetName(),
+		LabelRepoNamespace: apprepo.GetNamespace(),
 	}
 }
 
 // cronJobName returns a unique name for the CronJob managed by an AppRepository
 func cronJobName(apprepo *apprepov1alpha1.AppRepository) string {
-	return fmt.Sprintf("apprepo-sync-%s", apprepo.GetName())
+	return fmt.Sprintf("apprepo-%s-sync-%s", apprepo.GetNamespace(), apprepo.GetName())
 }
 
 // deleteJobName returns a unique name for the Job to cleanup AppRepository
-func deleteJobName(reponame string) string {
-	return fmt.Sprintf("apprepo-cleanup-%s", reponame)
+func deleteJobName(reponame, reponamespace string) string {
+	return fmt.Sprintf("apprepo-%s-cleanup-%s", reponamespace, reponame)
 }
 
 // apprepoSyncJobArgs returns a list of args for the sync container

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -311,7 +311,6 @@ func (c *Controller) syncHandler(key string) error {
 	// cronjob for an app repo in another namespace, then we should
 	// log a warning to the event recorder and return it.
 	if !metav1.IsControlledBy(cronjob, apprepo) && !objectBelongsTo(cronjob, apprepo) {
-		log.Errorf("Cronjob: %+v\nAppRepo: %+v", cronjob.ObjectMeta, apprepo.ObjectMeta)
 		msg := fmt.Sprintf(MessageResourceExists, cronjob.Name)
 		c.recorder.Event(apprepo, corev1.EventTypeWarning, ErrResourceExists, msg)
 		return fmt.Errorf(msg)

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -17,6 +17,7 @@ func Test_newCronJob(t *testing.T) {
 	dbName = "assets"
 	dbUser = "admin"
 	dbSecretName = "mongodb"
+	const kubeappsNamespace = "kubeapps"
 	tests := []struct {
 		name             string
 		apprepo          *apprepov1alpha1.AppRepository
@@ -46,8 +47,7 @@ func Test_newCronJob(t *testing.T) {
 			},
 			batchv1beta1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "apprepo-sync-my-charts",
-					Namespace: "kubeapps",
+					Name: "apprepo-kubeapps-sync-my-charts",
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(
 							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
@@ -57,6 +57,10 @@ func Test_newCronJob(t *testing.T) {
 								Kind:    "AppRepository",
 							}),
 					},
+					Labels: map[string]string{
+						LabelRepoName:      "my-charts",
+						LabelRepoNamespace: "kubeapps",
+					},
 				},
 				Spec: batchv1beta1.CronJobSpec{
 					Schedule:          "*/10 * * * *",
@@ -65,7 +69,10 @@ func Test_newCronJob(t *testing.T) {
 						Spec: batchv1.JobSpec{
 							Template: corev1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Labels: map[string]string{"apprepositories.kubeapps.com/repo-name": "my-charts"},
+									Labels: map[string]string{
+										LabelRepoName:      "my-charts",
+										LabelRepoNamespace: "kubeapps",
+									},
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: "OnFailure",
@@ -129,8 +136,7 @@ func Test_newCronJob(t *testing.T) {
 			},
 			batchv1beta1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "apprepo-sync-my-charts",
-					Namespace: "kubeapps",
+					Name: "apprepo-kubeapps-sync-my-charts",
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(
 							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
@@ -140,6 +146,10 @@ func Test_newCronJob(t *testing.T) {
 								Kind:    "AppRepository",
 							}),
 					},
+					Labels: map[string]string{
+						LabelRepoName:      "my-charts",
+						LabelRepoNamespace: "kubeapps",
+					},
 				},
 				Spec: batchv1beta1.CronJobSpec{
 					Schedule:          "*/20 * * * *",
@@ -148,7 +158,10 @@ func Test_newCronJob(t *testing.T) {
 						Spec: batchv1.JobSpec{
 							Template: corev1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Labels: map[string]string{"apprepositories.kubeapps.com/repo-name": "my-charts"},
+									Labels: map[string]string{
+										LabelRepoName:      "my-charts",
+										LabelRepoNamespace: "kubeapps",
+									},
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: "OnFailure",
@@ -204,9 +217,9 @@ func Test_newCronJob(t *testing.T) {
 				crontab = tt.crontab
 				defer func() { crontab = "" }()
 			}
-			result := newCronJob(tt.apprepo)
-			if diff := deep.Equal(tt.expected, *result); diff != nil {
-				t.Error(diff)
+			result := newCronJob(tt.apprepo, kubeappsNamespace)
+			if got, want := *result, tt.expected; !cmp.Equal(want, got) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}
 		})
 	}
@@ -217,6 +230,7 @@ func Test_newSyncJob(t *testing.T) {
 	dbName = "assets"
 	dbUser = "admin"
 	dbSecretName = "mongodb"
+	const kubeappsNamespace = "kubeapps"
 	tests := []struct {
 		name             string
 		apprepo          *apprepov1alpha1.AppRepository
@@ -245,8 +259,7 @@ func Test_newSyncJob(t *testing.T) {
 			},
 			batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "apprepo-sync-my-charts-",
-					Namespace:    "kubeapps",
+					GenerateName: "apprepo-kubeapps-sync-my-charts-",
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(
 							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
@@ -261,7 +274,75 @@ func Test_newSyncJob(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{"apprepositories.kubeapps.com/repo-name": "my-charts"},
+							Labels: map[string]string{
+								LabelRepoName:      "my-charts",
+								LabelRepoNamespace: "kubeapps",
+							},
+						},
+						Spec: corev1.PodSpec{
+							RestartPolicy: "OnFailure",
+							Containers: []corev1.Container{
+								{
+									Name:    "sync",
+									Image:   repoSyncImage,
+									Command: []string{"/chart-repo"},
+									Args: []string{
+										"sync",
+										"--database-type=mongodb",
+										"--database-url=mongodb.kubeapps",
+										"--database-user=admin",
+										"--database-name=assets",
+										"my-charts",
+										"https://charts.acme.com/my-charts",
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: "DB_PASSWORD",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "mongodb"}, Key: "mongodb-root-password"}},
+										},
+									},
+									VolumeMounts: nil,
+								},
+							},
+							Volumes: nil,
+						},
+					},
+				},
+			},
+			"",
+		},
+		{
+			"an app repository in another namespace results in jobs without owner references",
+			&apprepov1alpha1.AppRepository{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AppRepository",
+					APIVersion: "kubeapps.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-charts",
+					Namespace: "my-other-namespace",
+					Labels: map[string]string{
+						"name":       "my-charts",
+						"created-by": "kubeapps",
+					},
+				},
+				Spec: apprepov1alpha1.AppRepositorySpec{
+					Type: "helm",
+					URL:  "https://charts.acme.com/my-charts",
+				},
+			},
+			batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "apprepo-my-other-namespace-sync-my-charts-",
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								LabelRepoName:      "my-charts",
+								LabelRepoNamespace: "my-other-namespace",
+							},
 						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: "OnFailure",
@@ -322,8 +403,7 @@ func Test_newSyncJob(t *testing.T) {
 			},
 			batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "apprepo-sync-my-charts-",
-					Namespace:    "kubeapps",
+					GenerateName: "apprepo-kubeapps-sync-my-charts-",
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(
 							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
@@ -338,7 +418,10 @@ func Test_newSyncJob(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{"apprepositories.kubeapps.com/repo-name": "my-charts"},
+							Labels: map[string]string{
+								LabelRepoName:      "my-charts",
+								LabelRepoNamespace: "kubeapps",
+							},
 						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: "OnFailure",
@@ -406,8 +489,7 @@ func Test_newSyncJob(t *testing.T) {
 			},
 			batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "apprepo-sync-my-charts-",
-					Namespace:    "kubeapps",
+					GenerateName: "apprepo-kubeapps-sync-my-charts-",
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(
 							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
@@ -422,7 +504,10 @@ func Test_newSyncJob(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{"apprepositories.kubeapps.com/repo-name": "my-charts"},
+							Labels: map[string]string{
+								LabelRepoName:      "my-charts",
+								LabelRepoNamespace: "kubeapps",
+							},
 						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: "OnFailure",
@@ -501,8 +586,7 @@ func Test_newSyncJob(t *testing.T) {
 			},
 			batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "apprepo-sync-my-charts-",
-					Namespace:    "kubeapps",
+					GenerateName: "apprepo-kubeapps-sync-my-charts-",
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(
 							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
@@ -517,7 +601,10 @@ func Test_newSyncJob(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{"apprepositories.kubeapps.com/repo-name": "my-charts"},
+							Labels: map[string]string{
+								LabelRepoName:      "my-charts",
+								LabelRepoNamespace: "kubeapps",
+							},
 						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: "OnFailure",
@@ -612,8 +699,7 @@ func Test_newSyncJob(t *testing.T) {
 			},
 			batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "apprepo-sync-my-charts-",
-					Namespace:    "kubeapps",
+					GenerateName: "apprepo-kubeapps-sync-my-charts-",
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(
 							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
@@ -629,8 +715,9 @@ func Test_newSyncJob(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"apprepositories.kubeapps.com/repo-name": "my-charts",
-								"foo":                                    "bar",
+								LabelRepoName:      "my-charts",
+								LabelRepoNamespace: "kubeapps",
+								"foo":              "bar",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -677,9 +764,9 @@ func Test_newSyncJob(t *testing.T) {
 				defer func() { userAgentComment = "" }()
 			}
 
-			result := newSyncJob(tt.apprepo)
-			if diff := deep.Equal(tt.expected, *result); diff != nil {
-				t.Error(diff)
+			result := newSyncJob(tt.apprepo, kubeappsNamespace)
+			if got, want := *result, tt.expected; !cmp.Equal(want, got) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}
 		})
 	}
@@ -690,6 +777,8 @@ func Test_newCleanupJob(t *testing.T) {
 	dbName = "assets"
 	dbUser = "admin"
 	dbSecretName = "mongodb"
+	const kubeappsNamespace = "kubeapps"
+
 	tests := []struct {
 		name      string
 		repoName  string
@@ -702,7 +791,7 @@ func Test_newCleanupJob(t *testing.T) {
 			"kubeapps",
 			batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "apprepo-cleanup-my-charts-",
+					GenerateName: "apprepo-kubeapps-cleanup-my-charts-",
 					Namespace:    "kubeapps",
 				},
 				Spec: batchv1.JobSpec{
@@ -740,9 +829,67 @@ func Test_newCleanupJob(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := newCleanupJob(tt.repoName, tt.namespace)
-			if diff := deep.Equal(tt.expected, *result); diff != nil {
-				t.Error(diff)
+			result := newCleanupJob(tt.repoName, tt.namespace, kubeappsNamespace)
+			if got, want := *result, tt.expected; !cmp.Equal(want, got) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func TestObjectBelongsTo(t *testing.T) {
+	testCases := []struct {
+		name   string
+		object metav1.Object
+		parent metav1.Object
+		expect bool
+	}{
+		{
+			name: "it recognises a cronjob belonging to an app repository in another namespace",
+			object: &batchv1beta1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "apprepo-kubeapps-sync-my-charts",
+					Namespace: "kubeapps",
+					Labels: map[string]string{
+						LabelRepoName:      "my-charts",
+						LabelRepoNamespace: "my-namespace",
+					},
+				},
+			},
+			parent: &apprepov1alpha1.AppRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-charts",
+					Namespace: "my-namespace",
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "it returns false if the namespace does not match",
+			object: &batchv1beta1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "apprepo-kubeapps-sync-my-charts",
+					Namespace: "kubeapps",
+					Labels: map[string]string{
+						LabelRepoName:      "my-charts",
+						LabelRepoNamespace: "my-namespace",
+					},
+				},
+			},
+			parent: &apprepov1alpha1.AppRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-charts",
+					Namespace: "my-namespace2",
+				},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, want := objectBelongsTo(tc.object, tc.parent), tc.expect; got != want {
+				t.Errorf("got: %t, want: %t", got, want)
 			}
 		})
 	}

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -85,20 +85,53 @@ actionTestCases.forEach(tc => {
 
 // Async action creators
 describe("deleteRepo", () => {
-  it("dispatches requestRepos and receivedRepos after deletion if no error", async () => {
-    const expectedActions = [
-      {
-        type: getType(repoActions.requestRepos),
-        payload: kubeappsNamespace,
-      },
-      {
-        type: getType(repoActions.receiveRepos),
-        payload: { foo: "bar" },
-      },
-    ];
+  context("dispatches requestRepos and receivedRepos after deletion if no error", async () => {
+    const currentNamespace = "current-namespace";
+    it("dispatches requestRepos with kubeapps namespace when reposPerNamespace is not set", async () => {
+      const storeWithFlag: any = mockStore({
+        config: {
+          namespace: kubeappsNamespace,
+          featureFlags: { reposPerNamespace: false },
+        },
+        namespace: { current: currentNamespace },
+      });
+      const expectedActions = [
+        {
+          type: getType(repoActions.requestRepos),
+          payload: kubeappsNamespace,
+        },
+        {
+          type: getType(repoActions.receiveRepos),
+          payload: { foo: "bar" },
+        },
+      ];
 
-    await store.dispatch(repoActions.deleteRepo("foo", "my-namespace"));
-    expect(store.getActions()).toEqual(expectedActions);
+      await storeWithFlag.dispatch(repoActions.deleteRepo("foo", "my-namespace"));
+      expect(storeWithFlag.getActions()).toEqual(expectedActions);
+    });
+
+    it("dispatches requestRepos with current namespace when reposPerNamespace is set", async () => {
+      const storeWithFlag: any = mockStore({
+        config: {
+          namespace: kubeappsNamespace,
+          featureFlags: { reposPerNamespace: true },
+        },
+        namespace: { current: currentNamespace },
+      });
+      const expectedActions = [
+        {
+          type: getType(repoActions.requestRepos),
+          payload: currentNamespace,
+        },
+        {
+          type: getType(repoActions.receiveRepos),
+          payload: { foo: "bar" },
+        },
+      ];
+
+      await storeWithFlag.dispatch(repoActions.deleteRepo("foo", "my-namespace"));
+      expect(storeWithFlag.getActions()).toEqual(expectedActions);
+    });
   });
 
   it("dispatches errorRepos if error deleting", async () => {

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -70,10 +70,14 @@ export const deleteRepo = (
   return async (dispatch, getState) => {
     const {
       namespace: { current },
+      config: { namespace: kubeappsNamespace, featureFlags },
     } = getState();
     try {
       await AppRepository.delete(name, namespace);
-      dispatch(fetchRepos(current));
+      const fetchFromNamespace: string = featureFlags.reposPerNamespace
+        ? current
+        : kubeappsNamespace;
+      dispatch(fetchRepos(fetchFromNamespace));
       return true;
     } catch (e) {
       dispatch(errorRepos(e, "delete"));


### PR DESCRIPTION
Ref :1496

With this change, the controller spawns cronjobs/jobs in the kubeapps namespace and successfully sync's public app repositories across all namespaces.

I also noticed that I was initially unable to delete app repositories in the kubeapps namespace, they'd stay in a deleting state with a finalizer. Turned out to be because the app repo controller was recreating cronjobs as soon as k8s was deleting them (as they were owned by the app repo).

The main changes are:
 * extra cli arg when the feature flag is set, which updates the informer to receive events on app repositories cluster wide,
 * Updating the controller struct to include a field for the kubeapps namespace so we can differentiate,
 * Updating so that OwnerReferences are only added for resources created in the same namespace as the app repository (ie. only for repos in the kubeapps namespace), as owner references are only allowed for resources in the same namespace
 * Allow controller to recognise a parent app repo even if it's not an owner, to avoid creating events for an app repo in another namespace (for now).

TODO:
* I QA'd with the switch on to verify it works, but haven't gone back and QA'd to ensure things work fine without the flag (ran out of time)
* Ensure for app repos from other namespaces with repo creds that the secret is included with the job (from the kubeapps copy).