### PR TITLE
Rename apprepo for kube handler

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -8,11 +8,11 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/kubeapps/common/response"
 	"github.com/kubeapps/kubeapps/pkg/agent"
-	"github.com/kubeapps/kubeapps/pkg/apprepo"
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
 	"github.com/kubeapps/kubeapps/pkg/chart/helm3to2"
 	"github.com/kubeapps/kubeapps/pkg/handlerutil"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
 	"helm.sh/helm/v3/pkg/action"
@@ -92,7 +92,7 @@ func WithHandlerConfig(storageForDriver agent.StorageForDriver, options Options)
 				return
 			}
 
-			appRepoHandler, err := apprepo.NewAppRepositoriesHandler(options.KubeappsNamespace)
+			kubeHandler, err := kube.NewHandler(options.KubeappsNamespace)
 			if err != nil {
 				log.Errorf("Failed to create handler: %v", err)
 				response.NewErrorResponse(http.StatusInternalServerError, authUserError).Write(w)
@@ -102,7 +102,7 @@ func WithHandlerConfig(storageForDriver agent.StorageForDriver, options Options)
 			cfg := Config{
 				Options:      options,
 				ActionConfig: actionConfig,
-				ChartClient:  chartUtils.NewChartClient(appRepoHandler, options.KubeappsNamespace, options.UserAgent),
+				ChartClient:  chartUtils.NewChartClient(kubeHandler, options.KubeappsNamespace, options.UserAgent),
 			}
 			f(cfg, w, req, params)
 		}

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -30,11 +30,11 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/heptiolabs/healthcheck"
 	"github.com/kubeapps/kubeapps/cmd/tiller-proxy/internal/handler"
-	"github.com/kubeapps/kubeapps/pkg/apprepo"
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
 	"github.com/kubeapps/kubeapps/pkg/handlerutil"
 	backendHandlers "github.com/kubeapps/kubeapps/pkg/http-handler"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 	tillerProxy "github.com/kubeapps/kubeapps/pkg/proxy"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -135,12 +135,12 @@ func main() {
 		log.Fatalf("POD_NAMESPACE should be defined")
 	}
 
-	appRepoHandler, err := apprepo.NewAppRepositoriesHandler(kubeappsNamespace)
+	kubeHandler, err := kube.NewHandler(kubeappsNamespace)
 	if err != nil {
 		log.Fatalf("Failed to create handler: %v", err)
 	}
 
-	chartClient := chartUtils.NewChartClient(appRepoHandler, kubeappsNamespace, userAgent())
+	chartClient := chartUtils.NewChartClient(kubeHandler, kubeappsNamespace, userAgent())
 
 	r := mux.NewRouter()
 

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -23,7 +23,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"github.com/kubeapps/kubeapps/pkg/apprepo"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 	"io"
 	"io/ioutil"
 	"log"
@@ -99,14 +99,14 @@ type Resolver interface {
 
 // ChartClient struct contains the clients required to retrieve charts info
 type ChartClient struct {
-	appRepoHandler    apprepo.AuthHandler
+	appRepoHandler    kube.AuthHandler
 	userAgent         string
 	kubeappsNamespace string
 	appRepo           *appRepov1.AppRepository
 }
 
 // NewChartClient returns a new ChartClient
-func NewChartClient(appRepoHandler apprepo.AuthHandler, kubeappsNamespace, userAgent string) *ChartClient {
+func NewChartClient(appRepoHandler kube.AuthHandler, kubeappsNamespace, userAgent string) *ChartClient {
 	return &ChartClient{
 		appRepoHandler:    appRepoHandler,
 		userAgent:         userAgent,

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/arschles/assert"
 	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	"github.com/kubeapps/kubeapps/pkg/apprepo"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	chartv2 "k8s.io/helm/pkg/proto/hapi/chart"
@@ -374,7 +374,7 @@ func TestInitNetClient(t *testing.T) {
 		}}
 
 		chUtils := ChartClient{
-			appRepoHandler:    &apprepo.FakeHandler{Secrets: secrets, AppRepos: apprepos},
+			appRepoHandler:    &kube.FakeHandler{Secrets: secrets, AppRepos: apprepos},
 			kubeappsNamespace: metav1.NamespaceSystem,
 		}
 

--- a/pkg/http-handler/http-handler_test.go
+++ b/pkg/http-handler/http-handler_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
-	"github.com/kubeapps/kubeapps/pkg/apprepo"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,7 +59,7 @@ func TestCreateAppRepository(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			createAppFunc := CreateAppRepository(&apprepo.FakeHandler{CreatedRepo: tc.appRepo, Err: tc.err})
+			createAppFunc := CreateAppRepository(&kube.FakeHandler{CreatedRepo: tc.appRepo, Err: tc.err})
 			req := httptest.NewRequest("POST", "https://foo.bar/backend/v1/namespaces/kubeapps/apprepositories", strings.NewReader("data"))
 			req = mux.SetURLVars(req, map[string]string{"namespace": "kubeapps"})
 
@@ -108,7 +108,7 @@ func TestDeleteAppRepository(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			deleteAppFunc := DeleteAppRepository(&apprepo.FakeHandler{Err: tc.err})
+			deleteAppFunc := DeleteAppRepository(&kube.FakeHandler{Err: tc.err})
 			req := httptest.NewRequest("POST", "https://foo.bar/backend/v1/namespaces/kubeapps/apprepositories", strings.NewReader("data"))
 			req = mux.SetURLVars(req, map[string]string{"namespace": "kubeapps"})
 
@@ -142,7 +142,7 @@ func TestGetNamespaces(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			getNSFunc := GetNamespaces(&apprepo.FakeHandler{Namespaces: tc.namespaces, Err: tc.err})
+			getNSFunc := GetNamespaces(&kube.FakeHandler{Namespaces: tc.namespaces, Err: tc.err})
 			req := httptest.NewRequest("GET", "https://foo.bar/backend/v1/namespaces", nil)
 
 			response := httptest.NewRecorder()

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apprepo
+package kube
 
 import (
 	"fmt"

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apprepo
+package kube
 
 import (
 	"encoding/json"
@@ -309,7 +309,7 @@ func TestDeleteAppRepository(t *testing.T) {
 				fakeapprepoclientset.NewSimpleClientset(makeAppRepoObjects(tc.existingRepos)...),
 				fakecoreclientset.NewSimpleClientset(makeSecretsForRepos(tc.existingRepos, kubeappsNamespace)...),
 			}
-			handler := appRepositoriesHandler{
+			handler := kubeHandler{
 				clientsetForConfig: func(*rest.Config) (combinedClientsetInterface, error) { return cs, nil },
 				kubeappsNamespace:  kubeappsNamespace,
 				svcClientset:       cs,
@@ -353,7 +353,7 @@ func errorCodeForK8sError(t *testing.T, err error) int {
 }
 
 func TestConfigForToken(t *testing.T) {
-	handler := appRepositoriesHandler{
+	handler := kubeHandler{
 		config: rest.Config{},
 	}
 	token := "abcd"
@@ -640,7 +640,7 @@ func TestGetNamespaces(t *testing.T) {
 				},
 			)
 
-			handler := appRepositoriesHandler{
+			handler := kubeHandler{
 				clientsetForConfig: func(*rest.Config) (combinedClientsetInterface, error) { return cs, nil },
 				kubeappsNamespace:  "kubeapps",
 				svcClientset:       cs,


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Final piece of refactoring I was working on. Renaming the package `apprepo` for `kube` since it's not only related to AppRepositories but other resources like namespaces or secrets.

