### PR TITLE
Use correct secret in kubeapps namespace when syncing an app repo

### DIFF
--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -205,6 +205,92 @@ func Test_newCronJob(t *testing.T) {
 			"kubeapps/v2.3",
 			"*/20 * * * *",
 		},
+		{
+			"it references the repo secret in kubeapps",
+			&apprepov1alpha1.AppRepository{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AppRepository",
+					APIVersion: "kubeapps.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-charts-in-otherns",
+					Namespace: "otherns",
+					Labels: map[string]string{
+						"name":       "my-charts",
+						"created-by": "kubeapps",
+					},
+				},
+				Spec: apprepov1alpha1.AppRepositorySpec{
+					Type: "helm",
+					URL:  "https://charts.acme.com/my-charts",
+					Auth: apprepov1alpha1.AppRepositoryAuth{
+						Header: &apprepov1alpha1.AppRepositoryAuthHeader{
+							SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "apprepo-my-charts-in-otherns"}, Key: "AuthorizationHeader"}},
+					},
+				},
+			},
+			batchv1beta1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "apprepo-otherns-sync-my-charts-in-otherns",
+					Labels: map[string]string{
+						LabelRepoName:      "my-charts-in-otherns",
+						LabelRepoNamespace: "otherns",
+					},
+				},
+				Spec: batchv1beta1.CronJobSpec{
+					Schedule:          "*/20 * * * *",
+					ConcurrencyPolicy: "Replace",
+					JobTemplate: batchv1beta1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{
+										LabelRepoName:      "my-charts-in-otherns",
+										LabelRepoNamespace: "otherns",
+									},
+								},
+								Spec: corev1.PodSpec{
+									RestartPolicy: "OnFailure",
+									Containers: []corev1.Container{
+										{
+											Name:    "sync",
+											Image:   repoSyncImage,
+											Command: []string{"/chart-repo"},
+											Args: []string{
+												"sync",
+												"--database-type=mongodb",
+												"--database-url=mongodb.kubeapps",
+												"--database-user=admin",
+												"--database-name=assets",
+												"--user-agent-comment=kubeapps/v2.3",
+												"my-charts-in-otherns",
+												"https://charts.acme.com/my-charts",
+											},
+											Env: []corev1.EnvVar{
+												{
+													Name: "DB_PASSWORD",
+													ValueFrom: &corev1.EnvVarSource{
+														SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "mongodb"}, Key: "mongodb-root-password"}},
+												},
+												{
+													Name: "AUTHORIZATION_HEADER",
+													ValueFrom: &corev1.EnvVarSource{
+														SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "otherns-apprepo-my-charts-in-otherns"}, Key: "AuthorizationHeader"}},
+												},
+											},
+											VolumeMounts: nil,
+										},
+									},
+									Volumes: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			"kubeapps/v2.3",
+			"*/20 * * * *",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -206,7 +206,7 @@ func Test_newCronJob(t *testing.T) {
 			"*/20 * * * *",
 		},
 		{
-			"it references the repo secret in kubeapps",
+			"a cronjob for an app repo in another namespace references the repo secret in kubeapps",
 			&apprepov1alpha1.AppRepository{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "AppRepository",

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -85,7 +85,7 @@ func makeSecretsForRepos(reposPerNamespace map[string][]repoStub, kubeappsNamesp
 			if namespace != kubeappsNamespace {
 				var appRepo runtime.Object = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      kubeappsSecretNameForRepo(repoStub.name, namespace),
+						Name:      KubeappsSecretNameForRepo(repoStub.name, namespace),
 						Namespace: kubeappsNamespace,
 					},
 				}
@@ -236,7 +236,7 @@ func TestAppRepositoryCreate(t *testing.T) {
 
 					// Verify the copy of the repo secret in in kubeapps is
 					// also stored if this is a per-namespace app repository.
-					kubeappsSecretName := kubeappsSecretNameForRepo(expectedAppRepo.ObjectMeta.Name, expectedAppRepo.ObjectMeta.Namespace)
+					kubeappsSecretName := KubeappsSecretNameForRepo(expectedAppRepo.ObjectMeta.Name, expectedAppRepo.ObjectMeta.Namespace)
 					expectedSecret.ObjectMeta.Name = kubeappsSecretName
 					expectedSecret.ObjectMeta.Namespace = tc.kubeappsNamespace
 					// The owner ref cannot be present for the copy in the kubeapps namespace.
@@ -332,7 +332,7 @@ func TestDeleteAppRepository(t *testing.T) {
 				// because the fake client does not handle finalizers but verified in real life.
 
 				// Ensure any copy of the repo credentials has been deleted from the kubeapps namespace.
-				_, err = cs.CoreV1().Secrets(kubeappsNamespace).Get(kubeappsSecretNameForRepo(tc.repoName, tc.requestNamespace), metav1.GetOptions{})
+				_, err = cs.CoreV1().Secrets(kubeappsNamespace).Get(KubeappsSecretNameForRepo(tc.repoName, tc.requestNamespace), metav1.GetOptions{})
 				if got, want := errorCodeForK8sError(t, err), 404; got != want {
 					t.Errorf("got: %d, want: %d", got, want)
 				}


### PR DESCRIPTION
Updates the cronjob spec so that, when an app repository is from a namespace other than kubeapps, the correct secret ref is used for the repo.

Ref: #1521 .
