### PR TITLE
Replace kubeops image when releasing a chart

### DIFF
--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -88,6 +88,7 @@ updateRepo() {
     replaceImage apprepository-controller "${targetChartPath}/values.yaml"
     replaceImage asset-syncer "${targetChartPath}/values.yaml"
     replaceImage assetsvc "${targetChartPath}/values.yaml"
+    replaceImage kubeops "${targetChartPath}/values.yaml"
 }
 
 commitAndPushChanges() {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

The image for `kubeops` was missing from the list that is changed when generating the released chart (so it was pointing to the dev image).