### PR TITLE
Kubeops manifests to follow YAML best practices

### DIFF
--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -20,50 +20,48 @@ spec:
         app: {{ template "kubeapps.kubeops.fullname" . }}
         release: {{ .Release.Name }}
     spec:
+{{- include "kubeapps.imagePullSecrets" . | indent 6 }}
       serviceAccountName: {{ template "kubeapps.kubeops.fullname" . }}
       # Increase termination timeout to let remaining operations to finish before killing the pods
       # This is because new releases/upgrades/deletions are synchronous operations
       terminationGracePeriodSeconds: 300
-{{- include "kubeapps.imagePullSecrets" . | indent 6 }}
-      containers:
-      - name: kubeops
-        image: {{ template "kubeapps.image" (list .Values.kubeops.image .Values.global) }}
-        command:
-        - /kubeops
-        args:
-        - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
-        - --assetsvc-url=http://{{ template "kubeapps.assetsvc.fullname" . }}:{{ .Values.assetsvc.service.port }}
-        ports:
-        - name: http
-          containerPort: {{ .Values.kubeops.service.port }}
-        {{- if .Values.kubeops.livenessProbe }}
-        livenessProbe: {{- toYaml .Values.kubeops.livenessProbe | nindent 12 }}
-        {{- end }}
-        {{- if .Values.kubeops.readinessProbe }}
-        readinessProbe: {{- toYaml .Values.kubeops.readinessProbe | nindent 12 }}
-        {{- end }}
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        resources:
-{{ toYaml .Values.kubeops.resources | indent 12 }}
-    {{- with .Values.kubeops.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+      {{- if .Values.kubeops.affinity }}
+      affinity: {{- include "kubeapps.tplValue" (dict "value" .Values.kubeops.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubeops.nodeSelector }}
+      nodeSelector: {{- include "kubeapps.tplValue" (dict "value" .Values.kubeops.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubeops.tolerations }}
+      tolerations: {{- include "kubeapps.tplValue" (dict "value" .Values.kubeops.tolerations "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
-    {{- with .Values.kubeops.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.kubeops.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+      containers:
+        - name: kubeops
+          image: {{ template "kubeapps.image" (list .Values.kubeops.image .Values.global) }}
+          command:
+            - /kubeops
+          args:
+            - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
+            - --assetsvc-url=http://{{ template "kubeapps.assetsvc.fullname" . }}:{{ .Values.assetsvc.service.port }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: {{ .Values.kubeops.service.port }}
+          {{- if .Values.kubeops.livenessProbe }}
+          livenessProbe: {{- toYaml .Values.kubeops.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.kubeops.readinessProbe }}
+          readinessProbe: {{- toYaml .Values.kubeops.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.kubeops.resources }}
+          resources: {{- toYaml .Values.kubeops.resources | nindent 12 }}
+          {{- end }}
 {{- end }}{{/* matches useHelm3 */}}

--- a/chart/kubeapps/templates/kubeops-rbac.yaml
+++ b/chart/kubeapps/templates/kubeops-rbac.yaml
@@ -54,12 +54,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/chart/kubeapps/templates/kubeops-service.yaml
+++ b/chart/kubeapps/templates/kubeops-service.yaml
@@ -11,10 +11,10 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: {{ .Values.kubeops.service.port }}
-    targetPort: http
-    protocol: TCP
-    name: http
+    - port: {{ .Values.kubeops.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
   selector:
     app: {{ template "kubeapps.kubeops.fullname" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

### Description of the change

This PR adapts the manifests for Kubeops so they're consistent with the rest of manifests. It also ensure that `yamllint` doesn't complain about the syntax.

### Benefits

- Consistency
- Better Readability

### Possible drawbacks

None