### PR TITLE
1521 delete tables on upgrade

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -98,10 +98,10 @@ Create name for the apprepository-controller based on the fullname
 {{- end -}}
 
 {{/*
-Create name for the apprepository bootstrap job
+Create name for the apprepository pre-upgrade job
 */}}
-{{- define "kubeapps.apprepository-jobs-bootstrap.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-apprepository-jobs-bootstrap
+{{- define "kubeapps.apprepository-jobs-preupgrade.fullname" -}}
+{{ template "kubeapps.fullname" . }}-internal-apprepository-jobs-preupgrade
 {{- end -}}
 
 {{/*

--- a/chart/kubeapps/templates/apprepository-jobs-preupgrade.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-preupgrade.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "kubeapps.apprepository-jobs-preupgrade.fullname" . }}
   annotations:
     helm.sh/hook: pre-upgrade
-    # helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: hook-succeeded
   labels:
     app: {{ template "kubeapps.apprepository-jobs-preupgrade.fullname" . }}
     chart: {{ template "kubeapps.chart" . }}

--- a/chart/kubeapps/templates/apprepository-jobs-preupgrade.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-preupgrade.yaml
@@ -1,0 +1,67 @@
+# Invalidate the chart cache during upgrade.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kubeapps.apprepository-jobs-preupgrade.fullname" . }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    # helm.sh/hook-delete-policy: hook-succeeded
+  labels:
+    app: {{ template "kubeapps.apprepository-jobs-preupgrade.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "kubeapps.apprepository-jobs-preupgrade.fullname" . }}
+        release: {{ .Release.Name }}
+    spec:
+{{- include "kubeapps.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.hooks.affinity }}
+      affinity: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.nodeSelector }}
+      nodeSelector: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hooks.tolerations }}
+      tolerations: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
+      restartPolicy: OnFailure
+      containers:
+        - name: invalidate-cache
+          image: {{ template "kubeapps.image" (list .Values.apprepository.syncImage .Values.global) }}
+          command:
+            - /asset-syncer
+          args:
+            - invalidate-cache
+            {{- if .Values.mongodb.enabled }}
+            - --database-type=mongodb
+            - --database-url={{ template "kubeapps.mongodb.fullname" . }}
+            - --database-user=root
+            - --database-name=charts
+            {{- end }}
+            {{- if .Values.postgresql.enabled }}
+            - --database-type=postgresql
+            - --database-url={{ template "kubeapps.postgresql.fullname" . }}:5432
+            - --database-user=postgres
+            - --database-name=assets
+            {{- end }}
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+            {{- if .Values.mongodb.enabled }}
+                  key: mongodb-root-password
+                  name: {{ .Values.mongodb.existingSecret }}
+            {{- end }}
+            {{- if .Values.postgresql.enabled }}
+                  key: postgresql-password
+                  name: {{ .Values.postgresql.existingSecret }}
+            {{- end }}

--- a/cmd/asset-syncer/invalidate-cache.go
+++ b/cmd/asset-syncer/invalidate-cache.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2020 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/kubeapps/common/datastore"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var invalidateCacheCmd = &cobra.Command{
+	Use:   "invalidate-cache",
+	Short: "removes all data so the cache can be rebuilt",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 0 {
+			logrus.Info("This command does not take any arguments")
+			cmd.Help()
+			return
+		}
+
+		if debug {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+
+		dbConfig := datastore.Config{URL: databaseURL, Database: databaseName, Username: databaseUser, Password: databasePassword}
+		manager, err := newManager(databaseType, dbConfig)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		err = manager.Init()
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		defer manager.Close()
+
+		err = manager.InvalidateCache()
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		logrus.Infof("Successfully invalidated cache")
+	},
+}

--- a/cmd/asset-syncer/main.go
+++ b/cmd/asset-syncer/main.go
@@ -59,7 +59,7 @@ func init() {
 
 	databasePassword = os.Getenv("DB_PASSWORD")
 
-	cmds := []*cobra.Command{syncCmd, deleteCmd}
+	cmds := []*cobra.Command{syncCmd, deleteCmd, invalidateCacheCmd}
 	for _, cmd := range cmds {
 		rootCmd.AddCommand(cmd)
 	}

--- a/cmd/asset-syncer/mongodb_utils.go
+++ b/cmd/asset-syncer/mongodb_utils.go
@@ -138,3 +138,9 @@ func (m *mongodbAssetManager) insertFiles(chartFilesID string, files models.Char
 	_, err := db.C(chartFilesCollection).UpsertId(chartFilesID, files)
 	return err
 }
+
+// InvalidateCache for mongodb currently is a noop to fulfil the interface.
+func (m *mongodbAssetManager) InvalidateCache() error {
+	// TODO: implement a cache invalidation
+	return nil
+}

--- a/cmd/asset-syncer/postgresql_db_test.go
+++ b/cmd/asset-syncer/postgresql_db_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/kubeapps/common/datastore"
@@ -72,13 +71,7 @@ func getInitializedManager(t *testing.T) (*postgresAssetManager, func()) {
 	pam := openTestManager(t)
 	cleanup := func() { pam.Close() }
 
-	tables := strings.Join([]string{dbutils.RepositoryTable, dbutils.ChartTable, dbutils.ChartFilesTable}, ",")
-	_, err := pam.DB.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", tables))
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
-
-	err = pam.initTables()
+	err := pam.InvalidateCache()
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -247,3 +247,14 @@ func (m *postgresAssetManager) insertFiles(chartFilesID string, files models.Cha
 	}
 	return err
 }
+
+// InvalidateCache for postgresql deletes and re-writes the schema
+func (m *postgresAssetManager) InvalidateCache() error {
+	tables := strings.Join([]string{dbutils.RepositoryTable, dbutils.ChartTable, dbutils.ChartFilesTable}, ",")
+	_, err := m.DB.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", tables))
+	if err != nil {
+		return err
+	}
+
+	return m.initTables()
+}

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -251,7 +251,7 @@ func (m *postgresAssetManager) insertFiles(chartFilesID string, files models.Cha
 // InvalidateCache for postgresql deletes and re-writes the schema
 func (m *postgresAssetManager) InvalidateCache() error {
 	tables := strings.Join([]string{dbutils.RepositoryTable, dbutils.ChartTable, dbutils.ChartFilesTable}, ",")
-	_, err := m.DB.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", tables))
+	_, err := m.DB.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tables))
 	if err != nil {
 		return err
 	}

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -81,6 +81,7 @@ type assetManager interface {
 	UpdateLastCheck(repoNamespace, repoName, checksum string, now time.Time) error
 	Init() error
 	Close() error
+	InvalidateCache() error
 	updateIcon(data []byte, contentType, ID string) error
 	filesExist(chartFilesID, digest string) bool
 	insertFiles(chartFilesID string, files models.ChartFiles) error


### PR DESCRIPTION
Ref: #1521 

Following on from #1526, this PR adds a pre-upgrade hook which invalidates the database cache of charts. When postgres is being used, this drops and recreates the tables. For mongodb, it's currently a no-op. I've not added functionality to check for a schema change at the moment, so this will rebuild the cache on every upgrade.

IRL test:
Initial deploy dev environment and verify schema is the original (ie. without namespace field in repos table):
```
$ k -n kubeapps exec kubeapps-postgresql-0 -- sh -c 'PGPASSWORD=$POSTGRES_PASSWORD psql -d assets -U $POSTGRES_USER -c "\d repos;"'
                                    Table "public.repos"
   Column    |       Type        | Collation | Nullable |              Default
-------------+-------------------+-----------+----------+-----------------------------------
 id          | integer           |           | not null | nextval('repos_id_seq'::regclass)
 name        | character varying |           |          |
 checksum    | character varying |           |          |
 last_update | character varying |           |          |
Indexes:
    "repos_pkey" PRIMARY KEY, btree (id)
    "repos_name_key" UNIQUE CONSTRAINT, btree (name)
```

Upgrade with the new sync image (which has the new schema): 
```
helm -n kubeapps upgrade --reuse-values kubeapps ./chart/kubeapps/ --set apprepository.syncImage.tag=2 --set apprepository.image.tag=1
```

See preupgrade job deployed successfully (before I added the hook-delete-policy):
```
$ k -n kubeapps logs kubeapps-internal-apprepository-jobs-preupgrade-jt9zz
time="2020-02-21T00:58:32Z" level=info msg="Successfully invalidated cache"
```

Re-check the table and now see it's updated.
```
  $ k -n kubeapps exec kubeapps-postgresql-0 -- sh -c 'PGPASSWORD=$POSTGRES_PASSWORD psql -d assets -U $POSTGRES_USER -c "\d repos;"'
                                    Table "public.repos"
   Column    |       Type        | Collation | Nullable |              Default
-------------+-------------------+-----------+----------+-----------------------------------
 id          | integer           |           | not null | nextval('repos_id_seq'::regclass)
 namespace   | character varying |           | not null |
 name        | character varying |           | not null |
 checksum    | character varying |           |          |
 last_update | character varying |           |          |
Indexes:
    "repos_pkey" PRIMARY KEY, btree (id)
    "repos_namespace_name_key" UNIQUE CONSTRAINT, btree (namespace, name)
Referenced by:
    TABLE "charts" CONSTRAINT "charts_repository_id_fkey" FOREIGN KEY (repository_id) REFERENCES repos(id)
```

Verified cache is being repopulated as app repo starts.