### PR TITLE
Update asset-syncer delete to use namespace.

### DIFF
--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -506,12 +506,12 @@ func newCleanupJob(reponame, namespace, kubeappsNamespace string) *batchv1.Job {
 			GenerateName: deleteJobName(reponame, namespace) + "-",
 			Namespace:    kubeappsNamespace,
 		},
-		Spec: cleanupJobSpec(reponame),
+		Spec: cleanupJobSpec(reponame, namespace),
 	}
 }
 
 // cleanupJobSpec returns a batchv1.JobSpec for running the chart-repo delete job
-func cleanupJobSpec(repoName string) batchv1.JobSpec {
+func cleanupJobSpec(repoName, repoNamespace string) batchv1.JobSpec {
 	return batchv1.JobSpec{
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
@@ -522,7 +522,7 @@ func cleanupJobSpec(repoName string) batchv1.JobSpec {
 						Name:    "delete",
 						Image:   repoSyncImage,
 						Command: []string{repoSyncCommand},
-						Args:    apprepoCleanupJobArgs(repoName),
+						Args:    apprepoCleanupJobArgs(repoName, repoNamespace),
 						Env: []corev1.EnvVar{
 							{
 								Name: "DB_PASSWORD",
@@ -606,10 +606,11 @@ func secretKeyRefForRepo(keyRef corev1.SecretKeySelector, apprepo *apprepov1alph
 }
 
 // apprepoCleanupJobArgs returns a list of args for the repo cleanup container
-func apprepoCleanupJobArgs(repoName string) []string {
+func apprepoCleanupJobArgs(repoName, repoNamespace string) []string {
 	return append([]string{
 		"delete",
 		repoName,
+		"--namespace=" + repoNamespace,
 	}, dbFlags()...)
 }
 

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -901,6 +901,7 @@ func Test_newCleanupJob(t *testing.T) {
 									Args: []string{
 										"delete",
 										"my-charts",
+										"--namespace=kubeapps",
 										"--database-type=mongodb",
 										"--database-url=mongodb.kubeapps",
 										"--database-user=admin",

--- a/cmd/asset-syncer/delete.go
+++ b/cmd/asset-syncer/delete.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/kubeapps/common/datastore"
+	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -47,7 +48,8 @@ var deleteCmd = &cobra.Command{
 		}
 		defer manager.Close()
 
-		if err = manager.Delete(args[0]); err != nil {
+		repo := models.Repo{Name: args[0], Namespace: namespace}
+		if err = manager.Delete(repo); err != nil {
 			logrus.Fatalf("Can't delete chart repository %s from database: %v", args[0], err)
 		}
 

--- a/cmd/asset-syncer/mongodb_utils.go
+++ b/cmd/asset-syncer/mongodb_utils.go
@@ -68,25 +68,25 @@ func (m *mongodbAssetManager) UpdateLastCheck(repoNamespace, repoName, checksum 
 	return err
 }
 
-func (m *mongodbAssetManager) Delete(repoName string) error {
+func (m *mongodbAssetManager) Delete(repo models.Repo) error {
 	db, closer := m.DBSession.DB()
 	defer closer()
 	_, err := db.C(chartCollection).RemoveAll(bson.M{
-		"repo.name": repoName,
+		"repo.name": repo.Name,
 	})
 	if err != nil {
 		return err
 	}
 
 	_, err = db.C(chartFilesCollection).RemoveAll(bson.M{
-		"repo.name": repoName,
+		"repo.name": repo.Name,
 	})
 	if err != nil {
 		return err
 	}
 
 	_, err = db.C(repositoryCollection).RemoveAll(bson.M{
-		"_id": repoName,
+		"_id": repo.Name,
 	})
 	return err
 }

--- a/cmd/asset-syncer/mongodb_utils_test.go
+++ b/cmd/asset-syncer/mongodb_utils_test.go
@@ -67,7 +67,7 @@ func Test_DeleteRepo(t *testing.T) {
 		"_id": "test",
 	})
 	manager := getMockManager(m)
-	err := manager.Delete("test")
+	err := manager.Delete(models.Repo{Name: "test"})
 	if err != nil {
 		t.Errorf("failed to delete chart repo test: %v", err)
 	}

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -75,7 +75,7 @@ func init() {
 }
 
 type assetManager interface {
-	Delete(repo string) error
+	Delete(repo models.Repo) error
 	Sync(repo models.RepoInternal, charts []models.Chart) error
 	RepoAlreadyProcessed(repoName, checksum string) bool
 	UpdateLastCheck(repoNamespace, repoName, checksum string, now time.Time) error

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -433,7 +433,7 @@ func (f *fileImporter) fetchAndImportFiles(name string, r *models.RepoInternal, 
 		return err
 	}
 
-	chartFiles := models.ChartFiles{ID: chartFilesID, Repo: &models.Repo{Name: r.Name, URL: r.URL}, Digest: cv.Digest}
+	chartFiles := models.ChartFiles{ID: chartFilesID, Repo: &models.Repo{Name: r.Name, Namespace: r.Namespace, URL: r.URL}, Digest: cv.Digest}
 	if v, ok := files[readmeFileName]; ok {
 		chartFiles.Readme = v
 	} else {


### PR DESCRIPTION
Ref #1521 
Follows #1532, and updates the delete command to include the repo namespace.

Note that I've updated the schema slightly, so that both `charts` and `chartfiles` tables use a composite foreign key to the `repos` table. This means that we can let postgres handle the cascading delete (much simpler [1]) and data integrity generally, while still allowing us to reference the relationship in any table.

[1] I wrote the test first and actually found that the existing code was deleting related charts but not the chart files. Didn't look into why, but the new code fixed it.