### PR TITLE
Allow to validate apprepositories

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -19,32 +19,28 @@ package chart
 import (
 	"bytes"
 	"crypto/sha256"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"github.com/kubeapps/kubeapps/pkg/kube"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
-	"time"
 
 	"github.com/ghodss/yaml"
 	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 	helm3chart "helm.sh/helm/v3/pkg/chart"
 	helm3loader "helm.sh/helm/v3/pkg/chart/loader"
+	corev1 "k8s.io/api/core/v1"
 	helm2loader "k8s.io/helm/pkg/chartutil"
 	helm2chart "k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/repo"
 )
 
 const (
-	defaultRepoURL        = "https://kubernetes-charts.storage.googleapis.com"
-	defaultTimeoutSeconds = 180
+	defaultRepoURL = "https://kubernetes-charts.storage.googleapis.com"
 )
 
 type repoIndex struct {
@@ -73,11 +69,6 @@ type Details struct {
 	Values string `json:"values,omitempty"`
 }
 
-// HTTPClient Interface to perform HTTP requests
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
 // ChartMultiVersion includes both Helm2Chart and Helm3Chart
 type ChartMultiVersion struct {
 	Helm2Chart *helm2chart.Chart
@@ -93,8 +84,8 @@ type LoadHelm3Chart func(in io.Reader) (*helm3chart.Chart, error)
 // Resolver for exposed funcs
 type Resolver interface {
 	ParseDetails(data []byte) (*Details, error)
-	GetChart(details *Details, netClient HTTPClient, requireV1Support bool) (*ChartMultiVersion, error)
-	InitNetClient(details *Details) (HTTPClient, error)
+	GetChart(details *Details, netClient kube.HTTPClient, requireV1Support bool) (*ChartMultiVersion, error)
+	InitNetClient(details *Details) (kube.HTTPClient, error)
 }
 
 // ChartClient struct contains the clients required to retrieve charts info
@@ -176,7 +167,7 @@ func parseIndex(data []byte) (*repo.IndexFile, error) {
 }
 
 // fetchRepoIndex returns a Helm repository
-func fetchRepoIndex(netClient *HTTPClient, repoURL string) (*repo.IndexFile, error) {
+func fetchRepoIndex(netClient *kube.HTTPClient, repoURL string) (*repo.IndexFile, error) {
 	req, err := getReq(repoURL)
 	if err != nil {
 		return nil, err
@@ -232,7 +223,7 @@ func findChartInRepoIndex(repoIndex *repo.IndexFile, repoURL, chartName, chartVe
 }
 
 // fetchChart returns the Chart content given an URL
-func fetchChart(netClient *HTTPClient, chartURL string, requireV1Support bool) (*ChartMultiVersion, error) {
+func fetchChart(netClient *kube.HTTPClient, chartURL string, requireV1Support bool) (*ChartMultiVersion, error) {
 	req, err := getReq(chartURL)
 	if err != nil {
 		return nil, err
@@ -275,103 +266,56 @@ func (c *ChartClient) ParseDetails(data []byte) (*Details, error) {
 	return details, nil
 }
 
-// clientWithDefaultHeaders implements chart.HTTPClient interface
-// and includes an override of the Do method which injects our default
-// headers - User-Agent and Authorization (when present)
-type clientWithDefaultHeaders struct {
-	client         HTTPClient
-	defaultHeaders http.Header
-}
-
-// Do HTTP request
-func (c *clientWithDefaultHeaders) Do(req *http.Request) (*http.Response, error) {
-	for k, v := range c.defaultHeaders {
-		// Only add the default header if it's not already set in the request.
-		if _, ok := req.Header[k]; !ok {
-			req.Header[k] = v
-		}
-	}
-	return c.client.Do(req)
-}
-
-// InitNetClient returns an HTTP client based on the chart details loading a
-// custom CA if provided (as a secret)
-func (c *ChartClient) InitNetClient(details *Details) (HTTPClient, error) {
-	// Require the SystemCertPool unless the env var is explicitly set.
-	caCertPool, err := x509.SystemCertPool()
-	if err != nil {
-		if _, ok := os.LookupEnv("TILLER_PROXY_ALLOW_EMPTY_CERT_POOL"); !ok {
-			return nil, err
-		}
-		caCertPool = x509.NewCertPool()
-	}
-
+func (c *ChartClient) parseDetailsForHTTPClient(details *Details) (*appRepov1.AppRepository, *corev1.Secret, *corev1.Secret, error) {
 	// We grab the specified app repository (for later access to the repo URL, as well as any specified
 	// auth).
 	appRepo, err := c.appRepoHandler.AsSVC().GetAppRepository(details.AppRepositoryResourceName, c.kubeappsNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get app repository %q: %v", details.AppRepositoryResourceName, err)
+		return nil, nil, nil, fmt.Errorf("unable to get app repository %q: %v", details.AppRepositoryResourceName, err)
 	}
 	c.appRepo = appRepo
 	auth := appRepo.Spec.Auth
 
+	var caCertSecret *corev1.Secret
 	if auth.CustomCA != nil {
-		caCertSecret, err := c.appRepoHandler.AsSVC().GetSecret(auth.CustomCA.SecretKeyRef.Name, c.kubeappsNamespace)
+		caCertSecret, err = c.appRepoHandler.AsSVC().GetSecret(auth.CustomCA.SecretKeyRef.Name, c.kubeappsNamespace)
 		if err != nil {
-			return nil, fmt.Errorf("unable to read secret %q: %v", auth.CustomCA.SecretKeyRef.Name, err)
-		}
-
-		// Append our cert to the system pool
-		customData, ok := caCertSecret.Data[auth.CustomCA.SecretKeyRef.Key]
-		if !ok {
-			return nil, fmt.Errorf("secret %q did not contain key %q", auth.CustomCA.SecretKeyRef.Name, auth.CustomCA.SecretKeyRef.Key)
-		}
-		if ok := caCertPool.AppendCertsFromPEM(customData); !ok {
-			return nil, fmt.Errorf("Failed to append %s to RootCAs", auth.CustomCA.SecretKeyRef.Name)
+			return nil, nil, nil, fmt.Errorf("unable to read secret %q: %v", auth.CustomCA.SecretKeyRef.Name, err)
 		}
 	}
 
-	defaultHeaders := http.Header{"User-Agent": []string{c.userAgent}}
+	var authSecret *corev1.Secret
 	if auth.Header != nil {
-		secret, err := c.appRepoHandler.AsSVC().GetSecret(auth.Header.SecretKeyRef.Name, c.kubeappsNamespace)
+		authSecret, err = c.appRepoHandler.AsSVC().GetSecret(auth.Header.SecretKeyRef.Name, c.kubeappsNamespace)
 		if err != nil {
-			return nil, err
+			return nil, nil, nil, err
 		}
-		defaultHeaders.Set("Authorization", string(secret.Data[auth.Header.SecretKeyRef.Key]))
 	}
 
-	// Return Transport for testing purposes
-	return &clientWithDefaultHeaders{
-		client: &http.Client{
-			Timeout: time.Second * defaultTimeoutSeconds,
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{
-					RootCAs: caCertPool,
-				},
-			},
-		},
-		defaultHeaders: defaultHeaders,
-	}, nil
+	return appRepo, caCertSecret, authSecret, nil
+}
+
+// InitNetClient returns an HTTP client based on the chart details loading a
+// custom CA if provided (as a secret)
+func (c *ChartClient) InitNetClient(details *Details) (kube.HTTPClient, error) {
+	appRepo, caCertSecret, authSecret, err := c.parseDetailsForHTTPClient(details)
+	if err != nil {
+		return nil, err
+	}
+	return kube.InitNetClient(appRepo, caCertSecret, authSecret, http.Header{"User-Agent": []string{c.userAgent}})
 }
 
 // GetChart retrieves and loads a Chart from a registry in both
 // v2 and v3 formats.
-func (c *ChartClient) GetChart(details *Details, netClient HTTPClient, requireV1Support bool) (*ChartMultiVersion, error) {
-	repoURL := c.appRepo.Spec.URL
-	if repoURL == "" {
-		// FIXME: Make configurable
-		repoURL = defaultRepoURL
-	}
-	repoURL = strings.TrimSuffix(strings.TrimSpace(repoURL), "/") + "/index.yaml"
+func (c *ChartClient) GetChart(details *Details, netClient kube.HTTPClient, requireV1Support bool) (*ChartMultiVersion, error) {
+	indexURL := strings.TrimSuffix(strings.TrimSpace(c.appRepo.Spec.URL), "/") + "/index.yaml"
 
-	log.Printf("Downloading repo %s index...", repoURL)
-	repoIndex, err := fetchRepoIndex(&netClient, repoURL)
+	repoIndex, err := fetchRepoIndex(&netClient, indexURL)
 	if err != nil {
 		return nil, err
 	}
 
-	chartURL, err := findChartInRepoIndex(repoIndex, repoURL, details.ChartName, details.Version)
+	chartURL, err := findChartInRepoIndex(repoIndex, indexURL, details.ChartName, details.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -39,10 +39,6 @@ import (
 	"k8s.io/helm/pkg/repo"
 )
 
-const (
-	defaultRepoURL = "https://kubernetes-charts.storage.googleapis.com"
-)
-
 type repoIndex struct {
 	checksum string
 	index    *repo.IndexFile

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -245,44 +245,6 @@ func TestparseDetailsForHTTPClient(t *testing.T) {
 			},
 			errorExpected: true,
 		},
-		// {
-		// 	name: "errors if custom CA key cannot be found in secret",
-		// 	details: &Details{
-		// 		AppRepositoryResourceName: appRepoName,
-		// 	},
-		// 	appRepoSpec: appRepov1.AppRepositorySpec{
-		// 		Auth: appRepov1.AppRepositoryAuth{
-		// 			CustomCA: &appRepov1.AppRepositoryCustomCA{
-		// 				SecretKeyRef: corev1.SecretKeySelector{
-		// 					corev1.LocalObjectReference{customCASecretName},
-		// 					"some-other-secret-key",
-		// 					nil,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// 	customCAData:  pem_cert,
-		// 	errorExpected: true,
-		// },
-		// {
-		// 	name: "errors if custom CA cannot be parsed",
-		// 	details: &Details{
-		// 		AppRepositoryResourceName: appRepoName,
-		// 	},
-		// 	appRepoSpec: appRepov1.AppRepositorySpec{
-		// 		Auth: appRepov1.AppRepositoryAuth{
-		// 			CustomCA: &appRepov1.AppRepositoryCustomCA{
-		// 				SecretKeyRef: corev1.SecretKeySelector{
-		// 					corev1.LocalObjectReference{customCASecretName},
-		// 					"custom-secret-key",
-		// 					nil,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// 	customCAData:  "not a valid cert",
-		// 	errorExpected: true,
-		// },
 		{
 			name: "authorization header added when passed an AppRepository CRD",
 			details: &Details{
@@ -368,32 +330,9 @@ func TestparseDetailsForHTTPClient(t *testing.T) {
 				}
 			}
 
-			// TODO: Move to kube
-			// clientWithDefaultHeaders, ok := httpClient.(*clientWithDefaultHeaders)
-			// if !ok {
-			// 	t.Fatalf("unable to assert expected type")
-			// }
-			// client, ok := clientWithDefaultHeaders.client.(*http.Client)
-			// if !ok {
-			// 	t.Fatalf("unable to assert expected type")
-			// }
-			// transport, ok := client.Transport.(*http.Transport)
-			// certPool := transport.TLSClientConfig.RootCAs
-
-			// if got, want := len(certPool.Subjects()), tc.numCertsExpected; got != want {
-			// 	t.Errorf("got: %d, want: %d", got, want)
-			// }
-
 			// If the Auth header was set, secrets should be returned
 			if tc.appRepoSpec.Auth.Header != nil && authSecret == nil {
 				t.Errorf("Expecting auth secret")
-				// _, ok := clientWithDefaultHeaders.defaultHeaders["Authorization"]
-				// if !ok {
-				// 	t.Fatalf("expected Authorization header but found none")
-				// }
-				// if got, want := clientWithDefaultHeaders.defaultHeaders.Get("Authorization"), authHeaderSecretData; got != want {
-				// 	t.Errorf("got: %q, want: %q", got, want)
-				// }
 			}
 			if tc.appRepoSpec.Auth.CustomCA != nil && caCertSecret == nil {
 				t.Errorf("Expecting auth secret")

--- a/pkg/chart/fake/chart.go
+++ b/pkg/chart/fake/chart.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 	chart3 "helm.sh/helm/v3/pkg/chart"
 	chart2 "k8s.io/helm/pkg/proto/hapi/chart"
 	"sigs.k8s.io/yaml"
@@ -34,7 +35,7 @@ func (f *FakeChart) ParseDetails(data []byte) (*chartUtils.Details, error) {
 	return details, err
 }
 
-func (f *FakeChart) GetChart(details *chartUtils.Details, netClient chartUtils.HTTPClient, requireV1Support bool) (*chartUtils.ChartMultiVersion, error) {
+func (f *FakeChart) GetChart(details *chartUtils.Details, netClient kube.HTTPClient, requireV1Support bool) (*chartUtils.ChartMultiVersion, error) {
 	vals, err := getValues([]byte(details.Values))
 	if err != nil {
 		return nil, err
@@ -66,6 +67,6 @@ func getValues(raw []byte) (map[string]interface{}, error) {
 	return values, nil
 }
 
-func (f *FakeChart) InitNetClient(details *chartUtils.Details) (chartUtils.HTTPClient, error) {
+func (f *FakeChart) InitNetClient(details *chartUtils.Details) (kube.HTTPClient, error) {
 	return &http.Client{}, nil
 }

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -18,6 +18,7 @@ package httphandler
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -74,6 +75,25 @@ func CreateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, r
 	}
 }
 
+// ValidateAppRepository returns a 200 if the connection to the AppRepo can be established
+func ValidateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
+	return func(w http.ResponseWriter, req *http.Request) {
+		token := auth.ExtractToken(req.Header.Get("Authorization"))
+		res, err := handler.AsUser(token).ValidateAppRepository(req.Body)
+		if err != nil {
+			returnK8sError(err, w)
+			return
+		}
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			returnK8sError(err, w)
+			return
+		}
+		w.WriteHeader(res.StatusCode)
+		w.Write(body)
+	}
+}
+
 // DeleteAppRepository deletes an App Repository
 func DeleteAppRepository(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
@@ -117,6 +137,7 @@ func SetupDefaultRoutes(r *mux.Router) error {
 	}
 	r.Methods("GET").Path("/namespaces").Handler(http.HandlerFunc(GetNamespaces(backendHandler)))
 	r.Methods("POST").Path("/namespaces/{namespace}/apprepositories").Handler(http.HandlerFunc(CreateAppRepository(backendHandler)))
+	r.Methods("POST").Path("/namespaces/{namespace}/apprepositories/validate").Handler(http.HandlerFunc(ValidateAppRepository(backendHandler)))
 	r.Methods("DELETE").Path("/namespaces/{namespace}/apprepositories/{name}").Handler(http.HandlerFunc(DeleteAppRepository(backendHandler)))
 	return nil
 }

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -90,7 +90,11 @@ func ValidateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter,
 			return
 		}
 		w.WriteHeader(res.StatusCode)
-		w.Write(body)
+		if res.StatusCode == 200 {
+			w.Write([]byte("OK"))
+		} else {
+			w.Write(body)
+		}
 	}
 }
 

--- a/pkg/http-handler/http-handler_test.go
+++ b/pkg/http-handler/http-handler_test.go
@@ -166,3 +166,34 @@ func TestGetNamespaces(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAppRepository(t *testing.T) {
+	testCases := []struct {
+		name         string
+		err          error
+		expectedCode int
+	}{
+		{
+			name:         "it should return OK if no error is detected",
+			expectedCode: 200,
+		},
+		{
+			name:         "it should return the error code if given",
+			err:          fmt.Errorf("Boom"),
+			expectedCode: 500,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			validateAppRepoFunc := ValidateAppRepository(&kube.FakeHandler{Err: tc.err})
+			req := httptest.NewRequest("POST", "https://foo.bar/backend/v1/namespaces/kubeapps/apprepositories/validate", strings.NewReader("data"))
+
+			response := httptest.NewRecorder()
+			validateAppRepoFunc(response, req)
+
+			if got, want := response.Code, tc.expectedCode; got != want {
+				t.Errorf("got: %d, want: %d\nBody: %s", got, want, response.Body)
+			}
+		})
+	}
+}

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -19,6 +19,7 @@ package kube
 import (
 	"fmt"
 	"io"
+	"net/http"
 
 	v1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -77,4 +78,9 @@ func (c *FakeHandler) GetSecret(name, namespace string) (*corev1.Secret, error) 
 		}
 	}
 	return nil, fmt.Errorf("not found")
+}
+
+// ValidateAppRepository fake
+func (c *FakeHandler) ValidateAppRepository(appRepoBody io.ReadCloser) (*http.Response, error) {
+	return nil, nil
 }

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -19,7 +19,9 @@ package kube
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
+	"strings"
 
 	v1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -82,5 +84,5 @@ func (c *FakeHandler) GetSecret(name, namespace string) (*corev1.Secret, error) 
 
 // ValidateAppRepository fake
 func (c *FakeHandler) ValidateAppRepository(appRepoBody io.ReadCloser) (*http.Response, error) {
-	return nil, nil
+	return &http.Response{Body: ioutil.NopCloser(strings.NewReader("valid: yaml")), StatusCode: 200}, c.Err
 }

--- a/pkg/kube/http_utils.go
+++ b/pkg/kube/http_utils.go
@@ -1,0 +1,102 @@
+/*
+Copyright (c) 2020 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	defaultTimeoutSeconds = 180
+)
+
+// HTTPClient Interface to perform HTTP requests
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// clientWithDefaultHeaders implements chart.HTTPClient interface
+// and includes an override of the Do method which injects our default
+// headers - User-Agent and Authorization (when present)
+type clientWithDefaultHeaders struct {
+	client         HTTPClient
+	defaultHeaders http.Header
+}
+
+// Do HTTP request
+func (c *clientWithDefaultHeaders) Do(req *http.Request) (*http.Response, error) {
+	for k, v := range c.defaultHeaders {
+		// Only add the default header if it's not already set in the request.
+		if _, ok := req.Header[k]; !ok {
+			req.Header[k] = v
+		}
+	}
+	return c.client.Do(req)
+}
+
+// InitNetClient returns an HTTP client based on the chart details loading a
+// custom CA if provided (as a secret)
+func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *corev1.Secret, defaultHeaders http.Header) (HTTPClient, error) {
+	// Require the SystemCertPool unless the env var is explicitly set.
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		if _, ok := os.LookupEnv("TILLER_PROXY_ALLOW_EMPTY_CERT_POOL"); !ok {
+			return nil, err
+		}
+		caCertPool = x509.NewCertPool()
+	}
+
+	if caCertSecret != nil {
+		// Append our cert to the system pool
+		customData, ok := caCertSecret.Data[appRepo.Spec.Auth.CustomCA.SecretKeyRef.Key]
+		if !ok {
+			return nil, fmt.Errorf("secret %q did not contain key %q", appRepo.Spec.Auth.CustomCA.SecretKeyRef.Name, appRepo.Spec.Auth.CustomCA.SecretKeyRef.Key)
+		}
+		if ok := caCertPool.AppendCertsFromPEM(customData); !ok {
+			return nil, fmt.Errorf("Failed to append %s to RootCAs", appRepo.Spec.Auth.CustomCA.SecretKeyRef.Name)
+		}
+	}
+
+	if defaultHeaders == nil {
+		defaultHeaders = http.Header{}
+	}
+	if authSecret != nil {
+		defaultHeaders.Set("Authorization", string(authSecret.Data[appRepo.Spec.Auth.Header.SecretKeyRef.Key]))
+	}
+
+	// Return Transport for testing purposes
+	return &clientWithDefaultHeaders{
+		client: &http.Client{
+			Timeout: time.Second * defaultTimeoutSeconds,
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{
+					RootCAs: caCertPool,
+				},
+			},
+		},
+		defaultHeaders: defaultHeaders,
+	}, nil
+}

--- a/pkg/kube/http_utils_test.go
+++ b/pkg/kube/http_utils_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright (c) 2020 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"crypto/x509"
+	"net/http"
+	"testing"
+
+	v1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const pemCert = `
+-----BEGIN CERTIFICATE-----
+MIIDETCCAfkCFEY03BjOJGqOuIMoBewOEDORMewfMA0GCSqGSIb3DQEBCwUAMEUx
+CzAJBgNVBAYTAkRFMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRl
+cm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTkwODE5MDQxNzU5WhcNMTkxMDA4MDQx
+NzU5WjBFMQswCQYDVQQGEwJERTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UE
+CgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEAzA+X6HcScuHxqxCc5gs68weW8i72qMjvcWvBG064SvpTuNDK
+ECEGvug6f8SFJjpA+hWjlqR5+UPMdfjMKPUEg1CI8JZm6lyNiB54iY50qvhv+qQg
+1STdAWNTzvqUXUMGIImzeXFnErxlq8WwwLGwPNT4eFxF8V8fzIhR8sqQKFLOqvpS
+7sCQwF5QOhziGfS+zParDLFsBoXQpWyDKqxb/yBSPwqijKkuW7kF4jGfPHD0Re3+
+rspXiq8+jWSwSJIPSIbya8DQqrMwFeLCAxABidPnlrwS0UUion557ylaBK6Cv0UB
+MojA4SMfjm5xRdzrOcoE8EcabxqoQD5rCIBgFQIDAQABMA0GCSqGSIb3DQEBCwUA
+A4IBAQCped08LTojPejkPqmp1edZa9rWWrCMviY5cvqb6t3P3erse+jVcBi9NOYz
+8ewtDbR0JWYvSW6p3+/nwyDG4oVfG5TiooAZHYHmgg4x9+5h90xsnmgLhIsyopPc
+Rltj86tRCl1YiuRpkWrOfRBGdYfkGEG4ihJzLHWRMCd1SmMwnmLliBctD7IeqBKw
+UKt8wcroO8/sj/Xd1/LCtNZ79/FdQFa4l3HnzhOJOrlQyh4gyK05EKdg6vv3un17
+l6NEPfiXd7dZvsWi9uY/PGBhu9EY/bdvuIOWDNNK262azk1A56HINpMrYBUcfti1
+YrvYQHgOtHsqCB/hFHWfZp1lg2Sx
+-----END CERTIFICATE-----
+`
+
+func TestInitNetClient(t *testing.T) {
+	systemCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	const (
+		authHeaderSecretName = "auth-header-secret-name"
+		authHeaderSecretData = "really-secret-stuff"
+		customCASecretName   = "custom-ca-secret-name"
+		appRepoName          = "custom-repo"
+	)
+
+	testCases := []struct {
+		name             string
+		customCAData     string
+		appRepoSpec      v1alpha1.AppRepositorySpec
+		errorExpected    bool
+		numCertsExpected int
+		expectedHeaders  http.Header
+	}{
+		{
+			name:             "default cert pool without auth",
+			numCertsExpected: len(systemCertPool.Subjects()),
+		},
+		{
+			name: "custom CA added when passed an AppRepository CRD",
+			appRepoSpec: v1alpha1.AppRepositorySpec{
+				Auth: v1alpha1.AppRepositoryAuth{
+					CustomCA: &v1alpha1.AppRepositoryCustomCA{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{customCASecretName},
+							"custom-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			customCAData:     pemCert,
+			numCertsExpected: len(systemCertPool.Subjects()) + 1,
+		},
+		{
+			name: "errors if custom CA key cannot be found in secret",
+			appRepoSpec: v1alpha1.AppRepositorySpec{
+				Auth: v1alpha1.AppRepositoryAuth{
+					CustomCA: &v1alpha1.AppRepositoryCustomCA{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{customCASecretName},
+							"some-other-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			customCAData:  pemCert,
+			errorExpected: true,
+		},
+		{
+			name: "errors if custom CA cannot be parsed",
+			appRepoSpec: v1alpha1.AppRepositorySpec{
+				Auth: v1alpha1.AppRepositoryAuth{
+					CustomCA: &v1alpha1.AppRepositoryCustomCA{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{customCASecretName},
+							"custom-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			customCAData:  "not a valid cert",
+			errorExpected: true,
+		},
+		{
+			name: "authorization header added when passed an AppRepository CRD",
+			appRepoSpec: v1alpha1.AppRepositorySpec{
+				Auth: v1alpha1.AppRepositoryAuth{
+					Header: &v1alpha1.AppRepositoryAuthHeader{
+						SecretKeyRef: corev1.SecretKeySelector{
+							corev1.LocalObjectReference{authHeaderSecretName},
+							"custom-secret-key",
+							nil,
+						},
+					},
+				},
+			},
+			numCertsExpected: len(systemCertPool.Subjects()),
+			expectedHeaders:  http.Header{"Authorization": []string{authHeaderSecretData}},
+		},
+	}
+
+	for _, tc := range testCases {
+		// The fake k8s client will contain secret for the CA and header respectively.
+		caCertSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      customCASecretName,
+				Namespace: metav1.NamespaceSystem,
+			},
+			Data: map[string][]byte{
+				"custom-secret-key": []byte(tc.customCAData),
+			},
+		}
+		authSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      authHeaderSecretName,
+				Namespace: metav1.NamespaceSystem,
+			},
+			Data: map[string][]byte{
+				"custom-secret-key": []byte(authHeaderSecretData),
+			},
+		}
+
+		appRepo := &v1alpha1.AppRepository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: metav1.NamespaceSystem,
+			},
+			Spec: tc.appRepoSpec,
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			var testCASecret *corev1.Secret
+			if tc.appRepoSpec.Auth.CustomCA != nil {
+				testCASecret = caCertSecret
+			}
+			var testAuthSecret *corev1.Secret
+			if tc.appRepoSpec.Auth.Header != nil {
+				testAuthSecret = authSecret
+			}
+			httpClient, err := InitNetClient(appRepo, testCASecret, testAuthSecret, nil)
+			if err != nil {
+				if tc.errorExpected {
+					return
+				}
+				t.Fatalf("%+v", err)
+			} else {
+				if tc.errorExpected {
+					t.Fatalf("got: nil, want: error")
+				}
+			}
+
+			clientWithDefaultHeaders, ok := httpClient.(*clientWithDefaultHeaders)
+			if !ok {
+				t.Fatalf("unable to assert expected type")
+			}
+			client, ok := clientWithDefaultHeaders.client.(*http.Client)
+			if !ok {
+				t.Fatalf("unable to assert expected type")
+			}
+			transport, ok := client.Transport.(*http.Transport)
+			certPool := transport.TLSClientConfig.RootCAs
+
+			if got, want := len(certPool.Subjects()), tc.numCertsExpected; got != want {
+				t.Errorf("got: %d, want: %d", got, want)
+			}
+
+			// If the Auth header was set, secrets should be returned
+			if tc.appRepoSpec.Auth.Header != nil {
+				_, ok := clientWithDefaultHeaders.defaultHeaders["Authorization"]
+				if !ok {
+					t.Fatalf("expected Authorization header but found none")
+				}
+				if got, want := clientWithDefaultHeaders.defaultHeaders.Get("Authorization"), authHeaderSecretData; got != want {
+					t.Errorf("got: %q, want: %q", got, want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/kube/http_utils_test.go
+++ b/pkg/kube/http_utils_test.go
@@ -146,8 +146,8 @@ func TestInitNetClient(t *testing.T) {
 				Name:      customCASecretName,
 				Namespace: metav1.NamespaceSystem,
 			},
-			Data: map[string][]byte{
-				"custom-secret-key": []byte(tc.customCAData),
+			StringData: map[string]string{
+				"custom-secret-key": tc.customCAData,
 			},
 		}
 		authSecret := &corev1.Secret{

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	authorizationapi "k8s.io/api/authorization/v1"
@@ -92,6 +94,7 @@ type handler interface {
 	GetNamespaces() ([]corev1.Namespace, error)
 	GetSecret(name, namespace string) (*corev1.Secret, error)
 	GetAppRepository(repoName, repoNamespace string) (*v1alpha1.AppRepository, error)
+	ValidateAppRepository(appRepoBody io.ReadCloser) (*http.Response, error)
 }
 
 // AuthHandler exposes handler functionality as a user or the current serviceaccount
@@ -206,6 +209,19 @@ func (a *kubeHandler) clientsetForRequest(token string) (combinedClientsetInterf
 	return clientset, err
 }
 
+func parseRepoAndSecret(appRepoBody io.ReadCloser) (*v1alpha1.AppRepository, *corev1.Secret, error) {
+	var appRepoRequest appRepositoryRequest
+	err := json.NewDecoder(appRepoBody).Decode(&appRepoRequest)
+	if err != nil {
+		log.Infof("unable to decode: %v", err)
+		return nil, nil, err
+	}
+
+	appRepo := appRepositoryForRequest(appRepoRequest)
+	repoSecret := secretForRequest(appRepoRequest, appRepo)
+	return appRepo, repoSecret, nil
+}
+
 // CreateAppRepository creates an AppRepository resource based on the request data
 func (a *userHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error) {
 	if a.kubeappsNamespace == "" {
@@ -213,24 +229,17 @@ func (a *userHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestName
 		return nil, fmt.Errorf("kubeappsNamespace must be configured to enable app repository handler")
 	}
 
-	var appRepoRequest appRepositoryRequest
-	err := json.NewDecoder(appRepoBody).Decode(&appRepoRequest)
+	appRepo, repoSecret, err := parseRepoAndSecret(appRepoBody)
 	if err != nil {
-		log.Infof("unable to decode: %v", err)
 		return nil, err
 	}
 
-	appRepo := appRepositoryForRequest(appRepoRequest)
-
-	// TODO(mnelson): validate both required data and request for index
-	// https://github.com/kubeapps/kubeapps/issues/1330
 	appRepo, err = a.clientset.KubeappsV1alpha1().AppRepositories(requestNamespace).Create(appRepo)
 
 	if err != nil {
 		return nil, err
 	}
 
-	repoSecret := secretForRequest(appRepoRequest, appRepo)
 	if repoSecret != nil {
 		_, err = a.clientset.CoreV1().Secrets(requestNamespace).Create(repoSecret)
 		if err != nil {
@@ -276,6 +285,24 @@ func (a *userHandler) DeleteAppRepository(repoName, repoNamespace string) error 
 		err = a.clientset.CoreV1().Secrets(a.kubeappsNamespace).Delete(KubeappsSecretNameForRepo(repoName, repoNamespace), &metav1.DeleteOptions{})
 	}
 	return err
+}
+
+func (a *userHandler) ValidateAppRepository(appRepoBody io.ReadCloser) (*http.Response, error) {
+	appRepo, repoSecret, err := parseRepoAndSecret(appRepoBody)
+	if err != nil {
+		return nil, err
+	}
+	cli, err := InitNetClient(appRepo, repoSecret, repoSecret, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create HTTP client: %w", err)
+	}
+	indexURL := strings.TrimSuffix(strings.TrimSpace(appRepo.Spec.URL), "/") + "/index.yaml"
+	req, err := http.NewRequest("GET", indexURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return cli.Do(req)
 }
 
 // GetAppRepository returns an AppRepository resource from a namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Add an endpoint in the backed to validate a given AppRepository. This has been implemented as a different endpoint than the "Create" one to make it optional so users can choose to ignore errors if returned.

### Possible drawbacks

If the repository requires to use a proxy setting some environment variables, that's still not supported.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref: #1330

### Additional information

I couldn't find a good way of testing the HTTP request but tested IRL.

It was necessary to move some code from the `chart` package to `kube`.