### PR TITLE
Allow to validate apprepositories from the dashboard

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -503,3 +503,40 @@ describe("checkChart", () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
+
+describe("validateRepo", () => {
+  it("dispatches checkRepo and validatedRepo if no error", async () => {
+    AppRepository.validate = jest.fn();
+    const expectedActions = [
+      {
+        type: getType(repoActions.checkRepo),
+      },
+      {
+        type: getType(repoActions.validatedRepo),
+      },
+    ];
+
+    const res = await store.dispatch(repoActions.validateRepo("url", "auth", "cert"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(res).toBe(true);
+  });
+
+  it("dispatches checkRepo and errorRepos when the validation failed", async () => {
+    const error = new Error("boom!");
+    AppRepository.validate = jest.fn(() => {
+      throw error;
+    });
+    const expectedActions = [
+      {
+        type: getType(repoActions.checkRepo),
+      },
+      {
+        type: getType(repoActions.errorRepos),
+        payload: { err: error, op: "validate" },
+      },
+    ];
+    const res = await store.dispatch(repoActions.validateRepo("url", "auth", "cert"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(res).toBe(false);
+  });
+});

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -505,14 +505,15 @@ describe("checkChart", () => {
 });
 
 describe("validateRepo", () => {
-  it("dispatches checkRepo and validatedRepo if no error", async () => {
-    AppRepository.validate = jest.fn();
+  it("dispatches repoValidating and repoValidated if no error", async () => {
+    AppRepository.validate = jest.fn(() => "OK");
     const expectedActions = [
       {
-        type: getType(repoActions.checkRepo),
+        type: getType(repoActions.repoValidating),
       },
       {
-        type: getType(repoActions.validatedRepo),
+        type: getType(repoActions.repoValidated),
+        payload: "OK",
       },
     ];
 
@@ -528,11 +529,32 @@ describe("validateRepo", () => {
     });
     const expectedActions = [
       {
-        type: getType(repoActions.checkRepo),
+        type: getType(repoActions.repoValidating),
       },
       {
         type: getType(repoActions.errorRepos),
         payload: { err: error, op: "validate" },
+      },
+    ];
+    const res = await store.dispatch(repoActions.validateRepo("url", "auth", "cert"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(res).toBe(false);
+  });
+
+  it("dispatches checkRepo and errorRepos when the validation cannot be parsed", async () => {
+    AppRepository.validate = jest.fn(() => {
+      return { statusCode: 409 };
+    });
+    const expectedActions = [
+      {
+        type: getType(repoActions.repoValidating),
+      },
+      {
+        type: getType(repoActions.errorRepos),
+        payload: {
+          err: new Error('Unable to parse validation response, got: {"statusCode":409}'),
+          op: "validate",
+        },
       },
     ];
     const res = await store.dispatch(repoActions.validateRepo("url", "auth", "cert"));

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -25,6 +25,11 @@ export const receiveRepo = createAction("RECEIVE_REPO", resolve => {
   return (repo: IAppRepository) => resolve(repo);
 });
 
+export const checkRepo = createAction("CHECK_REPO");
+export const validatedRepo = createAction("VALIDATED_REPO", resolve => {
+  return (data: any) => resolve(data);
+});
+
 // Clear repo is basically receiving an empty repo
 export const clearRepo = createAction("RECEIVE_REPO", resolve => {
   return () => resolve({} as IAppRepository);
@@ -41,12 +46,15 @@ export const redirect = createAction("REDIRECT", resolve => {
 
 export const redirected = createAction("REDIRECTED");
 export const errorRepos = createAction("ERROR_REPOS", resolve => {
-  return (err: Error, op: "create" | "update" | "fetch" | "delete") => resolve({ err, op });
+  return (err: Error, op: "create" | "update" | "fetch" | "delete" | "validate") =>
+    resolve({ err, op });
 });
 
 const allActions = [
   addRepo,
   addedRepo,
+  checkRepo,
+  validatedRepo,
   clearRepo,
   errorRepos,
   requestRepos,
@@ -170,6 +178,25 @@ export const installRepo = (
       return true;
     } catch (e) {
       dispatch(errorRepos(e, "create"));
+      return false;
+    }
+  };
+};
+
+export const validateRepo = (
+  repoURL: string,
+  authHeader: string,
+  customCA: string,
+): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
+  return async dispatch => {
+    try {
+      dispatch(checkRepo());
+      const data = await AppRepository.validate(repoURL, authHeader, customCA);
+      dispatch(validatedRepo(data));
+
+      return true;
+    } catch (e) {
+      dispatch(errorRepos(e, "validate"));
       return false;
     }
   };

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.test.tsx
@@ -8,7 +8,7 @@ import { AppRepoForm } from "./AppRepoForm";
 
 const defaultProps = {
   install: jest.fn(),
-  validate: jest.fn(),
+  validate: jest.fn(() => true),
   namespace: "kubeapps",
   isFetching: false,
   errors: {},
@@ -39,9 +39,9 @@ it("should install a repository with a custom auth header", done => {
   const button = wrapper.find(AppRepoForm).find(".button-primary");
   button.simulate("submit");
 
-  expect(install).toBeCalledWith("my-repo", "kubeapps", "http://foo.bar", "foo", "bar", "");
   // Wait for the Modal to be closed
   setTimeout(() => {
+    expect(install).toBeCalledWith("my-repo", "kubeapps", "http://foo.bar", "foo", "bar", "");
     expect(wrapper.state("modalIsOpen")).toBe(false);
     done();
   }, 1);
@@ -65,16 +65,16 @@ it("should install a repository with basic auth", done => {
   const button = wrapper.find(AppRepoForm).find(".button-primary");
   button.simulate("submit");
 
-  expect(install).toBeCalledWith(
-    "my-repo",
-    "kubeapps",
-    "http://foo.bar",
-    "Basic Zm9vOmJhcg==",
-    "",
-    "",
-  );
   // Wait for the Modal to be closed
   setTimeout(() => {
+    expect(install).toBeCalledWith(
+      "my-repo",
+      "kubeapps",
+      "http://foo.bar",
+      "Basic Zm9vOmJhcg==",
+      "",
+      "",
+    );
     expect(wrapper.state("modalIsOpen")).toBe(false);
     done();
   }, 1);
@@ -97,9 +97,16 @@ it("should install a repository with a bearer token", done => {
   const button = wrapper.find(AppRepoForm).find(".button-primary");
   button.simulate("submit");
 
-  expect(install).toBeCalledWith("my-repo", "kubeapps", "http://foo.bar", "Bearer foobar", "", "");
   // Wait for the Modal to be closed
   setTimeout(() => {
+    expect(install).toBeCalledWith(
+      "my-repo",
+      "kubeapps",
+      "http://foo.bar",
+      "Bearer foobar",
+      "",
+      "",
+    );
     expect(wrapper.state("modalIsOpen")).toBe(false);
     done();
   }, 1);
@@ -122,23 +129,23 @@ it("should install a repository with a podSpecTemplate", done => {
   const button = wrapper.find(AppRepoForm).find(".button-primary");
   button.simulate("submit");
 
-  expect(install).toBeCalledWith(
-    "my-repo",
-    "kubeapps",
-    "http://foo.bar",
-    "Bearer ",
-    "",
-    "foo: bar",
-  );
   // Wait for the Modal to be closed
   setTimeout(() => {
+    expect(install).toBeCalledWith(
+      "my-repo",
+      "kubeapps",
+      "http://foo.bar",
+      "Bearer ",
+      "",
+      "foo: bar",
+    );
     expect(wrapper.state("modalIsOpen")).toBe(false);
     done();
   }, 1);
 });
 
 describe("render error", () => {
-  it("renders a conflict error", () => {
+  it("renders a conflict error", done => {
     const wrapper = mount(<AppRepoAddButton {...defaultProps} />);
     ReactModal.setAppElement(document.createElement("div"));
     wrapper.setState({ modalIsOpen: true });
@@ -149,18 +156,21 @@ describe("render error", () => {
     button.simulate("submit");
     wrapper.setProps({ errors: { create: new ConflictError("already exists!") } });
 
-    expect(wrapper.find(ErrorSelector).text()).toContain(
-      "App Repository my-repo already exists, try a different name.",
-    );
-    // Now changing the name should not change the error message
-    wrapper.setState({ name: "my-app-2" });
-    wrapper.update();
-    expect(wrapper.find(ErrorSelector).text()).toContain(
-      "App Repository my-repo already exists, try a different name.",
-    );
+    setTimeout(() => {
+      expect(wrapper.find(ErrorSelector).text()).toContain(
+        "App Repository my-repo already exists, try a different name.",
+      );
+      // Now changing the name should not change the error message
+      wrapper.setState({ name: "my-app-2" });
+      wrapper.update();
+      expect(wrapper.find(ErrorSelector).text()).toContain(
+        "App Repository my-repo already exists, try a different name.",
+      );
+      done();
+    }, 1);
   });
 
-  it("renders an 'unprocessable entity' error", () => {
+  it("renders an 'unprocessable entity' error", done => {
     const wrapper = mount(<AppRepoAddButton {...defaultProps} />);
     ReactModal.setAppElement(document.createElement("div"));
     wrapper.setState({ modalIsOpen: true });
@@ -171,9 +181,12 @@ describe("render error", () => {
     button.simulate("submit");
     wrapper.setProps({ errors: { create: new UnprocessableEntity("cannot process this!") } });
 
-    expect(wrapper.find(ErrorSelector).text()).toContain(
-      "Something went wrong processing App Repository my-repo",
-    );
-    expect(wrapper.find(ErrorSelector).text()).toContain("cannot process this!");
+    setTimeout(() => {
+      expect(wrapper.find(ErrorSelector).text()).toContain(
+        "Something went wrong processing App Repository my-repo",
+      );
+      expect(wrapper.find(ErrorSelector).text()).toContain("cannot process this!");
+      done();
+    }, 1);
   });
 });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.test.tsx
@@ -8,7 +8,10 @@ import { AppRepoForm } from "./AppRepoForm";
 
 const defaultProps = {
   install: jest.fn(),
+  validate: jest.fn(),
   namespace: "kubeapps",
+  isFetching: false,
+  errors: {},
 };
 
 it("should open a modal with the repository form", () => {
@@ -33,7 +36,7 @@ it("should install a repository with a custom auth header", done => {
     customCA: "bar",
   });
 
-  const button = wrapper.find(AppRepoForm).find(".button");
+  const button = wrapper.find(AppRepoForm).find(".button-primary");
   button.simulate("submit");
 
   expect(install).toBeCalledWith("my-repo", "kubeapps", "http://foo.bar", "foo", "bar", "");
@@ -59,7 +62,7 @@ it("should install a repository with basic auth", done => {
     password: "bar",
   });
 
-  const button = wrapper.find(AppRepoForm).find(".button");
+  const button = wrapper.find(AppRepoForm).find(".button-primary");
   button.simulate("submit");
 
   expect(install).toBeCalledWith(
@@ -91,7 +94,7 @@ it("should install a repository with a bearer token", done => {
     token: "foobar",
   });
 
-  const button = wrapper.find(AppRepoForm).find(".button");
+  const button = wrapper.find(AppRepoForm).find(".button-primary");
   button.simulate("submit");
 
   expect(install).toBeCalledWith("my-repo", "kubeapps", "http://foo.bar", "Bearer foobar", "", "");
@@ -116,7 +119,7 @@ it("should install a repository with a podSpecTemplate", done => {
     syncJobPodTemplate: "foo: bar",
   });
 
-  const button = wrapper.find(AppRepoForm).find(".button");
+  const button = wrapper.find(AppRepoForm).find(".button-primary");
   button.simulate("submit");
 
   expect(install).toBeCalledWith(
@@ -142,9 +145,9 @@ describe("render error", () => {
     wrapper.update();
     wrapper.find(AppRepoForm).setState({ name: "my-repo" });
 
-    const button = wrapper.find(AppRepoForm).find(".button");
+    const button = wrapper.find(AppRepoForm).find(".button-primary");
     button.simulate("submit");
-    wrapper.setProps({ error: new ConflictError("already exists!") });
+    wrapper.setProps({ errors: { create: new ConflictError("already exists!") } });
 
     expect(wrapper.find(ErrorSelector).text()).toContain(
       "App Repository my-repo already exists, try a different name.",
@@ -164,9 +167,9 @@ describe("render error", () => {
     wrapper.update();
     wrapper.find(AppRepoForm).setState({ name: "my-repo" });
 
-    const button = wrapper.find(AppRepoForm).find(".button");
+    const button = wrapper.find(AppRepoForm).find(".button-primary");
     button.simulate("submit");
-    wrapper.setProps({ error: new UnprocessableEntity("cannot process this!") });
+    wrapper.setProps({ errors: { create: new UnprocessableEntity("cannot process this!") } });
 
     expect(wrapper.find(ErrorSelector).text()).toContain(
       "Something went wrong processing App Repository my-repo",

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -81,7 +81,7 @@ export class AppRepoAddButton extends React.Component<
             validate={this.props.validate}
             onAfterInstall={this.closeModal}
             isFetching={this.props.isFetching}
-            validateError={this.props.errors.validate}
+            validationError={this.props.errors.validate}
           />
         </Modal>
         {redirectTo && <Redirect to={redirectTo} />}

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -21,7 +21,13 @@ const RequiredRBACRoles: IRBACRole[] = [
 ];
 
 interface IAppRepoAddButtonProps {
-  error?: Error;
+  errors: {
+    create?: Error;
+    delete?: Error;
+    fetch?: Error;
+    update?: Error;
+    validate?: Error;
+  };
   install: (
     name: string,
     namespace: string,
@@ -30,6 +36,8 @@ interface IAppRepoAddButtonProps {
     customCA: string,
     syncJobPodTemplate: string,
   ) => Promise<boolean>;
+  validate: (url: string, authHeader: string, customCA: string) => Promise<any>;
+  isFetching: boolean;
   redirectTo?: string;
   namespace: string;
 }
@@ -59,16 +67,22 @@ export class AppRepoAddButton extends React.Component<
           onRequestClose={this.closeModal}
           contentLabel="Modal"
         >
-          {this.props.error && (
+          {this.props.errors.create && (
             <ErrorSelector
-              error={this.props.error}
+              error={this.props.errors.create}
               defaultRequiredRBACRoles={{ create: RequiredRBACRoles }}
               action="create"
               namespace={this.props.namespace}
               resource={`App Repository ${this.state.lastSubmittedName}`}
             />
           )}
-          <AppRepoForm install={this.install} onAfterInstall={this.closeModal} />
+          <AppRepoForm
+            install={this.install}
+            validate={this.props.validate}
+            onAfterInstall={this.closeModal}
+            isFetching={this.props.isFetching}
+            validateError={this.props.errors.validate}
+          />
         </Modal>
         {redirectTo && <Redirect to={redirectTo} />}
       </React.Fragment>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -1,6 +1,6 @@
 import { shallow } from "enzyme";
 import * as React from "react";
-import { UnexpectedErrorAlert } from "../../ErrorAlert";
+import UnexpectedErrorPage from "../../ErrorAlert/UnexpectedErrorAlert";
 import { AppRepoForm } from "./AppRepoForm";
 
 const defaultProps = {
@@ -14,53 +14,48 @@ it("should render the repo form", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
-it("should render a validation error", () => {
-  const wrapper = shallow(<AppRepoForm {...defaultProps} validateError={new Error("Boom!")} />);
-  expect(wrapper.find(UnexpectedErrorAlert)).toExist();
-  expect(wrapper.find(UnexpectedErrorAlert).html()).toMatch(/Validation Failed. Got:.*Boom!/);
-});
-
-it("should render validation confirmation", done => {
-  const validate = jest.fn(() => true);
-  const wrapper = shallow(<AppRepoForm {...defaultProps} validate={validate} />);
-  wrapper.setState({
-    url: "http://charts.com",
-    authMethod: "custom",
-    authHeader: "Bearer foo",
-    customCA: "valid cert",
-  });
-
-  const button = wrapper.find("button").filterWhere(b => b.text() === "Validate");
-  expect(button).toExist();
-  expect(button.prop("disabled")).toBe(false);
-  button.simulate("click");
-
-  expect(validate).toHaveBeenCalledWith("http://charts.com", "Bearer foo", "valid cert");
-  setTimeout(() => {
-    expect(wrapper.text()).toMatch("Repository successfully validated");
-    done();
-  }, 1);
-});
-
-it("disables the validation button if there is no url", () => {
-  const wrapper = shallow(<AppRepoForm {...defaultProps} />);
-  const button = wrapper.find("button").filterWhere(b => b.text() === "Validate");
-  expect(button).toExist();
-  expect(button.prop("disabled")).toBe(true);
-});
-
-it("disables the validation button if the syncJobTemplate is not empty", () => {
-  const wrapper = shallow(<AppRepoForm {...defaultProps} />);
-  wrapper.setState({ url: "http://charts.com", syncJobPodTemplate: "not-empty" });
-  const button = wrapper.find("button").filterWhere(b => b.text() === "Validate");
-  expect(button).toExist();
-  expect(button.prop("disabled")).toBe(true);
-});
-
-it("disables the submit and validation button while fetching", () => {
+it("disables the submit button while fetching", () => {
   const wrapper = shallow(<AppRepoForm {...defaultProps} isFetching={true} />);
-  const buttons = wrapper.find("button");
-  buttons.forEach(button => {
-    expect(button.prop("disabled")).toBe(true);
-  });
+  expect(wrapper.find("button").prop("disabled")).toBe(true);
+});
+
+it("should show a validation error", () => {
+  const wrapper = shallow(<AppRepoForm {...defaultProps} validationError={new Error("Boom!")} />);
+  expect(
+    wrapper
+      .find(UnexpectedErrorPage)
+      .dive()
+      .text(),
+  ).toContain("Boom!");
+});
+
+it("should call the install method when the validation success", async () => {
+  const validate = jest.fn(() => true);
+  const install = jest.fn(() => true);
+  const wrapper = shallow(<AppRepoForm {...defaultProps} validate={validate} install={install} />);
+  const button = wrapper.find("form");
+  button.simulate("submit", { preventDefault: jest.fn() });
+  // wait for async functions
+  await new Promise(s => s());
+  expect(install).toHaveBeenCalled();
+});
+
+it("should not call the install method when the validation fails unless forced", async () => {
+  const validate = jest.fn(() => false);
+  const install = jest.fn(() => true);
+  const wrapper = shallow(<AppRepoForm {...defaultProps} validate={validate} install={install} />);
+  let button = wrapper.find("form");
+
+  button.simulate("submit", { preventDefault: jest.fn() });
+  // wait for async functions
+  await new Promise(s => s());
+  expect(install).not.toHaveBeenCalled();
+  wrapper.update();
+  button = wrapper.find("button");
+  expect(button.text()).toContain("Install Repo (force)");
+
+  wrapper.find("form").simulate("submit", { preventDefault: jest.fn() });
+  // wait for async functions
+  await new Promise(s => s());
+  expect(install).toHaveBeenCalled();
 });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -1,0 +1,66 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+import { UnexpectedErrorAlert } from "../../ErrorAlert";
+import { AppRepoForm } from "./AppRepoForm";
+
+const defaultProps = {
+  install: jest.fn(),
+  validate: jest.fn(),
+  isFetching: false,
+};
+
+it("should render the repo form", () => {
+  const wrapper = shallow(<AppRepoForm {...defaultProps} />);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("should render a validation error", () => {
+  const wrapper = shallow(<AppRepoForm {...defaultProps} validateError={new Error("Boom!")} />);
+  expect(wrapper.find(UnexpectedErrorAlert)).toExist();
+  expect(wrapper.find(UnexpectedErrorAlert).html()).toMatch(/Validation Failed. Got:.*Boom!/);
+});
+
+it("should render validation confirmation", done => {
+  const validate = jest.fn(() => true);
+  const wrapper = shallow(<AppRepoForm {...defaultProps} validate={validate} />);
+  wrapper.setState({
+    url: "http://charts.com",
+    authMethod: "custom",
+    authHeader: "Bearer foo",
+    customCA: "valid cert",
+  });
+
+  const button = wrapper.find("button").filterWhere(b => b.text() === "Validate");
+  expect(button).toExist();
+  expect(button.prop("disabled")).toBe(false);
+  button.simulate("click");
+
+  expect(validate).toHaveBeenCalledWith("http://charts.com", "Bearer foo", "valid cert");
+  setTimeout(() => {
+    expect(wrapper.text()).toMatch("Repository successfully validated");
+    done();
+  }, 1);
+});
+
+it("disables the validation button if there is no url", () => {
+  const wrapper = shallow(<AppRepoForm {...defaultProps} />);
+  const button = wrapper.find("button").filterWhere(b => b.text() === "Validate");
+  expect(button).toExist();
+  expect(button.prop("disabled")).toBe(true);
+});
+
+it("disables the validation button if the syncJobTemplate is not empty", () => {
+  const wrapper = shallow(<AppRepoForm {...defaultProps} />);
+  wrapper.setState({ url: "http://charts.com", syncJobPodTemplate: "not-empty" });
+  const button = wrapper.find("button").filterWhere(b => b.text() === "Validate");
+  expect(button).toExist();
+  expect(button.prop("disabled")).toBe(true);
+});
+
+it("disables the submit and validation button while fetching", () => {
+  const wrapper = shallow(<AppRepoForm {...defaultProps} isFetching={true} />);
+  const buttons = wrapper.find("button");
+  buttons.forEach(button => {
+    expect(button.prop("disabled")).toBe(true);
+  });
+});

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -13,6 +13,7 @@ const defaultProps = {
   resyncRepo: jest.fn(),
   resyncAllRepos: jest.fn(),
   install: jest.fn(),
+  validate: jest.fn(),
   namespace: defaultNamespace,
   displayReposPerNamespaceMsg: false,
   isFetching: false,

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -14,6 +14,7 @@ export interface IAppRepoListProps {
     delete?: Error;
     fetch?: Error;
     update?: Error;
+    validate?: Error;
   };
   repos: IAppRepository[];
   fetchRepos: (namespace: string) => void;
@@ -28,6 +29,7 @@ export interface IAppRepoListProps {
     customCA: string,
     syncJobPodTemplate: string,
   ) => Promise<boolean>;
+  validate: (url: string, authHeader: string, customCA: string) => Promise<any>;
   namespace: string;
   displayReposPerNamespaceMsg: boolean;
   isFetching: boolean;
@@ -85,6 +87,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
       deleteRepo,
       resyncRepo,
       resyncAllRepos,
+      validate,
     } = this.props;
     const renderNamespace = namespace === definedNamespaces.all;
     return (
@@ -116,7 +119,13 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
             </tbody>
           </table>
         </LoadingWrapper>
-        <AppRepoAddButton error={errors.create} install={install} namespace={namespace} />
+        <AppRepoAddButton
+          errors={errors}
+          install={install}
+          validate={validate}
+          namespace={namespace}
+          isFetching={isFetching}
+        />
         <AppRepoRefreshAllButton resyncAllRepos={resyncAllRepos} repos={repos} />
         {displayReposPerNamespaceMsg && (
           <MessageAlert header="Looking for other app repositories?">

--- a/dashboard/src/components/Config/AppRepoList/__snapshots__/AppRepoButton.test.tsx.snap
+++ b/dashboard/src/components/Config/AppRepoList/__snapshots__/AppRepoButton.test.tsx.snap
@@ -2,8 +2,11 @@
 
 exports[`should open a modal with the repository form 1`] = `
 <AppRepoAddButton
+  errors={Object {}}
   install={[Function]}
+  isFetching={false}
   namespace="kubeapps"
+  validate={[Function]}
 >
   <button
     className="button button-primary"
@@ -232,9 +235,7 @@ exports[`should open a modal with the repository form 1`] = `
                         </pre>
                       </label>
                     </div>
-                    <div
-                      style="margin-bottom: 1em;"
-                    >
+                    <div>
                       <label
                         for="syncJobPodTemplate"
                       >
@@ -279,15 +280,15 @@ exports[`should open a modal with the repository form 1`] = `
                         data-id="tooltip"
                       >
                         <span>
-                          It's possible to modify the default sync job.
-                          <br />
-                          More info
+                          It's possible to modify the default sync job. More info
                           <a
                             target="_blank"
                             href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/private-app-repository.md#modifying-the-synchronization-job"
                           >
                             here
                           </a>
+                          <br />
+                          When modifying the default sync job, the pre-validation is not supported.
                         </span>
                       </div>
                       <pre
@@ -307,6 +308,13 @@ exports[`should open a modal with the repository form 1`] = `
                       </pre>
                     </div>
                     <div>
+                      <button
+                        class="button"
+                        type="button"
+                        disabled=""
+                      >
+                        Validate
+                      </button>
                       <button
                         class="button button-primary"
                         type="submit"

--- a/dashboard/src/components/Config/AppRepoList/__snapshots__/AppRepoButton.test.tsx.snap
+++ b/dashboard/src/components/Config/AppRepoList/__snapshots__/AppRepoButton.test.tsx.snap
@@ -309,17 +309,10 @@ exports[`should open a modal with the repository form 1`] = `
                     </div>
                     <div>
                       <button
-                        class="button"
-                        type="button"
-                        disabled=""
-                      >
-                        Validate
-                      </button>
-                      <button
                         class="button button-primary"
                         type="submit"
                       >
-                        Install Repo
+                        Install Repo 
                       </button>
                     </div>
                   </div>

--- a/dashboard/src/components/Config/AppRepoList/__snapshots__/AppRepoForm.test.tsx.snap
+++ b/dashboard/src/components/Config/AppRepoList/__snapshots__/AppRepoForm.test.tsx.snap
@@ -251,19 +251,11 @@ exports[`should render the repo form 1`] = `
       </div>
       <div>
         <button
-          className="button"
-          disabled={true}
-          onClick={[Function]}
-          type="button"
-        >
-          Validate
-        </button>
-        <button
           className="button button-primary"
           disabled={false}
           type="submit"
         >
-          Install Repo
+          Install Repo 
         </button>
       </div>
     </div>

--- a/dashboard/src/components/Config/AppRepoList/__snapshots__/AppRepoForm.test.tsx.snap
+++ b/dashboard/src/components/Config/AppRepoList/__snapshots__/AppRepoForm.test.tsx.snap
@@ -1,0 +1,272 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render the repo form 1`] = `
+<form
+  className="container padding-b-bigger"
+  onSubmit={[Function]}
+>
+  <div
+    className="row"
+  >
+    <div
+      className="col-12"
+    >
+      <div>
+        <h2>
+          Add an App Repository
+        </h2>
+      </div>
+      <div>
+        <label
+          htmlFor="kubeapps-repo-name"
+        >
+          Name:
+        </label>
+        <input
+          id="kubeapps-repo-name"
+          onChange={[Function]}
+          pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+          placeholder="example"
+          required={true}
+          title="Use lower case alphanumeric characters, '-' or '.'"
+          type="text"
+          value=""
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="kubeapps-repo-url"
+        >
+          URL:
+        </label>
+        <input
+          id="kubeapps-repo-url"
+          onChange={[Function]}
+          placeholder="https://charts.example.com/stable"
+          required={true}
+          type="url"
+          value=""
+        />
+      </div>
+      <div>
+        <span>
+          Authorization (optional):
+        </span>
+        <div
+          className="row"
+        >
+          <div
+            className="col-2"
+          >
+            <label
+              className="margin-l-big"
+              htmlFor="kubeapps-repo-auth-method-none"
+            >
+              <input
+                defaultChecked={true}
+                id="kubeapps-repo-auth-method-none"
+                name="auth"
+                onChange={[Function]}
+                type="radio"
+                value="none"
+              />
+              None
+              <br />
+            </label>
+            <label
+              htmlFor="kubeapps-repo-auth-method-basic"
+            >
+              <input
+                id="kubeapps-repo-auth-method-basic"
+                name="auth"
+                onChange={[Function]}
+                type="radio"
+                value="basic"
+              />
+              Basic Auth
+              <br />
+            </label>
+            <label
+              htmlFor="kubeapps-repo-auth-method-bearer"
+            >
+              <input
+                id="kubeapps-repo-auth-method-bearer"
+                name="auth"
+                onChange={[Function]}
+                type="radio"
+                value="bearer"
+              />
+              Bearer Token
+              <br />
+            </label>
+            <label
+              htmlFor="kubeapps-repo-auth-method-custom"
+            >
+              <input
+                id="kubeapps-repo-auth-method-custom"
+                name="auth"
+                onChange={[Function]}
+                type="radio"
+                value="custom"
+              />
+              Custom
+              <br />
+            </label>
+          </div>
+          <div
+            aria-live="polite"
+            className="col-10"
+          >
+            <div
+              className="secondary-input"
+              hidden={true}
+            >
+              <label
+                htmlFor="kubeapps-repo-username"
+              >
+                Username
+              </label>
+              <input
+                id="kubeapps-repo-username"
+                onChange={[Function]}
+                placeholder="Username"
+                type="text"
+                value=""
+              />
+              <label
+                htmlFor="kubeapps-repo-password"
+              >
+                Password
+              </label>
+              <input
+                id="kubeapps-repo-password"
+                onChange={[Function]}
+                placeholder="Password"
+                type="password"
+                value=""
+              />
+            </div>
+            <div
+              className="secondary-input"
+              hidden={true}
+            >
+              <label
+                htmlFor="kubeapps-repo-token"
+              >
+                Token
+              </label>
+              <input
+                id="kubeapps-repo-token"
+                onChange={[Function]}
+                type="text"
+                value=""
+              />
+            </div>
+            <div
+              className="secondary-input"
+              hidden={true}
+            >
+              <label
+                htmlFor="kubeapps-repo-custom-header"
+              >
+                Complete Authorization Header
+              </label>
+              <input
+                id="kubeapps-repo-custom-header"
+                onChange={[Function]}
+                placeholder="Bearer xrxNcWghpRLdcPHFgVRM73rr4N7qjvjm"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="margin-t-big"
+      >
+        <label>
+          <span>
+            Custom CA Certificate (optional):
+          </span>
+          <pre
+            className="CodeContainer"
+          >
+            <textarea
+              className="Code"
+              onChange={[Function]}
+              placeholder="-----BEGIN CERTIFICATE-----
+            ...
+            -----END CERTIFICATE-----"
+              rows={4}
+              value=""
+            />
+          </pre>
+        </label>
+      </div>
+      <div>
+        <label
+          htmlFor="syncJobPodTemplate"
+        >
+          Custom Sync Job Template (optional)
+        </label>
+        <Hint
+          id="syncJobHelp"
+          reactTooltipOpts={
+            Object {
+              "delayHide": 1000,
+            }
+          }
+        >
+          <span>
+            It's possible to modify the default sync job. More info
+             
+            <a
+              href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/private-app-repository.md#modifying-the-synchronization-job"
+              target="_blank"
+            >
+              here
+            </a>
+            <br />
+            When modifying the default sync job, the pre-validation is not supported.
+          </span>
+        </Hint>
+        <pre
+          className="CodeContainer"
+        >
+          <textarea
+            className="Code"
+            id="syncJobPodTemplate"
+            onChange={[Function]}
+            placeholder="spec:
+            containers:
+            - env:
+              - name: FOO
+                value: BAR
+          "
+            rows={4}
+            value=""
+          />
+        </pre>
+      </div>
+      <div>
+        <button
+          className="button"
+          disabled={true}
+          onClick={[Function]}
+          type="button"
+        >
+          Validate
+        </button>
+        <button
+          className="button button-primary"
+          disabled={false}
+          type="submit"
+        >
+          Install Repo
+        </button>
+      </div>
+    </div>
+  </div>
+</form>
+`;

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -45,6 +45,9 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
         actions.repos.installRepo(name, namespace, url, authHeader, customCA, syncJobPodTemplate),
       );
     },
+    validate: async (url: string, authHeader: string, customCA: string) => {
+      return dispatch(actions.repos.validateRepo(url, authHeader, customCA));
+    },
     resyncRepo: async (name: string, namespace: string) => {
       return dispatch(actions.repos.resyncRepo(name, namespace));
     },

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -61,9 +61,9 @@ const reposReducer = (
         lastAdded: action.payload,
         repos: [...state.repos, action.payload],
       };
-    case getType(actions.repos.checkRepo):
+    case getType(actions.repos.repoValidating):
       return { ...state, isFetching: true };
-    case getType(actions.repos.validatedRepo):
+    case getType(actions.repos.repoValidated):
       return { ...state, isFetching: false, errors: { ...state.errors, validate: undefined } };
     case getType(actions.repos.resetForm):
       return { ...state, form: { ...state.form, name: "", namespace: "", url: "" } };

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -12,6 +12,7 @@ export interface IAppRepositoryState {
     delete?: Error;
     fetch?: Error;
     update?: Error;
+    validate?: Error;
   };
   lastAdded?: IAppRepository;
   isFetching: boolean;
@@ -60,6 +61,10 @@ const reposReducer = (
         lastAdded: action.payload,
         repos: [...state.repos, action.payload],
       };
+    case getType(actions.repos.checkRepo):
+      return { ...state, isFetching: true };
+    case getType(actions.repos.validatedRepo):
+      return { ...state, isFetching: false, errors: { ...state.errors, validate: undefined } };
     case getType(actions.repos.resetForm):
       return { ...state, form: { ...state.form, name: "", namespace: "", url: "" } };
     case getType(actions.repos.showForm):

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -48,10 +48,9 @@ export class AppRepository {
   }
 
   public static async validate(repoURL: string, authHeader: string, customCA: string) {
-    const { data } = await axiosWithAuth.post<ICreateAppRepositoryResponse>(
-      url.backend.apprepositories.validate(),
-      { appRepository: { name, repoURL, authHeader, customCA } },
-    );
+    const { data } = await axiosWithAuth.post<any>(url.backend.apprepositories.validate(), {
+      appRepository: { name, repoURL, authHeader, customCA },
+    });
     return data;
   }
 

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -47,6 +47,14 @@ export class AppRepository {
     return data;
   }
 
+  public static async validate(repoURL: string, authHeader: string, customCA: string) {
+    const { data } = await axiosWithAuth.post<ICreateAppRepositoryResponse>(
+      url.backend.apprepositories.validate(),
+      { appRepository: { name, repoURL, authHeader, customCA } },
+    );
+    return data;
+  }
+
   private static APIBase: string = APIBase;
   private static APIEndpoint: string = `${AppRepository.APIBase}/apis/kubeapps.com/v1alpha1`;
   private static getResourceLink(namespace?: string): string {

--- a/dashboard/src/shared/AxiosInstance.test.ts
+++ b/dashboard/src/shared/AxiosInstance.test.ts
@@ -160,7 +160,7 @@ describe("createAxiosInterceptorWithAuth", () => {
     Auth.unsetAuthCookie = jest.fn();
     const expectedActions = [
       {
-        payload: "Request failed with status code 401",
+        payload: "not ajson paylod",
         type: "AUTHENTICATION_ERROR",
       },
       {

--- a/dashboard/src/shared/AxiosInstance.ts
+++ b/dashboard/src/shared/AxiosInstance.ts
@@ -40,8 +40,13 @@ export function addErrorHandling(axiosInstance: AxiosInstance, store: Store<ISto
         dispatch(actions.auth.expireSession());
       }
       let message = err.message;
-      if (err.response && err.response.data.message) {
-        message = err.response.data.message;
+      if (err.response) {
+        if (err.response.data.message) {
+          message = err.response.data.message;
+        }
+        if (typeof err.response.data === "string") {
+          message = err.response.data;
+        }
       }
 
       const dispatchErrorAndLogout = (m: string) => {

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -13,6 +13,7 @@ export const backend = {
   apprepositories: {
     base: (namespace: string) => `api/v1/namespaces/${namespace}/apprepositories`,
     create: (namespace: string) => backend.apprepositories.base(namespace),
+    validate: () => `${backend.apprepositories.base("kubeapps")}/validate`,
     delete: (name: string, namespace: string) =>
       `${backend.apprepositories.base(namespace)}/${name}`,
   },


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Follow up of #1534 

Validate apprepositories from the dashboard before submitting them. As explained in the other PR, this validation is optional, allowing users to skip it if they think so:

![Screenshot from 2020-02-27 11-14-29](https://user-images.githubusercontent.com/4025665/75434909-8e6e3900-5952-11ea-8f19-ecc16a6b0a24.png)

### Possible drawbacks

Changing the spec of the sync job is not supported for the validation endpoint so the button is disabled if the template gets modified.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1330
