### PR TITLE
Update repoAlreadyProcessed, updateIcon and fileExists.

### DIFF
--- a/cmd/asset-syncer/mongodb_utils.go
+++ b/cmd/asset-syncer/mongodb_utils.go
@@ -53,11 +53,11 @@ func (m *mongodbAssetManager) Sync(repo models.Repo, charts []models.Chart) erro
 	return m.importCharts(charts)
 }
 
-func (m *mongodbAssetManager) RepoAlreadyProcessed(repoName string, checksum string) bool {
+func (m *mongodbAssetManager) RepoAlreadyProcessed(repo models.Repo, checksum string) bool {
 	db, closer := m.DBSession.DB()
 	defer closer()
 	lastCheck := &models.RepoCheck{}
-	err := db.C(repositoryCollection).Find(bson.M{"_id": repoName}).One(lastCheck)
+	err := db.C(repositoryCollection).Find(bson.M{"_id": repo.Name}).One(lastCheck)
 	return err == nil && checksum == lastCheck.Checksum
 }
 
@@ -119,13 +119,13 @@ func (m *mongodbAssetManager) importCharts(charts []models.Chart) error {
 	return err
 }
 
-func (m *mongodbAssetManager) updateIcon(data []byte, contentType, ID string) error {
+func (m *mongodbAssetManager) updateIcon(repo models.Repo, data []byte, contentType, ID string) error {
 	db, closer := m.DBSession.DB()
 	defer closer()
 	return db.C(chartCollection).UpdateId(ID, bson.M{"$set": bson.M{"raw_icon": data, "icon_content_type": contentType}})
 }
 
-func (m *mongodbAssetManager) filesExist(chartFilesID, digest string) bool {
+func (m *mongodbAssetManager) filesExist(repo models.Repo, chartFilesID, digest string) bool {
 	db, closer := m.DBSession.DB()
 	defer closer()
 	err := db.C(chartFilesCollection).Find(bson.M{"_id": chartFilesID, "digest": digest}).One(&models.ChartFiles{})

--- a/cmd/asset-syncer/mongodb_utils_test.go
+++ b/cmd/asset-syncer/mongodb_utils_test.go
@@ -101,7 +101,7 @@ func Test_repoAlreadyProcessed(t *testing.T) {
 				*args.Get(0).(*models.RepoCheck) = tt.mockedLastCheck
 			}).Return(nil)
 			manager := getMockManager(m)
-			res := manager.RepoAlreadyProcessed("", tt.checksum)
+			res := manager.RepoAlreadyProcessed(models.Repo{Namespace: "repo-namespace", Name: "repo-name"}, tt.checksum)
 			if res != tt.processed {
 				t.Errorf("Expected alreadyProcessed to be %v got %v", tt.processed, res)
 			}

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -58,7 +58,7 @@ var syncCmd = &cobra.Command{
 		}
 
 		// Check if the repo has been already processed
-		if manager.RepoAlreadyProcessed(repo.Name, repo.Checksum) {
+		if manager.RepoAlreadyProcessed(models.Repo{Namespace: repo.Namespace, Name: repo.Name}, repo.Checksum) {
 			logrus.WithFields(logrus.Fields{"url": repo.URL}).Info("Skipping repository since there are no updates")
 			return
 		}

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -77,13 +77,13 @@ func init() {
 type assetManager interface {
 	Delete(repo models.Repo) error
 	Sync(repo models.Repo, charts []models.Chart) error
-	RepoAlreadyProcessed(repoName, checksum string) bool
+	RepoAlreadyProcessed(repo models.Repo, checksum string) bool
 	UpdateLastCheck(repoNamespace, repoName, checksum string, now time.Time) error
 	Init() error
 	Close() error
 	InvalidateCache() error
-	updateIcon(data []byte, contentType, ID string) error
-	filesExist(chartFilesID, digest string) bool
+	updateIcon(repo models.Repo, data []byte, contentType, ID string) error
+	filesExist(repo models.Repo, chartFilesID, digest string) bool
 	insertFiles(chartId string, files models.ChartFiles) error
 }
 
@@ -383,7 +383,7 @@ func (f *fileImporter) fetchAndImportIcon(c models.Chart, r *models.RepoInternal
 		contentType = "image/png"
 	}
 
-	return f.manager.updateIcon(b, contentType, c.ID)
+	return f.manager.updateIcon(models.Repo{Namespace: r.Namespace, Name: r.Name}, b, contentType, c.ID)
 }
 
 func (f *fileImporter) fetchAndImportFiles(name string, r *models.RepoInternal, cv models.ChartVersion) error {
@@ -391,7 +391,7 @@ func (f *fileImporter) fetchAndImportFiles(name string, r *models.RepoInternal, 
 	chartFilesID := fmt.Sprintf("%s-%s", chartID, cv.Version)
 
 	// Check if we already have indexed files for this chart version and digest
-	if f.manager.filesExist(chartFilesID, cv.Digest) {
+	if f.manager.filesExist(models.Repo{Namespace: r.Namespace, Name: r.Name}, chartFilesID, cv.Digest) {
 		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Debug("skipping existing files")
 		return nil
 	}


### PR DESCRIPTION
Ref: #1521 , follows #1538 

Updates `repoAlreadyProcessed`, `updateIcon` and `fileExists` to work per-namespace, testing appropriately.

I think that's it for the PG functions, so I'll next see what's involved for mongo.