### PR TITLE
Hide pre-upgrade job unless feature flag set.

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 3.4.2
+version: 3.4.3
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/apprepository-jobs-preupgrade.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-preupgrade.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.featureFlags.reposPerNamespace -}}
 # Invalidate the chart cache during upgrade.
 apiVersion: batch/v1
 kind: Job
@@ -65,3 +66,4 @@ spec:
                   key: postgresql-password
                   name: {{ .Values.postgresql.existingSecret }}
             {{- end }}
+{{- end -}}


### PR DESCRIPTION
I had landed the pre-upgrade template *after* the most recent kubeapps release (1.8.2) thinking that it was safe, as the next chart release would include support for the cache invalidation, but this was not a safe assumption, since we had a chart release on Monday to update the nginx image in #1536 . Since this release included the pre-upgrade template which calls a new command to invalidate cache, the upgrade fails as we have not yet released a kubeapps version including the cache invalidation (see https://kubernetes.slack.com/archives/C9D3TSUG4/p1582667703003300)

I'll land to get the release out.

I'm also keen to update our CI so that on a chart bump, we actually test the upgrade from the previous chart version and don't release.