### PR TITLE
Kubeapps Chart - Update PostgreSQL/MongoDB dependencies

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 3.4.3
+version: 3.4.4
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/requirements.lock
+++ b/chart/kubeapps/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 7.8.4
+  version: 7.8.6
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 8.3.4
-digest: sha256:d595686796d9c5c5e1543d48eb4ffdf17cfb342f24399a2831bc282724d4bdca
-generated: "2020-02-20T15:26:56.326701+01:00"
+  version: 8.4.2
+digest: sha256:50d16adab428d7a83c2c394ddd532cff6edb208bd2523e4dd837f950162a7c02
+generated: "2020-02-26T13:27:30.52726+01:00"


### PR DESCRIPTION
### Description of the change

This PR bumps the version of MongoDB & PostgreSQL chart dependencies.

### Benefits

The PostgreSQL chart used a **initContainer** by default to adapt permissions. This **initContainer** was executed as a "root" container that is incompatible with some K8s distros such as [OpenShift](https://www.openshift.com/) or [VMware Tanzu Kubernetes Grid](https://my.vmware.com/web/vmware/info?slug=infrastructure_operations_management/vmware_tanzu_kubernetes_grid/1_16).

Since we're also enabling a **securityContext** by default to address the same issue, the **initContainer** is not mandatory and was disable by default at https://github.com/helm/charts/pull/20910

By bumping the PostgreSQL dependency to the latest version, we'll ensure no "root" containers are executed when installing Kubeapps using PostgreSQL as database.

### Possible drawbacks

None