### PR TITLE
OperatorList check if OLM is installed

### DIFF
--- a/dashboard/src/actions/index.ts
+++ b/dashboard/src/actions/index.ts
@@ -7,6 +7,7 @@ import * as charts from "./charts";
 import * as config from "./config";
 import * as kube from "./kube";
 import * as namespace from "./namespace";
+import * as operators from "./operators";
 import * as repos from "./repos";
 
 export default {
@@ -17,6 +18,7 @@ export default {
   config,
   kube,
   namespace,
+  operators,
   repos,
   shared: {
     pushSearchFilter: (f: string) => push(`?q=${f}`),

--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -1,0 +1,47 @@
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+import { getType } from "typesafe-actions";
+import actions from ".";
+import { Operators } from "../shared/Operators";
+
+const { operators: operatorActions } = actions;
+const mockStore = configureMockStore([thunk]);
+
+let store: any;
+
+beforeEach(() => {
+  store = mockStore({});
+  Operators.isOLMInstalled = jest.fn();
+});
+
+afterEach(jest.resetAllMocks);
+
+describe("checkOLMInstalled", () => {
+  it("dispatches OLM_INSTALLED when succeded", async () => {
+    Operators.isOLMInstalled = jest.fn(() => true);
+    const expectedActions = [
+      {
+        type: getType(operatorActions.checkingOLM),
+      },
+      {
+        type: getType(operatorActions.OLMInstalled),
+      },
+    ];
+    await store.dispatch(operatorActions.checkOLMInstalled());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches OLM_NOT_INSTALLED when failed", async () => {
+    Operators.isOLMInstalled = jest.fn(() => false);
+    const expectedActions = [
+      {
+        type: getType(operatorActions.checkingOLM),
+      },
+      {
+        type: getType(operatorActions.OLMNotInstalled),
+      },
+    ];
+    await store.dispatch(operatorActions.checkOLMInstalled());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});

--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -1,0 +1,27 @@
+import { ThunkAction } from "redux-thunk";
+import { ActionType, createAction } from "typesafe-actions";
+
+import { Operators } from "../shared/Operators";
+import { IStoreState } from "../shared/types";
+
+export const checkingOLM = createAction("CHECKING_OLM");
+export const OLMInstalled = createAction("OLM_INSTALLED");
+export const OLMNotInstalled = createAction("OLM_NOT_INSTALLED");
+
+const actions = [checkingOLM, OLMInstalled, OLMNotInstalled];
+
+export type OperatorAction = ActionType<typeof actions[number]>;
+
+export function checkOLMInstalled(): ThunkAction<
+  Promise<boolean>,
+  IStoreState,
+  null,
+  OperatorAction
+> {
+  return async dispatch => {
+    dispatch(checkingOLM());
+    const installed = await Operators.isOLMInstalled();
+    installed ? dispatch(OLMInstalled()) : dispatch(OLMNotInstalled());
+    return installed;
+  };
+}

--- a/dashboard/src/components/OperatorList/OLMNotFound.tsx
+++ b/dashboard/src/components/OperatorList/OLMNotFound.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { Link } from "react-router-dom";
+
+import { NotFoundErrorAlert } from "../ErrorAlert";
+
+const OLMNotFound: React.SFC = () => {
+  return (
+    <NotFoundErrorAlert header="Operator Lifecycle Manager (OLM) not installed.">
+      <div>
+        <p>
+          Ask an administrator to install the{" "}
+          <a
+            href="https://github.com/operator-framework/operator-lifecycle-manager"
+            target="_blank"
+          >
+            Operator Lifecycle Manager
+          </a>{" "}
+          to browse, provision and manage Operators within Kubeapps.
+        </p>
+        <Link className="button button-primary button-small" to={"/charts/svc-cat/catalog"}>
+          Install OLM
+        </Link>
+      </div>
+    </NotFoundErrorAlert>
+  );
+};
+
+export default OLMNotFound;

--- a/dashboard/src/components/OperatorList/OLMNotFound.tsx
+++ b/dashboard/src/components/OperatorList/OLMNotFound.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { Link } from "react-router-dom";
 
 import { NotFoundErrorAlert } from "../ErrorAlert";
 
@@ -17,9 +16,7 @@ const OLMNotFound: React.SFC = () => {
           </a>{" "}
           to browse, provision and manage Operators within Kubeapps.
         </p>
-        <Link className="button button-primary button-small" to={"/charts/svc-cat/catalog"}>
-          Install OLM
-        </Link>
+        <button className="button button-primary button-small">Install OLM</button>
       </div>
     </NotFoundErrorAlert>
   );

--- a/dashboard/src/components/OperatorList/OLMNotFound.tsx
+++ b/dashboard/src/components/OperatorList/OLMNotFound.tsx
@@ -2,24 +2,45 @@ import * as React from "react";
 
 import { NotFoundErrorAlert } from "../ErrorAlert";
 
-const OLMNotFound: React.SFC = () => {
-  return (
-    <NotFoundErrorAlert header="Operator Lifecycle Manager (OLM) not installed.">
-      <div>
-        <p>
-          Ask an administrator to install the{" "}
-          <a
-            href="https://github.com/operator-framework/operator-lifecycle-manager"
-            target="_blank"
-          >
-            Operator Lifecycle Manager
-          </a>{" "}
-          to browse, provision and manage Operators within Kubeapps.
-        </p>
-        <button className="button button-primary button-small">Install OLM</button>
-      </div>
-    </NotFoundErrorAlert>
-  );
-};
+class OLMNotFound extends React.Component {
+  public render() {
+    return (
+      <NotFoundErrorAlert header="Operator Lifecycle Manager (OLM) not installed.">
+        <div>
+          <p>
+            Ask an administrator to install the{" "}
+            <a
+              href="https://github.com/operator-framework/operator-lifecycle-manager"
+              target="_blank"
+            >
+              Operator Lifecycle Manager
+            </a>{" "}
+            to browse, provision and manage Operators within Kubeapps.
+          </p>
+          To install the OLM, execute the following command in a terminal with <code>kubectl</code>{" "}
+          available and configured:
+          <section className="AppNotes Terminal elevation-1 margin-v-big">
+            <div className="Terminal__Top type-small">
+              <div className="Terminal__Top__Buttons">
+                <span className="Terminal__Top__Button Terminal__Top__Button--red" />
+                <span className="Terminal__Top__Button Terminal__Top__Button--yellow" />
+                <span className="Terminal__Top__Button Terminal__Top__Button--green" />
+              </div>
+            </div>
+            <div className="Terminal__Tab">
+              <pre className="Terminal__Code">
+                <code>
+                  curl -sL
+                  https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.14.1/install.sh
+                  | bash -s 0.14.1
+                </code>
+              </pre>
+            </div>
+          </section>
+        </div>
+      </NotFoundErrorAlert>
+    );
+  }
+}
 
 export default OLMNotFound;

--- a/dashboard/src/components/OperatorList/OperatorList.test.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.test.tsx
@@ -1,7 +1,7 @@
 import { shallow } from "enzyme";
 import * as React from "react";
 import itBehavesLike from "../../shared/specs";
-import NotFoundErrorPage from "../ErrorAlert/NotFoundErrorAlert";
+import OLMNotFound from "./OLMNotFound";
 import OperatorList, { IOperatorListProps } from "./OperatorList";
 
 const defaultProps: IOperatorListProps = {
@@ -19,10 +19,10 @@ it("call the OLM check and render the NotFound message if not found", () => {
   const checkOLMInstalled = jest.fn();
   const wrapper = shallow(<OperatorList {...defaultProps} checkOLMInstalled={checkOLMInstalled} />);
   expect(checkOLMInstalled).toHaveBeenCalled();
-  expect(wrapper.find(NotFoundErrorPage)).toExist();
+  expect(wrapper.find(OLMNotFound)).toExist();
 });
 
 it("render the operator list if the OLM is installed", () => {
   const wrapper = shallow(<OperatorList {...defaultProps} isOLMInstalled={true} />);
-  expect(wrapper.find(NotFoundErrorPage)).not.toExist();
+  expect(wrapper.find(OLMNotFound)).not.toExist();
 });

--- a/dashboard/src/components/OperatorList/OperatorList.test.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.test.tsx
@@ -1,0 +1,28 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+import itBehavesLike from "../../shared/specs";
+import NotFoundErrorPage from "../ErrorAlert/NotFoundErrorAlert";
+import OperatorList, { IOperatorListProps } from "./OperatorList";
+
+const defaultProps: IOperatorListProps = {
+  isFetching: false,
+  checkOLMInstalled: jest.fn(),
+  isOLMInstalled: false,
+};
+
+itBehavesLike("aLoadingComponent", {
+  component: OperatorList,
+  props: { ...defaultProps, isFetching: true },
+});
+
+it("call the OLM check and render the NotFound message if not found", () => {
+  const checkOLMInstalled = jest.fn();
+  const wrapper = shallow(<OperatorList {...defaultProps} checkOLMInstalled={checkOLMInstalled} />);
+  expect(checkOLMInstalled).toHaveBeenCalled();
+  expect(wrapper.find(NotFoundErrorPage)).toExist();
+});
+
+it("render the operator list if the OLM is installed", () => {
+  const wrapper = shallow(<OperatorList {...defaultProps} isOLMInstalled={true} />);
+  expect(wrapper.find(NotFoundErrorPage)).not.toExist();
+});

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+
+import LoadingWrapper from "../LoadingWrapper";
+import PageHeader from "../PageHeader";
+import OLMNotFound from "./OLMNotFound";
+
+export interface IOperatorListProps {
+  isFetching: boolean;
+  checkOLMInstalled: () => Promise<boolean>;
+  isOLMInstalled: boolean;
+}
+
+class OperatorList extends React.Component<IOperatorListProps> {
+  public componentDidMount() {
+    this.props.checkOLMInstalled();
+  }
+
+  public render() {
+    const { isFetching, isOLMInstalled } = this.props;
+    return (
+      <div>
+        <PageHeader>
+          <h1>Operators</h1>
+        </PageHeader>
+        <main>
+          <LoadingWrapper loaded={!isFetching}>
+            {isOLMInstalled ? <p>OLM Installed!</p> : <OLMNotFound />}
+          </LoadingWrapper>
+        </main>
+      </div>
+    );
+  }
+}
+
+export default OperatorList;

--- a/dashboard/src/components/OperatorList/__snapshots__/OperatorList.test.tsx.snap
+++ b/dashboard/src/components/OperatorList/__snapshots__/OperatorList.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loading spinner matches the snapshot 1`] = `
+<div>
+  <PageHeader>
+    <h1>
+      Operators
+    </h1>
+  </PageHeader>
+  <main>
+    <LoadingWrapper
+      loaded={false}
+      type={0}
+    >
+      <NotFoundErrorPage
+        header="Operator Lifecycle Manager (OLM) not installed."
+      >
+        <div>
+          <p>
+            Ask an administrator to install the
+             
+            <a
+              href="https://github.com/operator-framework/operator-lifecycle-manager"
+              target="_blank"
+            >
+              Operator Lifecycle Manager
+            </a>
+             
+            to browse, provision and manage Operators within Kubeapps.
+          </p>
+          <Link
+            className="button button-primary button-small"
+            to="/charts/svc-cat/catalog"
+          >
+            Install OLM
+          </Link>
+        </div>
+      </NotFoundErrorPage>
+    </LoadingWrapper>
+  </main>
+</div>
+`;

--- a/dashboard/src/components/OperatorList/__snapshots__/OperatorList.test.tsx.snap
+++ b/dashboard/src/components/OperatorList/__snapshots__/OperatorList.test.tsx.snap
@@ -12,30 +12,7 @@ exports[`loading spinner matches the snapshot 1`] = `
       loaded={false}
       type={0}
     >
-      <NotFoundErrorPage
-        header="Operator Lifecycle Manager (OLM) not installed."
-      >
-        <div>
-          <p>
-            Ask an administrator to install the
-             
-            <a
-              href="https://github.com/operator-framework/operator-lifecycle-manager"
-              target="_blank"
-            >
-              Operator Lifecycle Manager
-            </a>
-             
-            to browse, provision and manage Operators within Kubeapps.
-          </p>
-          <Link
-            className="button button-primary button-small"
-            to="/charts/svc-cat/catalog"
-          >
-            Install OLM
-          </Link>
-        </div>
-      </NotFoundErrorPage>
+      <OLMNotFound />
     </LoadingWrapper>
   </main>
 </div>

--- a/dashboard/src/components/OperatorList/index.ts
+++ b/dashboard/src/components/OperatorList/index.ts
@@ -1,0 +1,3 @@
+import OperatorList from "./OperatorList";
+
+export default OperatorList;

--- a/dashboard/src/containers/OperatorsListContainer/OperatorsListContainer.tsx
+++ b/dashboard/src/containers/OperatorsListContainer/OperatorsListContainer.tsx
@@ -1,26 +1,23 @@
-import * as React from "react";
 import { connect } from "react-redux";
 import { RouteComponentProps } from "react-router";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
 
+import actions from "../../actions";
+import OperatorList from "../../components/OperatorList";
 import { IStoreState } from "../../shared/types";
 
-function mapStateToProps(
-  { apps, namespace, charts }: IStoreState,
-  { location }: RouteComponentProps<{}>,
-) {
-  return {};
+function mapStateToProps({ operators }: IStoreState, { location }: RouteComponentProps<{}>) {
+  return {
+    isFetching: operators.isFetching,
+    isOLMInstalled: operators.isOLMInstalled,
+  };
 }
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
-  return {};
+  return {
+    checkOLMInstalled: () => dispatch(actions.operators.checkOLMInstalled()),
+  };
 }
 
-class Comp extends React.Component {
-  public render() {
-    return <h1>This component has not been built yet</h1>;
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Comp);
+export default connect(mapStateToProps, mapDispatchToProps)(OperatorList);

--- a/dashboard/src/reducers/index.ts
+++ b/dashboard/src/reducers/index.ts
@@ -8,6 +8,7 @@ import chartsReducer from "./charts";
 import configReducer from "./config";
 import kubeReducer from "./kube";
 import namespaceReducer from "./namespace";
+import operatorReducer from "./operators";
 import reposReducer from "./repos";
 
 const rootReducer = combineReducers<IStoreState>({
@@ -19,6 +20,7 @@ const rootReducer = combineReducers<IStoreState>({
   kube: kubeReducer,
   namespace: namespaceReducer,
   repos: reposReducer,
+  operators: operatorReducer,
 });
 
 export default rootReducer;

--- a/dashboard/src/reducers/operators.test.ts
+++ b/dashboard/src/reducers/operators.test.ts
@@ -1,0 +1,58 @@
+import { getType } from "typesafe-actions";
+import actions from "../actions";
+
+import operatorReducer from "./operators";
+import { IOperatorsState } from "./operators";
+
+describe("catalogReducer", () => {
+  let initialState: IOperatorsState;
+
+  beforeEach(() => {
+    initialState = {
+      isFetching: false,
+      isOLMInstalled: false,
+    };
+  });
+
+  describe("operators", () => {
+    const actionTypes = {
+      checkingOLM: getType(actions.operators.checkingOLM),
+      OLMInstalled: getType(actions.operators.OLMInstalled),
+      OLMNotInstalled: getType(actions.operators.OLMNotInstalled),
+    };
+
+    describe("reducer actions", () => {
+      it("sets isFetching when checking if the OLM is installed", () => {
+        expect(
+          operatorReducer(undefined, {
+            type: actionTypes.checkingOLM as any,
+          }),
+        ).toEqual({ ...initialState, isFetching: true });
+      });
+
+      it("unsets isFetching and mark OLM as installed", () => {
+        const state = operatorReducer(undefined, {
+          type: actionTypes.checkingOLM as any,
+        });
+        expect(state).toEqual({ ...initialState, isFetching: true });
+        expect(
+          operatorReducer(undefined, {
+            type: actionTypes.OLMInstalled as any,
+          }),
+        ).toEqual({ ...initialState, isOLMInstalled: true });
+      });
+
+      it("unsets isFetching and mark OLM as not installed", () => {
+        const state = operatorReducer(undefined, {
+          type: actionTypes.checkingOLM as any,
+        });
+        expect(state).toEqual({ ...initialState, isFetching: true });
+        expect(
+          operatorReducer(undefined, {
+            type: actionTypes.OLMNotInstalled as any,
+          }),
+        ).toEqual({ ...initialState, isOLMInstalled: false });
+      });
+    });
+  });
+});

--- a/dashboard/src/reducers/operators.ts
+++ b/dashboard/src/reducers/operators.ts
@@ -1,0 +1,40 @@
+import { LocationChangeAction } from "connected-react-router";
+import { getType } from "typesafe-actions";
+
+import { OperatorAction } from "actions/operators";
+import actions from "../actions";
+import { NamespaceAction } from "../actions/namespace";
+
+export interface IOperatorsState {
+  isFetching: boolean;
+  isOLMInstalled: boolean;
+}
+
+const initialState: IOperatorsState = {
+  isFetching: false,
+  isOLMInstalled: false,
+};
+
+const catalogReducer = (
+  state: IOperatorsState = initialState,
+  action: OperatorAction | LocationChangeAction | NamespaceAction,
+): IOperatorsState => {
+  const { operators } = actions;
+  switch (action.type) {
+    case getType(operators.checkingOLM):
+      return { ...state, isFetching: true };
+    case getType(operators.OLMInstalled):
+      return { ...state, isOLMInstalled: true };
+    case getType(operators.OLMNotInstalled):
+      return { ...state, isOLMInstalled: false };
+    // TODO(andresmgot): Enable error cleanup when managing errors
+    // case LOCATION_CHANGE:
+    //   return { ...state, errors: {} };
+    // case getType(actions.namespace.setNamespace):
+    //   return { ...state, errors: {} };
+    default:
+      return { ...state };
+  }
+};
+
+export default catalogReducer;

--- a/dashboard/src/reducers/operators.ts
+++ b/dashboard/src/reducers/operators.ts
@@ -24,9 +24,9 @@ const catalogReducer = (
     case getType(operators.checkingOLM):
       return { ...state, isFetching: true };
     case getType(operators.OLMInstalled):
-      return { ...state, isOLMInstalled: true };
+      return { ...state, isOLMInstalled: true, isFetching: false };
     case getType(operators.OLMNotInstalled):
-      return { ...state, isOLMInstalled: false };
+      return { ...state, isOLMInstalled: false, isFetching: false };
     // TODO(andresmgot): Enable error cleanup when managing errors
     // case LOCATION_CHANGE:
     //   return { ...state, errors: {} };

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -1,0 +1,27 @@
+import { axiosWithAuth } from "./AxiosInstance";
+import { Operators } from "./Operators";
+
+it("check if the OLM has been installed", async () => {
+  axiosWithAuth.get = jest.fn(() => {
+    return { status: 200 };
+  });
+  expect(await Operators.isOLMInstalled()).toBe(true);
+  expect(axiosWithAuth.get).toHaveBeenCalled();
+  expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
+    "api/kube/apis/apiextensions.k8s.io/v1/customresourcedefinitions/clusterserviceversions.operators.coreos.com",
+  );
+});
+
+it("OLM is not installed if the request fails", async () => {
+  axiosWithAuth.get = jest.fn(() => {
+    throw new Error("nope");
+  });
+  expect(await Operators.isOLMInstalled()).toBe(false);
+});
+
+it("OLM is not installed if the request returns != 200", async () => {
+  axiosWithAuth.get = jest.fn(() => {
+    return { status: 404 };
+  });
+  expect(await Operators.isOLMInstalled()).toBe(false);
+});

--- a/dashboard/src/shared/Operators.ts
+++ b/dashboard/src/shared/Operators.ts
@@ -1,0 +1,13 @@
+import * as urls from "../shared/url";
+import { axiosWithAuth } from "./AxiosInstance";
+
+export class Operators {
+  public static async isOLMInstalled() {
+    try {
+      const { status } = await axiosWithAuth.get(urls.api.operators.crd);
+      return status === 200;
+    } catch (err) {
+      return false;
+    }
+  }
+}

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -1,4 +1,5 @@
 import * as jsonSchema from "json-schema";
+import { IOperatorsState } from "reducers/operators";
 import { IAuthState } from "../reducers/auth";
 import { IServiceCatalogState } from "../reducers/catalog";
 import { IConfigState } from "../reducers/config";
@@ -232,6 +233,7 @@ export interface IStoreState {
   kube: IKubeState;
   repos: IAppRepositoryState;
   namespace: INamespaceState;
+  operators: IOperatorsState;
 }
 
 interface IK8sResource {

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -56,4 +56,9 @@ export const api = {
     sync: (broker: IServiceBroker) =>
       `${api.clusterservicebrokers.base}/clusterservicebrokers/${broker.metadata.name}`,
   },
+
+  operators: {
+    crd: `${APIBase}/apis/apiextensions.k8s.io/v1/customresourcedefinitions/clusterserviceversions.operators.coreos.com`,
+    csv: `${APIBase}/apis/clusterserviceversions.operators.coreos.com/v1`,
+  },
 };


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Starting the `OperatorList` component. This PR adds the check to show a warning error if OLM is not installed. To check if it's installed we are checking if the CRD `clusterserviceversions.operators.coreos.com` exists.

![Screenshot from 2020-03-04 16-58-08](https://user-images.githubusercontent.com/4025665/75898074-dd780a80-5e39-11ea-987f-6a3cbf043bfc.png)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref #1552

