### PR TITLE
Ensure invalidate-cache doesn't run by default.

### DIFF
--- a/chart/kubeapps/templates/apprepository-jobs-preupgrade.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-preupgrade.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.featureFlags.invalidateCache }}
 # Ensure db indexes are set and invalidate the chart cache during both install and upgrade.
 apiVersion: batch/v1
 kind: Job
@@ -66,3 +67,4 @@ spec:
                   key: postgresql-password
                   name: {{ .Values.postgresql.existingSecret }}
             {{- end }}
+{{- end }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -641,4 +641,6 @@ authProxy:
 ## These are used to switch on in development features or new features not yet released.
 featureFlags:
   reposPerNamespace: false
+  # The invalidateCache flag must be set to default to true when we next release the Kubeapps app.
+  invalidateCache: false
   operators: false

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -36,6 +36,7 @@ deploy-dev: deploy-dex deploy-openldap update-apiserver-etc-hosts
 		--set useHelm3=true \
 		--set postgresql.enabled=true \
 		--set featureFlags.reposPerNamespace=true \
+		--set featureFlags.invalidateCache=true \
 		--set mongodb.enabled=false
 	kubectl apply -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
 	@echo "\nEnsure you have the entry '127.0.0.1 dex.dex' in your /etc/hosts, then run\n"

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -123,6 +123,7 @@ if [[ "${HELM_VERSION:-}" =~ "v2" ]]; then
     "${HELM_CLIENT_TLS_FLAGS[@]}" \
     --set tillerProxy.tls.key="$(cat "${CERTS_DIR}/helm.key.pem")" \
     --set tillerProxy.tls.cert="$(cat "${CERTS_DIR}/helm.cert.pem")" \
+    --set featureFlags.invalidateCache=true \
     "${img_flags[@]}" \
     "${db_flags[@]}"
 else
@@ -131,6 +132,7 @@ else
   kubectl create ns kubeapps
   helm dep up "${ROOT_DIR}/chart/kubeapps/"
   helm install kubeapps-ci --namespace kubeapps "${ROOT_DIR}/chart/kubeapps" \
+    --set featureFlags.invalidateCache=true \
     "${img_flags[@]}" \
     "${db_flags[@]}" \
     --set useHelm3=true


### PR DESCRIPTION
Since we are going to release a new chart without a new kubeapps version, we need to ensure the cache invalidation is not run (since the subcommand is not available for current kubeapps).

At the same time, we want to ensure that it can be run optionally for dev/CI while testing current master, as it is required for the mongodb namespace work.

I had originally wanted to update the command run so it is run conditionally on whether the binary supports it, but since the container image is build from scratch, I don't have any shell to work with.