### PR TITLE
use global.registry for testimages too

### DIFF
--- a/chart/kubeapps/templates/tests/test-assetsvc.yaml
+++ b/chart/kubeapps/templates/tests/test-assetsvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: {{ .Release.Name }}-assetsvc-test
-      image: {{ .Values.testImage.repository }}:{{ .Values.testImage.tag }}
+      image: {{ template "kubeapps.image" (list .Values.testImage .Values.global) }}
       env:
         - name: ASSETSVC_HOST
           value: {{ template "kubeapps.assetsvc.fullname" . }}.{{ .Release.Namespace }}

--- a/chart/kubeapps/templates/tests/test-dashboard.yaml
+++ b/chart/kubeapps/templates/tests/test-dashboard.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: {{ .Release.Name }}-dashboard-test
-      image: {{ .Values.testImage.repository }}:{{ .Values.testImage.tag }}
+      image: {{ template "kubeapps.image" (list .Values.testImage .Values.global) }}
       env:
         - name: DASHBOARD_HOST
           value: {{ template "kubeapps.fullname" . }}.{{ .Release.Namespace }}

--- a/chart/kubeapps/templates/tests/test-tiller-proxy.yaml
+++ b/chart/kubeapps/templates/tests/test-tiller-proxy.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: {{ .Release.Name }}-tiller-proxy-test
-      image: {{ .Values.testImage.repository }}:{{ .Values.testImage.tag }}
+      image: {{ template "kubeapps.image" (list .Values.testImage .Values.global) }}
       env:
         - name: TILLER_PROXY_HOST
           value: {{ template "kubeapps.tiller-proxy.fullname" . }}.{{ .Release.Namespace }}


### PR DESCRIPTION
Signed-off-by: David Karlsen <david@davidkarlsen.com>


### Description of the change
Use global image registry for testimages too

### Benefits

Consistency between resources

### Possible drawbacks

none

### Applicable issues

  - fixes https://github.com/bitnami/charts/issues/2007

### Additional information
https://github.com/bitnami/charts/issues/2007

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeapps/kubeapps/1564)
<!-- Reviewable:end -->
