### PR TITLE
Use backend to retrieve operator icons

### DIFF
--- a/chart/kubeapps/templates/kubeops-rbac.yaml
+++ b/chart/kubeapps/templates/kubeops-rbac.yaml
@@ -79,5 +79,42 @@ subjects:
     name: {{ template "kubeapps.kubeops.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}
+{{- if .Values.featureFlags.operators }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "kubeapps:controller:kubeops-operators-{{ .Release.Namespace }}"
+  labels:
+    app: {{ template "kubeapps.kubeops.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - packages.operators.coreos.com
+    resources:
+      - packagemanifests/icon
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "kubeapps:controller:kubeops-operators-{{ .Release.Namespace }}"
+  labels:
+    app: {{ template "kubeapps.kubeops.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "kubeapps:controller:kubeops-operators-{{ .Release.Namespace }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubeapps.kubeops.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
 {{- end -}}
 {{- end }}{{/* matches useHelm3 */}}

--- a/chart/kubeapps/templates/tiller-proxy-rbac.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-rbac.yaml
@@ -79,5 +79,42 @@ subjects:
     name: {{ template "kubeapps.tiller-proxy.fullname" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}
+{{- if .Values.allowNamespaceDiscovery }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "kubeapps:controller:tiller-proxy-operators-{{ .Release.Namespace }}"
+  labels:
+    app: {{ template "kubeapps.tiller-proxy.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - namespaces
+  verbs:
+    - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "kubeapps:controller:tiller-proxy-operators-{{ .Release.Namespace }}"
+  labels:
+    app: {{ template "kubeapps.tiller-proxy.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "kubeapps:controller:tiller-proxy-operators-{{ .Release.Namespace }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubeapps.tiller-proxy.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
 {{- end -}}
 {{- end }}{{/* matches useHelm3 */}}

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -60,8 +60,7 @@ class OperatorList extends React.Component<IOperatorListProps> {
               key={operator.metadata.name}
               link={`/operators/ns/${this.props.namespace}/${operator.metadata.name}`}
               title={operator.metadata.name}
-              // TODO(andresmgot): Icons are protected by RBAC so we need to use the backend to retrieve those
-              // icon={TBD}
+              icon={`api/v1/namespaces/${this.props.namespace}/operator/${operator.metadata.name}/logo`}
               info={`v${operator.status.channels[0].currentCSVDesc.version}`}
               tag1Content={operator.status.channels[0].currentCSVDesc.annotations.categories}
               tag2Content={operator.status.provider.name}

--- a/dashboard/src/components/OperatorList/__snapshots__/OperatorList.test.tsx.snap
+++ b/dashboard/src/components/OperatorList/__snapshots__/OperatorList.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`render the operator list if the OLM is installed 1`] = `
     >
       <CardGrid>
         <InfoCard
+          icon="api/v1/namespaces/default/operator/foo/logo"
           info="v1.0.0"
           key="foo"
           link="/operators/ns/default/foo"

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -86,3 +86,8 @@ func (c *FakeHandler) GetSecret(name, namespace string) (*corev1.Secret, error) 
 func (c *FakeHandler) ValidateAppRepository(appRepoBody io.ReadCloser) (*http.Response, error) {
 	return &http.Response{Body: ioutil.NopCloser(strings.NewReader("valid: yaml")), StatusCode: 200}, c.Err
 }
+
+// GetOperatorLogo fake
+func (c *FakeHandler) GetOperatorLogo(namespace, name string) ([]byte, error) {
+	return []byte{}, nil
+}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of #1559 to retrieve operator icons. The backend is the one contacting the K8s API in order to get these resources using its serviceaccount. Since it's necessary to get icons from operators in any namespace this needs to be a ClusterRole/ClusterRoleBinding.

![Screenshot from 2020-03-06 18-16-13](https://user-images.githubusercontent.com/4025665/76106740-c1aa6b00-5fd7-11ea-87bd-92a43295d90d.png)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1552

