### PR TITLE
Fix PANIC(runtime error) when creating release

### DIFF
--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -62,11 +62,11 @@ func (h *TillerProxy) logStatus(name string) {
 func (h *TillerProxy) CreateRelease(w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
 	log.Printf("Creating Helm Release")
 	chartDetails, chartMulti, err := handlerutil.ParseAndGetChart(req, h.ChartClient, requireV1Support)
-	ch := chartMulti.Helm2Chart
 	if err != nil {
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return
 	}
+	ch := chartMulti.Helm2Chart
 	if !h.DisableUserAuthCheck {
 		manifest, err := h.ProxyClient.ResolveManifest(params["namespace"], chartDetails.Values, ch)
 		if err != nil {


### PR DESCRIPTION
When err is not nil, chartMulti is nil

Signed-off-by: sayaoailun <guojianwei007@126.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
When creating release, I got this `[negroni] PANIC: runtime error: invalid memory address or nil pointer dereference`. I checked the code and found this:

https://github.com/kubeapps/kubeapps/blob/b772c3b5d31ce06d93546b724095c8f009d42d65/cmd/tiller-proxy/internal/handler/handler.go#L64-L69

