### PR TITLE
Update the dashboard's assetsvc URIs to be namespaced.

### DIFF
--- a/cmd/assetsvc/handler_test.go
+++ b/cmd/assetsvc/handler_test.go
@@ -47,9 +47,12 @@ type bodyAPIResponse struct {
 var chartsList []*models.Chart
 var cc count
 
-const testChartReadme = "# Quickstart\n\n```bash\nhelm install my-repo/my-chart\n```"
-const testChartValues = "image:\n  registry: docker.io\n  repository: my-repo/my-chart\n  tag: 0.1.0"
-const testChartSchema = `{"properties": {"type": "object"}}`
+const (
+	testChartReadme = "# Quickstart\n\n```bash\nhelm install my-repo/my-chart\n```"
+	testChartValues = "image:\n  registry: docker.io\n  repository: my-repo/my-chart\n  tag: 0.1.0"
+	testChartSchema = `{"properties": {"type": "object"}}`
+	namespace       = "kubeapps-namespace"
+)
 
 func iconBytes() []byte {
 	var b bytes.Buffer
@@ -80,13 +83,13 @@ func Test_chartAttributes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := chartAttributes(tt.chart)
+			c := chartAttributes(namespace, tt.chart)
 			assert.Equal(t, tt.chart.ID, c.ID)
 			assert.Equal(t, tt.chart.RawIcon, c.RawIcon)
 			if len(tt.chart.RawIcon) == 0 {
 				assert.Equal(t, len(c.Icon), 0, "icon url should be undefined")
 			} else {
-				assert.Equal(t, c.Icon, pathPrefix+"/assets/"+tt.chart.ID+"/logo", "the icon url should be the same")
+				assert.Equal(t, c.Icon, pathPrefix+"/ns/"+namespace+"/assets/"+tt.chart.ID+"/logo", "the icon url should be the same")
 				assert.Equal(t, c.IconContentType, tt.chart.IconContentType, "the icon content type should be the same")
 			}
 		})
@@ -104,10 +107,10 @@ func Test_chartVersionAttributes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cv := chartVersionAttributes(tt.chart.ID, tt.chart.ChartVersions[0])
+			cv := chartVersionAttributes(namespace, tt.chart.ID, tt.chart.ChartVersions[0])
 			assert.Equal(t, cv.Version, tt.chart.ChartVersions[0].Version, "version string should be the same")
-			assert.Equal(t, cv.Readme, pathPrefix+"/assets/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[0].Version+"/README.md", "README.md resource path should be the same")
-			assert.Equal(t, cv.Values, pathPrefix+"/assets/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[0].Version+"/values.yaml", "values.yaml resource path should be the same")
+			assert.Equal(t, cv.Readme, pathPrefix+"/ns/"+namespace+"/assets/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[0].Version+"/README.md", "README.md resource path should be the same")
+			assert.Equal(t, cv.Values, pathPrefix+"/ns/"+namespace+"/assets/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[0].Version+"/values.yaml", "values.yaml resource path should be the same")
 		})
 	}
 }
@@ -129,11 +132,11 @@ func Test_newChartResponse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cResponse := newChartResponse(&tt.chart)
+			cResponse := newChartResponse(namespace, &tt.chart)
 			assert.Equal(t, cResponse.Type, "chart", "response type is chart")
 			assert.Equal(t, cResponse.ID, tt.chart.ID, "chart ID should be the same")
 			assert.Equal(t, cResponse.Relationships["latestChartVersion"].Data.(models.ChartVersion).Version, tt.chart.ChartVersions[0].Version, "latestChartVersion should match version at index 0")
-			assert.Equal(t, cResponse.Links.(selfLink).Self, pathPrefix+"/charts/"+tt.chart.ID, "self link should be the same")
+			assert.Equal(t, cResponse.Links.(selfLink).Self, pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID, "self link should be the same")
 			// We don't send the raw icon down the wire.
 			assert.Nil(t, cResponse.Attributes.(models.Chart).RawIcon)
 		})
@@ -163,13 +166,13 @@ func Test_newChartListResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clResponse := newChartListResponse(tt.input)
+			clResponse := newChartListResponse(namespace, tt.input)
 			assert.Equal(t, len(clResponse), len(tt.result), "number of charts in response should be the same")
 			for i := range tt.result {
 				assert.Equal(t, clResponse[i].Type, "chart", "response type is chart")
 				assert.Equal(t, clResponse[i].ID, tt.result[i].ID, "chart ID should be the same")
 				assert.Equal(t, clResponse[i].Relationships["latestChartVersion"].Data.(models.ChartVersion).Version, tt.result[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
-				assert.Equal(t, clResponse[i].Links.(selfLink).Self, pathPrefix+"/charts/"+tt.result[i].ID, "self link should be the same")
+				assert.Equal(t, clResponse[i].Links.(selfLink).Self, pathPrefix+"/ns/"+namespace+"/charts/"+tt.result[i].ID, "self link should be the same")
 			}
 		})
 	}
@@ -192,17 +195,17 @@ func Test_newChartVersionResponse(t *testing.T) {
 			chart: models.Chart{
 				ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "1.2.3"}}, RawIcon: iconBytes(), IconContentType: "image/svg",
 			},
-			expectedIcon: "/v1/assets/my-repo/my-chart/logo",
+			expectedIcon: "/v1/ns/" + namespace + "/assets/my-repo/my-chart/logo",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for i := range tt.chart.ChartVersions {
-				cvResponse := newChartVersionResponse(&tt.chart, tt.chart.ChartVersions[i])
+				cvResponse := newChartVersionResponse(namespace, &tt.chart, tt.chart.ChartVersions[i])
 				assert.Equal(t, cvResponse.Type, "chartVersion", "response type is chartVersion")
 				assert.Equal(t, cvResponse.ID, tt.chart.ID+"-"+tt.chart.ChartVersions[i].Version, "reponse id should have chart version suffix")
-				assert.Equal(t, cvResponse.Links.(interface{}).(selfLink).Self, pathPrefix+"/charts/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[i].Version, "self link should be the same")
+				assert.Equal(t, cvResponse.Links.(interface{}).(selfLink).Self, pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[i].Version, "self link should be the same")
 				assert.Equal(t, cvResponse.Attributes.(models.ChartVersion).Version, tt.chart.ChartVersions[i].Version, "chart version in the response should be the same")
 
 				// The chart should have had its icon url set and raw icon data removed.
@@ -234,12 +237,12 @@ func Test_newChartVersionListResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cvListResponse := newChartVersionListResponse(&tt.chart)
+			cvListResponse := newChartVersionListResponse(namespace, &tt.chart)
 			assert.Equal(t, len(cvListResponse), len(tt.chart.ChartVersions), "number of chart versions in response should be the same")
 			for i := range tt.chart.ChartVersions {
 				assert.Equal(t, cvListResponse[i].Type, "chartVersion", "response type is chartVersion")
 				assert.Equal(t, cvListResponse[i].ID, tt.chart.ID+"-"+tt.chart.ChartVersions[i].Version, "reponse id should have chart version suffix")
-				assert.Equal(t, cvListResponse[i].Links.(interface{}).(selfLink).Self, pathPrefix+"/charts/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[i].Version, "self link should be the same")
+				assert.Equal(t, cvListResponse[i].Links.(interface{}).(selfLink).Self, pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[i].Version, "self link should be the same")
 				assert.Equal(t, cvListResponse[i].Attributes.(models.ChartVersion).Version, tt.chart.ChartVersions[i].Version, "chart version in the response should be the same")
 			}
 		})
@@ -285,7 +288,7 @@ func Test_listCharts(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/charts"+tt.query, nil)
-			listCharts(w, req, Params{})
+			listCharts(w, req, Params{"namespace": namespace})
 
 			m.AssertExpectations(t)
 			assert.Equal(t, http.StatusOK, w.Code)
@@ -300,7 +303,7 @@ func Test_listCharts(t *testing.T) {
 			for i, resp := range data {
 				assert.Equal(t, resp.ID, tt.charts[i].ID, "chart id in the response should be the same")
 				assert.Equal(t, resp.Type, "chart", "response type is chart")
-				assert.Equal(t, resp.Links.(map[string]interface{})["self"], pathPrefix+"/charts/"+tt.charts[i].ID, "self link should be the same")
+				assert.Equal(t, resp.Links.(map[string]interface{})["self"], pathPrefix+"/ns/"+namespace+"/charts/"+tt.charts[i].ID, "self link should be the same")
 				assert.Equal(t, resp.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.charts[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 			}
 			assert.Equal(t, b.Meta, tt.meta, "response meta should be the same")
@@ -415,6 +418,7 @@ func Test_getChart(t *testing.T) {
 			req := httptest.NewRequest("GET", "/charts/"+tt.chart.ID, nil)
 			parts := strings.Split(tt.chart.ID, "/")
 			params := Params{
+				"namespace": namespace,
 				"repo":      parts[0],
 				"chartName": parts[1],
 			}
@@ -428,7 +432,7 @@ func Test_getChart(t *testing.T) {
 				json.NewDecoder(w.Body).Decode(&b)
 				assert.Equal(t, b.Data.ID, tt.chart.ID, "chart id in the response should be the same")
 				assert.Equal(t, b.Data.Type, "chart", "response type is chart")
-				assert.Equal(t, b.Data.Links.(map[string]interface{})["self"], pathPrefix+"/charts/"+tt.chart.ID, "self link should be the same")
+				assert.Equal(t, b.Data.Links.(map[string]interface{})["self"], pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID, "self link should be the same")
 				assert.Equal(t, b.Data.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.chart.ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 			}
 		})

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -109,10 +109,13 @@ function getAppUpdateInfo(
   currentVersion: string,
   appVersion: string,
 ): ThunkAction<Promise<void>, IStoreState, null, AppsAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
     dispatch(requestAppUpdateInfo());
+    const {
+      config: { namespace },
+    } = getState();
     try {
-      const chartsInfo = await Chart.listWithFilters(chartName, currentVersion, appVersion);
+      const chartsInfo = await Chart.listWithFilters(namespace, chartName, currentVersion, appVersion);
       let updateInfo: IChartUpdateInfo = {
         upToDate: true,
         repository: { name: "", url: "" },

--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -12,8 +12,12 @@ let axiosGetMock = jest.fn();
 let store: any;
 let response: any;
 
+const namespace = "chart-namespace";
+
 beforeEach(() => {
-  store = mockStore();
+  store = mockStore({
+    config: { namespace },
+  });
   axiosGetMock.mockImplementation(() => {
     return {
       status: 200,
@@ -38,7 +42,7 @@ describe("fetchCharts", () => {
     ];
     await store.dispatch(actions.charts.fetchCharts("foo"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(axiosGetMock.mock.calls[0][0]).toBe("api/assetsvc/v1/charts/foo");
+    expect(axiosGetMock.mock.calls[0][0]).toBe(`api/assetsvc/v1/ns/${namespace}/charts/foo`);
   });
 
   it("returns a 404 error", async () => {
@@ -80,7 +84,7 @@ describe("fetchChartVersions", () => {
     ];
     await store.dispatch(actions.charts.fetchChartVersions("foo"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(axiosGetMock.mock.calls[0][0]).toBe("api/assetsvc/v1/charts/foo/versions");
+    expect(axiosGetMock.mock.calls[0][0]).toBe(`api/assetsvc/v1/ns/${namespace}/charts/foo/versions`);
   });
 });
 
@@ -96,7 +100,7 @@ describe("getChartVersion", () => {
     ];
     await store.dispatch(actions.charts.getChartVersion("foo", "1.0.0"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(axiosGetMock.mock.calls[0][0]).toBe("api/assetsvc/v1/charts/foo/versions/1.0.0");
+    expect(axiosGetMock.mock.calls[0][0]).toBe(`api/assetsvc/v1/ns/${namespace}/charts/foo/versions/1.0.0`);
   });
 
   it("gets a chart version with tag", async () => {
@@ -111,7 +115,7 @@ describe("getChartVersion", () => {
     await store.dispatch(actions.charts.getChartVersion("foo", "1.0.0-alpha+1.2.3-beta2"));
     expect(store.getActions()).toEqual(expectedActions);
     expect(axiosGetMock.mock.calls[0][0]).toBe(
-      "api/assetsvc/v1/charts/foo/versions/1.0.0-alpha%2B1.2.3-beta2",
+      `api/assetsvc/v1/ns/${namespace}/charts/foo/versions/1.0.0-alpha%2B1.2.3-beta2`,
     );
   });
 
@@ -215,7 +219,7 @@ describe("fetchChartVersionsAndSelectVersion", () => {
     ];
     await store.dispatch(actions.charts.fetchChartVersionsAndSelectVersion("foo", "1.0.0"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(axiosGetMock.mock.calls[0][0]).toBe("api/assetsvc/v1/charts/foo/versions");
+    expect(axiosGetMock.mock.calls[0][0]).toBe(`api/assetsvc/v1/ns/${namespace}/charts/foo/versions`);
   });
 
   it("returns a not found error", async () => {
@@ -233,7 +237,7 @@ describe("fetchChartVersionsAndSelectVersion", () => {
     axiosWithAuth.get = axiosGetMock;
     await store.dispatch(actions.charts.fetchChartVersionsAndSelectVersion("foo", "1.0.0"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(axiosGetMock.mock.calls[0][0]).toBe("api/assetsvc/v1/charts/foo/versions");
+    expect(axiosGetMock.mock.calls[0][0]).toBe(`api/assetsvc/v1/ns/${namespace}/charts/foo/versions`);
   });
 });
 

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -71,10 +71,13 @@ function dispatchError(dispatch: Dispatch, err: Error) {
 export function fetchCharts(
   repo: string,
 ): ThunkAction<Promise<void>, IStoreState, null, ChartsAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      config: { namespace },
+    } = getState();
     dispatch(requestCharts());
     try {
-      const charts = await Chart.fetchCharts(repo);
+      const charts = await Chart.fetchCharts(namespace, repo);
       if (charts) {
         dispatch(receiveCharts(charts));
       }
@@ -87,10 +90,13 @@ export function fetchCharts(
 export function fetchChartVersions(
   id: string,
 ): ThunkAction<Promise<IChartVersion[] | undefined>, IStoreState, null, ChartsAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      config: { namespace },
+    } = getState();
     dispatch(requestCharts());
     try {
-      const versions = await Chart.fetchChartVersions(id);
+      const versions = await Chart.fetchChartVersions(namespace, id);
       if (versions) {
         dispatch(receiveChartVersions(versions));
       }
@@ -102,14 +108,14 @@ export function fetchChartVersions(
   };
 }
 
-async function getChart(id: string, version: string) {
+async function getChart(namespace: string, id: string, version: string) {
   let values = "";
   let schema = {};
-  const chartVersion = await Chart.getChartVersion(id, version);
+  const chartVersion = await Chart.getChartVersion(namespace, id, version);
   if (chartVersion) {
     try {
-      values = await Chart.getValues(id, version);
-      schema = await Chart.getSchema(id, version);
+      values = await Chart.getValues(namespace, id, version);
+      schema = await Chart.getSchema(namespace, id, version);
     } catch (e) {
       if (e.constructor !== NotFoundError) {
         throw e;
@@ -123,10 +129,13 @@ export function getChartVersion(
   id: string,
   version: string,
 ): ThunkAction<Promise<void>, IStoreState, null, ChartsAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      config: { namespace },
+    } = getState();
     try {
       dispatch(requestCharts());
-      const { chartVersion, values, schema } = await getChart(id, version);
+      const { chartVersion, values, schema } = await getChart(namespace, id, version);
       if (chartVersion) {
         dispatch(selectChartVersion(chartVersion, values, schema));
       }
@@ -140,10 +149,13 @@ export function getDeployedChartVersion(
   id: string,
   version: string,
 ): ThunkAction<Promise<void>, IStoreState, null, ChartsAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      config: { namespace },
+    } = getState();
     try {
       dispatch(requestDeployedChartVersion());
-      const { chartVersion, values, schema } = await getChart(id, version);
+      const { chartVersion, values, schema } = await getChart(namespace, id, version);
       if (chartVersion) {
         dispatch(receiveDeployedChartVersion(chartVersion, values, schema));
       }
@@ -177,9 +189,12 @@ export function getChartReadme(
   id: string,
   version: string,
 ): ThunkAction<Promise<void>, IStoreState, null, ChartsAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      config: { namespace },
+    } = getState();
     try {
-      const readme = await Chart.getReadme(id, version);
+      const readme = await Chart.getReadme(namespace, id, version);
       dispatch(selectReadme(readme));
     } catch (e) {
       dispatch(errorReadme(e.toString()));

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -482,6 +482,7 @@ describe("checkChart", () => {
 
     await store.dispatch(repoActions.checkChart("my-repo", "my-chart"));
     expect(store.getActions()).toEqual(expectedActions);
+    expect(Chart.fetchChartVersions).toBeCalledWith("kubeapps-namespace", "my-repo/my-chart");
   });
 
   it("dispatches requestRepo and errorChart if error fetching", async () => {
@@ -501,6 +502,7 @@ describe("checkChart", () => {
 
     await store.dispatch(repoActions.checkChart("my-repo", "my-chart"));
     expect(store.getActions()).toEqual(expectedActions);
+    expect(Chart.fetchChartVersions).toBeCalledWith("kubeapps-namespace", "my-repo/my-chart");
   });
 });
 

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -223,7 +223,7 @@ export function checkChart(
     dispatch(requestRepo());
     const appRepository = await AppRepository.get(repo, namespace);
     try {
-      await Chart.fetchChartVersions(`${repo}/${chartName}`);
+      await Chart.fetchChartVersions(namespace, `${repo}/${chartName}`);
       dispatch(receiveRepo(appRepository));
       return true;
     } catch (e) {

--- a/dashboard/src/shared/Chart.ts
+++ b/dashboard/src/shared/Chart.ts
@@ -38,15 +38,6 @@ export default class Chart {
     return data;
   }
 
-  public static async exists(id: string, version: string, repo: string) {
-    try {
-      await axiosWithAuth.get(URL.api.charts.getVersion(`${repo}/${id}`, version));
-    } catch (e) {
-      return false;
-    }
-    return true;
-  }
-
   public static async listWithFilters(name: string, version: string, appVersion: string) {
     const url = `${Chart.APIEndpoint}/charts?name=${name}&version=${encodeURIComponent(
       version,

--- a/dashboard/src/shared/Chart.ts
+++ b/dashboard/src/shared/Chart.ts
@@ -4,37 +4,37 @@ import { IChart, IChartVersion } from "./types";
 import * as URL from "./url";
 
 export default class Chart {
-  public static async fetchCharts(repo: string) {
-    const { data } = await axiosWithAuth.get<{ data: IChart[] }>(URL.api.charts.list(repo));
+  public static async fetchCharts(namespace: string, repo: string) {
+    const { data } = await axiosWithAuth.get<{ data: IChart[] }>(URL.api.charts.list(namespace, repo));
     return data.data;
   }
 
-  public static async fetchChartVersions(id: string) {
+  public static async fetchChartVersions(namespace: string, id: string) {
     const { data } = await axiosWithAuth.get<{ data: IChartVersion[] }>(
-      URL.api.charts.listVersions(id),
+      URL.api.charts.listVersions(namespace, id),
     );
     return data.data;
   }
 
-  public static async getChartVersion(id: string, version: string) {
+  public static async getChartVersion(namespace: string, id: string, version: string) {
     const { data } = await axiosWithAuth.get<{ data: IChartVersion }>(
-      URL.api.charts.getVersion(id, version),
+      URL.api.charts.getVersion(namespace, id, version),
     );
     return data.data;
   }
 
-  public static async getReadme(id: string, version: string) {
-    const { data } = await axiosWithAuth.get<string>(URL.api.charts.getReadme(id, version));
+  public static async getReadme(namespace: string, id: string, version: string) {
+    const { data } = await axiosWithAuth.get<string>(URL.api.charts.getReadme(namespace, id, version));
     return data;
   }
 
-  public static async getValues(id: string, version: string) {
-    const { data } = await axiosWithAuth.get<string>(URL.api.charts.getValues(id, version));
+  public static async getValues(namespace: string, id: string, version: string) {
+    const { data } = await axiosWithAuth.get<string>(URL.api.charts.getValues(namespace, id, version));
     return data;
   }
 
-  public static async getSchema(id: string, version: string) {
-    const { data } = await axiosWithAuth.get<JSONSchema4>(URL.api.charts.getSchema(id, version));
+  public static async getSchema(namespace: string, id: string, version: string) {
+    const { data } = await axiosWithAuth.get<JSONSchema4>(URL.api.charts.getSchema(namespace, id, version));
     return data;
   }
 

--- a/dashboard/src/shared/Chart.ts
+++ b/dashboard/src/shared/Chart.ts
@@ -38,8 +38,8 @@ export default class Chart {
     return data;
   }
 
-  public static async listWithFilters(name: string, version: string, appVersion: string) {
-    const url = `${Chart.APIEndpoint}/charts?name=${name}&version=${encodeURIComponent(
+  public static async listWithFilters(namespace: string, name: string, version: string, appVersion: string) {
+    const url = `${Chart.APIEndpoint}/ns/${namespace}/charts?name=${name}&version=${encodeURIComponent(
       version,
     )}&appversion=${appVersion}`;
     const { data } = await axiosWithAuth.get<{ data: IChart[] }>(url);

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -32,17 +32,17 @@ export const api = {
 
   charts: {
     base: "api/assetsvc/v1",
-    get: (id: string) => `${api.charts.base}/charts/${id}`,
-    getReadme: (id: string, version: string) =>
-      `${api.charts.base}/assets/${id}/versions/${encodeURIComponent(version)}/README.md`,
-    getValues: (id: string, version: string) =>
-      `${api.charts.base}/assets/${id}/versions/${encodeURIComponent(version)}/values.yaml`,
-    getSchema: (id: string, version: string) =>
-      `${api.charts.base}/assets/${id}/versions/${encodeURIComponent(version)}/values.schema.json`,
-    getVersion: (id: string, version: string) =>
-      `${api.charts.base}/charts/${id}/versions/${encodeURIComponent(version)}`,
-    list: (repo?: string) => `${api.charts.base}/charts${repo ? `/${repo}` : ""}`,
-    listVersions: (id: string) => `${api.charts.get(id)}/versions`,
+    get: (namespace: string, id: string) => `${api.charts.base}/ns/${namespace}/charts/${id}`,
+    getReadme: (namespace: string, id: string, version: string) =>
+      `${api.charts.base}/ns/${namespace}/assets/${id}/versions/${encodeURIComponent(version)}/README.md`,
+    getValues: (namespace: string, id: string, version: string) =>
+      `${api.charts.base}/ns/${namespace}/assets/${id}/versions/${encodeURIComponent(version)}/values.yaml`,
+    getSchema: (namespace: string, id: string, version: string) =>
+      `${api.charts.base}/ns/${namespace}/assets/${id}/versions/${encodeURIComponent(version)}/values.schema.json`,
+    getVersion: (namespace: string, id: string, version: string) =>
+      `${api.charts.base}/ns/${namespace}/charts/${id}/versions/${encodeURIComponent(version)}`,
+    list: (namespace: string, repo?: string) => `${api.charts.base}/ns/${namespace}/charts${repo ? `/${repo}` : ""}`,
+    listVersions: (namespace: string, id: string) => `${api.charts.get(namespace, id)}/versions`,
   },
 
   serviceinstances: {


### PR DESCRIPTION
Follows #1567 , Ref #1521 

Updates the frontend URIs to match the new assetsvc's namespaced URIs. Currently it just uses the config kubeapps namespace so that this can land. I'll continue by making this dependent on the selected namespace, when the feature flag is set.