### PR TITLE
Return namespaced self-links in responses.

### DIFF
--- a/cmd/assetsvc/handler_test.go
+++ b/cmd/assetsvc/handler_test.go
@@ -47,9 +47,12 @@ type bodyAPIResponse struct {
 var chartsList []*models.Chart
 var cc count
 
-const testChartReadme = "# Quickstart\n\n```bash\nhelm install my-repo/my-chart\n```"
-const testChartValues = "image:\n  registry: docker.io\n  repository: my-repo/my-chart\n  tag: 0.1.0"
-const testChartSchema = `{"properties": {"type": "object"}}`
+const (
+	testChartReadme = "# Quickstart\n\n```bash\nhelm install my-repo/my-chart\n```"
+	testChartValues = "image:\n  registry: docker.io\n  repository: my-repo/my-chart\n  tag: 0.1.0"
+	testChartSchema = `{"properties": {"type": "object"}}`
+	namespace       = "kubeapps-namespace"
+)
 
 func iconBytes() []byte {
 	var b bytes.Buffer
@@ -80,13 +83,13 @@ func Test_chartAttributes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := chartAttributes(tt.chart)
+			c := chartAttributes(namespace, tt.chart)
 			assert.Equal(t, tt.chart.ID, c.ID)
 			assert.Equal(t, tt.chart.RawIcon, c.RawIcon)
 			if len(tt.chart.RawIcon) == 0 {
 				assert.Equal(t, len(c.Icon), 0, "icon url should be undefined")
 			} else {
-				assert.Equal(t, c.Icon, pathPrefix+"/assets/"+tt.chart.ID+"/logo", "the icon url should be the same")
+				assert.Equal(t, c.Icon, pathPrefix+"/ns/"+namespace+"/assets/"+tt.chart.ID+"/logo", "the icon url should be the same")
 				assert.Equal(t, c.IconContentType, tt.chart.IconContentType, "the icon content type should be the same")
 			}
 		})
@@ -104,10 +107,10 @@ func Test_chartVersionAttributes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cv := chartVersionAttributes(tt.chart.ID, tt.chart.ChartVersions[0])
+			cv := chartVersionAttributes(namespace, tt.chart.ID, tt.chart.ChartVersions[0])
 			assert.Equal(t, cv.Version, tt.chart.ChartVersions[0].Version, "version string should be the same")
-			assert.Equal(t, cv.Readme, pathPrefix+"/assets/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[0].Version+"/README.md", "README.md resource path should be the same")
-			assert.Equal(t, cv.Values, pathPrefix+"/assets/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[0].Version+"/values.yaml", "values.yaml resource path should be the same")
+			assert.Equal(t, cv.Readme, pathPrefix+"/ns/"+namespace+"/assets/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[0].Version+"/README.md", "README.md resource path should be the same")
+			assert.Equal(t, cv.Values, pathPrefix+"/ns/"+namespace+"/assets/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[0].Version+"/values.yaml", "values.yaml resource path should be the same")
 		})
 	}
 }
@@ -129,11 +132,11 @@ func Test_newChartResponse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cResponse := newChartResponse(&tt.chart)
+			cResponse := newChartResponse(namespace, &tt.chart)
 			assert.Equal(t, cResponse.Type, "chart", "response type is chart")
 			assert.Equal(t, cResponse.ID, tt.chart.ID, "chart ID should be the same")
 			assert.Equal(t, cResponse.Relationships["latestChartVersion"].Data.(models.ChartVersion).Version, tt.chart.ChartVersions[0].Version, "latestChartVersion should match version at index 0")
-			assert.Equal(t, cResponse.Links.(selfLink).Self, pathPrefix+"/charts/"+tt.chart.ID, "self link should be the same")
+			assert.Equal(t, cResponse.Links.(selfLink).Self, pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID, "self link should be the same")
 			// We don't send the raw icon down the wire.
 			assert.Nil(t, cResponse.Attributes.(models.Chart).RawIcon)
 		})
@@ -163,13 +166,13 @@ func Test_newChartListResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clResponse := newChartListResponse(tt.input)
+			clResponse := newChartListResponse(namespace, tt.input)
 			assert.Equal(t, len(clResponse), len(tt.result), "number of charts in response should be the same")
 			for i := range tt.result {
 				assert.Equal(t, clResponse[i].Type, "chart", "response type is chart")
 				assert.Equal(t, clResponse[i].ID, tt.result[i].ID, "chart ID should be the same")
 				assert.Equal(t, clResponse[i].Relationships["latestChartVersion"].Data.(models.ChartVersion).Version, tt.result[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
-				assert.Equal(t, clResponse[i].Links.(selfLink).Self, pathPrefix+"/charts/"+tt.result[i].ID, "self link should be the same")
+				assert.Equal(t, clResponse[i].Links.(selfLink).Self, pathPrefix+"/ns/"+namespace+"/charts/"+tt.result[i].ID, "self link should be the same")
 			}
 		})
 	}
@@ -192,17 +195,17 @@ func Test_newChartVersionResponse(t *testing.T) {
 			chart: models.Chart{
 				ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "1.2.3"}}, RawIcon: iconBytes(), IconContentType: "image/svg",
 			},
-			expectedIcon: "/v1/assets/my-repo/my-chart/logo",
+			expectedIcon: "/v1/ns/" + namespace + "/assets/my-repo/my-chart/logo",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for i := range tt.chart.ChartVersions {
-				cvResponse := newChartVersionResponse(&tt.chart, tt.chart.ChartVersions[i])
+				cvResponse := newChartVersionResponse(namespace, &tt.chart, tt.chart.ChartVersions[i])
 				assert.Equal(t, cvResponse.Type, "chartVersion", "response type is chartVersion")
 				assert.Equal(t, cvResponse.ID, tt.chart.ID+"-"+tt.chart.ChartVersions[i].Version, "reponse id should have chart version suffix")
-				assert.Equal(t, cvResponse.Links.(interface{}).(selfLink).Self, pathPrefix+"/charts/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[i].Version, "self link should be the same")
+				assert.Equal(t, cvResponse.Links.(interface{}).(selfLink).Self, pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[i].Version, "self link should be the same")
 				assert.Equal(t, cvResponse.Attributes.(models.ChartVersion).Version, tt.chart.ChartVersions[i].Version, "chart version in the response should be the same")
 
 				// The chart should have had its icon url set and raw icon data removed.
@@ -234,12 +237,12 @@ func Test_newChartVersionListResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cvListResponse := newChartVersionListResponse(&tt.chart)
+			cvListResponse := newChartVersionListResponse(namespace, &tt.chart)
 			assert.Equal(t, len(cvListResponse), len(tt.chart.ChartVersions), "number of chart versions in response should be the same")
 			for i := range tt.chart.ChartVersions {
 				assert.Equal(t, cvListResponse[i].Type, "chartVersion", "response type is chartVersion")
 				assert.Equal(t, cvListResponse[i].ID, tt.chart.ID+"-"+tt.chart.ChartVersions[i].Version, "reponse id should have chart version suffix")
-				assert.Equal(t, cvListResponse[i].Links.(interface{}).(selfLink).Self, pathPrefix+"/charts/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[i].Version, "self link should be the same")
+				assert.Equal(t, cvListResponse[i].Links.(interface{}).(selfLink).Self, pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[i].Version, "self link should be the same")
 				assert.Equal(t, cvListResponse[i].Attributes.(models.ChartVersion).Version, tt.chart.ChartVersions[i].Version, "chart version in the response should be the same")
 			}
 		})
@@ -285,7 +288,7 @@ func Test_listCharts(t *testing.T) {
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/charts"+tt.query, nil)
-			listCharts(w, req, Params{})
+			listCharts(w, req, Params{"namespace": namespace})
 
 			m.AssertExpectations(t)
 			assert.Equal(t, http.StatusOK, w.Code)
@@ -300,7 +303,7 @@ func Test_listCharts(t *testing.T) {
 			for i, resp := range data {
 				assert.Equal(t, resp.ID, tt.charts[i].ID, "chart id in the response should be the same")
 				assert.Equal(t, resp.Type, "chart", "response type is chart")
-				assert.Equal(t, resp.Links.(map[string]interface{})["self"], pathPrefix+"/charts/"+tt.charts[i].ID, "self link should be the same")
+				assert.Equal(t, resp.Links.(map[string]interface{})["self"], pathPrefix+"/ns/"+namespace+"/charts/"+tt.charts[i].ID, "self link should be the same")
 				assert.Equal(t, resp.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.charts[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 			}
 			assert.Equal(t, b.Meta, tt.meta, "response meta should be the same")
@@ -415,6 +418,7 @@ func Test_getChart(t *testing.T) {
 			req := httptest.NewRequest("GET", "/charts/"+tt.chart.ID, nil)
 			parts := strings.Split(tt.chart.ID, "/")
 			params := Params{
+				"namespace": namespace,
 				"repo":      parts[0],
 				"chartName": parts[1],
 			}
@@ -428,7 +432,7 @@ func Test_getChart(t *testing.T) {
 				json.NewDecoder(w.Body).Decode(&b)
 				assert.Equal(t, b.Data.ID, tt.chart.ID, "chart id in the response should be the same")
 				assert.Equal(t, b.Data.Type, "chart", "response type is chart")
-				assert.Equal(t, b.Data.Links.(map[string]interface{})["self"], pathPrefix+"/charts/"+tt.chart.ID, "self link should be the same")
+				assert.Equal(t, b.Data.Links.(map[string]interface{})["self"], pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID, "self link should be the same")
 				assert.Equal(t, b.Data.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.chart.ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 			}
 		})


### PR DESCRIPTION
While testing #1573 I found the icons weren't rendering because the frontend uses the icon url in the response [1], which hadn't been updated to be namespaced. Turns out there were a few others that I've also updated.

[1] Oddly, we don't have the dashboard using the similar links for the readme or schema.

Ref: #1521 