### PR TITLE
Add installation instructions for operators

### DIFF
--- a/dashboard/src/components/OperatorView/OperatorHeader.test.tsx
+++ b/dashboard/src/components/OperatorView/OperatorHeader.test.tsx
@@ -9,6 +9,7 @@ const defaultProps = {
   namespace: "kubeapps",
   version: "1.0.0",
   provider: "Kubeapps",
+  namespaced: false,
 };
 
 it("renders the header", () => {

--- a/dashboard/src/components/OperatorView/OperatorHeader.tsx
+++ b/dashboard/src/components/OperatorView/OperatorHeader.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
+import OperatorInstallation from "./OperatorInstallation";
 
 interface IOperatorHeaderProps {
   id: string;
@@ -8,9 +9,14 @@ interface IOperatorHeaderProps {
   namespace: string;
   version: string;
   provider: string;
+  namespaced: boolean;
 }
 
 class OperatorHeader extends React.Component<IOperatorHeaderProps> {
+  public state = {
+    modalIsOpen: false,
+  };
+
   public render() {
     const { id, icon, description, namespace, version, provider } = this.props;
     return (
@@ -33,13 +39,33 @@ class OperatorHeader extends React.Component<IOperatorHeaderProps> {
             </div>
           </div>
           <div className="col-2 ChartHeader__button">
-            <button className="button button-primary button-accent">Deploy</button>
+            <button className="button button-primary button-accent" onClick={this.openModal}>
+              Deploy
+            </button>
+            <OperatorInstallation
+              name={id}
+              namespaced={this.props.namespaced}
+              closeModal={this.closeModal}
+              modalIsOpen={this.state.modalIsOpen}
+            />
           </div>
         </div>
         <hr />
       </header>
     );
   }
+
+  public openModal = () => {
+    this.setState({
+      modalIsOpen: true,
+    });
+  };
+
+  public closeModal = () => {
+    this.setState({
+      modalIsOpen: false,
+    });
+  };
 }
 
 export default OperatorHeader;

--- a/dashboard/src/components/OperatorView/OperatorInstallation.tsx
+++ b/dashboard/src/components/OperatorView/OperatorInstallation.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { X } from "react-feather";
+import * as Modal from "react-modal";
+
+// TODO(andresmgot) This is a temporary component
+// A form should be rendered instead asking for the operator
+// details and creating a Subscription
+
+interface IOperatorInstallationProps {
+  name: string;
+  namespaced: boolean;
+  closeModal: () => void;
+  modalIsOpen: boolean;
+}
+
+class OperatorInstallation extends React.Component<IOperatorInstallationProps> {
+  public render() {
+    return (
+      <Modal
+        className="centered-modal"
+        isOpen={this.props.modalIsOpen}
+        onRequestClose={this.props.closeModal}
+        contentLabel="Modal"
+      >
+        <div className="container">
+          <div className="row">
+            <div className="col-10">
+              <h5>Install {this.props.name}</h5>
+            </div>
+            <div className="col-2 text-r">
+              <a onClick={this.props.closeModal} style={{ color: "inherit" }}>
+                <X />
+              </a>
+            </div>
+          </div>
+          Install the operator by running the following command:
+          <section className="AppNotes Terminal elevation-1 margin-v-big">
+            <div className="Terminal__Top type-small">
+              <div className="Terminal__Top__Buttons">
+                <span className="Terminal__Top__Button Terminal__Top__Button--red" />
+                <span className="Terminal__Top__Button Terminal__Top__Button--yellow" />
+                <span className="Terminal__Top__Button Terminal__Top__Button--green" />
+              </div>
+            </div>
+            <div className="Terminal__Tab">
+              <pre className="Terminal__Code">
+                <code>kubectl create -f https://operatorhub.io/install/{this.props.name}.yaml</code>
+              </pre>
+            </div>
+          </section>
+          {this.props.namespaced ? (
+            <span>
+              This Operator will be installed in the <code>my-{this.props.name}</code> namespace and
+              will be usable from this namespace only.
+            </span>
+          ) : (
+            <span>
+              This Operator will be installed in the <code>operators</code> namespace and will be
+              usable from all namespaces in the cluster.
+            </span>
+          )}
+        </div>
+      </Modal>
+    );
+  }
+}
+
+export default OperatorInstallation;

--- a/dashboard/src/components/OperatorView/OperatorView.test.tsx
+++ b/dashboard/src/components/OperatorView/OperatorView.test.tsx
@@ -2,6 +2,7 @@ import { shallow } from "enzyme";
 import * as React from "react";
 import { NotFoundError } from "../../shared/types";
 import UnexpectedErrorPage from "../ErrorAlert/UnexpectedErrorAlert";
+import OperatorDescription from "./OperatorDescription";
 import OperatorView from "./OperatorView";
 
 const defaultProps = {
@@ -10,6 +11,36 @@ const defaultProps = {
   isFetching: false,
   namespace: "kubeapps",
 };
+
+const defaultOperator = {
+  metadata: {
+    name: "foo",
+    namespace: "kubeapps",
+  },
+  status: {
+    provider: {
+      name: "Kubeapps",
+    },
+    defaultChannel: "beta",
+    channels: [
+      {
+        name: "beta",
+        currentCSVDesc: {
+          displayName: "Foo",
+          version: "1.0.0",
+          description: "this is a testing operator",
+          annotations: {
+            capabilities: "Basic Install",
+            repository: "github.com/kubeapps/kubeapps",
+            containerImage: "kubeapps/kubeapps",
+            createdAt: "one day",
+          },
+          installModes: [],
+        },
+      },
+    ],
+  },
+} as any;
 
 it("calls getOperator when mounting the component", () => {
   const getOperator = jest.fn();
@@ -40,32 +71,20 @@ it("shows an error if the operator doesn't have any channel defined", () => {
 });
 
 it("renders a full OperatorView", () => {
+  const wrapper = shallow(<OperatorView {...defaultProps} operator={defaultOperator} />);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("selects the default channel", () => {
   const operator = {
-    metadata: {
-      name: "foo",
-      namespace: "kubeapps",
-    },
+    ...defaultOperator,
     status: {
-      provider: {
-        name: "Kubeapps",
-      },
-      channels: [
-        {
-          currentCSVDesc: {
-            displayName: "Foo",
-            version: "1.0.0",
-            description: "this is a testing operator",
-            annotations: {
-              capabilities: "Basic Install",
-              repository: "github.com/kubeapps/kubeapps",
-              containerImage: "kubeapps/kubeapps",
-              createdAt: "one day",
-            },
-          },
-        },
-      ],
+      ...defaultOperator.status,
+      channels: [{ name: "alpha" }, defaultOperator.status.channels[0]],
     },
   };
   const wrapper = shallow(<OperatorView {...defaultProps} operator={operator as any} />);
-  expect(wrapper).toMatchSnapshot();
+  expect(wrapper.find(OperatorDescription).prop("description")).toEqual(
+    "this is a testing operator",
+  );
 });

--- a/dashboard/src/components/OperatorView/OperatorView.tsx
+++ b/dashboard/src/components/OperatorView/OperatorView.tsx
@@ -5,7 +5,7 @@ import { ErrorSelector } from "../ErrorAlert";
 import UnexpectedErrorPage from "../ErrorAlert/UnexpectedErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
 import CapabiliyLevel from "./OperatorCapabilityLevel";
-import OperatorReadme from "./OperatorDescription";
+import OperatorDescription from "./OperatorDescription";
 import OperatorHeader from "./OperatorHeader";
 
 interface IOperatorViewProps {
@@ -31,14 +31,16 @@ class OperatorView extends React.Component<IOperatorViewProps> {
     if (isFetching || !operator) {
       return <LoadingWrapper />;
     }
-    if (operator.status.channels.length === 0) {
+    const channel = operator.status.channels.find(ch => ch.name === operator.status.defaultChannel);
+    if (!channel) {
       return (
         <UnexpectedErrorPage
           text={`Operator ${operatorName} doesn't define a valid channel. This is needed to extract required info.`}
         />
       );
     }
-    const { currentCSVDesc } = operator.status.channels[0];
+    const { currentCSVDesc } = channel;
+    const namespaced = currentCSVDesc.installModes.find(m => m.type === "AllNamespaces");
     return (
       <section className="ChartView padding-b-big">
         <OperatorHeader
@@ -48,12 +50,13 @@ class OperatorView extends React.Component<IOperatorViewProps> {
           version={currentCSVDesc.version}
           namespace={namespace}
           provider={operator.status.provider.name}
+          namespaced={!namespaced?.supported}
         />
         <main>
           <div className="container container-fluid">
             <div className="row">
               <div className="col-9 ChartView__readme-container">
-                <OperatorReadme description={currentCSVDesc.description} />
+                <OperatorDescription description={currentCSVDesc.description} />
               </div>
               <div className="col-3 ChartView__sidebar-container">
                 <aside className="ChartViewSidebar bg-light margin-v-big padding-h-normal padding-b-normal">

--- a/dashboard/src/components/OperatorView/__snapshots__/OperatorHeader.test.tsx.snap
+++ b/dashboard/src/components/OperatorView/__snapshots__/OperatorHeader.test.tsx.snap
@@ -53,9 +53,16 @@ exports[`renders the header 1`] = `
     >
       <button
         className="button button-primary button-accent"
+        onClick={[Function]}
       >
         Deploy
       </button>
+      <OperatorInstallation
+        closeModal={[Function]}
+        modalIsOpen={false}
+        name="foo"
+        namespaced={false}
+      />
     </div>
   </div>
   <hr />

--- a/dashboard/src/components/OperatorView/__snapshots__/OperatorView.test.tsx.snap
+++ b/dashboard/src/components/OperatorView/__snapshots__/OperatorView.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`renders a full OperatorView 1`] = `
     icon="api/v1/namespaces/kubeapps/operator/foo/logo"
     id="foo"
     namespace="kubeapps"
+    namespaced={true}
     provider="Kubeapps"
     version="1.0.0"
   />

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -221,6 +221,7 @@ export interface IPackageManifestStatus {
   provider: {
     name: string;
   };
+  defaultChannel: string;
   channels: Array<{
     name: string;
     currentCSV: string;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Add installation instructions for Operators. This is a provisional approach while we develop a proper form to create these Operators through Kubeapps. In this case, we point to the publicly available YAML that the operator hub provides:

![Screenshot from 2020-03-10 16-27-05](https://user-images.githubusercontent.com/4025665/76331355-55897900-62ef-11ea-9f38-4b4978fc035f.png)

There are two types of operators: namespaced or non-namespaced (global). This information is available in the channels that the PackageManifest specifies. The manifest published in the OperatorHub refers to the default channel so we need to check that one. 

Namespaced operators are installed in a namespace called `my-<operator>` while global are installed in the `operators` namespace.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1552
