### PR TITLE
Update assetsvc chart test for namespaced URIs

### DIFF
--- a/chart/kubeapps/templates/tests/test-assetsvc.yaml
+++ b/chart/kubeapps/templates/tests/test-assetsvc.yaml
@@ -16,5 +16,5 @@ spec:
       command:
         - sh
         - -c
-        - curl -o /tmp/output $ASSETSVC_HOST:$ASSETSVC_PORT/v1/charts && cat /tmp/output && cat /tmp/output | grep wordpress
+        - curl -o /tmp/output $ASSETSVC_HOST:$ASSETSVC_PORT/v1/ns/{{ .Release.Namespace }}/charts && cat /tmp/output && cat /tmp/output | grep wordpress
   restartPolicy: Never

--- a/cmd/assetsvc/handler.go
+++ b/cmd/assetsvc/handler.go
@@ -118,22 +118,8 @@ func getPaginatedChartList(namespace, repo string, pageNumber, pageSize int, sho
 	return newChartListResponse(namespace, charts), meta{totalPages}, err
 }
 
-// listCharts returns a list of charts
+// listCharts returns a list of charts based on filter params
 func listCharts(w http.ResponseWriter, req *http.Request, params Params) {
-	pageNumber, pageSize := getPageNumberAndSize(req)
-	cl, meta, err := getPaginatedChartList(params["namespace"], "", pageNumber, pageSize, showDuplicates(req))
-	if err != nil {
-		log.WithError(err).Error("could not fetch charts")
-		response.NewErrorResponse(http.StatusInternalServerError, "could not fetch all charts").Write(w)
-		return
-	}
-	response.NewDataResponseWithMeta(cl, meta).Write(w)
-}
-
-// listRepoCharts returns a list of charts in the given repo
-// TODO: mnelson: Refactor to have just one `listCharts` function where params
-// can be empty.
-func listRepoCharts(w http.ResponseWriter, req *http.Request, params Params) {
 	pageNumber, pageSize := getPageNumberAndSize(req)
 	cl, meta, err := getPaginatedChartList(params["namespace"], params["repo"], pageNumber, pageSize, showDuplicates(req))
 	if err != nil {

--- a/cmd/assetsvc/handler_test.go
+++ b/cmd/assetsvc/handler_test.go
@@ -355,7 +355,7 @@ func Test_listRepoCharts(t *testing.T) {
 				"repo": "my-repo",
 			}
 
-			listRepoCharts(w, req, params)
+			listCharts(w, req, params)
 
 			m.AssertExpectations(t)
 			assert.Equal(t, http.StatusOK, w.Code)

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -47,7 +47,7 @@ func setupRoutes() http.Handler {
 	apiv1.Methods("GET").Path("/ns/{namespace}/charts").Queries("name", "{chartName}", "version", "{version}", "appversion", "{appversion}", "showDuplicates", "{showDuplicates}").Handler(WithParams(listChartsWithFilters))
 	apiv1.Methods("GET").Path("/ns/{namespace}/charts").Handler(WithParams(listCharts))
 	apiv1.Methods("GET").Path("/ns/{namespace}/charts").Queries("showDuplicates", "{showDuplicates}").Handler(WithParams(listCharts))
-	apiv1.Methods("GET").Path("/ns/{namespace}/charts/{repo}").Handler(WithParams(listRepoCharts))
+	apiv1.Methods("GET").Path("/ns/{namespace}/charts/{repo}").Handler(WithParams(listCharts))
 	apiv1.Methods("GET").Path("/ns/{namespace}/charts/{repo}/{chartName}").Handler(WithParams(getChart))
 	apiv1.Methods("GET").Path("/ns/{namespace}/charts/{repo}/{chartName}/versions").Handler(WithParams(listChartVersions))
 	apiv1.Methods("GET").Path("/ns/{namespace}/charts/{repo}/{chartName}/versions/{version}").Handler(WithParams(getChartVersion))


### PR DESCRIPTION
Last change for namespaced assetsvc to pass on CI, but I'm not landing this as it also would mean we can't release the chart for a previous version.

Other thoughts I had:
 * Temporarily update the assetsvc to still respond for non-namespaced requests: this would turn in to a security issue later when we check to ensure the requestor has perms, also quite a bit of code just to work around a CI issue.
 * Update the test URI to something like the live probe: fails to be a useful test at that point
 * I don't think we can choose the URL conditionally because (a) it's going to depend on which app version is installed, and (b) helm template tags for testing semvers is dangerous (exits on error).

It seems like we really should be keeping a branch for the currently released chart, and if we want to update the currently released chart we land to that branch and release, while master of the chart is always for master of the app code. Has this been talked about in the past (other than my mentioning it once before)?