### PR TITLE
Add form to create an operator instance

### DIFF
--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -155,3 +155,72 @@ describe("getCSVs", () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
+
+describe("getCSV", () => {
+  it("returns an an ClusterServiceVersion", async () => {
+    const csv = { metadata: { name: "foo" } };
+    Operators.getCSV = jest.fn(() => csv);
+    const expectedActions = [
+      {
+        type: getType(operatorActions.requestCSV),
+      },
+      {
+        type: getType(operatorActions.receiveCSV),
+        payload: csv,
+      },
+    ];
+    await store.dispatch(operatorActions.getCSV("default", "foo"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches an error", async () => {
+    Operators.getCSV = jest.fn(() => {
+      throw new Error("Boom!");
+    });
+    const expectedActions = [
+      {
+        type: getType(operatorActions.requestCSV),
+      },
+      {
+        type: getType(operatorActions.errorCSVs),
+        payload: new Error("Boom!"),
+      },
+    ];
+    await store.dispatch(operatorActions.getCSV("default", "foo"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe("createResource", () => {
+  it("creates a resource", async () => {
+    Operators.createResource = jest.fn(() => true);
+    const expectedActions = [
+      {
+        type: getType(operatorActions.creatingResource),
+      },
+      {
+        type: getType(operatorActions.resourceCreated),
+        payload: true,
+      },
+    ];
+    await store.dispatch(operatorActions.createResource("default", "v1", "pods", {}));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches an error", async () => {
+    Operators.createResource = jest.fn(() => {
+      throw new Error("Boom!");
+    });
+    const expectedActions = [
+      {
+        type: getType(operatorActions.creatingResource),
+      },
+      {
+        type: getType(operatorActions.errorResourceCreate),
+        payload: new Error("Boom!"),
+      },
+    ];
+    await store.dispatch(operatorActions.createResource("default", "v1", "pods", {}));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});

--- a/dashboard/src/components/DeploymentFormBody/AdvancedDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/AdvancedDeploymentForm.tsx
@@ -22,10 +22,9 @@ class AdvancedDeploymentForm extends React.Component<IAdvancedDeploymentForm> {
           editorProps={{ $blockScrolling: Infinity }}
           value={this.props.appValues}
           className="editor"
+          fontSize="15px"
         />
-        <p>
-          <b>Note:</b> Only comments from the original chart values will be preserved.
-        </p>
+        {this.props.children}
       </div>
     );
   }

--- a/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.tsx
@@ -200,7 +200,11 @@ class DeploymentFormBody extends React.Component<
             <AdvancedDeploymentForm
               appValues={this.props.appValues}
               handleValuesChange={this.handleValuesChange}
-            />
+            >
+              <p>
+                <b>Note:</b> Only comments from the original chart values will be preserved.
+              </p>
+            </AdvancedDeploymentForm>
           </TabPanel>
           <TabPanel>{this.renderDiff()}</TabPanel>
         </Tabs>

--- a/dashboard/src/components/DeploymentFormBody/__snapshots__/DeploymentFormBody.test.tsx.snap
+++ b/dashboard/src/components/DeploymentFormBody/__snapshots__/DeploymentFormBody.test.tsx.snap
@@ -81,7 +81,14 @@ exports[`renders the full DeploymentFormBody 1`] = `
         <AdvancedDeploymentForm
           appValues="foo: bar"
           handleValuesChange={[Function]}
-        />
+        >
+          <p>
+            <b>
+              Note:
+            </b>
+             Only comments from the original chart values will be preserved.
+          </p>
+        </AdvancedDeploymentForm>
       </TabPanel>
       <TabPanel
         className="react-tabs__tab-panel"

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.test.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.test.tsx
@@ -1,0 +1,78 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+import { Tabs } from "react-tabs";
+import OperatorInstanceForm from ".";
+import itBehavesLike from "../../shared/specs";
+import { ConflictError, IClusterServiceVersion } from "../../shared/types";
+import { ErrorSelector } from "../ErrorAlert";
+import NotFoundErrorPage from "../ErrorAlert/NotFoundErrorAlert";
+import { IOperatorInstanceFormProps } from "./OperatorInstanceForm";
+
+const defaultProps: IOperatorInstanceFormProps = {
+  csvName: "foo",
+  crdName: "foo-cluster",
+  isFetching: false,
+  namespace: "kubeapps",
+  getCSV: jest.fn(),
+  createResource: jest.fn(),
+  push: jest.fn(),
+  errors: {},
+};
+
+const defaultCRD = {
+  name: defaultProps.crdName,
+  kind: "Foo",
+  description: "useful description",
+} as any;
+
+itBehavesLike("aLoadingComponent", {
+  component: OperatorInstanceForm,
+  props: { ...defaultProps, isFetching: true },
+});
+
+it("retrieves CSV when mounted", () => {
+  const getCSV = jest.fn();
+  shallow(<OperatorInstanceForm {...defaultProps} getCSV={getCSV} />);
+  expect(getCSV).toHaveBeenCalledWith(defaultProps.namespace, defaultProps.csvName);
+});
+
+it("retrieves the example values and the target CRD from the given CSV", () => {
+  const csv = {
+    metadata: {
+      annotations: {
+        "alm-examples": '[{"kind": "Foo", "apiVersion": "v1"}]',
+      },
+    },
+    spec: {
+      customresourcedefinitions: {
+        owned: [defaultCRD],
+      },
+    },
+  } as IClusterServiceVersion;
+  const wrapper = shallow(<OperatorInstanceForm {...defaultProps} />);
+  wrapper.setProps({ csv });
+  expect(wrapper.state()).toMatchObject({
+    defaultValues: "kind: Foo\napiVersion: v1\n",
+    crd: defaultCRD,
+  });
+});
+
+it("renders an error if there is some error fetching", () => {
+  const wrapper = shallow(
+    <OperatorInstanceForm {...defaultProps} errors={{ fetch: new Error("Boom!") }} />,
+  );
+  expect(wrapper.find(ErrorSelector)).toExist();
+});
+
+it("renders an error if the CRD is not populated", () => {
+  const wrapper = shallow(<OperatorInstanceForm {...defaultProps} />);
+  expect(wrapper.find(NotFoundErrorPage)).toExist();
+});
+
+it("renders an error if the creation failed", () => {
+  const wrapper = shallow(<OperatorInstanceForm {...defaultProps} />);
+  wrapper.setState({ crd: defaultCRD });
+  wrapper.setProps({ errors: { create: new ConflictError() } });
+  expect(wrapper.find(ErrorSelector)).toExist();
+  expect(wrapper.find(Tabs)).toExist();
+});

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
@@ -1,0 +1,208 @@
+import { RouterAction } from "connected-react-router";
+import * as yaml from "js-yaml";
+import * as Moniker from "moniker-native";
+import * as React from "react";
+import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
+
+import { IClusterServiceVersion, IClusterServiceVersionCRD, IResource } from "../../shared/types";
+import ConfirmDialog from "../ConfirmDialog";
+import AdvancedDeploymentForm from "../DeploymentFormBody/AdvancedDeploymentForm";
+import Differential from "../DeploymentFormBody/Differential";
+import { ErrorSelector } from "../ErrorAlert";
+import NotFoundErrorPage from "../ErrorAlert/NotFoundErrorAlert";
+import LoadingWrapper from "../LoadingWrapper";
+import PageHeader from "../PageHeader";
+
+export interface IOperatorInstanceFormProps {
+  csvName: string;
+  crdName: string;
+  isFetching: boolean;
+  namespace: string;
+  getCSV: (namespace: string, csvName: string) => void;
+  createResource: (
+    namespace: string,
+    apiVersion: string,
+    resource: string,
+    body: object,
+  ) => Promise<boolean>;
+  push: (location: string) => RouterAction;
+  csv?: IClusterServiceVersion;
+  errors: {
+    fetch?: Error;
+    create?: Error;
+  };
+}
+
+export interface IOperatorInstanceFormBodyState {
+  name: string;
+  values: string;
+  defaultValues: string;
+  restoreDefaultValuesModalIsOpen: boolean;
+  submittedResourceName: string;
+  crd?: IClusterServiceVersionCRD;
+}
+
+class DeploymentFormBody extends React.Component<
+  IOperatorInstanceFormProps,
+  IOperatorInstanceFormBodyState
+> {
+  public state: IOperatorInstanceFormBodyState = {
+    name: Moniker.choose(),
+    values: "",
+    defaultValues: "",
+    submittedResourceName: "",
+    restoreDefaultValuesModalIsOpen: false,
+  };
+
+  public componentDidMount() {
+    const { getCSV, csvName, namespace } = this.props;
+    getCSV(namespace, csvName);
+  }
+
+  public componentDidUpdate(prevProps: IOperatorInstanceFormProps) {
+    const { csv, crdName } = this.props;
+    if (csv && csv !== prevProps.csv) {
+      csv.spec.customresourcedefinitions.owned.forEach(ownedCRD => {
+        if (ownedCRD.name === crdName) {
+          // Got the target CRD, extract the example
+          const kind = ownedCRD.kind;
+          const rawExamples = csv.metadata.annotations["alm-examples"];
+          const examples = JSON.parse(rawExamples) as IResource[];
+          examples.forEach(example => {
+            if (example.kind === kind) {
+              // Found the example, set the default values
+              const yamlValues = yaml.safeDump(example);
+              this.setState({
+                values: yamlValues,
+                defaultValues: yamlValues,
+                crd: ownedCRD,
+              });
+            }
+          });
+        }
+      });
+    }
+  }
+
+  public render() {
+    const { isFetching, errors, csvName, crdName } = this.props;
+    const { crd, submittedResourceName } = this.state;
+
+    if (errors.fetch) {
+      return (
+        <ErrorSelector
+          error={errors.fetch}
+          resource={`Operator Instance "${csvName}" (${crd?.name})`}
+        />
+      );
+    }
+    if (isFetching) {
+      return <LoadingWrapper />;
+    }
+    if (!crd) {
+      return (
+        <NotFoundErrorPage
+          header={
+            <span>
+              {crdName} not found in the definition of {csvName}
+            </span>
+          }
+        />
+      );
+    }
+    return (
+      <>
+        <PageHeader>
+          <h1>Create {crd.kind}</h1>
+        </PageHeader>
+        <main>
+          {errors.create && (
+            <ErrorSelector
+              error={errors.create}
+              resource={`Operator Instance "${submittedResourceName}" (${crd?.name})`}
+            />
+          )}
+          <p>{crd.description}</p>
+          <ConfirmDialog
+            modalIsOpen={this.state.restoreDefaultValuesModalIsOpen}
+            loading={false}
+            confirmationText={"Are you sure you want to restore the default instance values?"}
+            confirmationButtonText={"Restore"}
+            onConfirm={this.restoreDefaultValues}
+            closeModal={this.closeRestoreDefaultValuesModal}
+          />
+          {this.renderTabs()}
+          <form className="container padding-b-bigger" onSubmit={this.handleDeploy}>
+            <div className="margin-t-big">
+              <button className="button button-primary" type="submit">
+                Submit
+              </button>
+              <button className="button" type="button" onClick={this.openRestoreDefaultValuesModal}>
+                Restore Defaults
+              </button>
+            </div>
+          </form>
+        </main>
+      </>
+    );
+  }
+
+  private handleValuesChange = (values: string) => {
+    this.setState({ values });
+  };
+
+  private renderTabs = () => {
+    return (
+      <div className="margin-t-normal row">
+        <Tabs className="col-8">
+          <TabList>
+            <Tab>YAML</Tab>
+            <Tab>Changes</Tab>
+          </TabList>
+          <TabPanel>
+            <AdvancedDeploymentForm
+              appValues={this.state.values}
+              handleValuesChange={this.handleValuesChange}
+            />
+          </TabPanel>
+          <TabPanel>
+            <Differential
+              title="Difference from example defaults"
+              oldValues={this.state.defaultValues}
+              newValues={this.state.values}
+              emptyDiffText="No changes detected from example defaults"
+            />
+          </TabPanel>
+        </Tabs>
+      </div>
+    );
+  };
+
+  private closeRestoreDefaultValuesModal = () => {
+    this.setState({ restoreDefaultValuesModalIsOpen: false });
+  };
+
+  private openRestoreDefaultValuesModal = () => {
+    this.setState({ restoreDefaultValuesModalIsOpen: true });
+  };
+
+  private restoreDefaultValues = () => {
+    this.setState({ values: this.state.defaultValues, restoreDefaultValuesModalIsOpen: false });
+  };
+
+  private handleDeploy = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const { createResource, push, namespace } = this.props;
+    const { values, crd } = this.state;
+    const resourceType = crd!.name.split(".")[0];
+    // TODO: Catch errors
+    const resource: IResource = yaml.safeLoad(values);
+    this.setState({ submittedResourceName: resource.metadata.name });
+    const created = await createResource(namespace, resource.apiVersion, resourceType, resource);
+    if (created) {
+      push(`/operators-instances/ns/${namespace}/${resource.metadata.name}`);
+    }
+  };
+}
+
+export default DeploymentFormBody;

--- a/dashboard/src/components/OperatorInstanceForm/__snapshots__/OperatorInstanceForm.test.tsx.snap
+++ b/dashboard/src/components/OperatorInstanceForm/__snapshots__/OperatorInstanceForm.test.tsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loading spinner matches the snapshot 1`] = `
+<LoadingWrapper
+  loaded={false}
+  type={0}
+/>
+`;

--- a/dashboard/src/components/OperatorInstanceForm/index.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/index.tsx
@@ -1,0 +1,3 @@
+import OperatorInstanceForm from "./OperatorInstanceForm";
+
+export default OperatorInstanceForm;

--- a/dashboard/src/containers/OperatorInstanceCreateContainer/OperatorInstanceCreateContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceCreateContainer/OperatorInstanceCreateContainer.tsx
@@ -1,26 +1,43 @@
-import * as React from "react";
+import { push } from "connected-react-router";
 import { connect } from "react-redux";
-import { RouteComponentProps } from "react-router";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
 
+import OperatorInstanceForm from "components/OperatorInstanceForm";
+import actions from "../../actions";
 import { IStoreState } from "../../shared/types";
 
+interface IRouteProps {
+  match: {
+    params: {
+      csv: string;
+      crd: string;
+    };
+  };
+}
+
 function mapStateToProps(
-  { apps, namespace, charts }: IStoreState,
-  { location }: RouteComponentProps<{}>,
+  { operators, namespace }: IStoreState,
+  { match: { params } }: IRouteProps,
 ) {
-  return {};
+  return {
+    namespace: namespace.current,
+    isFetching: operators.isFetching,
+    csv: operators.csv,
+    errors: operators.errors,
+    csvName: params.csv,
+    crdName: params.crd,
+  };
 }
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
-  return {};
+  return {
+    getCSV: (namespace: string, name: string) =>
+      dispatch(actions.operators.getCSV(namespace, name)),
+    createResource: (namespace: string, apiVersion: string, resource: string, body: object) =>
+      dispatch(actions.operators.createResource(namespace, apiVersion, resource, body)),
+    push: (location: string) => dispatch(push(location)),
+  };
 }
 
-class Comp extends React.Component {
-  public render() {
-    return <h1>This component has not been built yet</h1>;
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Comp);
+export default connect(mapStateToProps, mapDispatchToProps)(OperatorInstanceForm);

--- a/dashboard/src/containers/OperatorInstanceCreateContainer/OperatorInstanceCreateContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceCreateContainer/OperatorInstanceCreateContainer.tsx
@@ -3,8 +3,8 @@ import { connect } from "react-redux";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
 
-import OperatorInstanceForm from "components/OperatorInstanceForm";
 import actions from "../../actions";
+import OperatorInstanceForm from "../../components/OperatorInstanceForm";
 import { IStoreState } from "../../shared/types";
 
 interface IRouteProps {

--- a/dashboard/src/containers/OperatorViewContainer/OperatorViewContainer.tsx
+++ b/dashboard/src/containers/OperatorViewContainer/OperatorViewContainer.tsx
@@ -22,7 +22,7 @@ function mapStateToProps(
     namespace: namespace.current,
     isFetching: operators.isFetching,
     operator: operators.operator,
-    error: operators.error,
+    error: operators.errors.fetch,
     operatorName: params.operator,
   };
 }

--- a/dashboard/src/containers/OperatorsListContainer/OperatorsListContainer.tsx
+++ b/dashboard/src/containers/OperatorsListContainer/OperatorsListContainer.tsx
@@ -16,7 +16,7 @@ function mapStateToProps(
     isFetching: operators.isFetching,
     isOLMInstalled: operators.isOLMInstalled,
     operators: operators.operators,
-    error: operators.error,
+    error: operators.errors.fetch,
   };
 }
 

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -69,7 +69,7 @@ class Routes extends React.Component<IRoutesProps> {
         "/operators/ns/:namespace": OperatorsListContainer,
         "/operators/ns/:namespace/:operator": OperatorViewContainer,
         "/operators-instances/ns/:namespace/:instanceName": OperatorInstanceViewContainer,
-        "/operators-instances/ns/:namespace/new/:operator/:instanceType": OperatorInstanceCreateContainer,
+        "/operators-instances/ns/:namespace/new/:csv/:crd": OperatorInstanceCreateContainer,
       });
     }
     return (

--- a/dashboard/src/reducers/operators.ts
+++ b/dashboard/src/reducers/operators.ts
@@ -11,8 +11,12 @@ export interface IOperatorsState {
   isOLMInstalled: boolean;
   operators: IResource[];
   operator?: IPackageManifest;
-  error?: Error;
+  errors: {
+    fetch?: Error;
+    create?: Error;
+  };
   csvs: IClusterServiceVersion[];
+  csv?: IClusterServiceVersion;
 }
 
 const initialState: IOperatorsState = {
@@ -20,6 +24,7 @@ const initialState: IOperatorsState = {
   isOLMInstalled: false,
   operators: [],
   csvs: [],
+  errors: {},
 };
 
 const catalogReducer = (
@@ -43,17 +48,27 @@ const catalogReducer = (
     case getType(operators.receiveOperator):
       return { ...state, isFetching: false, operator: action.payload };
     case getType(operators.errorOperators):
-      return { ...state, isFetching: false, error: action.payload };
+      return { ...state, isFetching: false, errors: { fetch: action.payload } };
     case getType(operators.requestCSVs):
       return { ...state, isFetching: true };
     case getType(operators.receiveCSVs):
       return { ...state, isFetching: false, csvs: action.payload };
+    case getType(operators.requestCSV):
+      return { ...state, isFetching: true };
+    case getType(operators.receiveCSV):
+      return { ...state, isFetching: false, csv: action.payload };
     case getType(operators.errorCSVs):
-      return { ...state, isFetching: false, error: action.payload };
+      return { ...state, isFetching: false, errors: { fetch: action.payload } };
+    case getType(operators.creatingResource):
+      return { ...state, isFetching: true };
+    case getType(operators.resourceCreated):
+      return { ...state, isFetching: false };
+    case getType(operators.errorResourceCreate):
+      return { ...state, isFetching: false, errors: { create: action.payload } };
     case LOCATION_CHANGE:
-      return { ...state, error: undefined };
+      return { ...state, errors: {} };
     case getType(actions.namespace.setNamespace):
-      return { ...state, error: undefined };
+      return { ...state, errors: {} };
     default:
       return { ...state };
   }

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -1,6 +1,6 @@
 import { axiosWithAuth } from "./AxiosInstance";
 import { Operators } from "./Operators";
-import { IClusterServiceVersion, IPackageManifest } from "./types";
+import { IClusterServiceVersion, IPackageManifest, IResource } from "./types";
 
 it("check if the OLM has been installed", async () => {
   axiosWithAuth.get = jest.fn(() => {
@@ -65,4 +65,31 @@ it("get csvs", async () => {
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
     `api/kube/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions`,
   );
+});
+
+it("get csv", async () => {
+  const csv = { metadata: { name: "foo" } } as IClusterServiceVersion;
+  const ns = "default";
+  axiosWithAuth.get = jest.fn(() => {
+    return { data: csv };
+  });
+  expect(await Operators.getCSV(ns, "foo")).toEqual(csv);
+  expect(axiosWithAuth.get).toHaveBeenCalled();
+  expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
+    `api/kube/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions/foo`,
+  );
+});
+
+it("creates a resource", async () => {
+  const resource = { metadata: { name: "foo" } } as IResource;
+  const ns = "default";
+  axiosWithAuth.post = jest.fn(() => {
+    return { data: resource };
+  });
+  expect(await Operators.createResource(ns, "v1", "pods", resource)).toEqual(resource);
+  expect(axiosWithAuth.post).toHaveBeenCalled();
+  expect((axiosWithAuth.post as jest.Mock).mock.calls[0]).toEqual([
+    `api/kube/apis/v1/namespaces/${ns}/pods`,
+    resource,
+  ]);
 });

--- a/dashboard/src/shared/Operators.ts
+++ b/dashboard/src/shared/Operators.ts
@@ -1,6 +1,6 @@
 import * as urls from "../shared/url";
 import { axiosWithAuth } from "./AxiosInstance";
-import { IClusterServiceVersion, IK8sList, IPackageManifest } from "./types";
+import { IClusterServiceVersion, IK8sList, IPackageManifest, IResource } from "./types";
 
 export class Operators {
   public static async isOLMInstalled() {
@@ -31,5 +31,25 @@ export class Operators {
       urls.api.operators.clusterServiceVersions(namespace),
     );
     return data.items;
+  }
+
+  public static async getCSV(namespace: string, name: string) {
+    const { data } = await axiosWithAuth.get<IClusterServiceVersion>(
+      urls.api.operators.clusterServiceVersion(namespace, name),
+    );
+    return data;
+  }
+
+  public static async createResource(
+    namespace: string,
+    apiVersion: string,
+    resource: string,
+    body: object,
+  ) {
+    const { data } = await axiosWithAuth.post<IResource>(
+      urls.api.operators.resources(namespace, apiVersion, resource),
+      body,
+    );
+    return data;
   }
 }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -158,7 +158,7 @@ export interface IResource {
   metadata: {
     name: string;
     namespace: string;
-    annotations: string;
+    annotations: any;
     creationTimestamp: string;
     selfLink: string;
     resourceVersion: string;
@@ -266,33 +266,35 @@ export interface IPackageManifest extends IResource {
   status: IPackageManifestStatus;
 }
 
+export interface IClusterServiceVersionCRD {
+  description: string;
+  displayName: string;
+  kind: string;
+  name: string;
+  version: string;
+  resources: Array<{
+    kind: string;
+    name: string;
+    version: string;
+  }>;
+  specDescriptors: Array<{
+    description: string;
+    displayName: string;
+    path: string;
+    "x-descriptors": string[];
+  }>;
+  statusDescriptors: Array<{
+    description: string;
+    displayName: string;
+    path: string;
+    "x-descriptors": string[];
+  }>;
+}
+
 export interface IClusterServiceVersionSpec {
   apiservicedefinitions: any;
   customresourcedefinitions: {
-    owned: Array<{
-      description: string;
-      displayName: string;
-      kind: string;
-      name: string;
-      version: string;
-      resources: Array<{
-        kind: string;
-        name: string;
-        version: string;
-      }>;
-      specDescriptors: Array<{
-        description: string;
-        displayName: string;
-        path: string;
-        "x-descriptors": string[];
-      }>;
-      statusDescriptors: Array<{
-        description: string;
-        displayName: string;
-        path: string;
-        "x-descriptors": string[];
-      }>;
-    }>;
+    owned: IClusterServiceVersionCRD[];
   };
   description: string;
   displayName: string;

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -72,7 +72,11 @@ export const api = {
       `${APIBase}/apis/packages.operators.coreos.com/v1/namespaces/${namespace}/packagemanifests/${name}`,
     clusterServiceVersions: (namespace: string) =>
       `${APIBase}/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/clusterserviceversions`,
+    clusterServiceVersion: (namespace: string, name: string) =>
+      `${APIBase}/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/clusterserviceversions/${name}`,
     operatorIcon: (namespace: string, name: string) =>
       `api/v1/namespaces/${namespace}/operator/${name}/logo`,
+    resources: (namespace: string, apiVersion: string, resource: string) =>
+      `${APIBase}/apis/${apiVersion}/namespaces/${namespace}/${resource}`,
   },
 };


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Once an operator is selected from the Catalog, render a deployment form for the custom resource, using as default the examples given as annotations:

![Screenshot from 2020-03-13 18-03-56](https://user-images.githubusercontent.com/4025665/76643543-8965d800-6555-11ea-9335-1814caf144be.png)

This component reuses the same benefits than the Chart deployment (as the button to restore the default values and the tab to check the changes to be submitted).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1552 

