### PR TITLE
Adapt kubeapps chart to stable deprecation

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 3.4.5
+version: 3.4.6
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -32,7 +32,7 @@ helm install kubeapps --namespace kubeapps bitnami/kubeapps --set useHelm3=true
 
 This chart bootstraps a [Kubeapps](https://kubeapps.com) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-It also packages the [Bitnami MongoDB chart](https://github.com/helm/charts/tree/master/stable/mongodb) or the [Bitnami PostgreSQL chart](https://github.com/helm/charts/tree/master/stable/postgresql) which is required for bootstrapping a deployment for the database requirements of the Kubeapps application.
+It also packages the [Bitnami MongoDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mongodb) or the [Bitnami PostgreSQL chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) which is required for bootstrapping a deployment for the database requirements of the Kubeapps application.
 
 ## Prerequisites
 

--- a/chart/kubeapps/requirements.lock
+++ b/chart/kubeapps/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 7.8.7
+  repository: https://charts.bitnami.com/bitnami
+  version: 7.8.10
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 8.6.1
-digest: sha256:11a7b8e79e9182b04cd4ca1b70634085515aa6a1090839a1e320de6c1477228b
-generated: "2020-03-09T11:14:46.301696723+01:00"
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.6.4
+digest: sha256:79bfab968c079ec3575dee0a727994e2c8e6e20417316d18a157665e36aa4ddc
+generated: "2020-03-16T14:54:18.855302086Z"

--- a/chart/kubeapps/requirements.yaml
+++ b/chart/kubeapps/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: mongodb
     version: ">= 0"
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
   - name: postgresql
     version: ">= 0"
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -506,7 +506,7 @@ dashboard:
   tolerations: {}
 
 ## MongoDB chart configuration
-## ref: https://github.com/helm/charts/blob/master/stable/mongodb/values.yaml
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml
 ##
 mongodb:
   ## Whether to deploy a mongodb server to satisfy the applications database requirements.
@@ -539,7 +539,7 @@ mongodb:
       memory: 256Mi
 
 ## PostgreSQL chart configuration
-## ref: https://github.com/helm/charts/blob/master/stable/postgresql/values.yaml
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 ##
 postgresql:
   ## Whether to deploy a postgresql server to satisfy the applications database requirements.

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -124,6 +124,7 @@ if [[ "${HELM_VERSION:-}" =~ "v2" ]]; then
   tiller-init-rbac
   # Install Kubeapps
   info "Installing Kubeapps..."
+  helm repo add bitnami https://charts.bitnami.com/bitnami
   helm dep up "${ROOT_DIR}/chart/kubeapps/"
   helm install --name kubeapps-ci --namespace kubeapps "${ROOT_DIR}/chart/kubeapps" \
     "${HELM_CLIENT_TLS_FLAGS[@]}" \


### PR DESCRIPTION
### Description of the change

Bitnami charts are no longer updated in the `stable` repository. This PR updates some references/links in the docs and also the `requirements.yaml` to pull the dependencies from the updated repository.

+info: https://github.com/helm/charts/issues/20969

### Possible drawbacks

As the `bitnami` repository already contains all the bitnami contributed charts, there are no drawbacks because:
- Changes in the docs shouldn't affect anything
- Charts included as deps are already in the "new" repository (new in terms of kubeapps `requirements.yaml`)