### PR TITLE
Return charts for specific namespace and global namespace.

### DIFF
--- a/chart/kubeapps/templates/assetsvc-deployment.yaml
+++ b/chart/kubeapps/templates/assetsvc-deployment.yaml
@@ -51,6 +51,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.mongodb.existingSecret }}
                   key: mongodb-root-password
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           {{- end }}
           {{- if .Values.postgresql.enabled }}
           args:
@@ -64,6 +68,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.postgresql.existingSecret }}
                   key: postgresql-password
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           {{- end }}
           ports:
             - name: http

--- a/cmd/asset-syncer/delete.go
+++ b/cmd/asset-syncer/delete.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"os"
+
 	"github.com/kubeapps/common/datastore"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/sirupsen/logrus"
@@ -38,7 +40,8 @@ var deleteCmd = &cobra.Command{
 		}
 
 		dbConfig := datastore.Config{URL: databaseURL, Database: databaseName, Username: databaseUser, Password: databasePassword}
-		manager, err := newManager(databaseType, dbConfig)
+		kubeappsNamespace := os.Getenv("POD_NAMESPACE")
+		manager, err := newManager(databaseType, dbConfig, kubeappsNamespace)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/asset-syncer/invalidate-cache.go
+++ b/cmd/asset-syncer/invalidate-cache.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"os"
+
 	"github.com/kubeapps/common/datastore"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -37,7 +39,8 @@ var invalidateCacheCmd = &cobra.Command{
 		}
 
 		dbConfig := datastore.Config{URL: databaseURL, Database: databaseName, Username: databaseUser, Password: databasePassword}
-		manager, err := newManager(databaseType, dbConfig)
+		kubeappsNamespace := os.Getenv("POD_NAMESPACE")
+		manager, err := newManager(databaseType, dbConfig, kubeappsNamespace)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/asset-syncer/mongodb_utils.go
+++ b/cmd/asset-syncer/mongodb_utils.go
@@ -32,8 +32,8 @@ type mongodbAssetManager struct {
 	*dbutils.MongodbAssetManager
 }
 
-func newMongoDBManager(config datastore.Config) assetManager {
-	m := dbutils.NewMongoDBManager(config)
+func newMongoDBManager(config datastore.Config, kubeappsNamespace string) assetManager {
+	m := dbutils.NewMongoDBManager(config, kubeappsNamespace)
 	return &mongodbAssetManager{m}
 }
 

--- a/cmd/asset-syncer/mongodb_utils_test.go
+++ b/cmd/asset-syncer/mongodb_utils_test.go
@@ -26,12 +26,13 @@ import (
 	"github.com/kubeapps/common/datastore/mockstore"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/kubeapps/kubeapps/pkg/dbutils"
+	"github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest"
 	"github.com/stretchr/testify/mock"
 )
 
 func getMockManager(m *mock.Mock) *mongodbAssetManager {
 	dbSession := mockstore.NewMockSession(m)
-	man := dbutils.NewMongoDBManager(datastore.Config{})
+	man := dbutils.NewMongoDBManager(datastore.Config{}, dbutilstest.KubeappsTestNamespace)
 	man.DBSession = dbSession
 	return &mongodbAssetManager{man}
 }

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -36,8 +36,8 @@ type postgresAssetManager struct {
 	*dbutils.PostgresAssetManager
 }
 
-func newPGManager(config datastore.Config) (assetManager, error) {
-	m, err := dbutils.NewPGManager(config)
+func newPGManager(config datastore.Config, kubeappsNamespace string) (assetManager, error) {
+	m, err := dbutils.NewPGManager(config, kubeappsNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/asset-syncer/postgresql_utils_test.go
+++ b/cmd/asset-syncer/postgresql_utils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubeapps/common/datastore"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/kubeapps/kubeapps/pkg/dbutils"
+	"github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -44,7 +45,7 @@ func Test_DeletePGRepo(t *testing.T) {
 	m := &mockDB{&mock.Mock{}}
 	m.On("Query", "DELETE FROM repos WHERE name = $1 AND namespace = $2", []interface{}{repo.Name, repo.Namespace})
 
-	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"})
+	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"}, dbutilstest.KubeappsTestNamespace)
 	man.DB = m
 	pgManager := &postgresAssetManager{man}
 	err := pgManager.Delete(repo)
@@ -56,7 +57,7 @@ func Test_DeletePGRepo(t *testing.T) {
 
 func Test_PGRepoAlreadyPropcessed(t *testing.T) {
 	m := &mockDB{&mock.Mock{}}
-	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"})
+	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"}, dbutilstest.KubeappsTestNamespace)
 	man.DB = m
 	pgManager := &postgresAssetManager{man}
 	m.On("QueryRow", "SELECT checksum FROM repos WHERE name = $1 AND namespace = $2", []interface{}{"foo", "repo-namespace"})
@@ -72,7 +73,7 @@ func Test_PGUpdateLastCheck(t *testing.T) {
 		checksum      = "bar"
 	)
 	now := time.Now()
-	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"})
+	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"}, dbutilstest.KubeappsTestNamespace)
 	man.DB = m
 	pgManager := &postgresAssetManager{man}
 	expectedQuery := `INSERT INTO repos (namespace, name, checksum, last_update)
@@ -89,7 +90,7 @@ func Test_PGremoveMissingCharts(t *testing.T) {
 	repo := models.Repo{Name: "repo"}
 	charts := []models.Chart{{ID: "foo", Repo: &repo}, {ID: "bar"}}
 	m := &mockDB{&mock.Mock{}}
-	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"})
+	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"}, dbutilstest.KubeappsTestNamespace)
 	man.DB = m
 	pgManager := &postgresAssetManager{man}
 	m.On("Query", "DELETE FROM charts WHERE chart_id NOT IN ('foo', 'bar') AND repo_name = $1 AND repo_namespace = $2", []interface{}{repo.Name, repo.Namespace})
@@ -102,7 +103,7 @@ func Test_PGupdateIcon(t *testing.T) {
 	contentType := "image/png"
 	id := "stable/wordpress"
 	m := &mockDB{&mock.Mock{}}
-	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"})
+	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"}, dbutilstest.KubeappsTestNamespace)
 	man.DB = m
 	pgManager := &postgresAssetManager{man}
 	m.On(
@@ -153,7 +154,7 @@ func Test_PGinsertFiles(t *testing.T) {
 	)
 	files := models.ChartFiles{ID: filesId, Readme: "foo", Values: "bar", Repo: &models.Repo{Namespace: namespace, Name: repoName}}
 	m := &mockDB{&mock.Mock{}}
-	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"})
+	man, _ := dbutils.NewPGManager(datastore.Config{URL: "localhost:4123"}, dbutilstest.KubeappsTestNamespace)
 	man.DB = m
 	pgManager := &postgresAssetManager{man}
 	m.On(

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -41,7 +41,8 @@ var syncCmd = &cobra.Command{
 		}
 
 		dbConfig := datastore.Config{URL: databaseURL, Database: databaseName, Username: databaseUser, Password: databasePassword}
-		manager, err := newManager(databaseType, dbConfig)
+		kubeappsNamespace := os.Getenv("POD_NAMESPACE")
+		manager, err := newManager(databaseType, dbConfig, kubeappsNamespace)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -87,11 +87,11 @@ type assetManager interface {
 	insertFiles(chartId string, files models.ChartFiles) error
 }
 
-func newManager(databaseType string, config datastore.Config) (assetManager, error) {
+func newManager(databaseType string, config datastore.Config, kubeappsNamespace string) (assetManager, error) {
 	if databaseType == "mongodb" {
-		return newMongoDBManager(config), nil
+		return newMongoDBManager(config, kubeappsNamespace), nil
 	} else if databaseType == "postgresql" {
-		return newPGManager(config)
+		return newPGManager(config, kubeappsNamespace)
 	} else {
 		return nil, fmt.Errorf("Unsupported database type %s", databaseType)
 	}

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -486,7 +486,7 @@ func Test_newManager(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := datastore.Config{URL: tt.dbURL, Database: tt.dbName, Username: tt.dbUser, Password: tt.dbPass}
-			_, err := newManager(tt.database, config)
+			_, err := newManager(tt.database, config, "kubeapps")
 			assert.NoErr(t, err)
 		})
 	}

--- a/cmd/assetsvc/handler_test.go
+++ b/cmd/assetsvc/handler_test.go
@@ -63,7 +63,7 @@ func iconBytes() []byte {
 
 func getMockManager(m *mock.Mock) *mongodbAssetManager {
 	dbSession := mockstore.NewMockSession(m)
-	man := dbutils.NewMongoDBManager(datastore.Config{})
+	man := dbutils.NewMongoDBManager(datastore.Config{}, "kubeapps")
 	man.DBSession = dbSession
 	return &mongodbAssetManager{man}
 }

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -70,8 +70,11 @@ func main() {
 	flag.Parse()
 
 	dbConfig := datastore.Config{URL: *dbURL, Database: *dbName, Username: *dbUsername, Password: dbPassword}
+
+	kubeappsNamespace := os.Getenv("POD_NAMESPACE")
+
 	var err error
-	manager, err = newManager(*dbType, dbConfig)
+	manager, err = newManager(*dbType, dbConfig, kubeappsNamespace)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/assetsvc/mongodb_utils.go
+++ b/cmd/assetsvc/mongodb_utils.go
@@ -29,8 +29,8 @@ type mongodbAssetManager struct {
 	*dbutils.MongodbAssetManager
 }
 
-func newMongoDBManager(config datastore.Config) assetManager {
-	m := dbutils.NewMongoDBManager(config)
+func newMongoDBManager(config datastore.Config, kubeappsNamespace string) assetManager {
+	m := dbutils.NewMongoDBManager(config, kubeappsNamespace)
 	return &mongodbAssetManager{m}
 }
 
@@ -43,7 +43,7 @@ func (m *mongodbAssetManager) getPaginatedChartList(namespace, repo string, page
 	pipeline := []bson.M{}
 	matcher := bson.M{}
 	if namespace != dbutils.AllNamespaces {
-		matcher["repo.namespace"] = namespace
+		matcher["repo.namespace"] = bson.M{"$in": []string{namespace, m.KubeappsNamespace}}
 	}
 	if repo != "" {
 		matcher["repo.name"] = repo

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -35,8 +35,8 @@ type postgresAssetManager struct {
 	dbutils.PostgresAssetManagerIface
 }
 
-func newPGManager(config datastore.Config) (assetManager, error) {
-	m, err := dbutils.NewPGManager(config)
+func newPGManager(config datastore.Config, kubeappsNamespace string) (assetManager, error) {
+	m, err := dbutils.NewPGManager(config, kubeappsNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -56,12 +56,12 @@ func (m *postgresAssetManager) getPaginatedChartList(namespace, repo string, pag
 	clauses := []string{}
 	queryParams := []interface{}{}
 	if namespace != dbutils.AllNamespaces {
-		clauses = append(clauses, "repo_namespace = $1")
-		queryParams = append(queryParams, namespace)
+		queryParams = append(queryParams, namespace, m.GetKubeappsNamespace())
+		clauses = append(clauses, fmt.Sprintf("(repo_namespace = $%d OR repo_namespace = $%d)", len(queryParams)-1, len(queryParams)))
 	}
 	if repo != "" {
-		clauses = append(clauses, "repo_name = $2")
 		queryParams = append(queryParams, repo)
+		clauses = append(clauses, fmt.Sprintf("repo_name = $%d", len(queryParams)))
 	}
 	repoQuery := ""
 	if len(clauses) > 0 {

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -57,7 +57,7 @@ func (m *postgresAssetManager) getPaginatedChartList(namespace, repo string, pag
 	queryParams := []interface{}{}
 	if namespace != dbutils.AllNamespaces {
 		queryParams = append(queryParams, namespace, m.GetKubeappsNamespace())
-		clauses = append(clauses, fmt.Sprintf("(repo_namespace = $%d OR repo_namespace = $%d)", len(queryParams)-1, len(queryParams)))
+		clauses = append(clauses, "(repo_namespace = $1 OR repo_namespace = $2)")
 	}
 	if repo != "" {
 		queryParams = append(queryParams, repo)

--- a/cmd/assetsvc/utils.go
+++ b/cmd/assetsvc/utils.go
@@ -33,11 +33,11 @@ type assetManager interface {
 	getChartsWithFilters(namespace, name, version, appVersion string) ([]*models.Chart, error)
 }
 
-func newManager(databaseType string, config datastore.Config) (assetManager, error) {
+func newManager(databaseType string, config datastore.Config, kubeappsNamespace string) (assetManager, error) {
 	if databaseType == "mongodb" {
-		return newMongoDBManager(config), nil
+		return newMongoDBManager(config, kubeappsNamespace), nil
 	} else if databaseType == "postgresql" {
-		return newPGManager(config)
+		return newPGManager(config, kubeappsNamespace)
 	} else {
 		return nil, fmt.Errorf("Unsupported database type %s", databaseType)
 	}

--- a/pkg/dbutils/dbutilstest/dbutilstest.go
+++ b/pkg/dbutils/dbutilstest/dbutilstest.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 )
 
+const KubeappsTestNamespace = "kubeapps"
+
 func IsEnvVarTrue(t *testing.T, envvar string) bool {
 	enableEnvVar := os.Getenv(envvar)
 	isTrue := false

--- a/pkg/dbutils/dbutilstest/mgtest/mgtest.go
+++ b/pkg/dbutils/dbutilstest/mgtest/mgtest.go
@@ -40,7 +40,7 @@ func OpenTestManager(t *testing.T) *dbutils.MongodbAssetManager {
 		URL:      "localhost:27017",
 		Username: "root",
 		Password: "testpassword",
-	})
+	}, dbutilstest.KubeappsTestNamespace)
 
 	err := manager.Init()
 	if err != nil {

--- a/pkg/dbutils/dbutilstest/pgtest/pgtest.go
+++ b/pkg/dbutils/dbutilstest/pgtest/pgtest.go
@@ -43,7 +43,7 @@ func openTestManager(t *testing.T) *dbutils.PostgresAssetManager {
 		URL:      "localhost:5432",
 		Database: "testdb",
 		Username: "postgres",
-	})
+	}, dbutilstest.KubeappsTestNamespace)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/dbutils/mongodb_utils.go
+++ b/pkg/dbutils/mongodb_utils.go
@@ -31,13 +31,14 @@ const (
 
 // MongodbAssetManager struct containing mongodb info
 type MongodbAssetManager struct {
-	mongoConfig datastore.Config
-	DBSession   datastore.Session
+	mongoConfig       datastore.Config
+	DBSession         datastore.Session
+	KubeappsNamespace string
 }
 
 // NewMongoDBManager creates an asset manager for MongoDB
-func NewMongoDBManager(config datastore.Config) *MongodbAssetManager {
-	return &MongodbAssetManager{config, nil}
+func NewMongoDBManager(config datastore.Config, kubeappsNamespace string) *MongodbAssetManager {
+	return &MongodbAssetManager{config, nil, kubeappsNamespace}
 }
 
 // Init creates dbsession

--- a/pkg/dbutils/postgresql_utils.go
+++ b/pkg/dbutils/postgresql_utils.go
@@ -55,16 +55,18 @@ type PostgresAssetManagerIface interface {
 	InvalidateCache() error
 	EnsureRepoExists(repoNamespace, repoName string) (int, error)
 	GetDB() PostgresDB
+	GetKubeappsNamespace() string
 }
 
 // PostgresAssetManager asset manager for postgres
 type PostgresAssetManager struct {
-	connStr string
-	DB      PostgresDB
+	connStr           string
+	DB                PostgresDB
+	kubeappsNamespace string
 }
 
 // NewPGManager creates an asset manager for PG
-func NewPGManager(config datastore.Config) (*PostgresAssetManager, error) {
+func NewPGManager(config datastore.Config, kubeappsNamespace string) (*PostgresAssetManager, error) {
 	url := strings.Split(config.URL, ":")
 	if len(url) != 2 {
 		return nil, fmt.Errorf("Can't parse database URL: %s", config.URL)
@@ -73,7 +75,7 @@ func NewPGManager(config datastore.Config) (*PostgresAssetManager, error) {
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
 		url[0], url[1], config.Username, config.Password, config.Database,
 	)
-	return &PostgresAssetManager{connStr, nil}, nil
+	return &PostgresAssetManager{connStr, nil, kubeappsNamespace}, nil
 }
 
 // Init connects to PG
@@ -214,4 +216,8 @@ SELECT ID FROM %s WHERE namespace=$1 AND name=$2
 
 func (m *PostgresAssetManager) GetDB() PostgresDB {
 	return m.DB
+}
+
+func (m *PostgresAssetManager) GetKubeappsNamespace() string {
+	return m.kubeappsNamespace
 }

--- a/pkg/dbutils/postgresql_utils_test.go
+++ b/pkg/dbutils/postgresql_utils_test.go
@@ -27,7 +27,7 @@ import (
 
 func Test_NewPGManager(t *testing.T) {
 	config := datastore.Config{URL: "10.11.12.13:5432", Database: "assets", Username: "postgres", Password: "123"}
-	m, err := NewPGManager(config)
+	m, err := NewPGManager(config, "kubeapps")
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}


### PR DESCRIPTION
Ref #1521 . Gives the assetsvc knowledge of the kubeapps namespace and updates `getPaginatedChartList` so that it returns charts in a specific namespace together with those from the kubeapps (global) namespace.

While there, found, tested and fixed another issue related to the SQL params (need to use dynamic numbering for the params).

The asset-sync commands are updated to store the kubeappsNamespace but this is not yet set in the environment or used, though it may enable us to stop the frontend from needing to know the kubeapps namespace.