### PR TITLE
Enable authz check for specific namespace.

### DIFF
--- a/cmd/assetsvc/main_test.go
+++ b/cmd/assetsvc/main_test.go
@@ -67,11 +67,11 @@ func Test_GetCharts(t *testing.T) {
 	}{
 		{"no charts", []*models.Chart{}},
 		{"one chart", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1"}}}},
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1"}}}},
 		},
 		{"two charts", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}},
 	}
 
@@ -109,11 +109,11 @@ func Test_GetChartsInRepo(t *testing.T) {
 	}{
 		{"repo has no charts", "my-repo", []*models.Chart{}},
 		{"repo has one chart", "my-repo", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 		}},
 		{"repo has many charts", "my-repo", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}},
 	}
 
@@ -153,19 +153,19 @@ func Test_GetChartInRepo(t *testing.T) {
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{ID: "my-repo/my-chart"},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}
@@ -206,19 +206,19 @@ func Test_ListChartVersions(t *testing.T) {
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{ID: "my-repo/my-chart"},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}
@@ -259,19 +259,19 @@ func Test_GetChartVersion(t *testing.T) {
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -90,8 +90,9 @@ func main() {
 	}
 
 	// assetsvc reverse proxy
-	// TODO(mnelson) remove this reverse proxy once the frontend sends requests
-	// directly to the assetsvc. Move the authz to the assetsvc itself.
+	// TODO(mnelson) remove this reverse proxy once the haproxy frontend
+	// proxies requests directly to the assetsvc. Move the authz to the
+	// assetsvc itself.
 	authGate := auth.AuthGate(kubeappsNamespace)
 	parsedAssetsvcURL, err := url.Parse(assetsvcURL)
 	if err != nil {

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -93,7 +93,7 @@ func main() {
 	// TODO(mnelson) remove this reverse proxy once the haproxy frontend
 	// proxies requests directly to the assetsvc. Move the authz to the
 	// assetsvc itself.
-	authGate := auth.AuthGate(kubeappsNamespace)
+	authGate := auth.AuthGate()
 	parsedAssetsvcURL, err := url.Parse(assetsvcURL)
 	if err != nil {
 		log.Fatalf("Unable to parse the assetsvc URL: %v", err)

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -90,8 +90,8 @@ func main() {
 	}
 
 	// assetsvc reverse proxy
-	// TODO(mnelson) remove this reverse proxy once the frontend sends requests directly
-	// to the assetsvc. Move the authz to the assetsvc itself.
+	// TODO(mnelson) remove this reverse proxy once the frontend sends requests
+	// directly to the assetsvc. Move the authz to the assetsvc itself.
 	authGate := auth.AuthGate(kubeappsNamespace)
 	parsedAssetsvcURL, err := url.Parse(assetsvcURL)
 	if err != nil {

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -93,7 +93,7 @@ func main() {
 	// TODO(mnelson) remove this reverse proxy once the haproxy frontend
 	// proxies requests directly to the assetsvc. Move the authz to the
 	// assetsvc itself.
-	authGate := auth.AuthGate()
+	authGate := auth.AuthGate(kubeappsNamespace)
 	parsedAssetsvcURL, err := url.Parse(assetsvcURL)
 	if err != nil {
 		log.Fatalf("Unable to parse the assetsvc URL: %v", err)

--- a/cmd/tiller-proxy/internal/handler/handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/handler_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package handler
 
 import (
-	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
@@ -453,11 +453,11 @@ func TestActions(t *testing.T) {
 		}
 		req := httptest.NewRequest("GET", fmt.Sprintf("http://foo.bar%s", test.RequestQuery), strings.NewReader(test.RequestBody))
 		if !test.DisableUserAuthCheck {
-			fauth := &authFake.FakeAuth{
-				ForbiddenActions: test.ForbiddenActions,
+			handler.CheckerForRequest = func(req *http.Request) (auth.Checker, error) {
+				return &authFake.FakeAuth{
+					ForbiddenActions: test.ForbiddenActions,
+				}, nil
 			}
-			ctx := context.WithValue(req.Context(), auth.UserKey, fauth)
-			req = req.WithContext(ctx)
 		}
 		response := httptest.NewRecorder()
 		// Perform request

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -193,6 +193,9 @@ func main() {
 	}
 
 	// assetsvc reverse proxy
+	// TODO(mnelson) remove this reverse proxy once the haproxy frontend
+	// proxies requests directly to the assetsvc. Move the authz to the
+	// assetsvc itself.
 	parsedAssetsvcURL, err := url.Parse(assetsvcURL)
 	if err != nil {
 		log.Fatalf("Unable to parse the assetsvc URL: %v", err)

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -149,7 +149,7 @@ func main() {
 	r.Handle("/live", health)
 	r.Handle("/ready", health)
 
-	authGate := auth.AuthGate(kubeappsNamespace)
+	authGate := auth.AuthGate()
 
 	// HTTP Handler
 	h := handler.TillerProxy{

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -149,7 +149,7 @@ func main() {
 	r.Handle("/live", health)
 	r.Handle("/ready", health)
 
-	authGate := auth.AuthGate()
+	authGate := auth.AuthGate(kubeappsNamespace)
 
 	// HTTP Handler
 	h := handler.TillerProxy{
@@ -204,7 +204,7 @@ func main() {
 	assetsvcRouter.Methods("GET").Path("/v1/ns/{ns}/assets/{repo}/{id}/logo").Handler(negroni.New(
 		negroni.Wrap(http.StripPrefix(assetsvcPrefix, assetsvcProxy)),
 	))
-	assetsvcRouter.Methods("GET").Handler(negroni.New(
+	assetsvcRouter.PathPrefix("/v1/ns/{namespace}/").Handler(negroni.New(
 		authGate,
 		negroni.Wrap(http.StripPrefix(assetsvcPrefix, assetsvcProxy)),
 	))

--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -40,7 +40,7 @@ describe("fetchCharts", () => {
       { type: getType(actions.charts.requestCharts) },
       { type: getType(actions.charts.receiveCharts), payload: response },
     ];
-    await store.dispatch(actions.charts.fetchCharts("foo"));
+    await store.dispatch(actions.charts.fetchCharts(namespace, "foo"));
     expect(store.getActions()).toEqual(expectedActions);
     expect(axiosGetMock.mock.calls[0][0]).toBe(`api/assetsvc/v1/ns/${namespace}/charts/foo`);
   });
@@ -57,7 +57,7 @@ describe("fetchCharts", () => {
       throw new Error("could not find chart");
     });
     axiosWithAuth.get = axiosGetMock;
-    await store.dispatch(actions.charts.fetchCharts("foo"));
+    await store.dispatch(actions.charts.fetchCharts(namespace, "foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -70,7 +70,7 @@ describe("fetchCharts", () => {
       throw new Error("something went wrong");
     });
     axiosWithAuth.get = axiosGetMock;
-    await store.dispatch(actions.charts.fetchCharts("foo"));
+    await store.dispatch(actions.charts.fetchCharts(namespace, "foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -69,12 +69,10 @@ function dispatchError(dispatch: Dispatch, err: Error) {
 }
 
 export function fetchCharts(
+  namespace: string,
   repo: string,
 ): ThunkAction<Promise<void>, IStoreState, null, ChartsAction> {
-  return async (dispatch, getState) => {
-    const {
-      config: { namespace },
-    } = getState();
+  return async dispatch => {
     dispatch(requestCharts());
     try {
       const charts = await Chart.fetchCharts(namespace, repo);

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -40,7 +40,7 @@ it("reloads charts when the repo changes", () => {
   const wrapper = shallow(<Catalog {...defaultProps} fetchCharts={fetchCharts} />);
   wrapper.setProps({ ...defaultProps, fetchCharts, repo: "bitnami" });
   expect(fetchCharts.mock.calls.length).toBe(2);
-  expect(fetchCharts.mock.calls[1]).toEqual(["bitnami"]);
+  expect(fetchCharts.mock.calls[1]).toEqual(["kubeapps", "bitnami"]);
 });
 
 it("updates the filter from props", () => {

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -15,7 +15,7 @@ interface ICatalogProps {
   charts: IChartState;
   repo: string;
   filter: string;
-  fetchCharts: (repo: string) => void;
+  fetchCharts: (namespace: string, repo: string) => void;
   pushSearchFilter: (filter: string) => RouterAction;
   namespace: string;
   getCSVs: (namespace: string) => void;
@@ -39,7 +39,7 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
   public componentDidMount() {
     const { repo, fetchCharts, filter, namespace, getCSVs, featureFlags } = this.props;
     this.setState({ filter });
-    fetchCharts(repo);
+    fetchCharts(namespace, repo);
     if (featureFlags.operators) {
       getCSVs(namespace);
     }
@@ -49,8 +49,8 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
     if (this.props.filter !== prevProps.filter) {
       this.setState({ filter: this.props.filter });
     }
-    if (this.props.repo !== prevProps.repo) {
-      this.props.fetchCharts(this.props.repo);
+    if (this.props.repo !== prevProps.repo || this.props.namespace !== prevProps.namespace) {
+      this.props.fetchCharts(this.props.namespace, this.props.repo);
     }
     if (this.props.namespace !== prevProps.namespace && this.props.featureFlags.operators) {
       this.props.getCSVs(this.props.namespace);

--- a/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
+++ b/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
@@ -23,7 +23,7 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    fetchCharts: (repo: string) => dispatch(actions.charts.fetchCharts(repo)),
+    fetchCharts: (namespace: string, repo: string) => dispatch(actions.charts.fetchCharts(namespace, repo)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
     getCSVs: (namespace: string) => dispatch(actions.operators.getCSVs(namespace)),
   };

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -126,6 +126,12 @@ func (u *UserAuth) Validate() error {
 	return u.k8sAuth.Validate()
 }
 
+// ValidateForNamespace checks if the user can access secrets in the given
+// namespace, as a check of whether they can view the namespace.
+func (u *UserAuth) ValidateForNamespace(namespace string) (bool, error) {
+	return u.k8sAuth.CanI("get", "", "Secret", namespace)
+}
+
 type resourceInfo struct {
 	Name       string
 	Namespaced bool

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -96,6 +96,7 @@ type Action struct {
 // Checker for the exported funcs
 type Checker interface {
 	Validate() error
+	ValidateForNamespace(namespace string) (bool, error)
 	GetForbiddenActions(namespace, action, manifest string) ([]Action, error)
 }
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -62,14 +62,15 @@ func (u k8sAuth) GetResourceList(groupVersion string) (*metav1.APIResourceList, 
 }
 
 func (u k8sAuth) CanI(verb, group, resource, namespace string) (bool, error) {
+	attr := &authorizationapi.ResourceAttributes{
+		Group:     group,
+		Resource:  resource,
+		Verb:      verb,
+		Namespace: namespace,
+	}
 	res, err := u.AuthCli.SelfSubjectAccessReviews().Create(&authorizationapi.SelfSubjectAccessReview{
 		Spec: authorizationapi.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &authorizationapi.ResourceAttributes{
-				Group:     group,
-				Resource:  resource,
-				Verb:      verb,
-				Namespace: namespace,
-			},
+			ResourceAttributes: attr,
 		},
 	})
 	if err != nil {
@@ -129,7 +130,7 @@ func (u *UserAuth) Validate() error {
 // ValidateForNamespace checks if the user can access secrets in the given
 // namespace, as a check of whether they can view the namespace.
 func (u *UserAuth) ValidateForNamespace(namespace string) (bool, error) {
-	return u.k8sAuth.CanI("get", "", "Secret", namespace)
+	return u.k8sAuth.CanI("get", "", "secrets", namespace)
 }
 
 type resourceInfo struct {

--- a/pkg/auth/authgate.go
+++ b/pkg/auth/authgate.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -12,35 +11,48 @@ import (
 	"github.com/urfave/negroni"
 )
 
-// Context key type for request contexts
-type contextKey int
-
-// UserKey is the context key for the User data in the request context
-const UserKey contextKey = 0
-
 // tokenPrefix is the string preceding the token in the Authorization header.
 const tokenPrefix = "Bearer "
 
-// AuthGate implements middleware to check if the user has access to the specific namespace
-// before continuing. If the path being handled by the AuthGate middleware does not include
-// the 'namespace' mux var, or the value is _all, then the check is for cluster-wide access.
-func AuthGate() negroni.HandlerFunc {
+// CheckerForRequest defines a function type so we can also inject a fake for tests
+// rather than setting a context value.
+type CheckerForRequest func(req *http.Request) (Checker, error)
+
+func AuthCheckerForRequest(req *http.Request) (Checker, error) {
+	token := ExtractToken(req.Header.Get("Authorization"))
+	if token == "" {
+		return nil, fmt.Errorf("Authorization token missing")
+	}
+	return NewAuth(token)
+}
+
+// AuthGate implements middleware to check if the user has access to read from
+// the specific namespace before continuing.
+//   * If the path being handled by the
+//     AuthGate middleware does not include the 'namespace' mux var, or the value
+//     is _all, then the check is for cluster-wide access.
+//   * If the namespace is the global chart namespace (ie. kubeappsNamespace) then
+//     we allow read access regardless.
+func AuthGate(kubeappsNamespace string) negroni.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-		token := ExtractToken(req.Header.Get("Authorization"))
-		if token == "" {
-			response.NewErrorResponse(http.StatusUnauthorized, "Unauthorized").Write(w)
-			return
-		}
-		userAuth, err := NewAuth(token)
+		userAuth, err := AuthCheckerForRequest(req)
 		if err != nil {
-			response.NewErrorResponse(http.StatusInternalServerError, err.Error()).Write(w)
+			response.NewErrorResponse(http.StatusUnauthorized, err.Error()).Write(w)
 			return
 		}
 		namespace := mux.Vars(req)["namespace"]
 		if namespace == dbutils.AllNamespaces {
 			namespace = ""
 		}
-		authz, err := userAuth.ValidateForNamespace(namespace)
+
+		// If the request is for the global public charts (ie. kubeappsNamespace)
+		// we do not check authz.
+		authz := false
+		if namespace == kubeappsNamespace {
+			authz = true
+		} else {
+			authz, err = userAuth.ValidateForNamespace(namespace)
+		}
 
 		if err != nil || !authz {
 			msg := fmt.Sprintf("Unable to validate user for namespace %q", namespace)
@@ -50,8 +62,7 @@ func AuthGate() negroni.HandlerFunc {
 			response.NewErrorResponse(http.StatusUnauthorized, msg).Write(w)
 			return
 		}
-		ctx := context.WithValue(req.Context(), UserKey, userAuth)
-		next(w, req.WithContext(ctx))
+		next(w, req)
 	}
 }
 

--- a/pkg/auth/fake/auth.go
+++ b/pkg/auth/fake/auth.go
@@ -28,6 +28,10 @@ func (f *FakeAuth) Validate() error {
 	return nil
 }
 
+func (f *FakeAuth) ValidateForNamespace(namespace string) (bool, error) {
+	return true, nil
+}
+
 func (f *FakeAuth) GetForbiddenActions(namespace, action, manifest string) ([]authUtils.Action, error) {
 	return f.ForbiddenActions, nil
 }

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -34,6 +34,7 @@ deploy-dev: deploy-dex deploy-openldap update-apiserver-etc-hosts
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
 		--set useHelm3=true \
+		--set allowNamespaceDiscovery=true \
 		--set postgresql.enabled=true \
 		--set featureFlags.reposPerNamespace=true \
 		--set featureFlags.invalidateCache=true \


### PR DESCRIPTION
Ref #1521 This PR updates the AuthGate used by the assetsvc and tiller-proxy to verify whether the user has access to a particular namespace (or cluster-wide access to all namespaces), rather than whether they've valid credentials to authenticate.

It can't land as is (and will fail CI), as I need to update the frontend so that the namespace is always included (even if we're not running with the feature flag) so that users who do not have access to the kubeapps namespace can still view the catalog.