### PR TITLE
Update fetchCharts to use namespace from UI

### DIFF
--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -40,7 +40,7 @@ describe("fetchCharts", () => {
       { type: getType(actions.charts.requestCharts) },
       { type: getType(actions.charts.receiveCharts), payload: response },
     ];
-    await store.dispatch(actions.charts.fetchCharts("foo"));
+    await store.dispatch(actions.charts.fetchCharts(namespace, "foo"));
     expect(store.getActions()).toEqual(expectedActions);
     expect(axiosGetMock.mock.calls[0][0]).toBe(`api/assetsvc/v1/ns/${namespace}/charts/foo`);
   });
@@ -57,7 +57,7 @@ describe("fetchCharts", () => {
       throw new Error("could not find chart");
     });
     axiosWithAuth.get = axiosGetMock;
-    await store.dispatch(actions.charts.fetchCharts("foo"));
+    await store.dispatch(actions.charts.fetchCharts(namespace, "foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -70,7 +70,7 @@ describe("fetchCharts", () => {
       throw new Error("something went wrong");
     });
     axiosWithAuth.get = axiosGetMock;
-    await store.dispatch(actions.charts.fetchCharts("foo"));
+    await store.dispatch(actions.charts.fetchCharts(namespace, "foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -69,12 +69,10 @@ function dispatchError(dispatch: Dispatch, err: Error) {
 }
 
 export function fetchCharts(
+  namespace: string,
   repo: string,
 ): ThunkAction<Promise<void>, IStoreState, null, ChartsAction> {
-  return async (dispatch, getState) => {
-    const {
-      config: { namespace },
-    } = getState();
+  return async dispatch => {
     dispatch(requestCharts());
     try {
       const charts = await Chart.fetchCharts(namespace, repo);

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -40,7 +40,7 @@ it("reloads charts when the repo changes", () => {
   const wrapper = shallow(<Catalog {...defaultProps} fetchCharts={fetchCharts} />);
   wrapper.setProps({ ...defaultProps, fetchCharts, repo: "bitnami" });
   expect(fetchCharts.mock.calls.length).toBe(2);
-  expect(fetchCharts.mock.calls[1]).toEqual(["bitnami"]);
+  expect(fetchCharts.mock.calls[1]).toEqual(["kubeapps", "bitnami"]);
 });
 
 it("updates the filter from props", () => {

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -15,7 +15,7 @@ interface ICatalogProps {
   charts: IChartState;
   repo: string;
   filter: string;
-  fetchCharts: (repo: string) => void;
+  fetchCharts: (namespace: string, repo: string) => void;
   pushSearchFilter: (filter: string) => RouterAction;
   namespace: string;
   getCSVs: (namespace: string) => void;
@@ -39,7 +39,7 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
   public componentDidMount() {
     const { repo, fetchCharts, filter, namespace, getCSVs, featureFlags } = this.props;
     this.setState({ filter });
-    fetchCharts(repo);
+    fetchCharts(namespace, repo);
     if (featureFlags.operators) {
       getCSVs(namespace);
     }
@@ -49,8 +49,8 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
     if (this.props.filter !== prevProps.filter) {
       this.setState({ filter: this.props.filter });
     }
-    if (this.props.repo !== prevProps.repo) {
-      this.props.fetchCharts(this.props.repo);
+    if (this.props.repo !== prevProps.repo || this.props.namespace !== prevProps.namespace) {
+      this.props.fetchCharts(this.props.namespace, this.props.repo);
     }
     if (this.props.namespace !== prevProps.namespace && this.props.featureFlags.operators) {
       this.props.getCSVs(this.props.namespace);

--- a/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
+++ b/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
@@ -23,7 +23,7 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    fetchCharts: (repo: string) => dispatch(actions.charts.fetchCharts(repo)),
+    fetchCharts: (namespace: string, repo: string) => dispatch(actions.charts.fetchCharts(namespace, repo)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
     getCSVs: (namespace: string) => dispatch(actions.operators.getCSVs(namespace)),
   };

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -62,14 +62,15 @@ func (u k8sAuth) GetResourceList(groupVersion string) (*metav1.APIResourceList, 
 }
 
 func (u k8sAuth) CanI(verb, group, resource, namespace string) (bool, error) {
+	attr := &authorizationapi.ResourceAttributes{
+		Group:     group,
+		Resource:  resource,
+		Verb:      verb,
+		Namespace: namespace,
+	}
 	res, err := u.AuthCli.SelfSubjectAccessReviews().Create(&authorizationapi.SelfSubjectAccessReview{
 		Spec: authorizationapi.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &authorizationapi.ResourceAttributes{
-				Group:     group,
-				Resource:  resource,
-				Verb:      verb,
-				Namespace: namespace,
-			},
+			ResourceAttributes: attr,
 		},
 	})
 	if err != nil {
@@ -129,7 +130,7 @@ func (u *UserAuth) Validate() error {
 // ValidateForNamespace checks if the user can access secrets in the given
 // namespace, as a check of whether they can view the namespace.
 func (u *UserAuth) ValidateForNamespace(namespace string) (bool, error) {
-	return u.k8sAuth.CanI("get", "", "Secret", namespace)
+	return u.k8sAuth.CanI("get", "", "secrets", namespace)
 }
 
 type resourceInfo struct {


### PR DESCRIPTION
Ref #1521, follows #1592 so that the dashboard always includes the current namespace when requesting the chart catalog.

This can be done (in fact, needs to be done) without the feature flag switch because in the previous PR the assetsvc was updated to check access to the given namespace before returning the catalog, and Kubeapps users may not have access to kubeapps own namespace. It works because the assetsvc returns both charts for the given namespace together with the global ones (from kubeapps own namespace) as long as the user can access the given namespace.

In real-life testing showed that the AuthGate was failing when it should pass, turned out to be that the resource name was "secrets" rather than "Secret" :/ (even though `auth can-i` works with either).

TODO: Still need to fix up behaviour when access is denied, as currently the dashboard sends you to the login page which is unhelpful (edit: though this is only visible if the auth fails for a namespace you *can* access, which can only happen as a result of a bug, so I'll ignore for now).
TODO2: images are being requested using the selected namespace, rather than the namespace from which the chart actually originates (ie. global charts in the bitnami namespace). Should be trivial fix but ran out of road.