### PR TITLE
OperatorInstance view

### DIFF
--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -294,3 +294,123 @@ describe("getResources", () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
+
+describe("getResources", () => {
+  it("get a resource in a namespace", async () => {
+    const csv = {
+      metadata: { name: "foo" },
+      spec: {
+        customresourcedefinitions: { owned: [{ name: "foo.kubeapps.com", version: "v1alpha1" }] },
+      },
+    };
+    const resource = { metadata: { name: "resource" } };
+    Operators.getCSV = jest.fn(() => csv);
+    Operators.getResource = jest.fn(() => resource);
+    const expectedActions = [
+      {
+        type: getType(operatorActions.requestCustomResource),
+      },
+      {
+        type: getType(operatorActions.requestCSV),
+      },
+      {
+        type: getType(operatorActions.receiveCSV),
+        payload: csv,
+      },
+      {
+        type: getType(operatorActions.receiveCustomResource),
+        payload: resource,
+      },
+    ];
+    await store.dispatch(operatorActions.getResource("default", "foo", "foo.kubeapps.com", "bar"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(Operators.getResource).toHaveBeenCalledWith(
+      "default",
+      "kubeapps.com/v1alpha1",
+      "foo",
+      "bar",
+    );
+  });
+
+  it("dispatches an error if getting a resource fails", async () => {
+    const csv = {
+      metadata: { name: "foo" },
+      spec: {
+        customresourcedefinitions: { owned: [{ name: "foo.kubeapps.com", version: "v1alpha1" }] },
+      },
+    };
+    Operators.getCSV = jest.fn(() => csv);
+    Operators.getResource = jest.fn(() => {
+      throw new Error("Boom!");
+    });
+    const expectedActions = [
+      {
+        type: getType(operatorActions.requestCustomResource),
+      },
+      {
+        type: getType(operatorActions.requestCSV),
+      },
+      {
+        type: getType(operatorActions.receiveCSV),
+        payload: csv,
+      },
+      {
+        type: getType(operatorActions.errorCustomResource),
+        payload: new Error("Boom!"),
+      },
+    ];
+    await store.dispatch(operatorActions.getResource("default", "foo", "foo.kubeapps.com", "bar"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches an error if the given csv is not found", async () => {
+    Operators.getCSV = jest.fn(() => undefined);
+    const expectedActions = [
+      {
+        type: getType(operatorActions.requestCustomResource),
+      },
+      {
+        type: getType(operatorActions.requestCSV),
+      },
+      {
+        type: getType(operatorActions.receiveCSV),
+      },
+      {
+        type: getType(operatorActions.errorCustomResource),
+        payload: new Error("CSV foo not found in default"),
+      },
+    ];
+    await store.dispatch(operatorActions.getResource("default", "foo", "foo.kubeapps.com", "bar"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches an error if the given crd is not found fails", async () => {
+    const csv = {
+      metadata: { name: "foo" },
+      spec: {
+        customresourcedefinitions: { owned: [{ name: "foo.kubeapps.com", version: "v1alpha1" }] },
+      },
+    };
+    Operators.getCSV = jest.fn(() => csv);
+    const expectedActions = [
+      {
+        type: getType(operatorActions.requestCustomResource),
+      },
+      {
+        type: getType(operatorActions.requestCSV),
+      },
+      {
+        type: getType(operatorActions.receiveCSV),
+        payload: csv,
+      },
+      {
+        type: getType(operatorActions.errorCustomResource),
+        payload: new Error("Not found a valid CRD definition for foo/not-foo.kubeapps.com"),
+      },
+    ];
+    await store.dispatch(
+      operatorActions.getResource("default", "foo", "not-foo.kubeapps.com", "bar"),
+    );
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});

--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -414,3 +414,38 @@ describe("getResources", () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
+
+describe("deleteResource", () => {
+  it("delete a resource in a namespace", async () => {
+    const resource = { metadata: { name: "resource" } } as any;
+    Operators.deleteResource = jest.fn();
+    const expectedActions = [
+      {
+        type: getType(operatorActions.deletingResource),
+      },
+      {
+        type: getType(operatorActions.resourceDeleted),
+      },
+    ];
+    await store.dispatch(operatorActions.deleteResource("default", "foos", resource));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches an error if deleting a resource fails", async () => {
+    const resource = { metadata: { name: "resource" } } as any;
+    Operators.deleteResource = jest.fn(() => {
+      throw new Error("Boom!");
+    });
+    const expectedActions = [
+      {
+        type: getType(operatorActions.deletingResource),
+      },
+      {
+        type: getType(operatorActions.errorResourceDelete),
+        payload: new Error("Boom!"),
+      },
+    ];
+    await store.dispatch(operatorActions.deleteResource("default", "foos", resource));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});

--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -45,6 +45,12 @@ export const errorResourceCreate = createAction("ERROR_RESOURCE_CREATE", resolve
   return (err: Error) => resolve(err);
 });
 
+export const deletingResource = createAction("DELETING_RESOURCE");
+export const resourceDeleted = createAction("RESOURCE_DELETED");
+export const errorResourceDelete = createAction("ERROR_RESOURCE_DELETE", resolve => {
+  return (err: Error) => resolve(err);
+});
+
 export const requestCustomResources = createAction("REQUEST_CUSTOM_RESOURCES");
 export const receiveCustomResources = createAction("RECEIVE_CUSTOM_RESOURCES", resolve => {
   return (resources: IResource[]) => resolve(resources);
@@ -81,6 +87,9 @@ const actions = [
   errorCustomResource,
   requestCustomResource,
   receiveCustomResource,
+  deletingResource,
+  resourceDeleted,
+  errorResourceDelete,
 ];
 
 export type OperatorAction = ActionType<typeof actions[number]>;
@@ -177,6 +186,29 @@ export function createResource(
       return true;
     } catch (e) {
       dispatch(errorResourceCreate(e));
+      return false;
+    }
+  };
+}
+
+export function deleteResource(
+  namespace: string,
+  plural: string,
+  resource: IResource,
+): ThunkAction<Promise<boolean>, IStoreState, null, OperatorAction> {
+  return async dispatch => {
+    dispatch(deletingResource());
+    try {
+      await Operators.deleteResource(
+        namespace,
+        resource.apiVersion,
+        plural,
+        resource.metadata.name,
+      );
+      dispatch(resourceDeleted());
+      return true;
+    } catch (e) {
+      dispatch(errorResourceDelete(e));
       return false;
     }
   };

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -142,15 +142,10 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
             return <AppListItem key={r.releaseName} app={r} />;
           })}
           {filteredCRs.map(r => {
-            return (
-              <CustomResourceListItem
-                key={r.metadata.name}
-                resource={r}
-                csv={this.props.csvs.find(csv =>
-                  csv.spec.customresourcedefinitions.owned.some(crd => crd.kind === r.kind),
-                )}
-              />
+            const csv = this.props.csvs.find(c =>
+              c.spec.customresourcedefinitions.owned.some(crd => crd.kind === r.kind),
             );
+            return <CustomResourceListItem key={r.metadata.name} resource={r} csv={csv!} />;
           })}
         </CardGrid>
       </div>

--- a/dashboard/src/components/AppList/CustomResourceListItem.tsx
+++ b/dashboard/src/components/AppList/CustomResourceListItem.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
-import UnexpectedErrorPage from "components/ErrorAlert/UnexpectedErrorAlert";
 import placeholder from "../../placeholder.png";
 import { IClusterServiceVersion, IResource } from "../../shared/types";
+import UnexpectedErrorPage from "../ErrorAlert/UnexpectedErrorAlert";
 import InfoCard from "../InfoCard";
 
 interface ICustomResourceListItemProps {

--- a/dashboard/src/components/AppList/CustomResourceListItem.tsx
+++ b/dashboard/src/components/AppList/CustomResourceListItem.tsx
@@ -6,19 +6,20 @@ import InfoCard from "../InfoCard";
 
 interface ICustomResourceListItemProps {
   resource: IResource;
-  csv?: IClusterServiceVersion;
+  csv: IClusterServiceVersion;
 }
 
 class CustomResourceListItem extends React.Component<ICustomResourceListItemProps> {
   public render() {
     const { resource, csv } = this.props;
-    const icon = csv?.spec.icon
+    const icon = csv.spec.icon
       ? `data:${csv.spec.icon[0].mediatype};base64,${csv.spec.icon[0].base64data}`
       : placeholder;
+    const crd = csv.spec.customresourcedefinitions.owned.find(c => c.kind === resource.kind);
     return (
       <InfoCard
         key={resource.metadata.name}
-        link={`/operators-instances/ns/${resource.metadata.namespace}/${resource.metadata.name}`}
+        link={`/operators-instances/ns/${resource.metadata.namespace}/${csv.metadata.name}/${crd?.name}/${resource.metadata.name}`}
         title={resource.metadata.name}
         icon={icon}
         info={`${resource.kind} v${csv?.spec.version || "-"}`}

--- a/dashboard/src/components/AppList/CustomResourceListItem.tsx
+++ b/dashboard/src/components/AppList/CustomResourceListItem.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import UnexpectedErrorPage from "components/ErrorAlert/UnexpectedErrorAlert";
 import placeholder from "../../placeholder.png";
 import { IClusterServiceVersion, IResource } from "../../shared/types";
 import InfoCard from "../InfoCard";
@@ -16,13 +17,21 @@ class CustomResourceListItem extends React.Component<ICustomResourceListItemProp
       ? `data:${csv.spec.icon[0].mediatype};base64,${csv.spec.icon[0].base64data}`
       : placeholder;
     const crd = csv.spec.customresourcedefinitions.owned.find(c => c.kind === resource.kind);
+    if (!crd) {
+      // Unexpected error, CRD should be present if resource is defined
+      return (
+        <UnexpectedErrorPage
+          text={`Unable to retrieve the CustomResourceDefinition for ${resource.kind} in ${csv.metadata.name}`}
+        />
+      );
+    }
     return (
       <InfoCard
         key={resource.metadata.name}
-        link={`/operators-instances/ns/${resource.metadata.namespace}/${csv.metadata.name}/${crd?.name}/${resource.metadata.name}`}
+        link={`/operators-instances/ns/${resource.metadata.namespace}/${csv.metadata.name}/${crd.name}/${resource.metadata.name}`}
         title={resource.metadata.name}
         icon={icon}
-        info={`${resource.kind} v${csv?.spec.version || "-"}`}
+        info={`${resource.kind} v${csv.spec.version || "-"}`}
         tag1Content={resource.metadata.namespace}
         tag2Content="operator"
       />

--- a/dashboard/src/components/AppView/AppNotes.scss
+++ b/dashboard/src/components/AppView/AppNotes.scss
@@ -1,3 +1,7 @@
 .Terminal {
   overflow-wrap: break-word;
 }
+
+.Terminal__Code code {
+  white-space: pre-wrap;
+}

--- a/dashboard/src/components/AppView/AppNotes.tsx
+++ b/dashboard/src/components/AppView/AppNotes.tsx
@@ -3,15 +3,16 @@ import * as React from "react";
 import "./AppNotes.css";
 
 interface IAppNotesProps {
+  title?: string;
   notes?: string | null;
 }
 
 class AppNotes extends React.PureComponent<IAppNotesProps> {
   public render() {
-    const { notes } = this.props;
+    const { title, notes } = this.props;
     return notes ? (
       <React.Fragment>
-        <h6>Notes</h6>
+        <h6>{title ? title : "Notes"}</h6>
         <section className="AppNotes Terminal elevation-1">
           <div className="Terminal__Top type-small">
             <div className="Terminal__Top__Buttons">

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
@@ -52,16 +52,17 @@ describe("renders a resource", () => {
   const csv = {
     metadata: { name: "foo" },
     spec: {
+      icon: [{}],
       customresourcedefinitions: {
         owned: [{ name: "foo.kubeapps.com", version: "v1alpha1", kind: "Foo" }],
       },
     },
   } as any;
   const resource = { kind: "Foo", spec: { test: true }, status: { alive: true } } as any;
-  const props = { ...defaultProps, csv, resource };
 
   it("renders the resource and CSV info", () => {
-    const wrapper = shallow(<OperatorInstance {...props} />);
+    const wrapper = shallow(<OperatorInstance {...defaultProps} />);
+    wrapper.setProps({ csv, resource });
     expect(wrapper.find(AppNotes)).toExist();
     expect(wrapper.find(AppValues)).toExist();
     expect(wrapper.find(".ChartInfo")).toExist();
@@ -72,9 +73,9 @@ describe("renders a resource", () => {
     const deleteResource = jest.fn(() => true);
     const push = jest.fn();
     const wrapper = shallow(
-      <OperatorInstance {...props} deleteResource={deleteResource} push={push} />,
+      <OperatorInstance {...defaultProps} deleteResource={deleteResource} push={push} />,
     );
-    wrapper.setState({ crd: csv.spec.customresourcedefinitions.owned[0] });
+    wrapper.setProps({ csv, resource });
     ReactModal.setAppElement(document.createElement("div"));
     wrapper.find(".button-danger").simulate("click");
 

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
@@ -1,0 +1,59 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+import itBehavesLike from "../../shared/specs";
+import AppNotes from "../AppView/AppNotes";
+import AppValues from "../AppView/AppValues";
+import { ErrorSelector } from "../ErrorAlert";
+import OperatorInstance, { IOperatorInstanceProps } from "./OperatorInstance";
+
+const defaultProps: IOperatorInstanceProps = {
+  isFetching: false,
+  namespace: "default",
+  csvName: "foo",
+  crdName: "foo.kubeapps.com",
+  instanceName: "foo-cluster",
+  getResource: jest.fn(),
+};
+
+itBehavesLike("aLoadingComponent", {
+  component: OperatorInstance,
+  props: { ...defaultProps, isFetching: true },
+});
+
+it("gets a resource when loading the component", () => {
+  const getResource = jest.fn();
+  shallow(<OperatorInstance {...defaultProps} getResource={getResource} />);
+  expect(getResource).toHaveBeenCalledWith(
+    defaultProps.namespace,
+    defaultProps.csvName,
+    defaultProps.crdName,
+    defaultProps.instanceName,
+  );
+});
+
+it("renders an error", () => {
+  const wrapper = shallow(<OperatorInstance {...defaultProps} error={new Error("Boom!")} />);
+  expect(wrapper.find(ErrorSelector)).toExist();
+  expect(wrapper.find(AppNotes)).not.toExist();
+});
+
+describe("renders a resource", () => {
+  const csv = {
+    metadata: { name: "foo" },
+    spec: {
+      customresourcedefinitions: {
+        owned: [{ name: "foo.kubeapps.com", version: "v1alpha1", kind: "Foo" }],
+      },
+    },
+  } as any;
+  const resource = { kind: "Foo", spec: { test: true }, status: { alive: true } } as any;
+  const props = { ...defaultProps, csv, resource };
+
+  it("renders the resource and CSV info", () => {
+    const wrapper = shallow(<OperatorInstance {...props} />);
+    expect(wrapper.find(AppNotes)).toExist();
+    expect(wrapper.find(AppValues)).toExist();
+    expect(wrapper.find(".ChartInfo")).toExist();
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
@@ -1,8 +1,10 @@
 import { shallow } from "enzyme";
 import * as React from "react";
+import * as ReactModal from "react-modal";
 import itBehavesLike from "../../shared/specs";
 import AppNotes from "../AppView/AppNotes";
 import AppValues from "../AppView/AppValues";
+import ConfirmDialog from "../ConfirmDialog";
 import { ErrorSelector } from "../ErrorAlert";
 import OperatorInstance, { IOperatorInstanceProps } from "./OperatorInstance";
 
@@ -13,6 +15,8 @@ const defaultProps: IOperatorInstanceProps = {
   crdName: "foo.kubeapps.com",
   instanceName: "foo-cluster",
   getResource: jest.fn(),
+  deleteResource: jest.fn(),
+  push: jest.fn(),
 };
 
 itBehavesLike("aLoadingComponent", {
@@ -29,6 +33,13 @@ it("gets a resource when loading the component", () => {
     defaultProps.crdName,
     defaultProps.instanceName,
   );
+});
+
+it("gets a resource again if the namespace changes", () => {
+  const getResource = jest.fn();
+  const wrapper = shallow(<OperatorInstance {...defaultProps} getResource={getResource} />);
+  wrapper.setProps({ namespace: "other" });
+  expect(getResource).toHaveBeenCalledTimes(2);
 });
 
 it("renders an error", () => {
@@ -55,5 +66,24 @@ describe("renders a resource", () => {
     expect(wrapper.find(AppValues)).toExist();
     expect(wrapper.find(".ChartInfo")).toExist();
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it("deletes the resource", async () => {
+    const deleteResource = jest.fn(() => true);
+    const push = jest.fn();
+    const wrapper = shallow(
+      <OperatorInstance {...props} deleteResource={deleteResource} push={push} />,
+    );
+    wrapper.setState({ crd: csv.spec.customresourcedefinitions.owned[0] });
+    ReactModal.setAppElement(document.createElement("div"));
+    wrapper.find(".button-danger").simulate("click");
+
+    const dialog = wrapper.find(ConfirmDialog);
+    expect(dialog.prop("modalIsOpen")).toEqual(true);
+    (dialog.prop("onConfirm") as any)();
+    expect(deleteResource).toHaveBeenCalledWith(defaultProps.namespace, "foo", resource);
+    // wait async calls
+    await new Promise(r => r());
+    expect(push).toHaveBeenCalledWith(`/apps/ns/${defaultProps.namespace}`);
   });
 });

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -1,11 +1,13 @@
+import { RouterAction } from "connected-react-router";
 import * as yaml from "js-yaml";
 import * as React from "react";
 
 import placeholder from "../../placeholder.png";
-import { IClusterServiceVersion, IResource } from "../../shared/types";
+import { IClusterServiceVersion, IClusterServiceVersionCRD, IResource } from "../../shared/types";
 import AppNotes from "../AppView/AppNotes";
 import AppValues from "../AppView/AppValues";
 import Card, { CardContent, CardFooter, CardGrid, CardIcon } from "../Card";
+import ConfirmDialog from "../ConfirmDialog";
 import { ErrorSelector } from "../ErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
 
@@ -21,19 +23,46 @@ export interface IOperatorInstanceProps {
     crdName: string,
     resourceName: string,
   ) => Promise<void>;
+  deleteResource: (namespace: string, crdName: string, resource: IResource) => Promise<boolean>;
+  push: (location: string) => RouterAction;
   error?: Error;
   resource?: IResource;
   csv?: IClusterServiceVersion;
 }
 
-class OperatorInstance extends React.Component<IOperatorInstanceProps> {
+export interface IOperatorInstanceState {
+  modalIsOpen: boolean;
+  crd?: IClusterServiceVersionCRD;
+}
+
+class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperatorInstanceState> {
+  public state: IOperatorInstanceState = {
+    modalIsOpen: false,
+  };
+
   public componentDidMount() {
     const { csvName, crdName, instanceName, namespace, getResource } = this.props;
     getResource(namespace, csvName, crdName, instanceName);
   }
 
+  public componentDidUpdate(prevProps: IOperatorInstanceProps) {
+    const { csvName, crdName, instanceName, namespace, getResource, resource, csv } = this.props;
+    if (prevProps.namespace !== namespace) {
+      getResource(namespace, csvName, crdName, instanceName);
+      return;
+    }
+
+    if (csv !== prevProps.csv || resource !== prevProps.resource) {
+      if (csv && resource) {
+        this.setState({
+          crd: csv.spec.customresourcedefinitions.owned.find(c => c.kind === resource.kind),
+        });
+      }
+    }
+  }
+
   public render() {
-    const { isFetching, error, resource, csv, instanceName } = this.props;
+    const { isFetching, error, resource, csv, instanceName, namespace } = this.props;
     return (
       <section className="AppView padding-b-big">
         <main>
@@ -43,19 +72,27 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps> {
                 error={error}
                 action="get"
                 resource={`Operator intance ${instanceName}`}
-                namespace={this.props.namespace}
+                namespace={namespace}
               />
             )}
             {resource && (
               <div className="row collapse-b-tablet">
-                <div className="col-3">{csv && this.renderCSVInfo(resource, csv)}</div>
+                <div className="col-3">{csv && this.renderCSVInfo(csv)}</div>
                 <div className="col-9">
                   <div className="row padding-t-bigger">
                     <div className="col-4">
                       <h5>{instanceName}</h5>
                     </div>
                     <div className="col-8 text-r">
-                      <button className="button button-danger">Delete</button>
+                      <button className="button button-danger" onClick={this.openModal}>
+                        Delete
+                      </button>
+                      <ConfirmDialog
+                        onConfirm={this.handleDeleteClick}
+                        modalIsOpen={this.state.modalIsOpen}
+                        loading={this.props.isFetching}
+                        closeModal={this.closeModal}
+                      />
                     </div>
                   </div>
                   <AppNotes title="Status" notes={yaml.safeDump(resource.status)} />
@@ -69,12 +106,12 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps> {
     );
   }
 
-  private renderCSVInfo = (resource: IResource, csv: IClusterServiceVersion) => {
+  private renderCSVInfo = (csv: IClusterServiceVersion) => {
     const { instanceName } = this.props;
+    const { crd } = this.state;
     const icon = csv.spec.icon?.length
       ? `data:${csv.spec.icon[0].mediatype};base64,${csv.spec.icon[0].base64data}`
       : placeholder;
-    const crd = csv.spec.customresourcedefinitions.owned.find(c => c.kind === resource.kind);
     return (
       <CardGrid className="ChartInfo">
         <Card>
@@ -92,6 +129,28 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps> {
         </Card>
       </CardGrid>
     );
+  };
+
+  private openModal = () => {
+    this.setState({
+      modalIsOpen: true,
+    });
+  };
+
+  private closeModal = async () => {
+    this.setState({
+      modalIsOpen: false,
+    });
+  };
+
+  private handleDeleteClick = async () => {
+    const { namespace, resource } = this.props;
+    const { crd } = this.state;
+    const deleted = await this.props.deleteResource(namespace, crd!.name.split(".")[0], resource!);
+    this.closeModal();
+    if (deleted) {
+      this.props.push(`/apps/ns/${namespace}`);
+    }
   };
 }
 

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -1,0 +1,98 @@
+import * as yaml from "js-yaml";
+import * as React from "react";
+
+import placeholder from "../../placeholder.png";
+import { IClusterServiceVersion, IResource } from "../../shared/types";
+import AppNotes from "../AppView/AppNotes";
+import AppValues from "../AppView/AppValues";
+import Card, { CardContent, CardFooter, CardGrid, CardIcon } from "../Card";
+import { ErrorSelector } from "../ErrorAlert";
+import LoadingWrapper from "../LoadingWrapper";
+
+export interface IOperatorInstanceProps {
+  isFetching: boolean;
+  namespace: string;
+  csvName: string;
+  crdName: string;
+  instanceName: string;
+  getResource: (
+    namespace: string,
+    csvName: string,
+    crdName: string,
+    resourceName: string,
+  ) => Promise<void>;
+  error?: Error;
+  resource?: IResource;
+  csv?: IClusterServiceVersion;
+}
+
+class OperatorInstance extends React.Component<IOperatorInstanceProps> {
+  public componentDidMount() {
+    const { csvName, crdName, instanceName, namespace, getResource } = this.props;
+    getResource(namespace, csvName, crdName, instanceName);
+  }
+
+  public render() {
+    const { isFetching, error, resource, csv, instanceName } = this.props;
+    return (
+      <section className="AppView padding-b-big">
+        <main>
+          <LoadingWrapper loaded={!isFetching}>
+            {error && (
+              <ErrorSelector
+                error={error}
+                action="get"
+                resource={`Operator intance ${instanceName}`}
+                namespace={this.props.namespace}
+              />
+            )}
+            {resource && (
+              <div className="row collapse-b-tablet">
+                <div className="col-3">{csv && this.renderCSVInfo(resource, csv)}</div>
+                <div className="col-9">
+                  <div className="row padding-t-bigger">
+                    <div className="col-4">
+                      <h5>{instanceName}</h5>
+                    </div>
+                    <div className="col-8 text-r">
+                      <button className="button button-danger">Delete</button>
+                    </div>
+                  </div>
+                  <AppNotes title="Status" notes={yaml.safeDump(resource.status)} />
+                  <AppValues values={yaml.safeDump(resource.spec)} />
+                </div>
+              </div>
+            )}
+          </LoadingWrapper>
+        </main>
+      </section>
+    );
+  }
+
+  private renderCSVInfo = (resource: IResource, csv: IClusterServiceVersion) => {
+    const { instanceName } = this.props;
+    const icon = csv.spec.icon?.length
+      ? `data:${csv.spec.icon[0].mediatype};base64,${csv.spec.icon[0].base64data}`
+      : placeholder;
+    const crd = csv.spec.customresourcedefinitions.owned.find(c => c.kind === resource.kind);
+    return (
+      <CardGrid className="ChartInfo">
+        <Card>
+          <CardIcon icon={icon} />
+          <CardContent>
+            <h5>{instanceName}</h5>
+            <p className="margin-b-reset">{crd?.description}</p>
+          </CardContent>
+          <CardFooter>
+            <div>
+              <div>Cluster Service Version: v{csv.spec.version}</div>
+              <div>Kind: {crd?.kind}</div>
+            </div>
+          </CardFooter>
+        </Card>
+      </CardGrid>
+    );
+  };
+}
+
+export default OperatorInstance;

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -109,7 +109,7 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
   private renderCSVInfo = (csv: IClusterServiceVersion) => {
     const { instanceName } = this.props;
     const { crd } = this.state;
-    const icon = csv.spec.icon?.length
+    const icon = csv.spec.icon.length
       ? `data:${csv.spec.icon[0].mediatype};base64,${csv.spec.icon[0].base64data}`
       : placeholder;
     return (
@@ -118,12 +118,12 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
           <CardIcon icon={icon} />
           <CardContent>
             <h5>{instanceName}</h5>
-            <p className="margin-b-reset">{crd?.description}</p>
+            <p className="margin-b-reset">{crd!.description}</p>
           </CardContent>
           <CardFooter>
             <div>
               <div>Cluster Service Version: v{csv.spec.version}</div>
-              <div>Kind: {crd?.kind}</div>
+              <div>Kind: {crd!.kind}</div>
             </div>
           </CardFooter>
         </Card>

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -118,12 +118,12 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
           <CardIcon icon={icon} />
           <CardContent>
             <h5>{instanceName}</h5>
-            <p className="margin-b-reset">{crd!.description}</p>
+            <p className="margin-b-reset">{crd?.description}</p>
           </CardContent>
           <CardFooter>
             <div>
               <div>Cluster Service Version: v{csv.spec.version}</div>
-              <div>Kind: {crd!.kind}</div>
+              <div>Kind: {crd?.kind}</div>
             </div>
           </CardFooter>
         </Card>

--- a/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
+++ b/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
@@ -32,7 +32,9 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
             className="ChartInfo"
           >
             <Card>
-              <CardIcon />
+              <CardIcon
+                icon="data:undefined;base64,undefined"
+              />
               <CardContent>
                 <h5>
                   foo-cluster
@@ -48,6 +50,7 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
                   </div>
                   <div>
                     Kind: 
+                    Foo
                   </div>
                 </div>
               </CardFooter>

--- a/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
+++ b/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loading spinner matches the snapshot 1`] = `
+<section
+  className="AppView padding-b-big"
+>
+  <main>
+    <LoadingWrapper
+      loaded={false}
+      type={0}
+    />
+  </main>
+</section>
+`;
+
+exports[`renders a resource renders the resource and CSV info 1`] = `
+<section
+  className="AppView padding-b-big"
+>
+  <main>
+    <LoadingWrapper
+      loaded={true}
+      type={0}
+    >
+      <div
+        className="row collapse-b-tablet"
+      >
+        <div
+          className="col-3"
+        >
+          <CardGrid
+            className="ChartInfo"
+          >
+            <Card>
+              <CardIcon />
+              <CardContent>
+                <h5>
+                  foo-cluster
+                </h5>
+                <p
+                  className="margin-b-reset"
+                />
+              </CardContent>
+              <CardFooter>
+                <div>
+                  <div>
+                    Cluster Service Version: v
+                  </div>
+                  <div>
+                    Kind: 
+                    Foo
+                  </div>
+                </div>
+              </CardFooter>
+            </Card>
+          </CardGrid>
+        </div>
+        <div
+          className="col-9"
+        >
+          <div
+            className="row padding-t-bigger"
+          >
+            <div
+              className="col-4"
+            >
+              <h5>
+                foo-cluster
+              </h5>
+            </div>
+            <div
+              className="col-8 text-r"
+            >
+              <button
+                className="button button-danger"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+          <AppNotes
+            notes="alive: true
+          "
+            title="Status"
+          />
+          <AppValues
+            values="test: true
+          "
+          />
+        </div>
+      </div>
+    </LoadingWrapper>
+  </main>
+</section>
+`;

--- a/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
+++ b/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
                   </div>
                   <div>
                     Kind: 
-                    Foo
                   </div>
                 </div>
               </CardFooter>
@@ -73,9 +72,16 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
             >
               <button
                 className="button button-danger"
+                onClick={[Function]}
               >
                 Delete
               </button>
+              <ConfirmDialog
+                closeModal={[Function]}
+                loading={false}
+                modalIsOpen={false}
+                onConfirm={[Function]}
+              />
             </div>
           </div>
           <AppNotes

--- a/dashboard/src/components/OperatorInstance/index.ts
+++ b/dashboard/src/components/OperatorInstance/index.ts
@@ -1,0 +1,3 @@
+import OperatorInstance from "./OperatorInstance";
+
+export default OperatorInstance;

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.test.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.test.tsx
@@ -26,6 +26,19 @@ const defaultCRD = {
   description: "useful description",
 } as any;
 
+const defaultCSV = {
+  metadata: {
+    annotations: {
+      "alm-examples": '[{"kind": "Foo", "apiVersion": "v1"}]',
+    },
+  },
+  spec: {
+    customresourcedefinitions: {
+      owned: [defaultCRD],
+    },
+  },
+} as any;
+
 itBehavesLike("aLoadingComponent", {
   component: OperatorInstanceForm,
   props: { ...defaultProps, isFetching: true },
@@ -38,20 +51,8 @@ it("retrieves CSV when mounted", () => {
 });
 
 it("retrieves the example values and the target CRD from the given CSV", () => {
-  const csv = {
-    metadata: {
-      annotations: {
-        "alm-examples": '[{"kind": "Foo", "apiVersion": "v1"}]',
-      },
-    },
-    spec: {
-      customresourcedefinitions: {
-        owned: [defaultCRD],
-      },
-    },
-  } as any;
   const wrapper = shallow(<OperatorInstanceForm {...defaultProps} />);
-  wrapper.setProps({ csv });
+  wrapper.setProps({ csv: defaultCSV });
   expect(wrapper.state()).toMatchObject({
     defaultValues: "kind: Foo\napiVersion: v1\n",
     crd: defaultCRD,
@@ -113,7 +114,7 @@ it("restores the default values", async () => {
 it("should submit the form", () => {
   const createResource = jest.fn();
   const wrapper = shallow(
-    <OperatorInstanceForm {...defaultProps} createResource={createResource} />,
+    <OperatorInstanceForm {...defaultProps} createResource={createResource} csv={defaultCSV} />,
   );
 
   const values = "apiVersion: v1\nmetadata:\n  name: foo";
@@ -138,7 +139,7 @@ it("should submit the form", () => {
 it("should catch a syntax error in the form", () => {
   const createResource = jest.fn();
   const wrapper = shallow(
-    <OperatorInstanceForm {...defaultProps} createResource={createResource} />,
+    <OperatorInstanceForm {...defaultProps} createResource={createResource} csv={defaultCSV} />,
   );
 
   const values = "metadata: invalid!\n  name: foo";
@@ -159,7 +160,7 @@ it("should catch a syntax error in the form", () => {
 it("should throw an eror if the element doesn't contain an apiVersion", () => {
   const createResource = jest.fn();
   const wrapper = shallow(
-    <OperatorInstanceForm {...defaultProps} createResource={createResource} />,
+    <OperatorInstanceForm {...defaultProps} createResource={createResource} csv={defaultCSV} />,
   );
 
   const values = "metadata:\nname: foo";

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
@@ -203,7 +203,7 @@ class DeploymentFormBody extends React.Component<
     e.preventDefault();
     // Clean possible previous errors
     this.setState({ error: undefined });
-    const { createResource, push, namespace } = this.props;
+    const { createResource, push, namespace, csv } = this.props;
     const { values, crd } = this.state;
     const resourceType = crd!.name.split(".")[0];
     let resource: IResource = {} as any;
@@ -227,7 +227,9 @@ class DeploymentFormBody extends React.Component<
     this.setState({ submittedResourceName: resourceName });
     const created = await createResource(namespace, resource.apiVersion, resourceType, resource);
     if (created) {
-      push(`/operators-instances/ns/${namespace}/${resourceName}`);
+      push(
+        `/operators-instances/ns/${namespace}/${csv?.metadata.name}/${crd?.name}/${resourceName}`,
+      );
     }
   };
 }

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
@@ -127,10 +127,10 @@ class DeploymentFormBody extends React.Component<
           {errors.create && (
             <ErrorSelector
               error={errors.create}
-              resource={`Operator Instance "${submittedResourceName}" (${crd?.name})`}
+              resource={`Operator Instance "${submittedResourceName}" (${crd.name})`}
             />
           )}
-          {error && <ErrorSelector error={error} resource={`Operator Instance (${crd?.name})`} />}
+          {error && <ErrorSelector error={error} resource={`Operator Instance (${crd.name})`} />}
           <p>{crd.description}</p>
           <ConfirmDialog
             modalIsOpen={this.state.restoreDefaultValuesModalIsOpen}
@@ -205,7 +205,14 @@ class DeploymentFormBody extends React.Component<
     this.setState({ error: undefined });
     const { createResource, push, namespace, csv } = this.props;
     const { values, crd } = this.state;
-    const resourceType = crd!.name.split(".")[0];
+    if (!crd || !csv) {
+      // Unexpected error, CRD and CSV should have been previously populated
+      this.setState({
+        error: new Error(`Missing CRD (${JSON.stringify(crd)}) or CSV (${JSON.stringify(csv)})`),
+      });
+      return;
+    }
+    const resourceType = crd.name.split(".")[0];
     let resource: IResource = {} as any;
     try {
       resource = yaml.safeLoad(values);
@@ -227,9 +234,7 @@ class DeploymentFormBody extends React.Component<
     this.setState({ submittedResourceName: resourceName });
     const created = await createResource(namespace, resource.apiVersion, resourceType, resource);
     if (created) {
-      push(
-        `/operators-instances/ns/${namespace}/${csv?.metadata.name}/${crd?.name}/${resourceName}`,
-      );
+      push(`/operators-instances/ns/${namespace}/${csv.metadata.name}/${crd.name}/${resourceName}`);
     }
   };
 }

--- a/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
@@ -1,26 +1,41 @@
-import * as React from "react";
 import { connect } from "react-redux";
-import { RouteComponentProps } from "react-router";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
 
+import actions from "../../actions";
+import OperatorInstance from "../../components/OperatorInstance";
 import { IStoreState } from "../../shared/types";
 
+interface IRouteProps {
+  match: {
+    params: {
+      csv: string;
+      crd: string;
+      instanceName: string;
+    };
+  };
+}
 function mapStateToProps(
-  { apps, namespace, charts }: IStoreState,
-  { location }: RouteComponentProps<{}>,
+  { apps, namespace, operators }: IStoreState,
+  { match: { params } }: IRouteProps,
 ) {
-  return {};
+  return {
+    namespace: namespace.current,
+    csvName: params.csv,
+    crdName: params.crd,
+    instanceName: params.instanceName,
+    isFetching: operators.isFetching,
+    resource: operators.resource,
+    csv: operators.csv,
+    error: operators.errors.fetch,
+  };
 }
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
-  return {};
+  return {
+    getResource: (namespace: string, csvName: string, crdName: string, resourceName: string) =>
+      dispatch(actions.operators.getResource(namespace, csvName, crdName, resourceName)),
+  };
 }
 
-class Comp extends React.Component {
-  public render() {
-    return <h1>This component has not been built yet</h1>;
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Comp);
+export default connect(mapStateToProps, mapDispatchToProps)(OperatorInstance);

--- a/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
@@ -1,10 +1,11 @@
+import { push } from "connected-react-router";
 import { connect } from "react-redux";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
 
 import actions from "../../actions";
 import OperatorInstance from "../../components/OperatorInstance";
-import { IStoreState } from "../../shared/types";
+import { IResource, IStoreState } from "../../shared/types";
 
 interface IRouteProps {
   match: {
@@ -27,7 +28,7 @@ function mapStateToProps(
     isFetching: operators.isFetching,
     resource: operators.resource,
     csv: operators.csv,
-    error: operators.errors.fetch,
+    error: operators.errors.fetch || operators.errors.delete,
   };
 }
 
@@ -35,6 +36,9 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
   return {
     getResource: (namespace: string, csvName: string, crdName: string, resourceName: string) =>
       dispatch(actions.operators.getResource(namespace, csvName, crdName, resourceName)),
+    deleteResource: (namespace: string, crdName: string, resource: IResource) =>
+      dispatch(actions.operators.deleteResource(namespace, crdName, resource)),
+    push: (location: string) => dispatch(push(location)),
   };
 }
 

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -68,7 +68,7 @@ class Routes extends React.Component<IRoutesProps> {
       Object.assign(privateRoutes, {
         "/operators/ns/:namespace": OperatorsListContainer,
         "/operators/ns/:namespace/:operator": OperatorViewContainer,
-        "/operators-instances/ns/:namespace/:instanceName": OperatorInstanceViewContainer,
+        "/operators-instances/ns/:namespace/:csv/:crd/:instanceName": OperatorInstanceViewContainer,
         "/operators-instances/ns/:namespace/new/:csv/:crd": OperatorInstanceCreateContainer,
       });
     }

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -68,8 +68,8 @@ class Routes extends React.Component<IRoutesProps> {
       Object.assign(privateRoutes, {
         "/operators/ns/:namespace": OperatorsListContainer,
         "/operators/ns/:namespace/:operator": OperatorViewContainer,
-        "/operators-instances/ns/:namespace/:csv/:crd/:instanceName": OperatorInstanceViewContainer,
         "/operators-instances/ns/:namespace/new/:csv/:crd": OperatorInstanceCreateContainer,
+        "/operators-instances/ns/:namespace/:csv/:crd/:instanceName": OperatorInstanceViewContainer,
       });
     }
     return (

--- a/dashboard/src/reducers/operators.test.ts
+++ b/dashboard/src/reducers/operators.test.ts
@@ -41,6 +41,8 @@ describe("catalogReducer", () => {
       requestCustomResources: getType(actions.operators.requestCustomResources),
       receiveCustomResources: getType(actions.operators.receiveCustomResources),
       errorCustomResource: getType(actions.operators.errorCustomResource),
+      requestCustomResource: getType(actions.operators.requestCustomResource),
+      receiveCustomResource: getType(actions.operators.receiveCustomResource),
     };
 
     describe("reducer actions", () => {
@@ -229,6 +231,20 @@ describe("catalogReducer", () => {
           payload: new Error("Boom!"),
         }),
       ).toEqual({ ...initialState, isFetching: false, errors: { fetch: new Error("Boom!") } });
+    });
+
+    it("sets receive resource", () => {
+      const state = operatorReducer(undefined, {
+        type: actionTypes.requestCustomResource as any,
+      });
+      const resource = {} as IResource;
+      expect(state).toEqual({ ...initialState, isFetching: true });
+      expect(
+        operatorReducer(undefined, {
+          type: actionTypes.receiveCustomResource as any,
+          payload: resource,
+        }),
+      ).toEqual({ ...initialState, isFetching: false, resource });
     });
   });
 });

--- a/dashboard/src/reducers/operators.test.ts
+++ b/dashboard/src/reducers/operators.test.ts
@@ -37,6 +37,8 @@ describe("catalogReducer", () => {
       errorCSVs: getType(actions.operators.errorCSVs),
       creatingResource: getType(actions.operators.creatingResource),
       resourceCreated: getType(actions.operators.resourceCreated),
+      deletingResource: getType(actions.operators.deletingResource),
+      resourceDeleted: getType(actions.operators.resourceDeleted),
       errorResourceCreate: getType(actions.operators.errorResourceCreate),
       requestCustomResources: getType(actions.operators.requestCustomResources),
       receiveCustomResources: getType(actions.operators.receiveCustomResources),
@@ -121,6 +123,22 @@ describe("catalogReducer", () => {
             type: actionTypes.setNamespace as any,
           }),
         ).toEqual({ ...initialState, error: undefined });
+      });
+
+      it("sets the initial state when changing namespace", () => {
+        expect(
+          operatorReducer(
+            {
+              ...initialState,
+              isFetching: true,
+              errors: { fetch: new Error("Boom!") },
+              operators: [{} as any],
+            },
+            {
+              type: actionTypes.setNamespace as any,
+            },
+          ),
+        ).toEqual({ ...initialState });
       });
 
       it("sets receive operator", () => {
@@ -245,6 +263,18 @@ describe("catalogReducer", () => {
           payload: resource,
         }),
       ).toEqual({ ...initialState, isFetching: false, resource });
+    });
+
+    it("sets deleting resource", () => {
+      const state = operatorReducer(undefined, {
+        type: actionTypes.deletingResource as any,
+      });
+      expect(state).toEqual({ ...initialState, isFetching: true });
+      expect(
+        operatorReducer(undefined, {
+          type: actionTypes.resourceDeleted as any,
+        }),
+      ).toEqual({ ...initialState, isFetching: false });
     });
   });
 });

--- a/dashboard/src/reducers/operators.ts
+++ b/dashboard/src/reducers/operators.ts
@@ -18,6 +18,7 @@ export interface IOperatorsState {
   csvs: IClusterServiceVersion[];
   csv?: IClusterServiceVersion;
   resources: IResource[];
+  resource?: IResource;
 }
 
 const initialState: IOperatorsState = {
@@ -73,6 +74,10 @@ const catalogReducer = (
       return { ...state, isFetching: false, resources: action.payload };
     case getType(operators.errorCustomResource):
       return { ...state, isFetching: false, errors: { fetch: action.payload } };
+    case getType(operators.requestCustomResource):
+      return { ...state, isFetching: true };
+    case getType(operators.receiveCustomResource):
+      return { ...state, isFetching: false, resource: action.payload };
     case LOCATION_CHANGE:
       return { ...state, errors: {} };
     case getType(actions.namespace.setNamespace):

--- a/dashboard/src/reducers/operators.ts
+++ b/dashboard/src/reducers/operators.ts
@@ -14,6 +14,7 @@ export interface IOperatorsState {
   errors: {
     fetch?: Error;
     create?: Error;
+    delete?: Error;
   };
   csvs: IClusterServiceVersion[];
   csv?: IClusterServiceVersion;
@@ -66,6 +67,12 @@ const catalogReducer = (
       return { ...state, isFetching: true };
     case getType(operators.resourceCreated):
       return { ...state, isFetching: false };
+    case getType(operators.deletingResource):
+      return { ...state, isFetching: true };
+    case getType(operators.resourceDeleted):
+      return { ...state, isFetching: false };
+    case getType(operators.errorResourceDelete):
+      return { ...state, isFetching: false, errors: { delete: action.payload } };
     case getType(operators.errorResourceCreate):
       return { ...state, isFetching: false, errors: { create: action.payload } };
     case getType(operators.requestCustomResources):
@@ -79,9 +86,9 @@ const catalogReducer = (
     case getType(operators.receiveCustomResource):
       return { ...state, isFetching: false, resource: action.payload };
     case LOCATION_CHANGE:
-      return { ...state, errors: {} };
+      return { ...initialState };
     case getType(actions.namespace.setNamespace):
-      return { ...state, errors: {} };
+      return { ...initialState };
     default:
       return { ...state };
   }

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -119,3 +119,16 @@ it("get a resource", async () => {
     `api/kube/apis/v1/namespaces/${ns}/pods/foo`,
   ]);
 });
+
+it("deletes a resource", async () => {
+  const resource = { metadata: { name: "foo" } } as IResource;
+  const ns = "default";
+  axiosWithAuth.delete = jest.fn(() => {
+    return { data: resource };
+  });
+  expect(await Operators.deleteResource(ns, "v1", "pods", "foo")).toEqual(resource);
+  expect(axiosWithAuth.delete).toHaveBeenCalled();
+  expect((axiosWithAuth.delete as jest.Mock).mock.calls[0]).toEqual([
+    `api/kube/apis/v1/namespaces/${ns}/pods/foo`,
+  ]);
+});

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -106,3 +106,16 @@ it("list resources", async () => {
     `api/kube/apis/v1/namespaces/${ns}/pods`,
   ]);
 });
+
+it("get a resource", async () => {
+  const resource = { metadata: { name: "foo" } } as IResource;
+  const ns = "default";
+  axiosWithAuth.get = jest.fn(() => {
+    return { data: resource };
+  });
+  expect(await Operators.getResource(ns, "v1", "pods", "foo")).toEqual(resource);
+  expect(axiosWithAuth.get).toHaveBeenCalled();
+  expect((axiosWithAuth.get as jest.Mock).mock.calls[0]).toEqual([
+    `api/kube/apis/v1/namespaces/${ns}/pods/foo`,
+  ]);
+});

--- a/dashboard/src/shared/Operators.ts
+++ b/dashboard/src/shared/Operators.ts
@@ -71,4 +71,16 @@ export class Operators {
     );
     return data;
   }
+
+  public static async deleteResource(
+    namespace: string,
+    apiVersion: string,
+    plural: string,
+    name: string,
+  ) {
+    const { data } = await axiosWithAuth.delete<any>(
+      urls.api.operators.resource(namespace, apiVersion, plural, name),
+    );
+    return data;
+  }
 }

--- a/dashboard/src/shared/Operators.ts
+++ b/dashboard/src/shared/Operators.ts
@@ -59,4 +59,16 @@ export class Operators {
     );
     return data;
   }
+
+  public static async getResource(
+    namespace: string,
+    apiVersion: string,
+    crd: string,
+    name: string,
+  ) {
+    const { data } = await axiosWithAuth.get<IResource>(
+      urls.api.operators.resource(namespace, apiVersion, crd, name),
+    );
+    return data;
+  }
 }

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -78,5 +78,7 @@ export const api = {
       `api/v1/namespaces/${namespace}/operator/${name}/logo`,
     resources: (namespace: string, apiVersion: string, resource: string) =>
       `${APIBase}/apis/${apiVersion}/namespaces/${namespace}/${resource}`,
+    resource: (namespace: string, apiVersion: string, resource: string, name: string) =>
+      `${APIBase}/apis/${apiVersion}/namespaces/${namespace}/${resource}/${name}`,
   },
 };


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Draft for the OperatorInstance view:
![Screenshot from 2020-03-19 13-32-37](https://user-images.githubusercontent.com/4025665/77068546-193cd380-69e7-11ea-97b9-a28b06be2240.png)

For the moment we are showing just some basic info. The current status (as a YAML) and the installation values along with a Card with basic information about the CRD and the ClusterServiceVersion. The plan is to keep adding things but in other PRs to facilitate the review. The next things I plan to add are:

 - Make the Delete button works (currently is a dummy button)
 - Retrieve resources associated to the operator instance and show the same things than for other apps:
   - Application status (worklads running)
   - Resource tables.

We should also be able to modify the instance but I will leave that for later.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1552 
