### PR TITLE
Operator instance delete button

### DIFF
--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -414,3 +414,38 @@ describe("getResources", () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
+
+describe("deleteResource", () => {
+  it("delete a resource in a namespace", async () => {
+    const resource = { metadata: { name: "resource" } } as any;
+    Operators.deleteResource = jest.fn();
+    const expectedActions = [
+      {
+        type: getType(operatorActions.deletingResource),
+      },
+      {
+        type: getType(operatorActions.resourceDeleted),
+      },
+    ];
+    await store.dispatch(operatorActions.deleteResource("default", "foos", resource));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches an error if deleting a resource fails", async () => {
+    const resource = { metadata: { name: "resource" } } as any;
+    Operators.deleteResource = jest.fn(() => {
+      throw new Error("Boom!");
+    });
+    const expectedActions = [
+      {
+        type: getType(operatorActions.deletingResource),
+      },
+      {
+        type: getType(operatorActions.errorResourceDelete),
+        payload: new Error("Boom!"),
+      },
+    ];
+    await store.dispatch(operatorActions.deleteResource("default", "foos", resource));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});

--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -45,6 +45,12 @@ export const errorResourceCreate = createAction("ERROR_RESOURCE_CREATE", resolve
   return (err: Error) => resolve(err);
 });
 
+export const deletingResource = createAction("DELETING_RESOURCE");
+export const resourceDeleted = createAction("RESOURCE_DELETED");
+export const errorResourceDelete = createAction("ERROR_RESOURCE_DELETE", resolve => {
+  return (err: Error) => resolve(err);
+});
+
 export const requestCustomResources = createAction("REQUEST_CUSTOM_RESOURCES");
 export const receiveCustomResources = createAction("RECEIVE_CUSTOM_RESOURCES", resolve => {
   return (resources: IResource[]) => resolve(resources);
@@ -81,6 +87,9 @@ const actions = [
   errorCustomResource,
   requestCustomResource,
   receiveCustomResource,
+  deletingResource,
+  resourceDeleted,
+  errorResourceDelete,
 ];
 
 export type OperatorAction = ActionType<typeof actions[number]>;
@@ -177,6 +186,29 @@ export function createResource(
       return true;
     } catch (e) {
       dispatch(errorResourceCreate(e));
+      return false;
+    }
+  };
+}
+
+export function deleteResource(
+  namespace: string,
+  plural: string,
+  resource: IResource,
+): ThunkAction<Promise<boolean>, IStoreState, null, OperatorAction> {
+  return async dispatch => {
+    dispatch(deletingResource());
+    try {
+      await Operators.deleteResource(
+        namespace,
+        resource.apiVersion,
+        plural,
+        resource.metadata.name,
+      );
+      dispatch(resourceDeleted());
+      return true;
+    } catch (e) {
+      dispatch(errorResourceDelete(e));
       return false;
     }
   };

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
@@ -35,6 +35,13 @@ it("gets a resource when loading the component", () => {
   );
 });
 
+it("gets a resource again if the namespace changes", () => {
+  const getResource = jest.fn();
+  const wrapper = shallow(<OperatorInstance {...defaultProps} getResource={getResource} />);
+  wrapper.setProps({ namespace: "other" });
+  expect(getResource).toHaveBeenCalledTimes(2);
+});
+
 it("renders an error", () => {
   const wrapper = shallow(<OperatorInstance {...defaultProps} error={new Error("Boom!")} />);
   expect(wrapper.find(ErrorSelector)).toExist();

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -46,7 +46,12 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
   }
 
   public componentDidUpdate(prevProps: IOperatorInstanceProps) {
-    const { resource, csv } = this.props;
+    const { csvName, crdName, instanceName, namespace, getResource, resource, csv } = this.props;
+    if (prevProps.namespace !== namespace) {
+      getResource(namespace, csvName, crdName, instanceName);
+      return;
+    }
+
     if (csv !== prevProps.csv || resource !== prevProps.resource) {
       if (csv && resource) {
         this.setState({

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -1,11 +1,13 @@
+import { RouterAction } from "connected-react-router";
 import * as yaml from "js-yaml";
 import * as React from "react";
 
 import placeholder from "../../placeholder.png";
-import { IClusterServiceVersion, IResource } from "../../shared/types";
+import { IClusterServiceVersion, IClusterServiceVersionCRD, IResource } from "../../shared/types";
 import AppNotes from "../AppView/AppNotes";
 import AppValues from "../AppView/AppValues";
 import Card, { CardContent, CardFooter, CardGrid, CardIcon } from "../Card";
+import ConfirmDialog from "../ConfirmDialog";
 import { ErrorSelector } from "../ErrorAlert";
 import LoadingWrapper from "../LoadingWrapper";
 
@@ -21,19 +23,41 @@ export interface IOperatorInstanceProps {
     crdName: string,
     resourceName: string,
   ) => Promise<void>;
+  deleteResource: (namespace: string, crdName: string, resource: IResource) => Promise<boolean>;
+  push: (location: string) => RouterAction;
   error?: Error;
   resource?: IResource;
   csv?: IClusterServiceVersion;
 }
 
-class OperatorInstance extends React.Component<IOperatorInstanceProps> {
+export interface IOperatorInstanceState {
+  modalIsOpen: boolean;
+  crd?: IClusterServiceVersionCRD;
+}
+
+class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperatorInstanceState> {
+  public state: IOperatorInstanceState = {
+    modalIsOpen: false,
+  };
+
   public componentDidMount() {
     const { csvName, crdName, instanceName, namespace, getResource } = this.props;
     getResource(namespace, csvName, crdName, instanceName);
   }
 
+  public componentDidUpdate(prevProps: IOperatorInstanceProps) {
+    const { resource, csv } = this.props;
+    if (csv !== prevProps.csv || resource !== prevProps.resource) {
+      if (csv && resource) {
+        this.setState({
+          crd: csv.spec.customresourcedefinitions.owned.find(c => c.kind === resource.kind),
+        });
+      }
+    }
+  }
+
   public render() {
-    const { isFetching, error, resource, csv, instanceName } = this.props;
+    const { isFetching, error, resource, csv, instanceName, namespace } = this.props;
     return (
       <section className="AppView padding-b-big">
         <main>
@@ -43,19 +67,27 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps> {
                 error={error}
                 action="get"
                 resource={`Operator intance ${instanceName}`}
-                namespace={this.props.namespace}
+                namespace={namespace}
               />
             )}
             {resource && (
               <div className="row collapse-b-tablet">
-                <div className="col-3">{csv && this.renderCSVInfo(resource, csv)}</div>
+                <div className="col-3">{csv && this.renderCSVInfo(csv)}</div>
                 <div className="col-9">
                   <div className="row padding-t-bigger">
                     <div className="col-4">
                       <h5>{instanceName}</h5>
                     </div>
                     <div className="col-8 text-r">
-                      <button className="button button-danger">Delete</button>
+                      <button className="button button-danger" onClick={this.openModal}>
+                        Delete
+                      </button>
+                      <ConfirmDialog
+                        onConfirm={this.handleDeleteClick}
+                        modalIsOpen={this.state.modalIsOpen}
+                        loading={this.props.isFetching}
+                        closeModal={this.closeModal}
+                      />
                     </div>
                   </div>
                   <AppNotes title="Status" notes={yaml.safeDump(resource.status)} />
@@ -69,12 +101,12 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps> {
     );
   }
 
-  private renderCSVInfo = (resource: IResource, csv: IClusterServiceVersion) => {
+  private renderCSVInfo = (csv: IClusterServiceVersion) => {
     const { instanceName } = this.props;
+    const { crd } = this.state;
     const icon = csv.spec.icon?.length
       ? `data:${csv.spec.icon[0].mediatype};base64,${csv.spec.icon[0].base64data}`
       : placeholder;
-    const crd = csv.spec.customresourcedefinitions.owned.find(c => c.kind === resource.kind);
     return (
       <CardGrid className="ChartInfo">
         <Card>
@@ -92,6 +124,28 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps> {
         </Card>
       </CardGrid>
     );
+  };
+
+  private openModal = () => {
+    this.setState({
+      modalIsOpen: true,
+    });
+  };
+
+  private closeModal = async () => {
+    this.setState({
+      modalIsOpen: false,
+    });
+  };
+
+  private handleDeleteClick = async () => {
+    const { namespace, resource } = this.props;
+    const { crd } = this.state;
+    const deleted = await this.props.deleteResource(namespace, crd!.name.split(".")[0], resource!);
+    this.closeModal();
+    if (deleted) {
+      this.props.push(`/apps/ns/${namespace}`);
+    }
   };
 }
 

--- a/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
+++ b/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
                   </div>
                   <div>
                     Kind: 
-                    Foo
                   </div>
                 </div>
               </CardFooter>
@@ -73,9 +72,16 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
             >
               <button
                 className="button button-danger"
+                onClick={[Function]}
               >
                 Delete
               </button>
+              <ConfirmDialog
+                closeModal={[Function]}
+                loading={false}
+                modalIsOpen={false}
+                onConfirm={[Function]}
+              />
             </div>
           </div>
           <AppNotes

--- a/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
@@ -1,10 +1,11 @@
+import { push } from "connected-react-router";
 import { connect } from "react-redux";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
 
 import actions from "../../actions";
 import OperatorInstance from "../../components/OperatorInstance";
-import { IStoreState } from "../../shared/types";
+import { IResource, IStoreState } from "../../shared/types";
 
 interface IRouteProps {
   match: {
@@ -27,7 +28,7 @@ function mapStateToProps(
     isFetching: operators.isFetching,
     resource: operators.resource,
     csv: operators.csv,
-    error: operators.errors.fetch,
+    error: operators.errors.fetch || operators.errors.delete,
   };
 }
 
@@ -35,6 +36,9 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
   return {
     getResource: (namespace: string, csvName: string, crdName: string, resourceName: string) =>
       dispatch(actions.operators.getResource(namespace, csvName, crdName, resourceName)),
+    deleteResource: (namespace: string, crdName: string, resource: IResource) =>
+      dispatch(actions.operators.deleteResource(namespace, crdName, resource)),
+    push: (location: string) => dispatch(push(location)),
   };
 }
 

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -68,8 +68,8 @@ class Routes extends React.Component<IRoutesProps> {
       Object.assign(privateRoutes, {
         "/operators/ns/:namespace": OperatorsListContainer,
         "/operators/ns/:namespace/:operator": OperatorViewContainer,
-        "/operators-instances/ns/:namespace/:csv/:crd/:instanceName": OperatorInstanceViewContainer,
         "/operators-instances/ns/:namespace/new/:csv/:crd": OperatorInstanceCreateContainer,
+        "/operators-instances/ns/:namespace/:csv/:crd/:instanceName": OperatorInstanceViewContainer,
       });
     }
     return (

--- a/dashboard/src/reducers/operators.test.ts
+++ b/dashboard/src/reducers/operators.test.ts
@@ -37,6 +37,8 @@ describe("catalogReducer", () => {
       errorCSVs: getType(actions.operators.errorCSVs),
       creatingResource: getType(actions.operators.creatingResource),
       resourceCreated: getType(actions.operators.resourceCreated),
+      deletingResource: getType(actions.operators.deletingResource),
+      resourceDeleted: getType(actions.operators.resourceDeleted),
       errorResourceCreate: getType(actions.operators.errorResourceCreate),
       requestCustomResources: getType(actions.operators.requestCustomResources),
       receiveCustomResources: getType(actions.operators.receiveCustomResources),
@@ -245,6 +247,18 @@ describe("catalogReducer", () => {
           payload: resource,
         }),
       ).toEqual({ ...initialState, isFetching: false, resource });
+    });
+
+    it("sets deleting resource", () => {
+      const state = operatorReducer(undefined, {
+        type: actionTypes.deletingResource as any,
+      });
+      expect(state).toEqual({ ...initialState, isFetching: true });
+      expect(
+        operatorReducer(undefined, {
+          type: actionTypes.resourceDeleted as any,
+        }),
+      ).toEqual({ ...initialState, isFetching: false });
     });
   });
 });

--- a/dashboard/src/reducers/operators.test.ts
+++ b/dashboard/src/reducers/operators.test.ts
@@ -125,6 +125,22 @@ describe("catalogReducer", () => {
         ).toEqual({ ...initialState, error: undefined });
       });
 
+      it("sets the initial state when changing namespace", () => {
+        expect(
+          operatorReducer(
+            {
+              ...initialState,
+              isFetching: true,
+              errors: { fetch: new Error("Boom!") },
+              operators: [{} as any],
+            },
+            {
+              type: actionTypes.setNamespace as any,
+            },
+          ),
+        ).toEqual({ ...initialState });
+      });
+
       it("sets receive operator", () => {
         const state = operatorReducer(undefined, {
           type: actionTypes.requestOperator as any,

--- a/dashboard/src/reducers/operators.ts
+++ b/dashboard/src/reducers/operators.ts
@@ -86,9 +86,9 @@ const catalogReducer = (
     case getType(operators.receiveCustomResource):
       return { ...state, isFetching: false, resource: action.payload };
     case LOCATION_CHANGE:
-      return { ...state, errors: {} };
+      return { ...initialState };
     case getType(actions.namespace.setNamespace):
-      return { ...state, errors: {} };
+      return { ...initialState };
     default:
       return { ...state };
   }

--- a/dashboard/src/reducers/operators.ts
+++ b/dashboard/src/reducers/operators.ts
@@ -14,6 +14,7 @@ export interface IOperatorsState {
   errors: {
     fetch?: Error;
     create?: Error;
+    delete?: Error;
   };
   csvs: IClusterServiceVersion[];
   csv?: IClusterServiceVersion;
@@ -66,6 +67,12 @@ const catalogReducer = (
       return { ...state, isFetching: true };
     case getType(operators.resourceCreated):
       return { ...state, isFetching: false };
+    case getType(operators.deletingResource):
+      return { ...state, isFetching: true };
+    case getType(operators.resourceDeleted):
+      return { ...state, isFetching: false };
+    case getType(operators.errorResourceDelete):
+      return { ...state, isFetching: false, errors: { delete: action.payload } };
     case getType(operators.errorResourceCreate):
       return { ...state, isFetching: false, errors: { create: action.payload } };
     case getType(operators.requestCustomResources):

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -119,3 +119,16 @@ it("get a resource", async () => {
     `api/kube/apis/v1/namespaces/${ns}/pods/foo`,
   ]);
 });
+
+it("deletes a resource", async () => {
+  const resource = { metadata: { name: "foo" } } as IResource;
+  const ns = "default";
+  axiosWithAuth.delete = jest.fn(() => {
+    return { data: resource };
+  });
+  expect(await Operators.deleteResource(ns, "v1", "pods", "foo")).toEqual(resource);
+  expect(axiosWithAuth.delete).toHaveBeenCalled();
+  expect((axiosWithAuth.delete as jest.Mock).mock.calls[0]).toEqual([
+    `api/kube/apis/v1/namespaces/${ns}/pods/foo`,
+  ]);
+});

--- a/dashboard/src/shared/Operators.ts
+++ b/dashboard/src/shared/Operators.ts
@@ -71,4 +71,16 @@ export class Operators {
     );
     return data;
   }
+
+  public static async deleteResource(
+    namespace: string,
+    apiVersion: string,
+    plural: string,
+    name: string,
+  ) {
+    const { data } = await axiosWithAuth.delete<any>(
+      urls.api.operators.resource(namespace, apiVersion, plural, name),
+    );
+    return data;
+  }
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of #1594. Reuses the ConfirmDialog component to delete an Operator instance:

![Peek 2020-03-19 16-55](https://user-images.githubusercontent.com/4025665/77087886-f371f780-6a03-11ea-948e-395fff2df22b.gif)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1552 

