### PR TITLE
Use namespace from the chart when rendering responses.

### DIFF
--- a/cmd/assetsvc/main_test.go
+++ b/cmd/assetsvc/main_test.go
@@ -67,11 +67,11 @@ func Test_GetCharts(t *testing.T) {
 	}{
 		{"no charts", []*models.Chart{}},
 		{"one chart", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1"}}}},
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1"}}}},
 		},
 		{"two charts", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}},
 	}
 
@@ -109,11 +109,11 @@ func Test_GetChartsInRepo(t *testing.T) {
 	}{
 		{"repo has no charts", "my-repo", []*models.Chart{}},
 		{"repo has one chart", "my-repo", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 		}},
 		{"repo has many charts", "my-repo", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}},
 	}
 
@@ -153,19 +153,19 @@ func Test_GetChartInRepo(t *testing.T) {
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{ID: "my-repo/my-chart"},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}
@@ -206,19 +206,19 @@ func Test_ListChartVersions(t *testing.T) {
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{ID: "my-repo/my-chart"},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}
@@ -259,19 +259,19 @@ func Test_GetChartVersion(t *testing.T) {
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -93,7 +93,7 @@ func main() {
 	// TODO(mnelson) remove this reverse proxy once the haproxy frontend
 	// proxies requests directly to the assetsvc. Move the authz to the
 	// assetsvc itself.
-	authGate := auth.AuthGate()
+	authGate := auth.AuthGate(kubeappsNamespace)
 	parsedAssetsvcURL, err := url.Parse(assetsvcURL)
 	if err != nil {
 		log.Fatalf("Unable to parse the assetsvc URL: %v", err)

--- a/cmd/tiller-proxy/internal/handler/handler_test.go
+++ b/cmd/tiller-proxy/internal/handler/handler_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package handler
 
 import (
-	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
@@ -453,11 +453,11 @@ func TestActions(t *testing.T) {
 		}
 		req := httptest.NewRequest("GET", fmt.Sprintf("http://foo.bar%s", test.RequestQuery), strings.NewReader(test.RequestBody))
 		if !test.DisableUserAuthCheck {
-			fauth := &authFake.FakeAuth{
-				ForbiddenActions: test.ForbiddenActions,
+			handler.CheckerForRequest = func(req *http.Request) (auth.Checker, error) {
+				return &authFake.FakeAuth{
+					ForbiddenActions: test.ForbiddenActions,
+				}, nil
 			}
-			ctx := context.WithValue(req.Context(), auth.UserKey, fauth)
-			req = req.WithContext(ctx)
 		}
 		response := httptest.NewRecorder()
 		// Perform request

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -152,6 +152,7 @@ func main() {
 	// HTTP Handler
 	h := handler.TillerProxy{
 		DisableUserAuthCheck: disableUserAuthCheck,
+		CheckerForRequest:    auth.AuthCheckerForRequest,
 		ListLimit:            listLimit,
 		ChartClient:          chartClient,
 		ProxyClient:          proxy,

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -149,8 +149,6 @@ func main() {
 	r.Handle("/live", health)
 	r.Handle("/ready", health)
 
-	authGate := auth.AuthGate()
-
 	// HTTP Handler
 	h := handler.TillerProxy{
 		DisableUserAuthCheck: disableUserAuthCheck,
@@ -161,30 +159,12 @@ func main() {
 
 	// Routes
 	apiv1 := r.PathPrefix("/v1").Subrouter()
-	apiv1.Methods("GET").Path("/releases").Handler(negroni.New(
-		authGate,
-		negroni.Wrap(handlerutil.WithoutParams(h.ListAllReleases)),
-	))
-	apiv1.Methods("GET").Path("/namespaces/{namespace}/releases").Handler(negroni.New(
-		authGate,
-		negroni.Wrap(handlerutil.WithParams(h.ListReleases)),
-	))
-	apiv1.Methods("POST").Path("/namespaces/{namespace}/releases").Handler(negroni.New(
-		authGate,
-		negroni.Wrap(handlerutil.WithParams(h.CreateRelease)),
-	))
-	apiv1.Methods("GET").Path("/namespaces/{namespace}/releases/{releaseName}").Handler(negroni.New(
-		authGate,
-		negroni.Wrap(handlerutil.WithParams(h.GetRelease)),
-	))
-	apiv1.Methods("PUT").Path("/namespaces/{namespace}/releases/{releaseName}").Handler(negroni.New(
-		authGate,
-		negroni.Wrap(handlerutil.WithParams(h.OperateRelease)),
-	))
-	apiv1.Methods("DELETE").Path("/namespaces/{namespace}/releases/{releaseName}").Handler(negroni.New(
-		authGate,
-		negroni.Wrap(handlerutil.WithParams(h.DeleteRelease)),
-	))
+	apiv1.Methods("GET").Path("/releases").Handler(handlerutil.WithoutParams(h.ListAllReleases))
+	apiv1.Methods("GET").Path("/namespaces/{namespace}/releases").Handler(handlerutil.WithParams(h.ListReleases))
+	apiv1.Methods("POST").Path("/namespaces/{namespace}/releases").Handler(handlerutil.WithParams(h.CreateRelease))
+	apiv1.Methods("GET").Path("/namespaces/{namespace}/releases/{releaseName}").Handler(handlerutil.WithParams(h.GetRelease))
+	apiv1.Methods("PUT").Path("/namespaces/{namespace}/releases/{releaseName}").Handler(handlerutil.WithParams(h.OperateRelease))
+	apiv1.Methods("DELETE").Path("/namespaces/{namespace}/releases/{releaseName}").Handler(handlerutil.WithParams(h.DeleteRelease))
 
 	// Backend routes unrelated to tiller-proxy functionality.
 	err = backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter())
@@ -204,9 +184,8 @@ func main() {
 	assetsvcPrefix := "/assetsvc"
 	assetsvcRouter := r.PathPrefix(assetsvcPrefix).Subrouter()
 	// Logos don't require authentication so bypass that step
-	assetsvcRouter.Methods("GET").Path("/v1/ns/{ns}/assets/{repo}/{id}/logo").Handler(negroni.New(
-		negroni.Wrap(http.StripPrefix(assetsvcPrefix, assetsvcProxy)),
-	))
+	assetsvcRouter.Methods("GET").Path("/v1/ns/{ns}/assets/{repo}/{id}/logo").Handler(http.StripPrefix(assetsvcPrefix, assetsvcProxy))
+	authGate := auth.AuthGate(kubeappsNamespace)
 	assetsvcRouter.PathPrefix("/v1/ns/{namespace}/").Handler(negroni.New(
 		authGate,
 		negroni.Wrap(http.StripPrefix(assetsvcPrefix, assetsvcProxy)),

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -96,6 +96,7 @@ type Action struct {
 // Checker for the exported funcs
 type Checker interface {
 	Validate() error
+	ValidateForNamespace(namespace string) (bool, error)
 	GetForbiddenActions(namespace, action, manifest string) ([]Action, error)
 }
 

--- a/pkg/auth/authgate.go
+++ b/pkg/auth/authgate.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -12,14 +11,20 @@ import (
 	"github.com/urfave/negroni"
 )
 
-// Context key type for request contexts
-type contextKey int
-
-// UserKey is the context key for the User data in the request context
-const UserKey contextKey = 0
-
 // tokenPrefix is the string preceding the token in the Authorization header.
 const tokenPrefix = "Bearer "
+
+// CheckerForRequest defines a function type so we can also inject a fake for tests
+// rather than setting a context value.
+type CheckerForRequest func(req *http.Request) (Checker, error)
+
+func AuthCheckerForRequest(req *http.Request) (Checker, error) {
+	token := ExtractToken(req.Header.Get("Authorization"))
+	if token == "" {
+		return nil, fmt.Errorf("Authorization token missing")
+	}
+	return NewAuth(token)
+}
 
 // AuthGate implements middleware to check if the user has access to read from
 // the specific namespace before continuing.
@@ -30,14 +35,9 @@ const tokenPrefix = "Bearer "
 //     we allow read access regardless.
 func AuthGate(kubeappsNamespace string) negroni.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-		token := ExtractToken(req.Header.Get("Authorization"))
-		if token == "" {
-			response.NewErrorResponse(http.StatusUnauthorized, "Unauthorized").Write(w)
-			return
-		}
-		userAuth, err := NewAuth(token)
+		userAuth, err := AuthCheckerForRequest(req)
 		if err != nil {
-			response.NewErrorResponse(http.StatusInternalServerError, err.Error()).Write(w)
+			response.NewErrorResponse(http.StatusUnauthorized, err.Error()).Write(w)
 			return
 		}
 		namespace := mux.Vars(req)["namespace"]
@@ -62,8 +62,7 @@ func AuthGate(kubeappsNamespace string) negroni.HandlerFunc {
 			response.NewErrorResponse(http.StatusUnauthorized, msg).Write(w)
 			return
 		}
-		ctx := context.WithValue(req.Context(), UserKey, userAuth)
-		next(w, req.WithContext(ctx))
+		next(w, req)
 	}
 }
 

--- a/pkg/auth/fake/auth.go
+++ b/pkg/auth/fake/auth.go
@@ -28,6 +28,10 @@ func (f *FakeAuth) Validate() error {
 	return nil
 }
 
+func (f *FakeAuth) ValidateForNamespace(namespace string) (bool, error) {
+	return true, nil
+}
+
 func (f *FakeAuth) GetForbiddenActions(namespace, action, manifest string) ([]authUtils.Action, error) {
 	return f.ForbiddenActions, nil
 }

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -34,7 +34,10 @@ deploy-dev: deploy-dex deploy-openldap update-apiserver-etc-hosts
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
 		--set useHelm3=true \
+		--set allowNamespaceDiscovery=true \
 		--set postgresql.enabled=true \
+		--set postgresql.volumePermissions.enabled=false \
+		--set postgresql.volumePermissions.image.pullPolicy=IfNotPresent \
 		--set featureFlags.reposPerNamespace=true \
 		--set featureFlags.invalidateCache=true \
 		--set mongodb.enabled=false

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -36,8 +36,6 @@ deploy-dev: deploy-dex deploy-openldap update-apiserver-etc-hosts
 		--set useHelm3=true \
 		--set allowNamespaceDiscovery=true \
 		--set postgresql.enabled=true \
-		--set postgresql.volumePermissions.enabled=false \
-		--set postgresql.volumePermissions.image.pullPolicy=IfNotPresent \
 		--set featureFlags.reposPerNamespace=true \
 		--set featureFlags.invalidateCache=true \
 		--set mongodb.enabled=false


### PR DESCRIPTION
Ref #1521. A lot of churn, but only three real changes:

1. Remove the AuthGate from tiller proxy (as discussed yesterday, tiller-proxy checks the user auth explicitly in the handlers), which allows us to restrict it to the assetsvc use-case. (EDIT: CI showed that this also required removing the implicit passing of values via the request context which the AuthGate set, now removed, as it's not particularly type-safe).
2. Update AuthGate to allow access to the global repositories via the assetsvc (ie. in kubeapps' own namespace)
3. Ensure the assetsvc uses the namespace of the chart when rendering results, rather than the requested namespace for the query, since we're including the global charts in a request for specific namespaces and we need icons and other links to match the asset.

Unrelated: When do you think we could switch the default for `allowNamespaceDiscovery` to true?