### PR TITLE
1521 remove disable auth check

### DIFF
--- a/cmd/tiller-proxy/README.md
+++ b/cmd/tiller-proxy/README.md
@@ -12,7 +12,6 @@ It is possible to configure this proxy with the following flags:
 
 ```
       --debug                           enable verbose output
-      --disable-auth                    Disable authorization check
       --home string                     location of your Helm config. Overrides $HELM_HOME (default "/root/.helm")
       --host string                     address of Tiller. Overrides $HELM_HOST
       --kube-context string             name of the kubeconfig context to use

--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -43,13 +43,10 @@ func returnForbiddenActions(forbiddenActions []auth.Action, w http.ResponseWrite
 
 // TillerProxy client and configuration
 type TillerProxy struct {
-	// TODO(mnelson): was DisableUserAuthCheck just an initial compatibility flag when the auth check
-	// was added? (ie. can it be removed).
-	DisableUserAuthCheck bool
-	CheckerForRequest    auth.CheckerForRequest
-	ListLimit            int
-	ChartClient          chartUtils.Resolver
-	ProxyClient          proxy.TillerClient
+	CheckerForRequest auth.CheckerForRequest
+	ListLimit         int
+	ChartClient       chartUtils.Resolver
+	ProxyClient       proxy.TillerClient
 }
 
 func (h *TillerProxy) logStatus(name string) {
@@ -70,26 +67,24 @@ func (h *TillerProxy) CreateRelease(w http.ResponseWriter, req *http.Request, pa
 		return
 	}
 	ch := chartMulti.Helm2Chart
-	if !h.DisableUserAuthCheck {
-		manifest, err := h.ProxyClient.ResolveManifest(params["namespace"], chartDetails.Values, ch)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		userAuth, err := h.CheckerForRequest(req)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "create", manifest)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		if len(forbiddenActions) > 0 {
-			returnForbiddenActions(forbiddenActions, w)
-			return
-		}
+	manifest, err := h.ProxyClient.ResolveManifest(params["namespace"], chartDetails.Values, ch)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	userAuth, err := h.CheckerForRequest(req)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "create", manifest)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	if len(forbiddenActions) > 0 {
+		returnForbiddenActions(forbiddenActions, w)
+		return
 	}
 	rel, err := h.ProxyClient.CreateRelease(chartDetails.ReleaseName, params["namespace"], chartDetails.Values, ch)
 	if err != nil {
@@ -129,27 +124,25 @@ func (h *TillerProxy) RollbackRelease(w http.ResponseWriter, req *http.Request, 
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return
 	}
-	if !h.DisableUserAuthCheck {
-		manifest, err := h.ProxyClient.ResolveManifestFromRelease(params["releaseName"], int32(revisionInt))
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		userAuth, err := h.CheckerForRequest(req)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		// Using "upgrade" action since the concept is the same
-		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "upgrade", manifest)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		if len(forbiddenActions) > 0 {
-			returnForbiddenActions(forbiddenActions, w)
-			return
-		}
+	manifest, err := h.ProxyClient.ResolveManifestFromRelease(params["releaseName"], int32(revisionInt))
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	userAuth, err := h.CheckerForRequest(req)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	// Using "upgrade" action since the concept is the same
+	forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "upgrade", manifest)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	if len(forbiddenActions) > 0 {
+		returnForbiddenActions(forbiddenActions, w)
+		return
 	}
 	rel, err := h.ProxyClient.RollbackRelease(params["releaseName"], params["namespace"], int32(revisionInt))
 	if err != nil {
@@ -170,26 +163,24 @@ func (h *TillerProxy) UpgradeRelease(w http.ResponseWriter, req *http.Request, p
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return
 	}
-	if !h.DisableUserAuthCheck {
-		manifest, err := h.ProxyClient.ResolveManifest(params["namespace"], chartDetails.Values, ch)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		userAuth, err := h.CheckerForRequest(req)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "upgrade", manifest)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		if len(forbiddenActions) > 0 {
-			returnForbiddenActions(forbiddenActions, w)
-			return
-		}
+	manifest, err := h.ProxyClient.ResolveManifest(params["namespace"], chartDetails.Values, ch)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	userAuth, err := h.CheckerForRequest(req)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "upgrade", manifest)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	if len(forbiddenActions) > 0 {
+		returnForbiddenActions(forbiddenActions, w)
+		return
 	}
 	rel, err := h.ProxyClient.UpdateRelease(params["releaseName"], params["namespace"], chartDetails.Values, ch)
 	if err != nil {
@@ -224,23 +215,21 @@ func (h *TillerProxy) ListReleases(w http.ResponseWriter, req *http.Request, par
 // TestRelease in the namespace given as Param
 func (h *TillerProxy) TestRelease(w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
 
-	if !h.DisableUserAuthCheck {
-		userAuth, err := h.CheckerForRequest(req)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		// helm tests only create pods so we only need to check that
-		manifest := "apiVersion: v1\nkind: Pod"
-		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "create", manifest)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		if len(forbiddenActions) > 0 {
-			returnForbiddenActions(forbiddenActions, w)
-			return
-		}
+	userAuth, err := h.CheckerForRequest(req)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	// helm tests only create pods so we only need to check that
+	manifest := "apiVersion: v1\nkind: Pod"
+	forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "create", manifest)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	if len(forbiddenActions) > 0 {
+		returnForbiddenActions(forbiddenActions, w)
+		return
 	}
 
 	testResult, err := h.ProxyClient.TestRelease(params["releaseName"], params["namespace"])
@@ -258,60 +247,56 @@ func (h *TillerProxy) GetRelease(w http.ResponseWriter, req *http.Request, param
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return
 	}
-	if !h.DisableUserAuthCheck {
-		manifest, err := h.ProxyClient.ResolveManifest(params["namespace"], rel.Config.Raw, rel.Chart)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		userAuth, err := h.CheckerForRequest(req)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "get", manifest)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		if len(forbiddenActions) > 0 {
-			returnForbiddenActions(forbiddenActions, w)
-			return
-		}
+	manifest, err := h.ProxyClient.ResolveManifest(params["namespace"], rel.Config.Raw, rel.Chart)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	userAuth, err := h.CheckerForRequest(req)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "get", manifest)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	if len(forbiddenActions) > 0 {
+		returnForbiddenActions(forbiddenActions, w)
+		return
 	}
 	response.NewDataResponse(*rel).Write(w)
 }
 
 // DeleteRelease removes a release from a namespace
 func (h *TillerProxy) DeleteRelease(w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
-	if !h.DisableUserAuthCheck {
-		rel, err := h.ProxyClient.GetRelease(params["releaseName"], params["namespace"])
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		manifest, err := h.ProxyClient.ResolveManifest(params["namespace"], rel.Config.Raw, rel.Chart)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		userAuth, err := h.CheckerForRequest(req)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "delete", manifest)
-		if err != nil {
-			response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
-			return
-		}
-		if len(forbiddenActions) > 0 {
-			returnForbiddenActions(forbiddenActions, w)
-			return
-		}
+	rel, err := h.ProxyClient.GetRelease(params["releaseName"], params["namespace"])
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	manifest, err := h.ProxyClient.ResolveManifest(params["namespace"], rel.Config.Raw, rel.Chart)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	userAuth, err := h.CheckerForRequest(req)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	forbiddenActions, err := userAuth.GetForbiddenActions(params["namespace"], "delete", manifest)
+	if err != nil {
+		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
+		return
+	}
+	if len(forbiddenActions) > 0 {
+		returnForbiddenActions(forbiddenActions, w)
+		return
 	}
 	purge := handlerutil.QueryParamIsTruthy("purge", req)
-	err := h.ProxyClient.DeleteRelease(params["releaseName"], params["namespace"], purge)
+	err = h.ProxyClient.DeleteRelease(params["releaseName"], params["namespace"], purge)
 	if err != nil {
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -47,12 +47,11 @@ import (
 )
 
 var (
-	settings             environment.EnvSettings
-	proxy                *tillerProxy.Proxy
-	kubeClient           kubernetes.Interface
-	disableUserAuthCheck bool
-	listLimit            int
-	timeout              int64
+	settings   environment.EnvSettings
+	proxy      *tillerProxy.Proxy
+	kubeClient kubernetes.Interface
+	listLimit  int
+	timeout    int64
 
 	tlsCaCertFile string // path to TLS CA certificate file
 	tlsCertFile   string // path to TLS certificate file
@@ -75,7 +74,6 @@ func init() {
 	pflag.StringVar(&tlsKeyFile, "tls-key", tlsKeyDefault, "path to TLS key file")
 	pflag.BoolVar(&tlsVerify, "tls-verify", false, "enable TLS for request and verify remote")
 	pflag.BoolVar(&tlsEnable, "tls", false, "enable TLS for request")
-	pflag.BoolVar(&disableUserAuthCheck, "disable-auth", false, "Disable authorization check")
 	pflag.IntVar(&listLimit, "list-max", 256, "maximum number of releases to fetch")
 	pflag.StringVar(&userAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
 	// Default timeout from https://github.com/helm/helm/blob/b0b0accdfc84e154b3d48ec334cd5b4f9b345667/cmd/helm/install.go#L216
@@ -151,11 +149,10 @@ func main() {
 
 	// HTTP Handler
 	h := handler.TillerProxy{
-		DisableUserAuthCheck: disableUserAuthCheck,
-		CheckerForRequest:    auth.AuthCheckerForRequest,
-		ListLimit:            listLimit,
-		ChartClient:          chartClient,
-		ProxyClient:          proxy,
+		CheckerForRequest: auth.AuthCheckerForRequest,
+		ListLimit:         listLimit,
+		ChartClient:       chartClient,
+		ProxyClient:       proxy,
 	}
 
 	// Routes

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -38,7 +38,6 @@ type resource struct {
 }
 
 type k8sAuthInterface interface {
-	Validate() error
 	GetResourceList(groupVersion string) (*metav1.APIResourceList, error)
 	CanI(verb, group, resource, namespace string) (bool, error)
 }
@@ -46,15 +45,6 @@ type k8sAuthInterface interface {
 type k8sAuth struct {
 	AuthCli      authorizationv1.AuthorizationV1Interface
 	DiscoveryCli discovery.DiscoveryInterface
-}
-
-func (u k8sAuth) Validate() error {
-	_, err := u.AuthCli.SelfSubjectRulesReviews().Create(&authorizationapi.SelfSubjectRulesReview{
-		Spec: authorizationapi.SelfSubjectRulesReviewSpec{
-			Namespace: "default",
-		},
-	})
-	return err
 }
 
 func (u k8sAuth) GetResourceList(groupVersion string) (*metav1.APIResourceList, error) {
@@ -95,7 +85,6 @@ type Action struct {
 
 // Checker for the exported funcs
 type Checker interface {
-	Validate() error
 	ValidateForNamespace(namespace string) (bool, error)
 	GetForbiddenActions(namespace, action, manifest string) ([]Action, error)
 }
@@ -121,11 +110,6 @@ func NewAuth(token string) (*UserAuth, error) {
 	}
 
 	return &UserAuth{k8sAuthCli}, nil
-}
-
-// Validate checks if the given token is valid
-func (u *UserAuth) Validate() error {
-	return u.k8sAuth.Validate()
 }
 
 // ValidateForNamespace checks if the user can access secrets in the given


### PR DESCRIPTION
Follow-up of #1596 (ref #1521), this PR:

1. Removes the `--disable-auth` flag and functionality
2. DRY up the tiller-proxy authz in the handlers
3. Removes the `Checker.Validate()` method from the interface, as its no longer used after 1596.