### PR TITLE
Add ApplicationStatus and resource tables to the OpeartorInstance

### DIFF
--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
@@ -2,15 +2,15 @@ import * as React from "react";
 
 import ResourceRef from "shared/ResourceRef";
 import LoadingWrapper, { LoaderType } from "../../../components/LoadingWrapper";
-import { IKubeItem, IResource, IServiceSpec } from "../../../shared/types";
+import { IK8sList, IKubeItem, IResource, IServiceSpec } from "../../../shared/types";
 import isSomeResourceLoading from "../helpers";
 import AccessURLItem from "./AccessURLItem";
 import { GetURLItemFromIngress } from "./AccessURLItem/AccessURLIngressHelper";
 import { GetURLItemFromService } from "./AccessURLItem/AccessURLServiceHelper";
 
 interface IAccessURLTableProps {
-  services: Array<IKubeItem<IResource>>;
-  ingresses: Array<IKubeItem<IResource>>;
+  services: Array<IKubeItem<IResource | IK8sList<IResource, {}>>>;
+  ingresses: Array<IKubeItem<IResource | IK8sList<IResource, {}>>>;
   ingressRefs: ResourceRef[];
   getResource: (r: ResourceRef) => void;
 }
@@ -46,9 +46,18 @@ class AccessURLTable extends React.Component<IAccessURLTableProps> {
     const publicServices: Array<IKubeItem<IResource>> = [];
     services.forEach(s => {
       if (s.item) {
-        const spec = s.item.spec as IServiceSpec;
-        if (spec.type === "LoadBalancer") {
-          publicServices.push(s);
+        const listItem = s.item as IK8sList<IResource, {}>;
+        if (listItem.items) {
+          listItem.items.forEach(item => {
+            if (item.spec.type === "LoadBalancer") {
+              publicServices.push({ isFetching: false, item });
+            }
+          });
+        } else {
+          const spec = (s.item as IResource).spec as IServiceSpec;
+          if (spec.type === "LoadBalancer") {
+            publicServices.push(s as IKubeItem<IResource>);
+          }
         }
       }
     });
@@ -81,7 +90,7 @@ class AccessURLTable extends React.Component<IAccessURLTableProps> {
     return accessTableSection;
   }
 
-  private renderTableEntry(i: IKubeItem<IResource>) {
+  private renderTableEntry(i: IKubeItem<IResource | IK8sList<IResource, {}>>) {
     if (i.error) {
       return (
         <tr key={i.error.message}>
@@ -90,11 +99,19 @@ class AccessURLTable extends React.Component<IAccessURLTableProps> {
       );
     }
     if (i.item) {
-      const urlItem =
-        i.item.kind === "Ingress" ? GetURLItemFromIngress(i.item) : GetURLItemFromService(i.item);
-      return <AccessURLItem key={`accessURL/${i.item.metadata.name}`} URLItem={urlItem} />;
+      const listItem = i.item as IK8sList<IResource, {}>;
+      if (listItem.items) {
+        return listItem.items.map(item => this.renderURLItem(item));
+      } else {
+        return this.renderURLItem(i.item as IResource);
+      }
     }
     return;
+  }
+
+  private renderURLItem(i: IResource) {
+    const urlItem = i.kind === "Ingress" ? GetURLItemFromIngress(i) : GetURLItemFromService(i);
+    return <AccessURLItem key={`accessURL/${i.metadata.name}`} URLItem={urlItem} />;
   }
 
   private fetchIngresses() {

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -39,7 +39,7 @@ interface IAppViewState {
   manifest: IResource[];
 }
 
-interface IPartialAppViewState {
+export interface IPartialAppViewState {
   deployRefs: ResourceRef[];
   statefulSetRefs: ResourceRef[];
   daemonSetRefs: ResourceRef[];

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.test.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 
 import itBehavesLike from "../../../../shared/specs";
 import { IKubeItem, IResource } from "../../../../shared/types";
+import DeploymentItemRow from "./DeploymentItem/DeploymentItem";
 import ResourceTableItem from "./ResourceTableItem";
 
 const kubeItem: IKubeItem<IResource> = {
@@ -82,6 +83,7 @@ context("when there is a valid resouce", () => {
     const deployment = {
       metadata: {
         name: "foo",
+        selfLink: "/foo",
       },
       status: { replicas: 1, updatedReplicas: 1, availableReplicas: 1 },
     } as IResource;
@@ -89,6 +91,29 @@ context("when there is a valid resouce", () => {
     const wrapper = shallow(
       <ResourceTableItem {...defaultProps} resource={kubeItem} name={deployment.metadata.name} />,
     );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders info about the resource status when given a list", () => {
+    const deployment = {
+      metadata: {
+        name: "foo",
+        selfLink: "/deployments/foo",
+      },
+      status: { replicas: 1, updatedReplicas: 1, availableReplicas: 1 },
+    } as IResource;
+    const kubeList = {
+      isFetching: false,
+      item: { items: [deployment] },
+    };
+    const wrapper = shallow(
+      <ResourceTableItem
+        {...defaultProps}
+        resource={kubeList as any}
+        name={deployment.metadata.name}
+      />,
+    );
+    expect(wrapper.find(DeploymentItemRow)).toExist();
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/__snapshots__/ResourceTableItem.test.tsx.snap
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/__snapshots__/ResourceTableItem.test.tsx.snap
@@ -45,3 +45,26 @@ exports[`when there is a valid resouce renders info about the resource status 1`
   className="flex"
 />
 `;
+
+exports[`when there is a valid resouce renders info about the resource status when given a list 1`] = `
+<tr
+  className="flex"
+  key="/deployments/foo"
+>
+  <DeploymentItemRow
+    resource={
+      Object {
+        "metadata": Object {
+          "name": "foo",
+          "selfLink": "/deployments/foo",
+        },
+        "status": Object {
+          "availableReplicas": 1,
+          "replicas": 1,
+          "updatedReplicas": 1,
+        },
+      }
+    }
+  />
+</tr>
+`;

--- a/dashboard/src/components/AppView/ResourceTable/__snapshots__/ResourceTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/ResourceTable/__snapshots__/ResourceTable.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`renders a ResourceItem 1`] = `
         resourceRef={
           ResourceRef {
             "apiVersion": undefined,
+            "filter": undefined,
             "kind": "Deployment",
             "name": "foo",
             "namespace": "default",

--- a/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
+++ b/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
@@ -66,9 +66,30 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
             <div
               className="col-4"
             >
-              <h5>
-                foo-cluster
-              </h5>
+              <Connect(ApplicationStatus)
+                daemonsetRefs={Array []}
+                deployRefs={
+                  Array [
+                    ResourceRef {
+                      "apiVersion": "apps/v1",
+                      "filter": Object {
+                        "metadata": Object {
+                          "ownerReferences": Array [
+                            Object {
+                              "kind": "Foo",
+                              "name": "foo-instance",
+                            },
+                          ],
+                        },
+                      },
+                      "kind": "Deployment",
+                      "name": undefined,
+                      "namespace": "default",
+                    },
+                  ]
+                }
+                statefulsetRefs={Array []}
+              />
             </div>
             <div
               className="col-8 text-r"
@@ -87,10 +108,53 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
               />
             </div>
           </div>
+          <Connect(AccessURLTable)
+            ingressRefs={Array []}
+            serviceRefs={Array []}
+          />
           <AppNotes
             notes="alive: true
           "
             title="Status"
+          />
+          <ResourceTable
+            resourceRefs={Array []}
+            title="Secrets"
+          />
+          <ResourceTable
+            resourceRefs={
+              Array [
+                ResourceRef {
+                  "apiVersion": "apps/v1",
+                  "filter": Object {
+                    "metadata": Object {
+                      "ownerReferences": Array [
+                        Object {
+                          "kind": "Foo",
+                          "name": "foo-instance",
+                        },
+                      ],
+                    },
+                  },
+                  "kind": "Deployment",
+                  "name": undefined,
+                  "namespace": "default",
+                },
+              ]
+            }
+            title="Deployments"
+          />
+          <ResourceTable
+            resourceRefs={Array []}
+            title="StatefulSets"
+          />
+          <ResourceTable
+            resourceRefs={Array []}
+            title="DaemonSets"
+          />
+          <ResourceTable
+            resourceRefs={Array []}
+            title="Services"
           />
           <AppValues
             values="test: true

--- a/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
+++ b/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
@@ -23,7 +23,8 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    fetchCharts: (namespace: string, repo: string) => dispatch(actions.charts.fetchCharts(namespace, repo)),
+    fetchCharts: (namespace: string, repo: string) =>
+      dispatch(actions.charts.fetchCharts(namespace, repo)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
     getCSVs: (namespace: string) => dispatch(actions.operators.getCSVs(namespace)),
   };

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -58,6 +58,23 @@ describe("authReducer", () => {
       });
     });
 
+    it("receives an item from a list", () => {
+      const resource = {
+        metadata: { name: "foo", selfLink: "/foo" },
+        status: { ready: false },
+      } as IResource;
+      const payload = { key: "foo", resource: { ...resource, status: { ready: true } } };
+      const type = actionTypes.receiveResource as any;
+      const stateWithItems = {
+        ...initialState,
+        items: { foo: { isFetching: true, resource } },
+      };
+      expect(kubeReducer(stateWithItems, { type, payload })).toEqual({
+        ...initialState,
+        items: { foo: { isFetching: false, item: payload.resource } },
+      });
+    });
+
     describe("openWatchResource", () => {
       it("adds a new socket to the state for the requested resource", () => {
         const newState = kubeReducer(undefined, {

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -1,7 +1,8 @@
 import { Auth } from "./Auth";
 import { axiosWithAuth } from "./AxiosInstance";
+import { ResourceKindsWithAPIVersions } from "./ResourceAPIVersion";
 import { ResourceKind, ResourceKindsWithPlurals } from "./ResourceKinds";
-import { IResource } from "./types";
+import { IK8sList, IResource } from "./types";
 
 export const APIBase = "api/kube";
 export let WebSocketAPIBase: string;
@@ -61,7 +62,7 @@ export class Kube {
     name?: string,
     query?: string,
   ) {
-    const { data } = await axiosWithAuth.get<IResource>(
+    const { data } = await axiosWithAuth.get<IResource | IK8sList<IResource, {}>>(
       this.getResourceURL(apiVersion, resource, namespace, name, query),
     );
     return data;
@@ -87,5 +88,10 @@ export class Kube {
   // Gets the plural form of the resource Kind for use in the resource path
   public static resourcePlural(kind: ResourceKind) {
     return ResourceKindsWithPlurals[kind];
+  }
+
+  // Gets the plural form of the resource Kind for use in the resource path
+  public static resourceAPIVersion(kind: ResourceKind) {
+    return ResourceKindsWithAPIVersions[kind];
   }
 }

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -90,7 +90,7 @@ export class Kube {
     return ResourceKindsWithPlurals[kind];
   }
 
-  // Gets the plural form of the resource Kind for use in the resource path
+  // Gets the apiVersion of the resource Kind for use in the resource path
   public static resourceAPIVersion(kind: ResourceKind) {
     return ResourceKindsWithAPIVersions[kind];
   }

--- a/dashboard/src/shared/ResourceAPIVersion.ts
+++ b/dashboard/src/shared/ResourceAPIVersion.ts
@@ -1,0 +1,15 @@
+// We explicitly define the apiVersions here, just in case a generic pluralizer
+// isn't sufficient. Note that apiVersions may change over time.
+export const ResourceKindsWithAPIVersions = {
+  ClusterRole: "rbac.authorization.k8s.io/v1",
+  ConfigMap: "v1",
+  DaemonSet: "apps/v1",
+  Deployment: "apps/v1",
+  Ingress: "extensions/v1beta1",
+  Secret: "v1",
+  Service: "v1",
+  StatefulSet: "apps/v1",
+  Pods: "v1",
+} as const;
+
+export type ResourceAPIVersion = keyof typeof ResourceKindsWithAPIVersions;

--- a/dashboard/src/shared/ResourceKinds.ts
+++ b/dashboard/src/shared/ResourceKinds.ts
@@ -11,6 +11,7 @@ export const ResourceKindsWithPlurals = {
   Secret: "secrets",
   Service: "services",
   StatefulSet: "statefulsets",
+  Pod: "pods",
 } as const;
 
 export type ResourceKind = keyof typeof ResourceKindsWithPlurals;

--- a/dashboard/src/shared/ResourceRef.ts
+++ b/dashboard/src/shared/ResourceRef.ts
@@ -1,6 +1,22 @@
+import { filter, matches } from "lodash";
 import { Kube } from "./Kube";
 import { ResourceKind } from "./ResourceKinds";
-import { IResource } from "./types";
+import { IClusterServiceVersionCRDResource, IK8sList, IResource } from "./types";
+
+export function fromCRD(
+  r: IClusterServiceVersionCRDResource,
+  namespace: string,
+  ownerReference: any,
+) {
+  const resource = {
+    apiVersion: Kube.resourceAPIVersion(r.kind as ResourceKind),
+    kind: r.kind,
+    metadata: {
+      name: r.name,
+    },
+  } as IResource;
+  return new ResourceRef(resource, namespace, { metadata: { ownerReferences: [ownerReference] } });
+}
 
 // ResourceRef defines a reference to a namespaced Kubernetes API Object and
 // provides helpers to retrieve the resource URL
@@ -9,12 +25,13 @@ class ResourceRef {
   public kind: ResourceKind;
   public name: string;
   public namespace: string;
+  public filter: any;
 
   // Creates a new ResourceRef instance from an existing IResource. Provide
   // defaultNamespace to set if the IResource doesn't specify a namespace.
   // TODO: add support for cluster-scoped resources, or add a ClusterResourceRef
   // class.
-  constructor(r: IResource, defaultNamespace?: string) {
+  constructor(r: IResource, defaultNamespace?: string, defaultFilter?: any) {
     this.apiVersion = r.apiVersion;
     this.kind = r.kind;
     this.name = r.metadata.name;
@@ -23,6 +40,7 @@ class ResourceRef {
       throw new Error(`Namespace missing for resource ${this.name}, define a default namespace`);
     }
     this.namespace = namespace;
+    this.filter = defaultFilter;
     return this;
   }
 
@@ -45,13 +63,19 @@ class ResourceRef {
     );
   }
 
-  public getResource() {
-    return Kube.getResource(
+  public async getResource() {
+    const resource = await Kube.getResource(
       this.apiVersion,
       Kube.resourcePlural(this.kind),
       this.namespace,
       this.name,
     );
+    const resourceList = resource as IK8sList<IResource, {}>;
+    if (resourceList.items) {
+      resourceList.items = filter(resourceList.items, matches(this.filter));
+      return resourceList;
+    }
+    return resource;
   }
 
   // Opens and returns a WebSocket for the requested resource. Note: it is

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -266,17 +266,19 @@ export interface IPackageManifest extends IResource {
   status: IPackageManifestStatus;
 }
 
+export interface IClusterServiceVersionCRDResource {
+  kind: string;
+  name: string;
+  version: string;
+}
+
 export interface IClusterServiceVersionCRD {
   description: string;
   displayName: string;
   kind: string;
   name: string;
   version: string;
-  resources: Array<{
-    kind: string;
-    name: string;
-    version: string;
-  }>;
+  resources: IClusterServiceVersionCRDResource[];
   specDescriptors: Array<{
     description: string;
     displayName: string;
@@ -510,7 +512,7 @@ export interface IKubeItem<T> {
 }
 
 export interface IKubeState {
-  items: { [s: string]: IKubeItem<IResource> };
+  items: { [s: string]: IKubeItem<IResource | IK8sList<IResource, {}>> };
   sockets: { [s: string]: { socket: WebSocket; closeTimer: () => void } };
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Show the ApplicationStatus along with the AccessURL table and all the other resource tables:

![Screenshot from 2020-03-23 19-09-28](https://user-images.githubusercontent.com/4025665/77349115-d35f7280-6d3a-11ea-9ab4-a982c752ad00.png)

The CRD doesn't have a specific reference to the resources it will create, instead it just list the different Kinds that it will create (e.g. Service, Deployment). Because of that, we need to list all those resources in the given namespace and filter out the ones that doesn't have the Custom Resource as owner.

There are several minor things that I found while working on this that require special attention:

 - When getting and watching a list of resources, first you get the resource list (e.g. DeploymentList) but then, you receive individual responses for each of the resoucers (e.g a Deployment) not the full list again.
 - When getting a list (e.g. DeploymentList) the resources within the list doesn't include its `kind` (I guess it's assumed from the list) so we cannot rely in that property. I am using the `selfLink` in this PR instead.

I may be missing more things to explain, please let me know if there is something that it's difficult to understand.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1552 
