### PR TITLE
Avoid re-auth on All Namespaces when selecting catalog

### DIFF
--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -4,7 +4,7 @@ import { ThunkAction } from "redux-thunk";
 import { ActionType, createAction } from "typesafe-actions";
 
 import Chart from "../shared/Chart";
-import { IChart, IChartVersion, IStoreState, NotFoundError } from "../shared/types";
+import { ForbiddenError, IChart, IChartVersion, IStoreState, NotFoundError } from "../shared/types";
 
 export const requestCharts = createAction("REQUEST_CHARTS");
 
@@ -63,6 +63,8 @@ export type ChartsAction = ActionType<typeof allActions[number]>;
 function dispatchError(dispatch: Dispatch, err: Error) {
   if (err.message.match("could not find")) {
     dispatch(errorChart(new NotFoundError(err.message)));
+  } else if (err.message.match("Unable to validate user")) {
+    dispatch(errorChart(new ForbiddenError(err.message)));
   } else {
     dispatch(errorChart(err));
   }

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -3,7 +3,7 @@ import context from "jest-plugin-context";
 import * as React from "react";
 
 import itBehavesLike from "../../shared/specs";
-import { IChart, IChartState } from "../../shared/types";
+import { ForbiddenError, IChart, IChartState } from "../../shared/types";
 import { CardGrid } from "../Card";
 import { MessageAlert } from "../ErrorAlert";
 import PageHeader from "../PageHeader";
@@ -100,7 +100,7 @@ describe("renderization", () => {
   });
 
   context("when there is an error fetching charts", () => {
-    it("should render an error", () => {
+    it("should render a generic error", () => {
       const props = {
         ...defaultProps,
         charts: {
@@ -114,12 +114,35 @@ describe("renderization", () => {
       const wrapper = shallow(<Catalog {...props} />);
       expect(wrapper.find(MessageAlert)).toExist();
       expect(wrapper.find(".Catalog")).not.toExist();
-      expect(
-        wrapper
-          .find(MessageAlert)
-          .children()
-          .text(),
-      ).toContain("Unable to fetch catalog");
+      const errText = wrapper
+        .find(MessageAlert)
+        .children()
+        .text();
+      expect(errText).toContain("Unable to fetch catalog");
+      expect(errText).not.toContain("Please choose a namespace");
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it("should render a specific error for a forbidden error", () => {
+      const props = {
+        ...defaultProps,
+        charts: {
+          ...defaultProps.charts,
+          selected: {
+            ...defaultProps.charts.selected,
+            error: new ForbiddenError("Bang!"),
+          },
+        },
+      };
+      const wrapper = shallow(<Catalog {...props} />);
+      expect(wrapper.find(MessageAlert)).toExist();
+      expect(wrapper.find(".Catalog")).not.toExist();
+      const errText = wrapper
+        .find(MessageAlert)
+        .children()
+        .text();
+      expect(errText).toContain("Unable to fetch catalog");
+      expect(errText).toContain("Please choose a namespace");
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -99,10 +99,35 @@ describe("renderization", () => {
     });
   });
 
+  context("when there is an error fetching charts", () => {
+    it("should render an error", () => {
+      const props = {
+        ...defaultProps,
+        charts: {
+          ...defaultProps.charts,
+          selected: {
+            ...defaultProps.charts.selected,
+            error: new Error("Bang!"),
+          },
+        },
+      };
+      const wrapper = shallow(<Catalog {...props} />);
+      expect(wrapper.find(MessageAlert)).toExist();
+      expect(wrapper.find(".Catalog")).not.toExist();
+      expect(
+        wrapper
+          .find(MessageAlert)
+          .children()
+          .text(),
+      ).toContain("Unable to fetch catalog");
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
   context("when fetching apps", () => {
     itBehavesLike("aLoadingComponent", {
       component: Catalog,
-      props: { ...defaultProps, charts: { isFetching: true, items: [] } },
+      props: { ...defaultProps, charts: { isFetching: true, items: [], selected: {} } },
     });
   });
 

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -65,7 +65,7 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
     } = this.props;
     const { listCharts, listOperators } = this.state;
     if (error) {
-      const isForbidden = error.constructor == ForbiddenError;
+      const isForbidden = error.constructor === ForbiddenError;
       return (
         <MessageAlert
           level={"error"}

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -2,7 +2,7 @@ import { RouterAction } from "connected-react-router";
 import * as React from "react";
 import { Link } from "react-router-dom";
 
-import { IChart, IChartState, IClusterServiceVersion } from "../../shared/types";
+import { ForbiddenError, IChart, IChartState, IClusterServiceVersion } from "../../shared/types";
 import { escapeRegExp } from "../../shared/utils";
 import { CardGrid } from "../Card";
 import { MessageAlert } from "../ErrorAlert";
@@ -65,13 +65,14 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
     } = this.props;
     const { listCharts, listOperators } = this.state;
     if (error) {
+      const isForbidden = error.constructor == ForbiddenError;
       return (
         <MessageAlert
           level={"error"}
           children={
             <div>
               <h5>Unable to fetch catalog</h5>
-              There was an error fetching the catalog. Please choose a namespace above to which you have access.
+              There was an error fetching the catalog.{ isForbidden && "Please choose a namespace above to which you have access." }
             </div>
           }
         />

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -59,11 +59,24 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
 
   public render() {
     const {
-      charts: { isFetching, items: allItems },
+      charts: { isFetching, selected: { error }, items: allItems },
       pushSearchFilter,
       csvs,
     } = this.props;
     const { listCharts, listOperators } = this.state;
+    if (error) {
+      return (
+        <MessageAlert
+          level={"error"}
+          children={
+            <div>
+              <h5>Unable to fetch catalog</h5>
+              There was an error fetching the catalog. Please choose a namespace above to which you have access.
+            </div>
+          }
+        />
+      );
+    }
     if (!isFetching && allItems.length === 0) {
       return (
         <MessageAlert

--- a/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
@@ -116,3 +116,16 @@ exports[`renderization when no charts should render an error 1`] = `
   </div>
 </MessageAlertPage>
 `;
+
+exports[`renderization when there is an error fetching charts should render an error 1`] = `
+<MessageAlertPage
+  level="error"
+>
+  <div>
+    <h5>
+      Unable to fetch catalog
+    </h5>
+    There was an error fetching the catalog. Please choose a namespace above to which you have access.
+  </div>
+</MessageAlertPage>
+`;

--- a/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`renderization when no charts should render an error 1`] = `
 </MessageAlertPage>
 `;
 
-exports[`renderization when there is an error fetching charts should render an error 1`] = `
+exports[`renderization when there is an error fetching charts should render a generic error 1`] = `
 <MessageAlertPage
   level="error"
 >
@@ -125,7 +125,21 @@ exports[`renderization when there is an error fetching charts should render an e
     <h5>
       Unable to fetch catalog
     </h5>
-    There was an error fetching the catalog. Please choose a namespace above to which you have access.
+    There was an error fetching the catalog.
+  </div>
+</MessageAlertPage>
+`;
+
+exports[`renderization when there is an error fetching charts should render a specific error for a forbidden error 1`] = `
+<MessageAlertPage
+  level="error"
+>
+  <div>
+    <h5>
+      Unable to fetch catalog
+    </h5>
+    There was an error fetching the catalog.
+    Please choose a namespace above to which you have access.
   </div>
 </MessageAlertPage>
 `;

--- a/dashboard/src/reducers/charts.test.ts
+++ b/dashboard/src/reducers/charts.test.ts
@@ -1,0 +1,58 @@
+import { getType } from "typesafe-actions";
+import actions from "../actions";
+
+import { IChartState } from "../shared/types";
+import chartsReducer from "./charts";
+
+describe("chartReducer", () => {
+  let initialState: IChartState;
+
+  beforeEach(() => {
+    initialState = {
+      isFetching: false,
+      items: [],
+      selected: {
+        versions: [],
+      },
+      deployed: {},
+    };
+  });
+  const error = new Error("Boom");
+  it("unsets an error when changing namespace", () => {
+    const state = chartsReducer(undefined, {
+      type: getType(actions.charts.errorChart) as any,
+      payload: error,
+    });
+    expect(state).toEqual({
+      ...initialState,
+      isFetching: false,
+      selected: {
+        ...initialState.selected,
+        error,
+      },
+    });
+
+    expect(
+      chartsReducer(undefined, {
+        type: getType(actions.namespace.setNamespace) as any,
+      }),
+    ).toEqual({ ...initialState });
+  });
+
+  it("sets the initial state when changing namespace", () => {
+    expect(
+      chartsReducer(
+        {
+          ...initialState,
+          isFetching: true,
+          selected: {
+            ...initialState.selected,
+            error,
+          },
+        {
+          type: getType(actions.namespace.setNamespace) as any,
+        },
+      ),
+    ).toEqual({ ...initialState });
+  });
+});

--- a/dashboard/src/reducers/charts.ts
+++ b/dashboard/src/reducers/charts.ts
@@ -2,6 +2,7 @@ import { getType } from "typesafe-actions";
 
 import actions from "../actions";
 import { ChartsAction } from "../actions/charts";
+import { NamespaceAction } from "../actions/namespace";
 import { IChartState } from "../shared/types";
 
 const initialState: IChartState = {
@@ -15,7 +16,7 @@ const initialState: IChartState = {
 
 const chartsSelectedReducer = (
   state: IChartState["selected"],
-  action: ChartsAction,
+  action: ChartsAction | NamespaceAction,
 ): IChartState["selected"] => {
   switch (action.type) {
     case getType(actions.charts.selectChartVersion):
@@ -46,7 +47,7 @@ const chartsSelectedReducer = (
   return state;
 };
 
-const chartsReducer = (state: IChartState = initialState, action: ChartsAction): IChartState => {
+const chartsReducer = (state: IChartState = initialState, action: ChartsAction | NamespaceAction): IChartState => {
   switch (action.type) {
     case getType(actions.charts.requestCharts):
       return { ...state, isFetching: true };
@@ -79,7 +80,13 @@ const chartsReducer = (state: IChartState = initialState, action: ChartsAction):
     case getType(actions.charts.selectReadme):
     case getType(actions.charts.errorReadme):
     case getType(actions.charts.errorChart):
-      return { ...state, selected: chartsSelectedReducer(state.selected, action) };
+      return {
+        ...state,
+        isFetching: false,
+        selected: chartsSelectedReducer(state.selected, action),
+      };
+    case getType(actions.namespace.setNamespace):
+      return { ...initialState };
     default:
   }
   return state;

--- a/pkg/auth/authgate.go
+++ b/pkg/auth/authgate.go
@@ -59,7 +59,7 @@ func AuthGate(kubeappsNamespace string) negroni.HandlerFunc {
 			if err != nil {
 				msg = fmt.Sprintf("%s: %s", msg, err.Error())
 			}
-			response.NewErrorResponse(http.StatusUnauthorized, msg).Write(w)
+			response.NewErrorResponse(http.StatusForbidden, msg).Write(w)
 			return
 		}
 		next(w, req)


### PR DESCRIPTION
The simple part of this PR was just switching the `authGate` to return a Forbidden rather than Unauthorized when a user requests the charts for a namespace to which they don't have access. This stopped the frontend from logging out, but a little more work was needed to display an error with an action the user can take.

This issue does not arise normally, because we already check whether a user has access to a namespace when selecting the namespace (ie. before we even attempt to get charts for the namespace), but because we currently use `All Namespaces` as the default when a user logs in, even though the user may not have access to resources across all namespaces, the issue appears when logging in as such a user and then selecting the catalog.

The correct solution, IMO, is to select the first namespace to which the user has access as the default, but we can't do this until `allowNamespaceDiscovery` is always on (?). Without that ability yet, I've instead displayed an error with an action for the user to take (selecting another namespace to which they have access). See what you think.