### PR TITLE
Fix catalog links in app repo page.

### DIFF
--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -114,6 +114,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
                   resyncRepo={resyncRepo}
                   repo={repo}
                   renderNamespace={renderNamespace}
+                  namespace={namespace}
                 />
               ))}
             </tbody>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
@@ -7,6 +7,7 @@ import ConfirmDialog from "../../ConfirmDialog";
 interface IAppRepoListItemProps {
   repo: IAppRepository;
   renderNamespace: boolean;
+  namespace: string;
   deleteRepo: (name: string, namespace: string) => Promise<boolean>;
   resyncRepo: (name: string, namespace: string) => void;
 }
@@ -21,11 +22,11 @@ export class AppRepoListItem extends React.Component<IAppRepoListItemProps, IApp
   };
 
   public render() {
-    const { renderNamespace, repo } = this.props;
+    const { namespace, renderNamespace, repo } = this.props;
     return (
       <tr key={repo.metadata.name}>
         <td>
-          <Link to={`/catalog/${repo.metadata.name}`}>{repo.metadata.name}</Link>
+          <Link to={`/catalog/ns/${namespace}/${repo.metadata.name}`}>{repo.metadata.name}</Link>
         </td>
         {renderNamespace && <td>{repo.metadata.namespace}</td>}
         <td>{repo.spec && repo.spec.url}</td>


### PR DESCRIPTION
Small follow-up to #1603 . The links from the app repo lists missed being updated to match the new route.