### PR TITLE
Restore test, fix apprepository-rbac

### DIFF
--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -93,7 +93,7 @@ rules:
       - secrets
     verbs:
       - create
-{{- end -}}
+{{ end }}
 {{- if .Values.featureFlags.reposPerNamespace -}}
 ---
 # Kubeapps can read and watch its own AppRepository resources cluster-wide.

--- a/integration/use-cases/create-registry.js
+++ b/integration/use-cases/create-registry.js
@@ -31,7 +31,7 @@ test("Creates a registry", async () => {
   let retries = 3;
   while (retries > 0) {
     try {
-      await expect(page).toMatch("gitlab", { timeout: 2000 });
+      await expect(page).toMatch("gitlab-runner", { timeout: 2000 });
       break;
     } catch (e) {
       // Refresh since the chart will get a bit of time to populate

--- a/integration/use-cases/create-registry.js
+++ b/integration/use-cases/create-registry.js
@@ -26,13 +26,7 @@ test("Creates a registry", async () => {
   // the Install Repo doesn't always register (in fact, from the
   // screenshot on failure, it appears to focus the button only (hover css applied)
   await expect(page).toClick("button", { text: "Install Repo" });
-
-  try {
-    await expect(page).toClick("a", { text: "my-repo" });
-  } catch (e) {
-    await expect(page).toClick("button", { text: "Install Repo" });
-    await expect(page).toMatch("Install Repo");
-  }
+  await expect(page).toClick("a", { text: "my-repo" });
 
   let retries = 3;
   while (retries > 0) {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of #1609

As explained there, the current test is giving a false positive in master. The reason is quite tricky. With the changes added in the RBAC templates, we were removing the blank line at the end of apprepository-rbac.yaml. This causes that the `Role` affected (`repositories-write`) was not being created and it fails quietly (note the `create---`):

```yaml
---
# Source: kubeapps/templates/apprepository-rbac.yaml
# Define role, but no binding, so users can be bound to this role
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: kubeapps2-repositories-write
rules:
  - apiGroups:
      - kubeapps.com
    resources:
      - apprepositories
    verbs:
      - "*"
  - apiGroups:
      - ""
    resources:
      - secrets
    verbs:
      - create---
# Kubeapps can read and watch its own AppRepository resources cluster-wide.
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
```

So giving write access to the operator serviceaccount was not doing anything. Fun bug...

