### PR TITLE
Show proper message when there are no workloads or URLs

### DIFF
--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
@@ -5,7 +5,6 @@ import * as React from "react";
 import itBehavesLike from "../../../shared/specs";
 
 import ResourceRef from "shared/ResourceRef";
-import LoadingWrapper from "../../../components/LoadingWrapper";
 import { IIngressSpec, IResource, IServiceSpec, IServiceStatus } from "../../../shared/types";
 import AccessURLItem from "./AccessURLItem";
 import AccessURLTable from "./AccessURLTable";
@@ -51,20 +50,9 @@ context("when fetching ingresses or services", () => {
   });
 });
 
-it("renders a message if there are no services or ingresses", () => {
+it("doesn't render anything if the application has no URL", () => {
   const wrapper = shallow(<AccessURLTable {...defaultProps} />);
-  expect(
-    wrapper
-      .find(LoadingWrapper)
-      .shallow()
-      .find(AccessURLItem),
-  ).not.toExist();
-  expect(
-    wrapper
-      .find(LoadingWrapper)
-      .shallow()
-      .text(),
-  ).toContain("The current application does not expose a public URL");
+  expect(wrapper.find("table")).not.toExist();
 });
 
 context("when the app contains services", () => {
@@ -85,12 +73,7 @@ context("when the app contains services", () => {
     } as IResource;
     const services = [{ isFetching: false, item: service }];
     const wrapper = shallow(<AccessURLTable {...defaultProps} services={services} />);
-    expect(
-      wrapper
-        .find(LoadingWrapper)
-        .shallow()
-        .text(),
-    ).toContain("The current application does not expose a public URL");
+    expect(wrapper.text()).toContain("The current application does not expose a public URL");
   });
 
   it("should show the table if any service is a LoadBalancer", () => {

--- a/dashboard/src/components/AppView/AccessURLTable/__snapshots__/AccessURLTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/AccessURLTable/__snapshots__/AccessURLTable.test.tsx.snap
@@ -1,48 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`when fetching ingresses or services loading spinner matches the snapshot 1`] = `
-<Fragment>
-  <h6>
-    Access URLs
-  </h6>
-  <LoadingWrapper
-    loaded={false}
-    type={1}
-  >
-    <table>
-      <thead>
-        <tr>
-          <th>
-            RESOURCE
-          </th>
-          <th>
-            TYPE
-          </th>
-          <th>
-            URL
-          </th>
-        </tr>
-      </thead>
-      <tbody />
-    </table>
-  </LoadingWrapper>
-</Fragment>
+<LoadingWrapper
+  loaded={false}
+  type={1}
+/>
 `;
 
 exports[`when fetching ingresses or services loading spinner matches the snapshot 2`] = `
-<Fragment>
-  <h6>
-    Access URLs
-  </h6>
-  <LoadingWrapper
-    loaded={false}
-    type={1}
-  >
-    <p>
-      The current application does not expose a public URL.
-    </p>
-  </LoadingWrapper>
-</Fragment>
+<LoadingWrapper
+  loaded={false}
+  type={1}
+/>
 `;
 
 exports[`when the app contains ingresses should show the table with available ingresses 1`] = `
@@ -50,41 +19,36 @@ exports[`when the app contains ingresses should show the table with available in
   <h6>
     Access URLs
   </h6>
-  <LoadingWrapper
-    loaded={true}
-    type={1}
-  >
-    <table>
-      <thead>
-        <tr>
-          <th>
-            RESOURCE
-          </th>
-          <th>
-            TYPE
-          </th>
-          <th>
-            URL
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <AccessURLItem
-          URLItem={
-            Object {
-              "URLs": Array [
-                "http://foo.bar/ready",
-              ],
-              "isLink": true,
-              "name": "foo",
-              "type": "Ingress",
-            }
+  <table>
+    <thead>
+      <tr>
+        <th>
+          RESOURCE
+        </th>
+        <th>
+          TYPE
+        </th>
+        <th>
+          URL
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <AccessURLItem
+        URLItem={
+          Object {
+            "URLs": Array [
+              "http://foo.bar/ready",
+            ],
+            "isLink": true,
+            "name": "foo",
+            "type": "Ingress",
           }
-          key="accessURL/foo"
-        />
-      </tbody>
-    </table>
-  </LoadingWrapper>
+        }
+        key="accessURL/foo"
+      />
+    </tbody>
+  </table>
 </Fragment>
 `;
 
@@ -93,38 +57,33 @@ exports[`when the app contains resources with errors displays the error 1`] = `
   <h6>
     Access URLs
   </h6>
-  <LoadingWrapper
-    loaded={true}
-    type={1}
-  >
-    <table>
-      <thead>
-        <tr>
-          <th>
-            RESOURCE
-          </th>
-          <th>
-            TYPE
-          </th>
-          <th>
-            URL
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          key="could not find Ingress"
+  <table>
+    <thead>
+      <tr>
+        <th>
+          RESOURCE
+        </th>
+        <th>
+          TYPE
+        </th>
+        <th>
+          URL
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        key="could not find Ingress"
+      >
+        <td
+          colSpan={3}
         >
-          <td
-            colSpan={3}
-          >
-            Error: 
-            could not find Ingress
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </LoadingWrapper>
+          Error: 
+          could not find Ingress
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </Fragment>
 `;
 
@@ -133,54 +92,49 @@ exports[`when the app contains services and ingresses should show the table with
   <h6>
     Access URLs
   </h6>
-  <LoadingWrapper
-    loaded={true}
-    type={1}
-  >
-    <table>
-      <thead>
-        <tr>
-          <th>
-            RESOURCE
-          </th>
-          <th>
-            TYPE
-          </th>
-          <th>
-            URL
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <AccessURLItem
-          URLItem={
-            Object {
-              "URLs": Array [
-                "http://foo.bar/ready",
-              ],
-              "isLink": true,
-              "name": "foo",
-              "type": "Ingress",
-            }
+  <table>
+    <thead>
+      <tr>
+        <th>
+          RESOURCE
+        </th>
+        <th>
+          TYPE
+        </th>
+        <th>
+          URL
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <AccessURLItem
+        URLItem={
+          Object {
+            "URLs": Array [
+              "http://foo.bar/ready",
+            ],
+            "isLink": true,
+            "name": "foo",
+            "type": "Ingress",
           }
-          key="accessURL/foo"
-        />
-        <AccessURLItem
-          URLItem={
-            Object {
-              "URLs": Array [
-                "Pending",
-              ],
-              "isLink": false,
-              "name": "foo",
-              "type": "Service LoadBalancer",
-            }
+        }
+        key="accessURL/foo"
+      />
+      <AccessURLItem
+        URLItem={
+          Object {
+            "URLs": Array [
+              "Pending",
+            ],
+            "isLink": false,
+            "name": "foo",
+            "type": "Service LoadBalancer",
           }
-          key="accessURL/foo"
-        />
-      </tbody>
-    </table>
-  </LoadingWrapper>
+        }
+        key="accessURL/foo"
+      />
+    </tbody>
+  </table>
 </Fragment>
 `;
 
@@ -189,40 +143,35 @@ exports[`when the app contains services should show the table if any service is 
   <h6>
     Access URLs
   </h6>
-  <LoadingWrapper
-    loaded={true}
-    type={1}
-  >
-    <table>
-      <thead>
-        <tr>
-          <th>
-            RESOURCE
-          </th>
-          <th>
-            TYPE
-          </th>
-          <th>
-            URL
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <AccessURLItem
-          URLItem={
-            Object {
-              "URLs": Array [
-                "Pending",
-              ],
-              "isLink": false,
-              "name": "foo",
-              "type": "Service LoadBalancer",
-            }
+  <table>
+    <thead>
+      <tr>
+        <th>
+          RESOURCE
+        </th>
+        <th>
+          TYPE
+        </th>
+        <th>
+          URL
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <AccessURLItem
+        URLItem={
+          Object {
+            "URLs": Array [
+              "Pending",
+            ],
+            "isLink": false,
+            "name": "foo",
+            "type": "Service LoadBalancer",
           }
-          key="accessURL/foo"
-        />
-      </tbody>
-    </table>
-  </LoadingWrapper>
+        }
+        key="accessURL/foo"
+      />
+    </tbody>
+  </table>
 </Fragment>
 `;

--- a/dashboard/src/components/ApplicationStatus/ApplicationStatus.test.tsx
+++ b/dashboard/src/components/ApplicationStatus/ApplicationStatus.test.tsx
@@ -94,11 +94,11 @@ describe("isFetching", () => {
     readyPods: number;
   }> = [
     {
-      title: "shows a deployed status if there are no resources",
+      title: "shows a warning if no workloads are present",
       deployments: [],
       statefulsets: [],
       daemonsets: [],
-      deployed: true,
+      deployed: false,
       totalPods: 0,
       readyPods: 0,
     },
@@ -314,6 +314,10 @@ describe("isFetching", () => {
       const getItem = (i?: IResource | IK8sList<IResource, {}>): IResource => {
         return has(i, "items") ? (i as IK8sList<IResource, {}>).items[0] : (i as IResource);
       };
+      if (!t.deployments.length && !t.statefulsets.length && !t.daemonsets.length) {
+        expect(wrapper.text()).toContain("No workload found");
+        return;
+      }
       expect(wrapper.text()).toContain(t.deployed ? "Ready" : "Not Ready");
       expect(wrapper.state()).toMatchObject({ totalPods: t.totalPods, readyPods: t.readyPods });
       // Check tooltip text

--- a/dashboard/src/components/ApplicationStatus/ApplicationStatus.tsx
+++ b/dashboard/src/components/ApplicationStatus/ApplicationStatus.tsx
@@ -106,6 +106,11 @@ class ApplicationStatus extends React.Component<IApplicationStatusProps, IApplic
         return this.helmStatusError(helmStatus);
       }
     }
+    if (this.state.totalPods === 0) {
+      return (
+        <span className="ApplicationStatus ApplicationStatus--pending">No workload found</span>
+      );
+    }
     return (
       <div className="ApplicationStatusPieChart">
         <a data-tip={true} data-for="app-status">


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Two small bug fixes:
 - When there are no workloads, say that instead of "Ready" since we cannot ensure that the application is actually ready.
 - When there are no URL items, skip the URL table

Before these changes:
![Screenshot from 2020-03-30 17-11-13](https://user-images.githubusercontent.com/4025665/77929888-79b2f700-72aa-11ea-9323-3e66af33b4ab.png)

After:
![Screenshot from 2020-03-30 17-14-17](https://user-images.githubusercontent.com/4025665/77929907-7fa8d800-72aa-11ea-8ec5-ca1f8bd929d5.png)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1552 
