### PR TITLE
Add OtherResources table to the operator view

### DIFF
--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/OtherResourceItem/OtherResourceItem.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/OtherResourceItem/OtherResourceItem.test.tsx
@@ -1,14 +1,26 @@
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import ResourceRef from "shared/ResourceRef";
+import ResourceRef from "../../../../../shared/ResourceRef";
+import { IResource } from "../../../../../shared/types";
 import OtherResourceItem from "./OtherResourceItem";
 
-it("renders a ConfigMap", () => {
+it("renders a ConfigMap as a resourceref", () => {
   const cm = {
     name: "foo",
     kind: "ConfigMap",
   } as ResourceRef;
+  const wrapper = shallow(<OtherResourceItem resource={cm} />);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("renders a ConfigMap as a resource", () => {
+  const cm = {
+    metadata: {
+      name: "foo",
+    },
+    kind: "ConfigMap",
+  } as IResource;
   const wrapper = shallow(<OtherResourceItem resource={cm} />);
   expect(wrapper).toMatchSnapshot();
 });

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/OtherResourceItem/OtherResourceItem.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/OtherResourceItem/OtherResourceItem.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import ResourceRef from "shared/ResourceRef";
+import ResourceRef from "../../../../../shared/ResourceRef";
+import { IResource } from "../../../../../shared/types";
 
 export interface IOtherResourceProps {
-  resource: ResourceRef;
+  resource: IResource | ResourceRef;
 }
 
 export const OtherResourceColumns: React.SFC = () => {
@@ -16,11 +17,19 @@ export const OtherResourceColumns: React.SFC = () => {
 
 const OtherResourceItem: React.SFC<IOtherResourceProps> = props => {
   const { resource } = props;
+  let name;
+  const fullResource = resource as IResource;
+  if (fullResource.metadata && fullResource.metadata.name) {
+    name = fullResource.metadata.name;
+  } else {
+    const resourceRef = resource as ResourceRef;
+    name = resourceRef.name;
+  }
   return (
-    <tr key={`otherResources/${resource.kind}/${resource.name}`} className="flex">
-      <td className="col-6">{resource.name}</td>
+    <>
+      <td className="col-6">{name}</td>
       <td className="col-6">{resource.kind}</td>
-    </tr>
+    </>
   );
 };
 

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/OtherResourceItem/__snapshots__/OtherResourceItem.test.tsx.snap
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/OtherResourceItem/__snapshots__/OtherResourceItem.test.tsx.snap
@@ -1,10 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a ConfigMap 1`] = `
-<tr
-  className="flex"
-  key="otherResources/ConfigMap/foo"
->
+exports[`renders a ConfigMap as a resource 1`] = `
+<Fragment>
   <td
     className="col-6"
   >
@@ -15,5 +12,20 @@ exports[`renders a ConfigMap 1`] = `
   >
     ConfigMap
   </td>
-</tr>
+</Fragment>
+`;
+
+exports[`renders a ConfigMap as a resourceref 1`] = `
+<Fragment>
+  <td
+    className="col-6"
+  >
+    foo
+  </td>
+  <td
+    className="col-6"
+  >
+    ConfigMap
+  </td>
+</Fragment>
 `;

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.test.tsx
@@ -130,7 +130,7 @@ context("when there is a valid resouce", () => {
     expect(wrapper.find("td").text()).toEqual("No resource found");
   });
 
-  it("shows skips an empty component if requested", () => {
+  it("skips an empty component if requested", () => {
     const kubeList = {
       isFetching: false,
       item: { items: [] },

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.test.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import itBehavesLike from "../../../../shared/specs";
 import { IKubeItem, IResource } from "../../../../shared/types";
 import DeploymentItemRow from "./DeploymentItem/DeploymentItem";
+import OtherResourceItem from "./OtherResourceItem";
 import ResourceTableItem from "./ResourceTableItem";
 
 const kubeItem: IKubeItem<IResource> = {
@@ -83,7 +84,7 @@ context("when there is a valid resouce", () => {
     const deployment = {
       metadata: {
         name: "foo",
-        selfLink: "/foo",
+        selfLink: "/deployments/foo",
       },
       status: { replicas: 1, updatedReplicas: 1, availableReplicas: 1 },
     } as IResource;
@@ -127,5 +128,35 @@ context("when there is a valid resouce", () => {
     );
     expect(wrapper.find("td")).toExist();
     expect(wrapper.find("td").text()).toEqual("No resource found");
+  });
+
+  it("shows skips an empty component if requested", () => {
+    const kubeList = {
+      isFetching: false,
+      item: { items: [] },
+    };
+    const wrapper = shallow(
+      <ResourceTableItem
+        {...defaultProps}
+        resource={kubeList as any}
+        name={""}
+        avoidEmptyResouce={true}
+      />,
+    );
+    expect(wrapper.find("td")).not.toExist();
+  });
+
+  it("renders a ConfigMap", () => {
+    const cm = {
+      metadata: {
+        name: "foo",
+        selfLink: "/configmaps/foo",
+      },
+    } as IResource;
+    kubeItem.item = cm;
+    const wrapper = shallow(
+      <ResourceTableItem {...defaultProps} resource={kubeItem} name={cm.metadata.name} />,
+    );
+    expect(wrapper.find(OtherResourceItem)).toExist();
   });
 });

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.tsx
@@ -5,6 +5,7 @@ import { IK8sList, IKubeItem, IResource, ISecret } from "../../../../shared/type
 import LoadingWrapper, { LoaderType } from "../../../LoadingWrapper";
 import DaemonSetItemRow from "./DaemonSetItem";
 import DeploymentItemRow from "./DeploymentItem";
+import OtherResourceItem from "./OtherResourceItem";
 import SecretItem from "./SecretItem/SecretItem";
 import ServiceItem from "./ServiceItem/ServiceItem";
 import StatefulSetItemRow from "./StatefulSetItem";
@@ -14,6 +15,7 @@ interface IResourceItemProps {
   resource?: IKubeItem<IResource | ISecret | IK8sList<IResource | ISecret, {}>>;
   watchResource: () => void;
   closeWatch: () => void;
+  avoidEmptyResouce?: boolean;
 }
 
 class WorkloadItem extends React.Component<IResourceItemProps> {
@@ -62,6 +64,9 @@ class WorkloadItem extends React.Component<IResourceItemProps> {
       const listItem = resource.item as IK8sList<IResource | ISecret, {}>;
       if (listItem.items) {
         if (listItem.items.length === 0) {
+          if (this.props.avoidEmptyResouce) {
+            return null;
+          }
           return (
             <tr className="flex">
               <td className="col-12">No resource found</td>
@@ -92,8 +97,9 @@ class WorkloadItem extends React.Component<IResourceItemProps> {
       return <ServiceItem resource={plainResource} />;
     } else if (r.metadata.selfLink.match("secrets")) {
       return <SecretItem resource={r as ISecret} />;
+    } else {
+      return <OtherResourceItem resource={plainResource} />;
     }
-    return null;
   };
 }
 

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/__snapshots__/ResourceTableItem.test.tsx.snap
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/__snapshots__/ResourceTableItem.test.tsx.snap
@@ -43,7 +43,23 @@ exports[`when fetching resources loading spinner matches the snapshot 2`] = `
 exports[`when there is a valid resouce renders info about the resource status 1`] = `
 <tr
   className="flex"
-/>
+>
+  <DeploymentItemRow
+    resource={
+      Object {
+        "metadata": Object {
+          "name": "foo",
+          "selfLink": "/deployments/foo",
+        },
+        "status": Object {
+          "availableReplicas": 1,
+          "replicas": 1,
+          "updatedReplicas": 1,
+        },
+      }
+    }
+  />
+</tr>
 `;
 
 exports[`when there is a valid resouce renders info about the resource status when given a list 1`] = `

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import ResourceItemContainer from "../../../containers/ResourceItemContainer";
 import ResourceRef from "../../../shared/ResourceRef";
 import { IResource } from "../../../shared/types";
+import OtherResourceItem from "./ResourceItem/OtherResourceItem";
 import ResourceTable from "./ResourceTable";
 
 it("skips the element if there are no resources", () => {
@@ -40,4 +41,24 @@ it("renders two resources", () => {
       .at(1)
       .prop("resourceRef"),
   ).toBe(deployRefs[1]);
+});
+
+it("renders OtherResourceItem", () => {
+  const resourceRefs = [
+    new ResourceRef({ kind: "ConfigMap", metadata: { name: "foo" } } as IResource, "default"),
+  ];
+  const wrapper = shallow(<ResourceTable resourceRefs={resourceRefs} title={""} />);
+  expect(wrapper.find(OtherResourceItem)).toExist();
+  expect(wrapper.find(ResourceItemContainer)).not.toExist();
+});
+
+it("renders OtherResource as ItemContainer", () => {
+  const resourceRefs = [
+    new ResourceRef({ kind: "ConfigMap", metadata: { name: "foo" } } as IResource, "default"),
+  ];
+  const wrapper = shallow(
+    <ResourceTable resourceRefs={resourceRefs} title={""} requestOtherResources={true} />,
+  );
+  expect(wrapper.find(OtherResourceItem)).not.toExist();
+  expect(wrapper.find(ResourceItemContainer)).toExist();
 });

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.tsx
@@ -14,6 +14,7 @@ import { StatefulSetColumns } from "./ResourceItem/StatefulSetItem/StatefulSetIt
 interface IResourceTableProps {
   title: string;
   resourceRefs: ResourceRef[];
+  requestOtherResources?: boolean;
 }
 
 class ResourceTable extends React.Component<IResourceTableProps> {
@@ -38,9 +39,20 @@ class ResourceTable extends React.Component<IResourceTableProps> {
                   case "Secret":
                     return <ResourceItemContainer key={r.getResourceURL()} resourceRef={r} />;
                   default:
-                    return (
+                    return this.props.requestOtherResources ? (
+                      <ResourceItemContainer
+                        key={r.getResourceURL()}
+                        resourceRef={r}
+                        avoidEmptyResouce={true}
+                      />
+                    ) : (
                       // We may not know the plural of the resource so we don't get the full resource URL
-                      <OtherResourceItem key={`${r.kind}/${r.namespace}/${r.name}`} resource={r} />
+                      <tr key={`otherResources/${r.kind}/${r.name}`} className="flex">
+                        <OtherResourceItem
+                          key={`${r.kind}/${r.namespace}/${r.name}`}
+                          resource={r}
+                        />
+                      </tr>
                     );
                 }
               })}

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -202,12 +202,12 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
                       />
                       <ResourceTable resourceRefs={resources.daemonSetRefs} title="DaemonSets" />
                       <ResourceTable resourceRefs={resources.serviceRefs} title="Services" />
-                      {resource.spec && <AppValues values={yaml.safeDump(resource.spec)} />}
-                      {/* TODO(andresmgot): Enable otherResourcesTable when they are fetched */}
-                      {/* <ResourceTable
+                      <ResourceTable
                         resourceRefs={resources.otherResources}
                         title="Other Resources"
-                      /> */}
+                        requestOtherResources={true}
+                      />
+                      {resource.spec && <AppValues values={yaml.safeDump(resource.spec)} />}
                     </>
                   )}
                 </div>

--- a/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
+++ b/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
@@ -162,6 +162,11 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
             resourceRefs={Array []}
             title="Services"
           />
+          <ResourceTable
+            requestOtherResources={true}
+            resourceRefs={Array []}
+            title="Other Resources"
+          />
           <AppValues
             values="test: true
           "

--- a/dashboard/src/shared/ResourceAPIVersion.ts
+++ b/dashboard/src/shared/ResourceAPIVersion.ts
@@ -2,12 +2,17 @@
 // isn't sufficient. Note that apiVersions may change over time.
 export const ResourceKindsWithAPIVersions = {
   ClusterRole: "rbac.authorization.k8s.io/v1",
+  ClusterRoleBinding: "rbac.authorization.k8s.io/v1",
   ConfigMap: "v1",
   DaemonSet: "apps/v1",
   Deployment: "apps/v1",
   Ingress: "extensions/v1beta1",
+  ReplicaSet: "apps/v1",
+  Role: "rbac.authorization.k8s.io/v1",
+  RoleBinding: "rbac.authorization.k8s.io/v1",
   Secret: "v1",
   Service: "v1",
+  ServiceAccount: "v1",
   StatefulSet: "apps/v1",
   Pods: "v1",
 } as const;

--- a/dashboard/src/shared/ResourceKinds.ts
+++ b/dashboard/src/shared/ResourceKinds.ts
@@ -4,14 +4,19 @@
 // maintain we can add a generic pluralizer and a way to override.
 export const ResourceKindsWithPlurals = {
   ClusterRole: "clusterroles",
+  ClusterRoleBinding: "clusterrolebindings",
   ConfigMap: "configmaps",
   DaemonSet: "daemonsets",
   Deployment: "deployments",
   Ingress: "ingresses",
+  ReplicaSet: "replicasets",
+  Role: "roles",
+  RoleBinding: "rolebindings",
   Secret: "secrets",
   Service: "services",
+  ServiceAccount: "serviceaccounts",
   StatefulSet: "statefulsets",
-  Pod: "pods",
+  Pods: "pods",
 } as const;
 
 export type ResourceKind = keyof typeof ResourceKindsWithPlurals;

--- a/dashboard/src/shared/ResourceRef.test.ts
+++ b/dashboard/src/shared/ResourceRef.test.ts
@@ -1,6 +1,6 @@
 import { Kube } from "./Kube";
-import ResourceRef from "./ResourceRef";
-import { IResource } from "./types";
+import ResourceRef, { fromCRD } from "./ResourceRef";
+import { IClusterServiceVersionCRDResource, IResource } from "./types";
 
 describe("ResourceRef", () => {
   describe("constructor", () => {
@@ -37,18 +37,6 @@ describe("ResourceRef", () => {
       expect(ref.namespace).toBe("default");
     });
 
-    it("throws an error if namespace not in the resource or default namespace not set", () => {
-      const r = {
-        apiVersion: "apps/v1",
-        kind: "Deployment",
-        metadata: {
-          name: "foo",
-        },
-      } as IResource;
-
-      expect(() => new ResourceRef(r)).toThrowError();
-    });
-
     it("allows the default namespace to be provided", () => {
       const r = {
         apiVersion: "apps/v1",
@@ -60,6 +48,50 @@ describe("ResourceRef", () => {
 
       const ref = new ResourceRef(r, "bar");
       expect(ref.namespace).toBe("bar");
+    });
+
+    describe("fromCRD", () => {
+      it("creates a resource ref with ownerReference", () => {
+        const r = {
+          kind: "Deployment",
+          name: "",
+          version: "",
+        } as IClusterServiceVersionCRDResource;
+        const ownerRef = {
+          metadata: {
+            name: "test",
+          },
+        };
+        const res = fromCRD(r, "default", ownerRef);
+        expect(res).toMatchObject({
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          name: "",
+          namespace: "default",
+          filter: { metadata: { ownerReferences: [ownerRef] } },
+        });
+      });
+
+      it("skips the namespace for a non namespaced element", () => {
+        const r = {
+          kind: "ClusterRole",
+          name: "",
+          version: "",
+        } as IClusterServiceVersionCRDResource;
+        const ownerRef = {
+          metadata: {
+            name: "test",
+          },
+        };
+        const res = fromCRD(r, "default", ownerRef);
+        expect(res).toMatchObject({
+          apiVersion: "rbac.authorization.k8s.io/v1",
+          kind: "ClusterRole",
+          name: "",
+          namespace: "",
+          filter: { metadata: { ownerReferences: [ownerRef] } },
+        });
+      });
     });
   });
 

--- a/dashboard/src/shared/ResourceRef.ts
+++ b/dashboard/src/shared/ResourceRef.ts
@@ -16,7 +16,7 @@ export function fromCRD(
     },
   } as IResource;
   // Avoid namespace for cluster-wide resources supported (ClusterRole, ClusterRoleBinding)
-  // TODO(andresmgot): This won't work for new resourceTypes, we would need to dinamically
+  // TODO(andresmgot): This won't work for new resource types, we would need to dinamically
   // resolve those
   const resourceNamespace = r.kind.startsWith("Cluster") ? "" : namespace;
   return new ResourceRef(resource, resourceNamespace, {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Add the Other Resources table to the Operator view to complete the view:

![Screenshot from 2020-03-31 13-35-29](https://user-images.githubusercontent.com/4025665/78022462-41b4be00-7355-11ea-9f18-36c1c043fa5c.png)

Note that even though we are just interested on knowing the name of the resources, we need to request the list of resources (in a namespace) and filter out.

There are a few tricky things in this PR:
 1. Some resources listed are not shown later. For example, an Operator may define Pods as one of the resource it creates but since those pods are not directly linked to the Operator CRD (the Deployment is instead), these resources are not shown in the table.
 2. Apart from the current workaround of guessing the apiVersion/plural, I needed to differentiate between namespaced and non-namespaced resources. This is becoming too hacky... but would work now for the alpha release.

To avoid any issues with the current approach for charts, we are maintaining the old behavior for helm releases (not requesting nor watching "other resources").

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1552 

