### PR TITLE
Don't yet default to using repos per namespace

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -640,6 +640,6 @@ authProxy:
 ## Feature flags
 ## These are used to switch on in development features or new features which are ready to be released.
 featureFlags:
-  reposPerNamespace: true
+  reposPerNamespace: false
   invalidateCache: true
   operators: false

--- a/integration/use-cases/create-registry.js
+++ b/integration/use-cases/create-registry.js
@@ -1,5 +1,5 @@
 test("Creates a registry", async () => {
-  await page.goto(getUrl("/#/config/ns/kubeapps/repos"));
+  await page.goto(getUrl("/#/config/repos"));
 
   await expect(page).toFillForm("form", {
     token: process.env.ADMIN_TOKEN


### PR DESCRIPTION
When I landed #1604 the other day, switching the default to use per-namespace app repos, it was with the thought that there was only a few small bugs to iron out, but there was quite a bit still missing, so switching off until I resolve that so that master isn't broken (CI doesn't show this only because it doesn't test per-namespace repos yet).