### PR TITLE
Update helm notes to match getting started for port-forward

### DIFF
--- a/chart/kubeapps/templates/NOTES.txt
+++ b/chart/kubeapps/templates/NOTES.txt
@@ -50,8 +50,7 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
 
 {{- $portNumber := include "kubeapps.frontend-port-number" . }}
    echo "Kubeapps URL: http://127.0.0.1:{{ $portNumber }}"
-   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kubeapps.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-   kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ $portNumber }}:{{ $portNumber }}
+   kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ template "kubeapps.fullname" . }} {{ $portNumber }}:{{ .Values.frontend.service.port }}
 
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
Updates the NOTES.txt for the Helm notes to match the getting started for port-forwarding.
Switching port forwarding from selecting the first pod to forwarding using the service. It should match the following:
```
kubectl port-forward -n kubeapps svc/kubeapps 8080:80
```
```
Kubeapps can be accessed via port 80 on the following DNS name from within your cluster:

   kubeapps.kubeapps.svc.cluster.local

To access Kubeapps from outside your K8s cluster, follow the steps below:

1. Get the Kubeapps URL by running these commands:
   echo "Kubeapps URL: http://127.0.0.1:8080"
   kubectl port-forward --namespace kubeapps service/kubeapps 8080:80

2. Open a browser and access Kubeapps using the obtained URL.
> k -n kubeapps get svc
NAME                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
kubeapps                      ClusterIP   10.107.22.58     <none>        80/TCP      53s
kubeapps-internal-assetsvc    ClusterIP   10.107.211.12    <none>        8080/TCP    53s
kubeapps-internal-dashboard   ClusterIP   10.100.149.241   <none>        8080/TCP    53s
kubeapps-internal-kubeops     ClusterIP   10.107.21.128    <none>        8080/TCP    53s
kubeapps-mongodb              ClusterIP   10.108.66.167    <none>        27017/TCP   53s
```
Tested by installing the helm chart.

### Benefits
The helm notes will be updated and match the getting started for setting up port-forwarding.

### Possible drawbacks
None

### Applicable issues

### Additional information
TODO: This has not been verified if it works correctly yet.
