### PR TITLE
Reduce subIcon size to fit in banner

### DIFF
--- a/dashboard/src/components/Card/CardIcon.scss
+++ b/dashboard/src/components/Card/CardIcon.scss
@@ -13,12 +13,12 @@
 .Card__subIcon {
   right: 10px;
   position: relative;
-  bottom: 40px;
+  bottom: 27px;
   background: transparent;
   height: 0px;
 }
 
 .Card__subIcon img {
-  max-height: 30px;
-  max-width: 30px;
+  max-height: 25px;
+  max-width: 25px;
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Make the subIcon a bit smaller so it fits within the banner section when it appears.

Before:

![Screenshot from 2020-04-03 10-33-58](https://user-images.githubusercontent.com/4025665/78342199-3520a780-7599-11ea-8e0c-4e60ee73c5ee.png)

After: 

![Screenshot from 2020-04-03 10-29-16](https://user-images.githubusercontent.com/4025665/78342207-38b42e80-7599-11ea-8ae0-6b25ecb82e90.png)
