### PR TITLE
Add a Categories section in the Operator list

### DIFF
--- a/dashboard/src/components/OperatorList/OperatorList.scss
+++ b/dashboard/src/components/OperatorList/OperatorList.scss
@@ -1,0 +1,3 @@
+.horizontal-column {
+  border-right: 1px solid lightgray;
+}

--- a/dashboard/src/components/OperatorList/OperatorList.test.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.test.tsx
@@ -160,6 +160,20 @@ describe("filter operators", () => {
     metadata: {
       name: "bar",
     },
+    status: {
+      ...sampleOperator.status,
+      channels: [
+        {
+          ...sampleOperator.status.channels[0],
+          currentCSVDesc: {
+            version: "1.0.0",
+            annotations: {
+              categories: "database, other",
+            },
+          },
+        },
+      ],
+    },
   } as any;
 
   it("setting the filter in the state", () => {
@@ -208,5 +222,23 @@ describe("filter operators", () => {
         .dive()
         .text(),
     ).toMatch("No Operator found");
+  });
+
+  it("filters by category", () => {
+    const wrapper = shallow(<OperatorList {...defaultProps} isOLMInstalled={true} csvs={[]} />);
+    wrapper.setProps({ operators: [sampleOperator, sampleOperator2] });
+    const column = wrapper.find(".horizontal-column").text();
+    expect(column).toContain("security");
+    expect(column).toContain("database");
+    expect(column).toContain("other");
+    expect(wrapper.find(InfoCard).length).toBe(2);
+
+    // Filter category "security"
+    wrapper.setState({
+      filterCategories: {
+        security: true,
+      },
+    });
+    expect(wrapper.find(InfoCard).length).toBe(1);
   });
 });

--- a/dashboard/src/components/OperatorList/OperatorList.test.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.test.tsx
@@ -6,6 +6,7 @@ import { CardGrid } from "../Card";
 import { ErrorSelector } from "../ErrorAlert";
 import InfoCard from "../InfoCard";
 import LoadingWrapper from "../LoadingWrapper";
+import { AUTO_PILOT, BASIC_INSTALL } from "../OperatorView/OperatorCapabilityLevel";
 import OLMNotFound from "./OLMNotFound";
 import OperatorList, { IOperatorListProps } from "./OperatorList";
 
@@ -39,6 +40,7 @@ const sampleOperator = {
           version: "1.0.0",
           annotations: {
             categories: "security",
+            capabilities: AUTO_PILOT,
           },
         },
       },
@@ -178,6 +180,7 @@ describe("filter operators", () => {
             version: "1.0.0",
             annotations: {
               categories: "database, other",
+              capabilities: BASIC_INSTALL,
             },
           },
         },
@@ -246,6 +249,20 @@ describe("filter operators", () => {
     wrapper.setState({
       filterCategories: {
         security: true,
+      },
+    });
+    expect(wrapper.find(InfoCard).length).toBe(1);
+  });
+
+  it("filters by capability", () => {
+    const wrapper = shallow(<OperatorList {...defaultProps} isOLMInstalled={true} csvs={[]} />);
+    wrapper.setProps({ operators: [sampleOperator, sampleOperator2] });
+    expect(wrapper.find(InfoCard).length).toBe(2);
+
+    // Filter by capability "Basic Install"
+    wrapper.setState({
+      filterCapabilities: {
+        [BASIC_INSTALL]: true,
       },
     });
     expect(wrapper.find(InfoCard).length).toBe(1);

--- a/dashboard/src/components/OperatorList/__snapshots__/OperatorList.test.tsx.snap
+++ b/dashboard/src/components/OperatorList/__snapshots__/OperatorList.test.tsx.snap
@@ -85,6 +85,93 @@ exports[`render the operator list with installed operators 1`] = `
               Categories
             </b>
           </div>
+          <div
+            className="margin-v-normal "
+          >
+            <b>
+              Capability Level
+            </b>
+          </div>
+          <div
+            key="Basic Install"
+          >
+            <label
+              className="checkbox"
+              key="Basic Install"
+              onChange={[Function]}
+            >
+              <input
+                type="checkbox"
+              />
+              <span>
+                Basic Install
+              </span>
+            </label>
+          </div>
+          <div
+            key="Seamless Upgrades"
+          >
+            <label
+              className="checkbox"
+              key="Seamless Upgrades"
+              onChange={[Function]}
+            >
+              <input
+                type="checkbox"
+              />
+              <span>
+                Seamless Upgrades
+              </span>
+            </label>
+          </div>
+          <div
+            key="Full Lifecycle"
+          >
+            <label
+              className="checkbox"
+              key="Full Lifecycle"
+              onChange={[Function]}
+            >
+              <input
+                type="checkbox"
+              />
+              <span>
+                Full Lifecycle
+              </span>
+            </label>
+          </div>
+          <div
+            key="Deep Insights"
+          >
+            <label
+              className="checkbox"
+              key="Deep Insights"
+              onChange={[Function]}
+            >
+              <input
+                type="checkbox"
+              />
+              <span>
+                Deep Insights
+              </span>
+            </label>
+          </div>
+          <div
+            key="Auto Pilot"
+          >
+            <label
+              className="checkbox"
+              key="Auto Pilot"
+              onChange={[Function]}
+            >
+              <input
+                type="checkbox"
+              />
+              <span>
+                Auto Pilot
+              </span>
+            </label>
+          </div>
         </div>
         <div
           className="col-10"
@@ -163,6 +250,93 @@ exports[`render the operator list without installed operators 1`] = `
             <b>
               Categories
             </b>
+          </div>
+          <div
+            className="margin-v-normal "
+          >
+            <b>
+              Capability Level
+            </b>
+          </div>
+          <div
+            key="Basic Install"
+          >
+            <label
+              className="checkbox"
+              key="Basic Install"
+              onChange={[Function]}
+            >
+              <input
+                type="checkbox"
+              />
+              <span>
+                Basic Install
+              </span>
+            </label>
+          </div>
+          <div
+            key="Seamless Upgrades"
+          >
+            <label
+              className="checkbox"
+              key="Seamless Upgrades"
+              onChange={[Function]}
+            >
+              <input
+                type="checkbox"
+              />
+              <span>
+                Seamless Upgrades
+              </span>
+            </label>
+          </div>
+          <div
+            key="Full Lifecycle"
+          >
+            <label
+              className="checkbox"
+              key="Full Lifecycle"
+              onChange={[Function]}
+            >
+              <input
+                type="checkbox"
+              />
+              <span>
+                Full Lifecycle
+              </span>
+            </label>
+          </div>
+          <div
+            key="Deep Insights"
+          >
+            <label
+              className="checkbox"
+              key="Deep Insights"
+              onChange={[Function]}
+            >
+              <input
+                type="checkbox"
+              />
+              <span>
+                Deep Insights
+              </span>
+            </label>
+          </div>
+          <div
+            key="Auto Pilot"
+          >
+            <label
+              className="checkbox"
+              key="Auto Pilot"
+              onChange={[Function]}
+            >
+              <input
+                type="checkbox"
+              />
+              <span>
+                Auto Pilot
+              </span>
+            </label>
           </div>
         </div>
         <div

--- a/dashboard/src/components/OperatorList/__snapshots__/OperatorList.test.tsx.snap
+++ b/dashboard/src/components/OperatorList/__snapshots__/OperatorList.test.tsx.snap
@@ -72,24 +72,47 @@ exports[`render the operator list with installed operators 1`] = `
       loaded={true}
       type={0}
     >
-      <h3>
-        Installed
-      </h3>
-      <CardGrid>
-        <InfoCard
-          icon="api/v1/namespaces/default/operator/foo/logo"
-          info="v1.0.0"
-          key="foo"
-          link="/ns/default/operators/foo"
-          tag1Content="security"
-          tag2Content="kubeapps"
-          title="foo"
-        />
-      </CardGrid>
-      <h3>
-        Available Operators
-      </h3>
-      <CardGrid />
+      <div
+        className="row margin-t-big"
+      >
+        <div
+          className="col-2 margin-t-big horizontal-column"
+        >
+          <div
+            className="margin-b-normal "
+          >
+            <b>
+              Categories
+            </b>
+          </div>
+        </div>
+        <div
+          className="col-10"
+        >
+          <div
+            className="padding-l-normal"
+          >
+            <h3>
+              Installed
+            </h3>
+            <CardGrid>
+              <InfoCard
+                icon="api/v1/namespaces/default/operator/foo/logo"
+                info="v1.0.0"
+                key="foo"
+                link="/ns/default/operators/foo"
+                tag1Content="security"
+                tag2Content="kubeapps"
+                title="foo"
+              />
+            </CardGrid>
+            <h3>
+              Available Operators
+            </h3>
+            <CardGrid />
+          </div>
+        </div>
+      </div>
     </LoadingWrapper>
   </main>
 </div>
@@ -128,20 +151,43 @@ exports[`render the operator list without installed operators 1`] = `
       loaded={true}
       type={0}
     >
-      <h3>
-        Available Operators
-      </h3>
-      <CardGrid>
-        <InfoCard
-          icon="api/v1/namespaces/default/operator/foo/logo"
-          info="v1.0.0"
-          key="foo"
-          link="/ns/default/operators/foo"
-          tag1Content="security"
-          tag2Content="kubeapps"
-          title="foo"
-        />
-      </CardGrid>
+      <div
+        className="row margin-t-big"
+      >
+        <div
+          className="col-2 margin-t-big horizontal-column"
+        >
+          <div
+            className="margin-b-normal "
+          >
+            <b>
+              Categories
+            </b>
+          </div>
+        </div>
+        <div
+          className="col-10"
+        >
+          <div
+            className="padding-l-normal"
+          >
+            <h3>
+              Available Operators
+            </h3>
+            <CardGrid>
+              <InfoCard
+                icon="api/v1/namespaces/default/operator/foo/logo"
+                info="v1.0.0"
+                key="foo"
+                link="/ns/default/operators/foo"
+                tag1Content="security"
+                tag2Content="kubeapps"
+                title="foo"
+              />
+            </CardGrid>
+          </div>
+        </div>
+      </div>
     </LoadingWrapper>
   </main>
 </div>


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

![Screenshot from 2020-04-06 16-22-10](https://user-images.githubusercontent.com/4025665/78571214-3d414700-7826-11ea-88f5-19b038f1365f.png)

Example of selecting "Database":

![Screenshot from 2020-04-06 16-22-27](https://user-images.githubusercontent.com/4025665/78571285-4df1bd00-7826-11ea-96c0-de4e7846701d.png)

Selecting multiple categories act as an "OR". For example: Selecting Database and Security would show Operators of both categories.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1552
