### PR TITLE
Add note about increasing `proxy_buffer_size` with nginx and Azure.

### DIFF
--- a/docs/user/using-an-OIDC-provider.md
+++ b/docs/user/using-an-OIDC-provider.md
@@ -51,6 +51,8 @@ For setting up an Azure Kubernetes cluster (aks) with Azure Active Directory you
 - Client-secret: A "Password" Key of the server Application.
 - OIDC Issuer URL: `https://sts.windows.net/<Tenant-ID>/`. The Tenant-ID can be found at `Home > Default Directory - Properties > Directory ID`.
 
+**Note**: If you are using an nginx reverse proxy to get to kubeapps you might need to increase the `proxy_buffer_size` as [Azure's session store is too large for nginx](https://oauth2-proxy.github.io/oauth2-proxy/auth-configuration#azure-auth-provider). Similar changes might also be required for other reverse proxies.
+
 ### Google OIDC
 
 In the case of Google we can use an OAuth 2.0 client ID. You can find more information [here](https://developers.google.com/identity/protocols/OpenIDConnect). In particular we will use a "Web Application".


### PR DESCRIPTION
When cookies become very big they might get cut up when using a reverse
proxy. This can easily happen when using Azure Active directory so we
should add a note about this in the setup instructions for this.

This is only a documentation change and follows the same format that is present in the document.