### PR TITLE
Fix temporary error message for Operators

### DIFF
--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -40,7 +40,7 @@ describe("checkOLMInstalled", () => {
         type: getType(operatorActions.checkingOLM),
       },
       {
-        type: getType(operatorActions.errorOperators),
+        type: getType(operatorActions.errorOLMCheck),
         payload: new Error("nope"),
       },
     ];

--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -327,6 +327,10 @@ describe("getResources", () => {
         type: getType(operatorActions.errorCustomResource),
         payload: new Error("Boom!"),
       },
+      {
+        type: getType(operatorActions.receiveCustomResources),
+        payload: [],
+      },
     ];
     await store.dispatch(operatorActions.getResources("default"));
     expect(store.getActions()).toEqual(expectedActions);

--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -6,6 +6,9 @@ import { IClusterServiceVersion, IPackageManifest, IResource, IStoreState } from
 
 export const checkingOLM = createAction("CHECKING_OLM");
 export const OLMInstalled = createAction("OLM_INSTALLED");
+export const errorOLMCheck = createAction("ERROR_OLM_CHECK", resolve => {
+  return (err: Error) => resolve(err);
+});
 
 export const requestOperators = createAction("REQUEST_OPERATORS");
 export const receiveOperators = createAction("RECEIVE_OPERATORS", resolve => {
@@ -76,6 +79,7 @@ export const receiveCustomResource = createAction("RECEIVE_CUSTOM_RESOURCE", res
 const actions = [
   checkingOLM,
   OLMInstalled,
+  errorOLMCheck,
   requestOperators,
   receiveOperators,
   errorOperators,
@@ -119,7 +123,7 @@ export function checkOLMInstalled(): ThunkAction<
       }
       return installed;
     } catch (e) {
-      dispatch(errorOperators(e));
+      dispatch(errorOLMCheck(e));
       return false;
     }
   };

--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -286,9 +286,7 @@ export function getResources(
       await Promise.all(crdPromises);
     });
     await Promise.all(csvPromises);
-    if (resources.length) {
-      dispatch(receiveCustomResources(resources));
-    }
+    dispatch(receiveCustomResources(resources));
     return resources;
   };
 }

--- a/dashboard/src/reducers/operators.test.ts
+++ b/dashboard/src/reducers/operators.test.ts
@@ -10,6 +10,12 @@ describe("catalogReducer", () => {
 
   beforeEach(() => {
     initialState = {
+      isFetchingElem: {
+        OLM: false,
+        operator: false,
+        csv: false,
+        resource: false,
+      },
       isFetching: false,
       isOLMInstalled: false,
       operators: [],
@@ -52,14 +58,22 @@ describe("catalogReducer", () => {
           operatorReducer(undefined, {
             type: actionTypes.checkingOLM as any,
           }),
-        ).toEqual({ ...initialState, isFetching: true });
+        ).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { OLM: true, operator: false, csv: false, resource: false },
+        });
       });
 
       it("unsets isFetching and mark OLM as installed", () => {
         const state = operatorReducer(undefined, {
           type: actionTypes.checkingOLM as any,
         });
-        expect(state).toEqual({ ...initialState, isFetching: true });
+        expect(state).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { OLM: true, operator: false, csv: false, resource: false },
+        });
         expect(
           operatorReducer(undefined, {
             type: actionTypes.OLMInstalled as any,
@@ -72,7 +86,11 @@ describe("catalogReducer", () => {
           type: actionTypes.requestOperators as any,
         });
         const op = {} as IPackageManifest;
-        expect(state).toEqual({ ...initialState, isFetching: true });
+        expect(state).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { OLM: false, operator: true, csv: false, resource: false },
+        });
         expect(
           operatorReducer(undefined, {
             type: actionTypes.receiveOperators as any,
@@ -85,7 +103,11 @@ describe("catalogReducer", () => {
         const state = operatorReducer(undefined, {
           type: actionTypes.requestOperators as any,
         });
-        expect(state).toEqual({ ...initialState, isFetching: true });
+        expect(state).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { OLM: false, operator: true, csv: false, resource: false },
+        });
         expect(
           operatorReducer(undefined, {
             type: actionTypes.errorOperators as any,
@@ -118,6 +140,7 @@ describe("catalogReducer", () => {
             {
               ...initialState,
               isFetching: true,
+              isFetchingElem: { OLM: true, operator: false, csv: false, resource: false },
               errors: { fetch: new Error("Boom!") },
               operators: [{} as any],
             },
@@ -133,7 +156,11 @@ describe("catalogReducer", () => {
           type: actionTypes.requestOperator as any,
         });
         const op = {} as IPackageManifest;
-        expect(state).toEqual({ ...initialState, isFetching: true });
+        expect(state).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { OLM: false, operator: true, csv: false, resource: false },
+        });
         expect(
           operatorReducer(undefined, {
             type: actionTypes.receiveOperator as any,
@@ -147,7 +174,11 @@ describe("catalogReducer", () => {
           type: actionTypes.requestCSVs as any,
         });
         const csv = {} as IClusterServiceVersion;
-        expect(state).toEqual({ ...initialState, isFetching: true });
+        expect(state).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { OLM: false, operator: false, csv: true, resource: false },
+        });
         expect(
           operatorReducer(undefined, {
             type: actionTypes.receiveCSVs as any,
@@ -160,7 +191,11 @@ describe("catalogReducer", () => {
         const state = operatorReducer(undefined, {
           type: actionTypes.requestCSVs as any,
         });
-        expect(state).toEqual({ ...initialState, isFetching: true });
+        expect(state).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { OLM: false, operator: false, csv: true, resource: false },
+        });
         expect(
           operatorReducer(undefined, {
             type: actionTypes.errorCSVs as any,
@@ -174,7 +209,11 @@ describe("catalogReducer", () => {
           type: actionTypes.requestCSV as any,
         });
         const csv = {} as IClusterServiceVersion;
-        expect(state).toEqual({ ...initialState, isFetching: true });
+        expect(state).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { OLM: false, operator: false, csv: true, resource: false },
+        });
         expect(
           operatorReducer(undefined, {
             type: actionTypes.receiveCSV as any,
@@ -189,7 +228,11 @@ describe("catalogReducer", () => {
         type: actionTypes.creatingResource as any,
       });
       const resource = {} as IResource;
-      expect(state).toEqual({ ...initialState, isFetching: true });
+      expect(state).toEqual({
+        ...initialState,
+        isFetching: true,
+        isFetchingElem: { OLM: false, operator: false, csv: false, resource: true },
+      });
       expect(
         operatorReducer(undefined, {
           type: actionTypes.resourceCreated as any,
@@ -202,7 +245,11 @@ describe("catalogReducer", () => {
       const state = operatorReducer(undefined, {
         type: actionTypes.creatingResource as any,
       });
-      expect(state).toEqual({ ...initialState, isFetching: true });
+      expect(state).toEqual({
+        ...initialState,
+        isFetching: true,
+        isFetchingElem: { OLM: false, operator: false, csv: false, resource: true },
+      });
       expect(
         operatorReducer(undefined, {
           type: actionTypes.errorResourceCreate as any,
@@ -216,7 +263,11 @@ describe("catalogReducer", () => {
         type: actionTypes.requestCustomResources as any,
       });
       const resource = {} as IResource;
-      expect(state).toEqual({ ...initialState, isFetching: true });
+      expect(state).toEqual({
+        ...initialState,
+        isFetching: true,
+        isFetchingElem: { OLM: false, operator: false, csv: false, resource: true },
+      });
       expect(
         operatorReducer(undefined, {
           type: actionTypes.receiveCustomResources as any,
@@ -229,7 +280,11 @@ describe("catalogReducer", () => {
       const state = operatorReducer(undefined, {
         type: actionTypes.requestCustomResources as any,
       });
-      expect(state).toEqual({ ...initialState, isFetching: true });
+      expect(state).toEqual({
+        ...initialState,
+        isFetching: true,
+        isFetchingElem: { OLM: false, operator: false, csv: false, resource: true },
+      });
       expect(
         operatorReducer(undefined, {
           type: actionTypes.errorCustomResource as any,
@@ -243,7 +298,11 @@ describe("catalogReducer", () => {
         type: actionTypes.requestCustomResource as any,
       });
       const resource = {} as IResource;
-      expect(state).toEqual({ ...initialState, isFetching: true });
+      expect(state).toEqual({
+        ...initialState,
+        isFetching: true,
+        isFetchingElem: { OLM: false, operator: false, csv: false, resource: true },
+      });
       expect(
         operatorReducer(undefined, {
           type: actionTypes.receiveCustomResource as any,
@@ -256,12 +315,38 @@ describe("catalogReducer", () => {
       const state = operatorReducer(undefined, {
         type: actionTypes.deletingResource as any,
       });
-      expect(state).toEqual({ ...initialState, isFetching: true });
+      expect(state).toEqual({
+        ...initialState,
+        isFetching: true,
+        isFetchingElem: { OLM: false, operator: false, csv: false, resource: true },
+      });
       expect(
         operatorReducer(undefined, {
           type: actionTypes.resourceDeleted as any,
         }),
       ).toEqual({ ...initialState, isFetching: false });
+    });
+
+    it("marks as still fetching if some resource is still fetching", () => {
+      let state = operatorReducer(undefined, {
+        type: actionTypes.checkingOLM as any,
+      });
+      state = operatorReducer(state, {
+        type: actionTypes.requestOperator as any,
+      });
+      expect(state).toEqual({
+        ...initialState,
+        isFetching: true,
+        isFetchingElem: { OLM: true, operator: true, csv: false, resource: false },
+      });
+      state = operatorReducer(state, {
+        type: actionTypes.OLMInstalled as any,
+      });
+      expect(state.isFetching).toBe(true);
+      state = operatorReducer(state, {
+        type: actionTypes.receiveOperator as any,
+      });
+      expect(state.isFetching).toBe(false);
     });
   });
 });

--- a/dashboard/src/reducers/operators.ts
+++ b/dashboard/src/reducers/operators.ts
@@ -8,6 +8,12 @@ import { IClusterServiceVersion, IPackageManifest, IResource } from "../shared/t
 
 export interface IOperatorsState {
   isFetching: boolean;
+  isFetchingElem: {
+    OLM: boolean;
+    operator: boolean;
+    csv: boolean;
+    resource: boolean;
+  };
   isOLMInstalled: boolean;
   operators: IResource[];
   operator?: IPackageManifest;
@@ -25,12 +31,29 @@ export interface IOperatorsState {
 
 const initialState: IOperatorsState = {
   isFetching: false,
+  isFetchingElem: {
+    OLM: false,
+    operator: false,
+    csv: false,
+    resource: false,
+  },
   isOLMInstalled: false,
   operators: [],
   csvs: [],
   errors: {},
   resources: [],
 };
+
+function isFetching(state: IOperatorsState, item: string, fetching: boolean) {
+  const composedIsFetching = {
+    ...state.isFetchingElem,
+    [item]: fetching,
+  };
+  return {
+    isFetching: Object.values(composedIsFetching).some(v => v),
+    isFetchingElem: composedIsFetching,
+  };
+}
 
 const catalogReducer = (
   state: IOperatorsState = initialState,
@@ -39,57 +62,103 @@ const catalogReducer = (
   const { operators } = actions;
   switch (action.type) {
     case getType(operators.checkingOLM):
-      return { ...state, isFetching: true };
+      return { ...state, ...isFetching(state, "OLM", true) };
     case getType(operators.OLMInstalled):
-      return { ...state, isOLMInstalled: true };
+      return { ...state, isOLMInstalled: true, ...isFetching(state, "OLM", false) };
+    case getType(operators.errorOLMCheck):
+      return {
+        ...state,
+        ...isFetching(state, "OLM", false),
+        errors: { fetch: action.payload },
+      };
     case getType(operators.requestOperators):
-      return { ...state, isFetching: true };
+      return { ...state, ...isFetching(state, "operator", true) };
     case getType(operators.receiveOperators):
-      return { ...state, isFetching: false, operators: action.payload };
+      return {
+        ...state,
+        ...isFetching(state, "operator", false),
+        operators: action.payload,
+      };
     case getType(operators.requestOperator):
-      return { ...state, isFetching: true };
+      return { ...state, ...isFetching(state, "operator", true) };
     case getType(operators.receiveOperator):
-      return { ...state, isFetching: false, operator: action.payload };
+      return {
+        ...state,
+        ...isFetching(state, "operator", false),
+        operator: action.payload,
+      };
     case getType(operators.errorOperators):
-      return { ...state, isFetching: false, errors: { fetch: action.payload } };
+      return {
+        ...state,
+        ...isFetching(state, "operator", false),
+        errors: { fetch: action.payload },
+      };
     case getType(operators.requestCSVs):
-      return { ...state, isFetching: true };
+      return { ...state, ...isFetching(state, "csv", true) };
     case getType(operators.receiveCSVs):
-      return { ...state, isFetching: false, csvs: action.payload };
+      return { ...state, ...isFetching(state, "csv", false), csvs: action.payload };
     case getType(operators.requestCSV):
-      return { ...state, isFetching: true };
+      return { ...state, ...isFetching(state, "csv", true) };
     case getType(operators.receiveCSV):
-      return { ...state, isFetching: false, csv: action.payload };
+      return { ...state, ...isFetching(state, "csv", false), csv: action.payload };
     case getType(operators.errorCSVs):
-      return { ...state, isFetching: false, errors: { fetch: action.payload } };
+      return {
+        ...state,
+        ...isFetching(state, "csv", false),
+        errors: { fetch: action.payload },
+      };
     case getType(operators.creatingResource):
-      return { ...state, isFetching: true };
+      return { ...state, ...isFetching(state, "resource", true) };
     case getType(operators.resourceCreated):
-      return { ...state, isFetching: false };
+      return { ...state, ...isFetching(state, "resource", false) };
     case getType(operators.updatingResource):
-      return { ...state, isFetching: true };
+      return { ...state, ...isFetching(state, "resource", true) };
     case getType(operators.resourceUpdated):
-      return { ...state, isFetching: false };
+      return { ...state, ...isFetching(state, "resource", false) };
     case getType(operators.deletingResource):
-      return { ...state, isFetching: true };
+      return { ...state, ...isFetching(state, "resource", true) };
     case getType(operators.resourceDeleted):
-      return { ...state, isFetching: false };
+      return { ...state, ...isFetching(state, "resource", false) };
     case getType(operators.errorResourceDelete):
-      return { ...state, isFetching: false, errors: { delete: action.payload } };
+      return {
+        ...state,
+        ...isFetching(state, "resource", false),
+        errors: { delete: action.payload },
+      };
     case getType(operators.errorResourceCreate):
-      return { ...state, isFetching: false, errors: { create: action.payload } };
+      return {
+        ...state,
+        ...isFetching(state, "resource", false),
+        errors: { create: action.payload },
+      };
     case getType(operators.errorResourceUpdate):
-      return { ...state, isFetching: false, errors: { update: action.payload } };
+      return {
+        ...state,
+        ...isFetching(state, "resource", false),
+        errors: { update: action.payload },
+      };
     case getType(operators.requestCustomResources):
-      return { ...state, isFetching: true };
+      return { ...state, ...isFetching(state, "resource", true) };
     case getType(operators.receiveCustomResources):
-      return { ...state, isFetching: false, resources: action.payload };
+      return {
+        ...state,
+        ...isFetching(state, "resource", false),
+        resources: action.payload,
+      };
     case getType(operators.errorCustomResource):
-      return { ...state, isFetching: false, errors: { fetch: action.payload } };
+      return {
+        ...state,
+        ...isFetching(state, "resource", false),
+        errors: { fetch: action.payload },
+      };
     case getType(operators.requestCustomResource):
-      return { ...state, isFetching: true };
+      return { ...state, ...isFetching(state, "resource", true) };
     case getType(operators.receiveCustomResource):
-      return { ...state, isFetching: false, resource: action.payload };
+      return {
+        ...state,
+        ...isFetching(state, "resource", false),
+        resource: action.payload,
+      };
     case LOCATION_CHANGE:
       return { ...state, isOLMInstalled: state.isOLMInstalled, errors: {} };
     case getType(actions.namespace.setNamespace):


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

When loading the Operators view, the error and "No operators found" messages are shown for a bit:

![Peek 2020-04-07 17-27](https://user-images.githubusercontent.com/4025665/78689536-bc05b500-78f6-11ea-93e2-709f25397182.gif)

This is because we are using the same isFetching properties for several things and once the first thing is fetched the flag is set to false (wrongly). This PR fixes that so `isFetching` is set to true only when everything has been fetched.

![Peek 2020-04-07 17-26](https://user-images.githubusercontent.com/4025665/78689663-df306480-78f6-11ea-9a10-2553d33c2ecb.gif)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1552 

