### PR TITLE
Fix repo filter in Catalog

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -20,7 +20,7 @@ const defaultChartState = {
 } as IChartState;
 const defaultProps = {
   charts: defaultChartState,
-  repo: "stable",
+  repo: "",
   filter: "",
   fetchCharts: jest.fn(),
   pushSearchFilter: jest.fn(),
@@ -312,6 +312,15 @@ describe("renderization", () => {
         const wrapper = shallow(<Catalog {...defaultProps} csvs={csvs} />);
         expect(wrapper.find(MessageAlert)).not.toExist();
         expect(wrapper.find(".Catalog")).toExist();
+      });
+
+      it("should skip operators if the repo filter is used", () => {
+        const wrapper = shallow(
+          <Catalog {...defaultProps} charts={chartState} csvs={csvs} repo="test" />,
+        );
+        const cardGrid = wrapper.find(CardGrid);
+        expect(cardGrid).toExist();
+        expect(cardGrid.children().length).toBe(chartState.items.length);
       });
     });
   });

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -84,10 +84,7 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
         />
       );
     }
-    const filteredCharts = this.filteredCharts(allItems);
-    const filteredCSVs = this.filteredCSVs(csvs);
-    const catalogItems = this.getCatalogItems(filteredCharts, filteredCSVs);
-    if (!isFetching && catalogItems.length === 0) {
+    if (!isFetching && allItems.length === 0 && csvs.length === 0) {
       return (
         <MessageAlert
           level={"warning"}
@@ -101,6 +98,9 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
         />
       );
     }
+    const filteredCharts = this.filteredCharts(allItems);
+    const filteredCSVs = this.shouldRenderOperators() ? this.filteredCSVs(csvs) : [];
+    const catalogItems = this.getCatalogItems(filteredCharts, filteredCSVs);
     const items = catalogItems.map(c => (
       <CatalogItem key={`${c.type}/${c.repoName || c.csv}/${c.name}`} item={c} />
     ));
@@ -118,7 +118,7 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
         </PageHeader>
         <LoadingWrapper loaded={!isFetching}>
           <div className="row">
-            {csvs.length > 0 && (
+            {this.shouldRenderOperators() && (
               <div className="col-2">
                 <div className="margin-b-normal">
                   <span>
@@ -143,7 +143,7 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
                 </div>
               </div>
             )}
-            <div className={csvs.length > 0 ? "col-10" : ""}>
+            <div className={this.shouldRenderOperators() ? "col-10" : ""}>
               <CardGrid>{items}</CardGrid>
             </div>
           </div>
@@ -211,6 +211,13 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
     this.setState({
       filter,
     });
+  };
+
+  // Render Operators only if there are Operators to render and if we are not
+  // filtering by repo
+  private shouldRenderOperators = () => {
+    const { csvs, repo } = this.props;
+    return csvs.length > 0 && !repo;
   };
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Another couple of minor fixes:
 - In the catalog, if a repository is selected we were still showing Operator instances
 - When setting a value in the search bar that doesn't match any element, we were showing the MessageAlert (instead that showing an empty list).

