### PR TITLE
Fix namespaced chart deploy - dashboard

### DIFF
--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -221,13 +221,13 @@ describe("deploy chart", () => {
 
   it("returns true if namespace is correct and deployment is successful", async () => {
     const res = await store.dispatch(
-      actions.apps.deployChart("my-version" as any, "my-release", "default"),
+      actions.apps.deployChart("my-version" as any, "chart-namespace", "my-release", "default"),
     );
     expect(res).toBe(true);
     expect(App.create).toHaveBeenCalledWith(
       "my-release",
       "default",
-      "kubeapps-ns",
+      "chart-namespace",
       "my-version",
       undefined,
     );
@@ -240,7 +240,7 @@ describe("deploy chart", () => {
 
   it("returns false and dispatches UnprocessableEntity if the namespace is _all", async () => {
     const res = await store.dispatch(
-      actions.apps.deployChart("my-version" as any, "my-release", definedNamespaces.all),
+      actions.apps.deployChart("my-version" as any, "chart-namespace", "my-release", definedNamespaces.all),
     );
     expect(res).toBe(false);
     const expectedActions = [
@@ -256,7 +256,7 @@ describe("deploy chart", () => {
   });
   it("returns false and dispatches UnprocessableEntity if the given values don't satisfy the schema ", async () => {
     const res = await store.dispatch(
-      actions.apps.deployChart("my-version" as any, "my-release", "default", "foo: 1", {
+      actions.apps.deployChart("my-version" as any, "chart-namespace", "my-release", "default", "foo: 1", {
         properties: { foo: { type: "string" } },
       }),
     );

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -277,6 +277,7 @@ describe("deploy chart", () => {
 describe("upgradeApp", () => {
   const provisionCMD = actions.apps.upgradeApp(
     "my-version" as any,
+    "kubeapps-ns",
     "my-release",
     definedNamespaces.all,
   );
@@ -319,7 +320,7 @@ describe("upgradeApp", () => {
 
   it("returns false and dispatches UnprocessableEntity if the given values don't satisfy the schema ", async () => {
     const res = await store.dispatch(
-      actions.apps.upgradeApp("my-version" as any, "my-release", "default", "foo: 1", {
+      actions.apps.upgradeApp("my-version" as any, "kubeapps-ns", "my-release", "default", "foo: 1", {
         properties: { foo: { type: "string" } },
       }),
     );

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -286,6 +286,7 @@ export function deployChart(
 
 export function upgradeApp(
   chartVersion: IChartVersion,
+  chartNamespace: string,
   releaseName: string,
   namespace: string,
   values?: string,
@@ -294,9 +295,6 @@ export function upgradeApp(
   return async (dispatch, getState) => {
     dispatch(requestUpgradeApp());
     try {
-      const {
-        config: { namespace: kubeappsNamespace },
-      } = getState();
       if (values && schema) {
         const validation = validate(values, schema);
         if (!validation.valid) {
@@ -308,7 +306,7 @@ export function upgradeApp(
           );
         }
       }
-      await App.upgrade(releaseName, namespace, kubeappsNamespace, chartVersion, values);
+      await App.upgrade(releaseName, namespace, chartNamespace, chartVersion, values);
       dispatch(receiveUpgradeApp());
       return true;
     } catch (e) {

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -248,6 +248,7 @@ export function fetchAppsWithUpdateInfo(
 
 export function deployChart(
   chartVersion: IChartVersion,
+  chartNamespace: string,
   releaseName: string,
   namespace: string,
   values?: string,
@@ -273,10 +274,7 @@ export function deployChart(
           );
         }
       }
-      const {
-        config: { namespace: kubeappsNamespace },
-      } = getState();
-      await App.create(releaseName, namespace, kubeappsNamespace, chartVersion, values);
+      await App.create(releaseName, namespace, chartNamespace, chartVersion, values);
       dispatch(receiveDeployApp());
       return true;
     } catch (e) {

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -20,6 +20,7 @@ interface IAppUpgradeProps {
   deployed: IChartState["deployed"];
   upgradeApp: (
     version: IChartVersion,
+    chartNamespace: string,
     releaseName: string,
     namespace: string,
     values?: string,

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -179,7 +179,7 @@ it("triggers a deployment when submitting the form", done => {
   );
   wrapper.setState({ appValues });
   wrapper.find("form").simulate("submit");
-  expect(deployChart).toHaveBeenCalledWith(versions[0], releaseName, namespace, appValues, schema);
+  expect(deployChart).toHaveBeenCalledWith(versions[0], defaultProps.chartNamespace, releaseName, namespace, appValues, schema);
   setTimeout(() => {
     expect(push).toHaveBeenCalledWith("/ns/default/apps/my-release");
     done();

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -24,6 +24,7 @@ export interface IDeploymentFormProps {
   selected: IChartState["selected"];
   deployChart: (
     version: IChartVersion,
+    chartNamespace: string,
     releaseName: string,
     namespace: string,
     values?: string,
@@ -154,13 +155,14 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
 
   public handleDeploy = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const { selected, deployChart, push, namespace } = this.props;
+    const { chartNamespace, selected, deployChart, push, namespace } = this.props;
     const { releaseName, appValues } = this.state;
 
     this.setState({ isDeploying: true, latestSubmittedReleaseName: releaseName });
     if (selected.version) {
       const deployed = await deployChart(
         selected.version,
+        chartNamespace,
         releaseName,
         namespace,
         appValues,

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -108,7 +108,7 @@ it("triggers an upgrade when submitting the form", done => {
   );
   wrapper.setState({ releaseName, appValues });
   wrapper.find("form").simulate("submit");
-  expect(upgradeApp).toHaveBeenCalledWith(versions[0], releaseName, namespace, appValues, schema);
+  expect(upgradeApp).toHaveBeenCalledWith(versions[0], "kubeapps", releaseName, namespace, appValues, schema);
   setTimeout(() => {
     expect(push).toHaveBeenCalledWith("/ns/default/apps/my-release");
     done();

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -23,6 +23,7 @@ export interface IUpgradeFormProps {
   deployed: IChartState["deployed"];
   upgradeApp: (
     version: IChartVersion,
+    chartNamespace: string,
     releaseName: string,
     namespace: string,
     values?: string,
@@ -125,13 +126,14 @@ class UpgradeForm extends React.Component<IUpgradeFormProps, IUpgradeFormState> 
 
   public handleDeploy = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const { selected, push, upgradeApp, releaseName, namespace } = this.props;
+    const { selected, push, upgradeApp, releaseName, namespace, repoNamespace } = this.props;
     const { appValues } = this.state;
 
     this.setState({ isDeploying: true });
     if (selected.version) {
       const deployed = await upgradeApp(
         selected.version,
+        repoNamespace,
         releaseName,
         namespace,
         appValues,

--- a/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -39,11 +39,12 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
   return {
     deployChart: (
       version: IChartVersion,
+      chartNamespace: string,
       releaseName: string,
       namespace: string,
       values?: string,
       schema?: JSONSchema4,
-    ) => dispatch(actions.apps.deployChart(version, releaseName, namespace, values, schema)),
+    ) => dispatch(actions.apps.deployChart(version, chartNamespace, releaseName, namespace, values, schema)),
     fetchChartVersions: (namespace: string, id: string) => dispatch(actions.charts.fetchChartVersions(namespace, id)),
     getChartVersion: (namespace: string, id: string, version: string) =>
       dispatch(actions.charts.getChartVersion(namespace, id, version)),

--- a/dashboard/src/containers/AppUpgradeContainer/AppUpgradeContainer.tsx
+++ b/dashboard/src/containers/AppUpgradeContainer/AppUpgradeContainer.tsx
@@ -60,11 +60,12 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     goBack: () => dispatch(goBack()),
     upgradeApp: (
       version: IChartVersion,
+      chartNamespace: string,
       releaseName: string,
       namespace: string,
       values?: string,
       schema?: JSONSchema4,
-    ) => dispatch(actions.apps.upgradeApp(version, releaseName, namespace, values, schema)),
+    ) => dispatch(actions.apps.upgradeApp(version, chartNamespace, releaseName, namespace, values, schema)),
     getDeployedChartVersion: (namespace: string, id: string, version: string) =>
       dispatch(actions.charts.getDeployedChartVersion(namespace, id, version)),
   };

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -100,8 +100,8 @@ describe("App", () => {
       expect(request.config.data).toEqual(
         JSON.stringify({
           appRepositoryResourceName: testChartVersion.relationships.chart.data.repo.name,
+          appRepositoryResourceNamespace: "kubeapps",
           chartName: testChartVersion.relationships.chart.data.name,
-          chartNamespace: "kubeapps",
           releaseName: "absent-ant",
           version: testChartVersion.attributes.version,
         }),
@@ -135,8 +135,8 @@ describe("App", () => {
       expect(request.config.data).toEqual(
         JSON.stringify({
           appRepositoryResourceName: testChartVersion.relationships.chart.data.repo.name,
+          appRepositoryResourceNamespace: "kubeapps",
           chartName: testChartVersion.relationships.chart.data.name,
-          chartNamespace: "kubeapps",
           releaseName: "absent-ant",
           version: testChartVersion.attributes.version,
         }),

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -136,6 +136,7 @@ describe("App", () => {
         JSON.stringify({
           appRepositoryResourceName: testChartVersion.relationships.chart.data.repo.name,
           chartName: testChartVersion.relationships.chart.data.name,
+          chartNamespace: "kubeapps",
           releaseName: "absent-ant",
           version: testChartVersion.attributes.version,
         }),

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -101,6 +101,7 @@ describe("App", () => {
         JSON.stringify({
           appRepositoryResourceName: testChartVersion.relationships.chart.data.repo.name,
           chartName: testChartVersion.relationships.chart.data.name,
+          chartNamespace: "kubeapps",
           releaseName: "absent-ant",
           version: testChartVersion.attributes.version,
         }),

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -43,7 +43,7 @@ export class App {
   public static async upgrade(
     releaseName: string,
     namespace: string,
-    kubeappsNamespace: string,
+    chartNamespace: string,
     chartVersion: IChartVersion,
     values?: string,
   ) {
@@ -52,6 +52,7 @@ export class App {
     const { data } = await axiosWithAuth.put(endpoint, {
       appRepositoryResourceName: chartAttrs.repo.name,
       chartName: chartAttrs.name,
+      chartNamespace,
       releaseName,
       values,
       version: chartVersion.attributes.version,

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -23,7 +23,7 @@ export class App {
   public static async create(
     releaseName: string,
     namespace: string,
-    kubeappsNamespace: string,
+    chartNamespace: string,
     chartVersion: IChartVersion,
     values?: string,
   ) {
@@ -32,6 +32,7 @@ export class App {
     const { data } = await axiosWithAuth.post(endpoint, {
       appRepositoryResourceName: chartAttrs.repo.name,
       chartName: chartAttrs.name,
+      chartNamespace,
       releaseName,
       values,
       version: chartVersion.attributes.version,

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -31,8 +31,8 @@ export class App {
     const endpoint = App.getResourceURL(namespace);
     const { data } = await axiosWithAuth.post(endpoint, {
       appRepositoryResourceName: chartAttrs.repo.name,
+      appRepositoryResourceNamespace: chartNamespace,
       chartName: chartAttrs.name,
-      chartNamespace,
       releaseName,
       values,
       version: chartVersion.attributes.version,
@@ -51,8 +51,8 @@ export class App {
     const endpoint = App.getResourceURL(namespace, releaseName);
     const { data } = await axiosWithAuth.put(endpoint, {
       appRepositoryResourceName: chartAttrs.repo.name,
+      appRepositoryResourceNamespace: chartNamespace,
       chartName: chartAttrs.name,
-      chartNamespace,
       releaseName,
       values,
       version: chartVersion.attributes.version,


### PR DESCRIPTION
Dashboard changes to send the chart namespace (`AppRepositoryResourceNamespace`) with the `App.create` and `App.Upgrade` requests.

Following PR will add the backend change.