### PR TITLE
Fix card shrink in Catalog

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -143,7 +143,7 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
                 </div>
               </div>
             )}
-            <div className={this.shouldRenderOperators() ? "col-10" : ""}>
+            <div className={this.shouldRenderOperators() ? "col-10" : "col-12"}>
               <CardGrid>{items}</CardGrid>
             </div>
           </div>

--- a/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`renderization when charts available should render the list of charts 1`
       className="row"
     >
       <div
-        className=""
+        className="col-12"
       >
         <CardGrid>
           <CatalogItem
@@ -88,7 +88,7 @@ exports[`renderization when fetching apps loading spinner matches the snapshot 1
       className="row"
     >
       <div
-        className=""
+        className="col-12"
       >
         <CardGrid />
       </div>


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

When there are less than 4 cards in the catalog, these cards shrink 

![Screenshot from 2020-04-08 17-32-51](https://user-images.githubusercontent.com/4025665/78803934-dd7ea380-79bf-11ea-9e47-5065ec1fea70.png)

We need to set the CSS properties to fill the whole row.

![Screenshot from 2020-04-08 17-40-11](https://user-images.githubusercontent.com/4025665/78804095-07d06100-79c0-11ea-9879-04ad341dcca7.png)
