### PR TITLE
Fix namespaced chart deploy backend

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -276,7 +276,7 @@ func (c *ChartClient) parseDetailsForHTTPClient(details *Details) (*appRepov1.Ap
 	// We grab the specified app repository (for later access to the repo URL, as well as any specified
 	// auth).
 	client := c.appRepoHandler.AsUser(details.UserToken)
-	if details.AppRepositoryResourceName == c.kubeappsNamespace {
+	if details.AppRepositoryResourceNamespace == c.kubeappsNamespace {
 		// If we're parsing a global repository (from the kubeappsNamespace), use a service client.
 		client = c.appRepoHandler.AsSVC()
 	}

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -197,10 +197,6 @@ func fakeLoadChartV2(in io.Reader) (*chartv2.Chart, error) {
 	return &chartv2.Chart{}, nil
 }
 
-func TestmeTest(t *testing.T) {
-	t.Fatalf("bar")
-}
-
 func TestParseDetailsForHTTPClient(t *testing.T) {
 	systemCertPool, err := x509.SystemCertPool()
 	if err != nil {

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -339,7 +339,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			appRepo, caCertSecret, authSecret, err := chUtils.parseDetailsForHTTPClient(tc.details)
+			appRepo, caCertSecret, authSecret, err := chUtils.parseDetailsForHTTPClient(tc.details, "dummy-user-token")
 
 			if err != nil {
 				if tc.errorExpected {

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -117,22 +117,25 @@ func TestParseDetails(t *testing.T) {
 			name: "parses request including app repo resource",
 			data: `{
 				"appRepositoryResourceName": "my-chart-repo",
+				"appRepositoryResourceNamespace": "my-repo-namespace",
 	        	"chartName": "test",
 	        	"releaseName": "foo",
 	        	"version": "1.0.0",
 	        	"values": "foo: bar"
 	        }`,
 			expected: &Details{
-				AppRepositoryResourceName: "my-chart-repo",
-				ChartName:                 "test",
-				ReleaseName:               "foo",
-				Version:                   "1.0.0",
-				Values:                    "foo: bar",
+				AppRepositoryResourceName:      "my-chart-repo",
+				AppRepositoryResourceNamespace: "my-repo-namespace",
+				ChartName:                      "test",
+				ReleaseName:                    "foo",
+				Version:                        "1.0.0",
+				Values:                         "foo: bar",
 			},
 		},
 		{
 			name: "errors if appRepositoryResourceName is not present",
 			data: `{
+				"appRepositoryResourceNamespace": "my-repo-namespace",
 				"chartName": "test",
 				"releaseName": "foo",
 				"version": "1.0.0",
@@ -144,6 +147,19 @@ func TestParseDetails(t *testing.T) {
 			name: "errors if appRepositoryResourceName is empty",
 			data: `{
 				"appRepositoryResourceName": "",
+				"appRepositoryResourceNamespace": "my-repo-namespace",
+				"chartName": "test",
+				"releaseName": "foo",
+				"version": "1.0.0",
+				"values": "foo: bar"
+			}`,
+			err: true,
+		},
+		{
+			name: "errors if appRepositoryResourceNamespace is empty",
+			data: `{
+				"appRepositoryResourceName": "my-repo",
+				"appRepositoryResourceNamespace": "",
 				"chartName": "test",
 				"releaseName": "foo",
 				"version": "1.0.0",
@@ -181,7 +197,11 @@ func fakeLoadChartV2(in io.Reader) (*chartv2.Chart, error) {
 	return &chartv2.Chart{}, nil
 }
 
-func TestparseDetailsForHTTPClient(t *testing.T) {
+func TestmeTest(t *testing.T) {
+	t.Fatalf("bar")
+}
+
+func TestParseDetailsForHTTPClient(t *testing.T) {
 	systemCertPool, err := x509.SystemCertPool()
 	if err != nil {
 		t.Fatalf("%+v", err)
@@ -193,6 +213,7 @@ func TestparseDetailsForHTTPClient(t *testing.T) {
 		customCASecretName   = "custom-ca-secret-name"
 		customCASecretData   = "some-cert-data"
 		appRepoName          = "custom-repo"
+		appRepoNamespace     = "my-namespace"
 	)
 
 	testCases := []struct {
@@ -205,14 +226,16 @@ func TestparseDetailsForHTTPClient(t *testing.T) {
 		{
 			name: "default cert pool without auth",
 			details: &Details{
-				AppRepositoryResourceName: appRepoName,
+				AppRepositoryResourceName:      appRepoName,
+				AppRepositoryResourceNamespace: appRepoNamespace,
 			},
 			numCertsExpected: len(systemCertPool.Subjects()),
 		},
 		{
 			name: "custom CA added when passed an AppRepository CRD",
 			details: &Details{
-				AppRepositoryResourceName: appRepoName,
+				AppRepositoryResourceName:      appRepoName,
+				AppRepositoryResourceNamespace: appRepoNamespace,
 			},
 			appRepoSpec: appRepov1.AppRepositorySpec{
 				Auth: appRepov1.AppRepositoryAuth{
@@ -230,7 +253,8 @@ func TestparseDetailsForHTTPClient(t *testing.T) {
 		{
 			name: "errors if secret for custom CA secret cannot be found",
 			details: &Details{
-				AppRepositoryResourceName: appRepoName,
+				AppRepositoryResourceName:      appRepoName,
+				AppRepositoryResourceNamespace: appRepoNamespace,
 			},
 			appRepoSpec: appRepov1.AppRepositorySpec{
 				Auth: appRepov1.AppRepositoryAuth{
@@ -248,7 +272,8 @@ func TestparseDetailsForHTTPClient(t *testing.T) {
 		{
 			name: "authorization header added when passed an AppRepository CRD",
 			details: &Details{
-				AppRepositoryResourceName: appRepoName,
+				AppRepositoryResourceName:      appRepoName,
+				AppRepositoryResourceNamespace: appRepoNamespace,
 			},
 			appRepoSpec: appRepov1.AppRepositorySpec{
 				Auth: appRepov1.AppRepositoryAuth{
@@ -266,7 +291,8 @@ func TestparseDetailsForHTTPClient(t *testing.T) {
 		{
 			name: "errors if auth secret cannot be found",
 			details: &Details{
-				AppRepositoryResourceName: appRepoName,
+				AppRepositoryResourceName:      appRepoName,
+				AppRepositoryResourceNamespace: appRepoNamespace,
 			},
 			appRepoSpec: appRepov1.AppRepositorySpec{
 				Auth: appRepov1.AppRepositoryAuth{
@@ -288,7 +314,7 @@ func TestparseDetailsForHTTPClient(t *testing.T) {
 		secrets := []*corev1.Secret{&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      customCASecretName,
-				Namespace: metav1.NamespaceSystem,
+				Namespace: appRepoNamespace,
 			},
 			Data: map[string][]byte{
 				"custom-secret-key": []byte(customCASecretData),
@@ -296,7 +322,7 @@ func TestparseDetailsForHTTPClient(t *testing.T) {
 		}, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      authHeaderSecretName,
-				Namespace: metav1.NamespaceSystem,
+				Namespace: appRepoNamespace,
 			},
 			Data: map[string][]byte{
 				"custom-secret-key": []byte(authHeaderSecretData),
@@ -306,7 +332,7 @@ func TestparseDetailsForHTTPClient(t *testing.T) {
 		apprepos := []*appRepov1.AppRepository{&appRepov1.AppRepository{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tc.details.AppRepositoryResourceName,
-				Namespace: metav1.NamespaceSystem,
+				Namespace: appRepoNamespace,
 			},
 			Spec: tc.appRepoSpec,
 		}}

--- a/pkg/chart/fake/chart.go
+++ b/pkg/chart/fake/chart.go
@@ -67,6 +67,6 @@ func getValues(raw []byte) (map[string]interface{}, error) {
 	return values, nil
 }
 
-func (f *FakeChart) InitNetClient(details *chartUtils.Details) (kube.HTTPClient, error) {
+func (f *FakeChart) InitNetClient(details *chartUtils.Details, userAuthToken string) (kube.HTTPClient, error) {
 	return &http.Client{}, nil
 }

--- a/pkg/handlerutil/handlerutil.go
+++ b/pkg/handlerutil/handlerutil.go
@@ -79,9 +79,8 @@ func ParseAndGetChart(req *http.Request, cu chartUtils.Resolver, requireV1Suppor
 	if err != nil {
 		return nil, nil, err
 	}
-	chartDetails.UserToken = auth.ExtractToken(req.Header.Get("Authorization"))
 
-	netClient, err := cu.InitNetClient(chartDetails)
+	netClient, err := cu.InitNetClient(chartDetails, auth.ExtractToken(req.Header.Get("Authorization")))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/handlerutil/handlerutil.go
+++ b/pkg/handlerutil/handlerutil.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/kubeapps/kubeapps/pkg/auth"
 	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
 )
 
@@ -78,6 +79,8 @@ func ParseAndGetChart(req *http.Request, cu chartUtils.Resolver, requireV1Suppor
 	if err != nil {
 		return nil, nil, err
 	}
+	chartDetails.UserToken = auth.ExtractToken(req.Header.Get("Authorization"))
+
 	netClient, err := cu.InitNetClient(chartDetails)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -251,15 +251,7 @@ func (a *userHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestName
 		if err != nil {
 			return nil, err
 		}
-		// If the namespace isn't kubeapps (ie. this is a per-namespace
-		// AppRepository), save a copy of the repository secret in kubeapps
-		// namespace using the service account clientset. This enables the
-		// existing assetsync service to be able to sync private
-		// AppRepositories in other namespaces. It is not ideal and is a
-		// temporary work-around until the asset-sync is updated to run
-		// cronjobs in other namespaces with the assetsvc receiving the data.
-		// See the relevant section of the design doc for details:
-		// https://docs.google.com/document/d/1YEeKC6nPLoq4oaxs9v8_UsmxrRfWxB6KCyqrh2-Q8x0/edit?ts=5e2adf87#heading=h.kilvd2vii0w
+		// TODO(#1647): Move app repo sync to namespaces so secret copy not required.
 		if requestNamespace != a.kubeappsNamespace {
 			repoSecret.ObjectMeta.Name = KubeappsSecretNameForRepo(appRepo.ObjectMeta.Name, appRepo.ObjectMeta.Namespace)
 			repoSecret.ObjectMeta.OwnerReferences = nil


### PR DESCRIPTION
Updates ChartDetails to include both the app repo namespace as well as the user token from the request, so that requests can be made on behalf of the user for the app repo in the specified namespace.

Ref #1521.