### PR TITLE
Update RBAC roles for apprepositories to be clusterroles so they can be used in many namespaces.

### DIFF
--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -93,8 +93,6 @@ rules:
       - secrets
     verbs:
       - create
-{{ end }}
-{{- if .Values.featureFlags.reposPerNamespace -}}
 ---
 # The Kubeapps app repository controller can read and watch its own
 # AppRepository resources cluster-wide. The read and write cluster-roles can
@@ -102,7 +100,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: "kubeapps:apprepositories-read"
+  name: "kubeapps:{{ .Release.Namespace }}:apprepositories-read"
   labels:
     app: {{ template "kubeapps.apprepository.fullname" . }}
     chart: {{ template "kubeapps.chart" . }}
@@ -122,7 +120,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: "kubeapps:controller:apprepositories-read"
+  name: "kubeapps:controller:{{ .Release.Namespace }}:apprepositories-read"
   labels:
     app: {{ template "kubeapps.apprepository.fullname" . }}
     chart: {{ template "kubeapps.chart" . }}
@@ -131,7 +129,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: "kubeapps:apprepositories-read"
+  name: "kubeapps:{{ .Release.Namespace }}:apprepositories-read"
 subjects:
   - kind: ServiceAccount
     name: {{ template "kubeapps.apprepository.fullname" . }}
@@ -140,7 +138,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: "kubeapps:apprepositories-write"
+  name: "kubeapps:{{ .Release.Namespace }}:apprepositories-write"
   labels:
     app: {{ template "kubeapps.apprepository.fullname" . }}
     chart: {{ template "kubeapps.chart" . }}

--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -122,7 +122,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: "kubeapps:controller:appreposities-read"
+  name: "kubeapps:controller:apprepositories-read"
   labels:
     app: {{ template "kubeapps.apprepository.fullname" . }}
     chart: {{ template "kubeapps.chart" . }}

--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -96,11 +96,13 @@ rules:
 {{ end }}
 {{- if .Values.featureFlags.reposPerNamespace -}}
 ---
-# Kubeapps can read and watch its own AppRepository resources cluster-wide.
+# The Kubeapps app repository controller can read and watch its own
+# AppRepository resources cluster-wide. The read and write cluster-roles can
+# also be bound to users in specific namespaces as required.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: "kubeapps:controller:apprepository-reader-{{ .Release.Namespace }}"
+  name: "kubeapps:apprepositories-read"
   labels:
     app: {{ template "kubeapps.apprepository.fullname" . }}
     chart: {{ template "kubeapps.chart" . }}
@@ -115,13 +117,12 @@ rules:
     verbs:
       - get
       - list
-      - update
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: "kubeapps:controller:apprepository-reader-{{ .Release.Namespace }}"
+  name: "kubeapps:controller:appreposities-read"
   labels:
     app: {{ template "kubeapps.apprepository.fullname" . }}
     chart: {{ template "kubeapps.chart" . }}
@@ -130,9 +131,32 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: "kubeapps:controller:apprepository-reader-{{ .Release.Namespace }}"
+  name: "kubeapps:apprepositories-read"
 subjects:
   - kind: ServiceAccount
     name: {{ template "kubeapps.apprepository.fullname" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "kubeapps:apprepositories-write"
+  labels:
+    app: {{ template "kubeapps.apprepository.fullname" . }}
+    chart: {{ template "kubeapps.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - kubeapps.com
+    resources:
+      - apprepositories
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
 {{- end -}}

--- a/docs/user/access-control.md
+++ b/docs/user/access-control.md
@@ -110,27 +110,25 @@ kubectl create clusterrolebinding example-kubeapps-service-catalog-admin --clust
 
 #### Read access to App Repositories
 
-In order to list the configured App Repositories in Kubeapps, [bind users/groups Subjects](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#command-line-utilities) to the `$RELEASE_NAME-repositories-read` role in the namespace Kubeapps was installed into by the helm chart.
+In order to list the configured App Repositories in Kubeapps, [bind users/groups Subjects](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#command-line-utilities) to the Kubeapps `apprepositories-read` clusterrole in the namespace Kubeapps was installed into by the helm chart.
 
 ```bash
 export KUBEAPPS_NAMESPACE=kubeapps
-export KUBEAPPS_RELEASE_NAME=kubeapps
 kubectl create -n $KUBEAPPS_NAMESPACE rolebinding example-kubeapps-repositories-read \
-  --role=$KUBEAPPS_RELEASE_NAME-repositories-read \
+  --clusterrole=kubeapps:$KUBEAPPS_NAMESPACE:apprepositories-read \
   --serviceaccount default:example
 ```
 
 #### Write access to App Repositories
 
 Likewise to the read access bind users/group Subjects to the
-`$KUBEAPPS_RELEASE_NAME-repositories-write` Role in the namespace Kubeapps is installed in
+Kubeapps `apprepositories-write` ClusterRole in the namespace Kubeapps is installed in
 for users to create and refresh App Repositories in Kubeapps
 
 ```bash
 export KUBEAPPS_NAMESPACE=kubeapps
-export KUBEAPPS_RELEASE_NAME=kubeapps
 kubectl create -n $KUBEAPPS_NAMESPACE rolebinding example-kubeapps-repositories-write \
-  --role=$KUBEAPPS_RELEASE_NAME-repositories-write \
+  --clusterrole=kubeapps:$KUBEAPPS_NAMESPACE:apprepositories-write \
   --serviceaccount default:example
 ```
 

--- a/docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
@@ -37,4 +37,38 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: oidc:kubeapps-user-ldap@example.org
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubeapps-user-apprepositories-read
+  namespace: kubeapps-user-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeapps:apprepositories-read
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: oidc:kubeapps-user@example.com
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: oidc:kubeapps-user-ldap@example.org
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubeapps-operator-apprepositories-write
+  namespace: kubeapps-user-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeapps:apprepositories-write
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: oidc:kubeapps-operator@example.com
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: oidc:kubeapps-operator-ldap@example.org
 

--- a/docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
@@ -46,7 +46,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubeapps:apprepositories-read
+  name: kubeapps:kubeapps:apprepositories-read
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
@@ -63,7 +63,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubeapps:apprepositories-write
+  name: kubeapps:kubeapps:apprepositories-write
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User

--- a/docs/user/private-app-repository.md
+++ b/docs/user/private-app-repository.md
@@ -202,18 +202,20 @@ The above will generate a Pod with the label `my-repo: isPrivate` and the enviro
 
 ## Per Namespace App Repositories
 
-Previously, once an App Repository was created in Kubeapps, the chart of that repository were then available cluster-wide to all users of Kubeapps. This was changed to allow creating App Repositories available only in specific namespaces, enabling future work supporting deploying charts with private docker registries. These can be created by anyone with the required RBAC for that namespace. You can still create an App Repository whose charts will be available to users in all namespaces by selecting "All Namespaces" when creating the repository.
+Previously, once an App Repository was created in Kubeapps, the charts of that repository were then available cluster-wide to all users of Kubeapps. This was changed to allow creating App Repositories available only in specific namespaces, enabling future work supporting deploying charts with private docker registries. These can be created by anyone with the required RBAC for that namespace. You can still create an App Repository whose charts will be available to users in all namespaces by selecting "All Namespaces" when creating the repository.
 
 You can give specific users the ability to create App Repositories in a specific namespace by granting them the necessary RBAC:
 
 ```bash
-kubectl -n custom-namespace create rolebinding username-apprepositories-read --user username --clusterrole kubeapps:apprepositories-write
+KUBEAPPS_NAMESPACE=kubeapps
+kubectl -n custom-namespace create rolebinding username-apprepositories-read --user username --clusterrole kubeapps:$KUBEAPPS_NAMESPACE:apprepositories-write
 ```
 
 or other users the ability to deploy charts from App Repositories in a specific namespace by granting them read access:
 
 ```bash
-kubectl -n custom-namespace create rolebinding username-apprepositories-read --user username --clusterrole kubeapps:apprepositories-read
+KUBEAPPS_NAMESPACE=kubeapps
+kubectl -n custom-namespace create rolebinding username-apprepositories-read --user username --clusterrole kubeapps:$KUBEAPPS_NAMESPACE:apprepositories-read
 ```
 
 There is work in progress to support AppRepositories with private docker registries in Kubeapps. Details about the design can be read on the [design document](https://docs.google.com/document/d/1YEeKC6nPLoq4oaxs9v8_UsmxrRfWxB6KCyqrh2-Q8x0/edit?ts=5e2adf87). More information will be added once it is available for general use.

--- a/docs/user/private-app-repository.md
+++ b/docs/user/private-app-repository.md
@@ -202,6 +202,18 @@ The above will generate a Pod with the label `my-repo: isPrivate` and the enviro
 
 ## Per Namespace App Repositories
 
-Previously, once an App Repository was created in Kubeapps, the charts of that repository were then available cluster-wide to all users of Kubeapps. This was changed to allow creating App Repositories available only in specific namespaces, enabling future work supporting deploying charts with private docker registries. You can still create an App Repository whose charts will be available to users in all namespaces by selecting "All Namespaces" when creating the repository.
+Previously, once an App Repository was created in Kubeapps, the chart of that repository were then available cluster-wide to all users of Kubeapps. This was changed to allow creating App Repositories available only in specific namespaces, enabling future work supporting deploying charts with private docker registries. These can be created by anyone with the required RBAC for that namespace. You can still create an App Repository whose charts will be available to users in all namespaces by selecting "All Namespaces" when creating the repository.
+
+You can give specific users the ability to create App Repositories in a specific namespace by granting them the necessary RBAC:
+
+```bash
+kubectl -n custom-namespace create rolebinding username-apprepositories-read --user username --clusterrole kubeapps:apprepositories-write
+```
+
+or other users the ability to deploy charts from App Repositories in a specific namespace by granting them read access:
+
+```bash
+kubectl -n custom-namespace create rolebinding username-apprepositories-read --user username --clusterrole kubeapps:apprepositories-read
+```
 
 There is work in progress to support AppRepositories with private docker registries in Kubeapps. Details about the design can be read on the [design document](https://docs.google.com/document/d/1YEeKC6nPLoq4oaxs9v8_UsmxrRfWxB6KCyqrh2-Q8x0/edit?ts=5e2adf87). More information will be added once it is available for general use.


### PR DESCRIPTION
Renames the apprepositories-read cluster role so that it is no longer controller specific, and can be used to assign users to the role in specific namespaces. (Also removed the 'update' verb from this, not sure why it was there given the name, seems to work without it, but I assume the controller needed to update app repo resources at some point?).

Similarly, add a related apprepositories-write cluster role (unbound).

Updates the dev setup (which I use) so that the `kubeapps-operator` user can create app repos in the `kubeapps-user-namespace`, while the `kubeapps-user` user can only read them (so can deploy).

Include usage of these clusterroles in the docs.

Ref: #1521 