### PR TITLE
Ensure AppRepo secret has owner references UID set.

### DIFF
--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -247,6 +247,10 @@ func (a *userHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestName
 	}
 
 	if repoSecret != nil {
+		// TODO(#1655) Fixes the immediate issue, but the proper fix would no
+		// longer set the complete owner reference during secretForRequest and
+		// rather do so explicitly here.
+		repoSecret.ObjectMeta.OwnerReferences[0].UID = appRepo.ObjectMeta.UID
 		_, err = a.clientset.CoreV1().Secrets(requestNamespace).Create(repoSecret)
 		if err != nil {
 			return nil, err

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -228,6 +228,13 @@ func TestAppRepositoryCreate(t *testing.T) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 				}
 
+				// TODO(#1655)
+				// The fake k8s API does not generate UID's for created object
+				// (among other things). We would need to add reactors to the fake
+				// to do so to test the UID being set on the secret.
+				// https://github.com/kubernetes/client-go/issues/439
+				// responseAppRepo.ObjectMeta.UID = "dead-beef"
+
 				// When appropriate, ensure the expected secret is stored.
 				if appRepoRequest.AppRepository.AuthHeader != "" {
 					expectedSecret := secretForRequest(appRepoRequest, responseAppRepo)


### PR DESCRIPTION
Fixes #1655 . With commit d5b277c, while adding the app repo validation of #1534, we inadvertently caused an app repo secret to be created without the owner reference UID.

This was because, prior to that change, the secret was not instantiated until we had created the repo with its UID, wherease after the change, the secret and app repo are instantiated in memory together before the app repo is actually created, so the secret ends up not knowing the UID of the app repo.

This was not caught by our tests because the `client-go` test fake does not set UIDs when creating objects (by default, though apparently we could add a reactor to fake this).