### PR TITLE
Omit chart sources if they don't exist

### DIFF
--- a/dashboard/src/components/ChartView/ChartView.test.tsx
+++ b/dashboard/src/components/ChartView/ChartView.test.tsx
@@ -29,7 +29,6 @@ const testChart: IChartVersion["relationships"]["chart"] = {
     repo: {
       name: "testrepo",
     },
-    sources: [] as string[],
   },
 } as IChartVersion["relationships"]["chart"];
 

--- a/dashboard/src/components/ChartView/ChartView.tsx
+++ b/dashboard/src/components/ChartView/ChartView.tsx
@@ -110,7 +110,7 @@ class ChartView extends React.Component<IChartViewProps> {
                       githubIDAsNames={this.isKubernetesCharts(chartAttrs.repo.url)}
                     />
                   </div>
-                  {chartAttrs.sources.length > 0 && (
+                  {chartAttrs.sources?.length > 0 && (
                     <div className="ChartViewSidebar__section">
                       <h2>Related</h2>
                       <div className="ChartSources">


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

I was trying to deploy chartmuseum with Kubeapps and it no longer contains `sources` in the chart information which caused a crash in the application.
