### PR TITLE
Docker registry secrets

### DIFF
--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
@@ -36,15 +36,15 @@ type AppRepository struct {
 
 // AppRepositorySpec is the spec for an AppRepository resource
 type AppRepositorySpec struct {
-	Type string            `json:"type"`
-	URL  string            `json:"url"`
-	Auth AppRepositoryAuth `json:"auth,omitempty"`
+	Type               string                 `json:"type"`
+	URL                string                 `json:"url"`
+	Auth               AppRepositoryAuth      `json:"auth,omitempty"`
+	ResyncRequests     uint                   `json:"resyncRequests"`
+	SyncJobPodTemplate corev1.PodTemplateSpec `json:"syncJobPodTemplate"`
 	// DockerRegistrySecrets is a list of dockerconfigjson secrets which exist
 	// in the same namespace as the AppRepository and should be included
 	// automatically for matching images.
-	DockerRegistrySecrets []string               `json:"dockerRegistrySecrets,omitempty"`
-	ResyncRequests        uint                   `json:"resyncRequests"`
-	SyncJobPodTemplate    corev1.PodTemplateSpec `json:"syncJobPodTemplate"`
+	DockerRegistrySecrets []string `json:"dockerRegistrySecrets,omitempty"`
 }
 
 // AppRepositoryAuth is the auth for an AppRepository resource

--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
@@ -36,11 +36,15 @@ type AppRepository struct {
 
 // AppRepositorySpec is the spec for an AppRepository resource
 type AppRepositorySpec struct {
-	Type               string                 `json:"type"`
-	URL                string                 `json:"url"`
-	Auth               AppRepositoryAuth      `json:"auth,omitempty"`
-	ResyncRequests     uint                   `json:"resyncRequests"`
-	SyncJobPodTemplate corev1.PodTemplateSpec `json:"syncJobPodTemplate"`
+	Type string            `json:"type"`
+	URL  string            `json:"url"`
+	Auth AppRepositoryAuth `json:"auth,omitempty"`
+	// DockerRegistrySecrets is a list of dockerconfigjson secrets which exist
+	// in the same namespace as the AppRepository and should be included
+	// automatically for matching images.
+	DockerRegistrySecrets []string               `json:"dockerRegistrySecrets,omitempty"`
+	ResyncRequests        uint                   `json:"resyncRequests"`
+	SyncJobPodTemplate    corev1.PodTemplateSpec `json:"syncJobPodTemplate"`
 }
 
 // AppRepositoryAuth is the auth for an AppRepository resource

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -80,7 +80,7 @@ func CreateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, r
 func ValidateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		token := auth.ExtractToken(req.Header.Get("Authorization"))
-		res, err := handler.AsUser(token).ValidateAppRepository(req.Body)
+		res, err := handler.AsUser(token).ValidateAppRepository(req.Body, mux.Vars(req)["namespace"])
 		if err != nil {
 			returnK8sError(err, w)
 			return

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -83,7 +83,7 @@ func (c *FakeHandler) GetSecret(name, namespace string) (*corev1.Secret, error) 
 }
 
 // ValidateAppRepository fake
-func (c *FakeHandler) ValidateAppRepository(appRepoBody io.ReadCloser) (*http.Response, error) {
+func (c *FakeHandler) ValidateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*http.Response, error) {
 	return &http.Response{Body: ioutil.NopCloser(strings.NewReader("valid: yaml")), StatusCode: 200}, c.Err
 }
 

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -99,7 +99,7 @@ type handler interface {
 	GetNamespaces() ([]corev1.Namespace, error)
 	GetSecret(name, namespace string) (*corev1.Secret, error)
 	GetAppRepository(repoName, repoNamespace string) (*v1alpha1.AppRepository, error)
-	ValidateAppRepository(appRepoBody io.ReadCloser) (*http.Response, error)
+	ValidateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*http.Response, error)
 	GetOperatorLogo(namespace, name string) ([]byte, error)
 }
 
@@ -139,9 +139,12 @@ type appRepositoryRequestDetails struct {
 	RepoURL            string                 `json:"repoURL"`
 	AuthHeader         string                 `json:"authHeader"`
 	CustomCA           string                 `json:"customCA"`
+	RegistrySecrets    []string               `json:"registrySecrets"`
 	SyncJobPodTemplate corev1.PodTemplateSpec `json:"syncJobPodTemplate"`
 	ResyncRequests     uint                   `json:"resyncRequests"`
 }
+
+var ErrGlobalRepositoryWithSecrets = fmt.Errorf("docker registry secrets cannot be set for app repositories available in all namespaces")
 
 // NewHandler returns an AppRepositories and Kubernetes handler configured with
 // the in-cluster config but overriding the token with an empty string, so that
@@ -240,6 +243,10 @@ func (a *userHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestName
 		return nil, err
 	}
 
+	if len(appRepo.Spec.DockerRegistrySecrets) > 0 && requestNamespace == a.kubeappsNamespace {
+		return nil, ErrGlobalRepositoryWithSecrets
+	}
+
 	appRepo, err = a.clientset.KubeappsV1alpha1().AppRepositories(requestNamespace).Create(appRepo)
 
 	if err != nil {
@@ -297,11 +304,15 @@ func (a *userHandler) DeleteAppRepository(repoName, repoNamespace string) error 
 	return err
 }
 
-func getValidationCliAndReq(appRepoBody io.ReadCloser) (HTTPClient, *http.Request, error) {
+func getValidationCliAndReq(appRepoBody io.ReadCloser, requestNamespace, kubeappsNamespace string) (HTTPClient, *http.Request, error) {
 	appRepo, repoSecret, err := parseRepoAndSecret(appRepoBody)
 	if err != nil {
 		return nil, nil, err
 	}
+	if len(appRepo.Spec.DockerRegistrySecrets) > 0 && requestNamespace == kubeappsNamespace {
+		return nil, nil, ErrGlobalRepositoryWithSecrets
+	}
+
 	cli, err := InitNetClient(appRepo, repoSecret, repoSecret, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Unable to create HTTP client: %w", err)
@@ -314,12 +325,13 @@ func getValidationCliAndReq(appRepoBody io.ReadCloser) (HTTPClient, *http.Reques
 	return cli, req, nil
 }
 
-func (a *userHandler) ValidateAppRepository(appRepoBody io.ReadCloser) (*http.Response, error) {
+func (a *userHandler) ValidateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*http.Response, error) {
 	// Split body parsing to a different function for ease testing
-	cli, req, err := getValidationCliAndReq(appRepoBody)
+	cli, req, err := getValidationCliAndReq(appRepoBody, requestNamespace, a.kubeappsNamespace)
 	if err != nil {
 		return nil, err
 	}
+
 	return cli.Do(req)
 }
 
@@ -363,11 +375,12 @@ func appRepositoryForRequest(appRepoRequest appRepositoryRequest) *v1alpha1.AppR
 			Name: appRepo.Name,
 		},
 		Spec: v1alpha1.AppRepositorySpec{
-			URL:                appRepo.RepoURL,
-			Type:               "helm",
-			Auth:               auth,
-			SyncJobPodTemplate: appRepo.SyncJobPodTemplate,
-			ResyncRequests:     appRepo.ResyncRequests,
+			URL:                   appRepo.RepoURL,
+			Type:                  "helm",
+			Auth:                  auth,
+			DockerRegistrySecrets: appRepo.RegistrySecrets,
+			SyncJobPodTemplate:    appRepo.SyncJobPodTemplate,
+			ResyncRequests:        appRepo.ResyncRequests,
 		},
 	}
 }

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -310,6 +310,8 @@ func getValidationCliAndReq(appRepoBody io.ReadCloser, requestNamespace, kubeapp
 		return nil, nil, err
 	}
 	if len(appRepo.Spec.DockerRegistrySecrets) > 0 && requestNamespace == kubeappsNamespace {
+		// TODO(mnelson): we may also want to validate that any docker registry secrets listed
+		// already exist in the namespace.
 		return nil, nil, ErrGlobalRepositoryWithSecrets
 	}
 

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -144,6 +144,8 @@ type appRepositoryRequestDetails struct {
 	ResyncRequests     uint                   `json:"resyncRequests"`
 }
 
+// ErrGlobalRepositoryWithSecrets defines the error returned when an attempt is
+// made to create registry secrets for a global repo.
 var ErrGlobalRepositoryWithSecrets = fmt.Errorf("docker registry secrets cannot be set for app repositories available in all namespaces")
 
 // NewHandler returns an AppRepositories and Kubernetes handler configured with


### PR DESCRIPTION
Ref: #1522 

Enables AppRepositories to be created with a list of docker registry secrets which should be included for matching registries.

Also ensures that a global AppRepository is not able to be created (or validated) with docker registry secrets.