### PR TITLE
Handle dockerhub secrets special case. Allow optional protocol.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/arschles/assert v1.0.0
 	github.com/disintegration/imaging v1.6.2
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-test/deep v1.0.4


### PR DESCRIPTION
Ref: #1617 . Updates the imagePullSecret injection in the post renderer for two cases:

- Dockerhub images use "docker.io" as the registry domain in the image ref (docker's `reference` library even adds it as such), while the credential in docker configs must be keyed with "https://index.docker.io/v1/".
- general registry domains in the docker credentials can be listed with or without an explicit protocol (https), so we update to append the imagePullSecret as long as the domain itself matches.