### PR TITLE
Update postrenderer to support pod spec templates.

### DIFF
--- a/pkg/agent/docker_secrets_postrenderer_test.go
+++ b/pkg/agent/docker_secrets_postrenderer_test.go
@@ -448,6 +448,34 @@ func TestGetResourcePodSpec(t *testing.T) {
 				"some": "spec",
 			},
 		},
+		{
+			name: "it returns the pod spec from a daemon set",
+			resource: map[interface{}]interface{}{
+				"kind": "DaemonSet",
+				"spec": map[interface{}]interface{}{
+					"template": map[interface{}]interface{}{
+						"spec": map[interface{}]interface{}{"some": "spec"},
+					},
+				},
+			},
+			result: map[interface{}]interface{}{
+				"some": "spec",
+			},
+		},
+		{
+			name: "it returns the pod spec from a deployment",
+			resource: map[interface{}]interface{}{
+				"kind": "Deployment",
+				"spec": map[interface{}]interface{}{
+					"template": map[interface{}]interface{}{
+						"spec": map[interface{}]interface{}{"some": "spec"},
+					},
+				},
+			},
+			result: map[interface{}]interface{}{
+				"some": "spec",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Just updates the post renderer to support getting the pod spec from all other resources which includes pod specs as a template.