### PR TITLE
Postrenderer support resourcelists

### DIFF
--- a/pkg/agent/docker_secrets_postrenderer.go
+++ b/pkg/agent/docker_secrets_postrenderer.go
@@ -52,19 +52,6 @@ func NewDockerSecretsPostRenderer(secrets map[string]string) (*DockerSecretsPost
 	return r, nil
 }
 
-// resourceListTypes defines all the list types for which we need to
-// search for pod templates.
-var resourceListTypes map[string]struct{} = map[string]struct{}{
-	"CronJobList":               struct{}{},
-	"DaemonSetList":             struct{}{},
-	"DeploymentList":            struct{}{},
-	"JobList":                   struct{}{},
-	"PodTemplateList":           struct{}{},
-	"ReplicaSetList":            struct{}{},
-	"ReplicationControllerList": struct{}{},
-	"StatefulSetList":           struct{}{},
-}
-
 func (r *DockerSecretsPostRenderer) processResourceList(resourceList []interface{}) {
 	for _, resourceItem := range resourceList {
 		resource, ok := resourceItem.(map[interface{}]interface{})
@@ -82,15 +69,11 @@ func (r *DockerSecretsPostRenderer) processResourceList(resourceList []interface
 			log.Errorf("invalid resource: non-string resource kind. %+v", resource)
 			continue
 		}
-		if _, ok := resourceListTypes[kind]; ok {
-			if items, ok := resource["items"]; ok {
-				if itemsSlice, ok := items.([]interface{}); ok {
-					r.processResourceList(itemsSlice)
-				} else {
-					log.Errorf("Items of list type did not contain a slice: %+v", resource)
-				}
+		if items, ok := resource["items"]; ok {
+			if itemsSlice, ok := items.([]interface{}); ok {
+				r.processResourceList(itemsSlice)
 			} else {
-				log.Errorf("list type did not contain an items key: %+v", resource)
+				log.Errorf("Items of list type did not contain a slice: %+v", resource)
 			}
 			continue
 		}

--- a/pkg/agent/docker_secrets_postrenderer_test.go
+++ b/pkg/agent/docker_secrets_postrenderer_test.go
@@ -476,6 +476,26 @@ func TestGetResourcePodSpec(t *testing.T) {
 				"some": "spec",
 			},
 		},
+		{
+			name: "it returns the pod spec from a CronJob",
+			resource: map[interface{}]interface{}{
+				"kind": "CronJob",
+				"spec": map[interface{}]interface{}{
+					"jobTemplate": map[interface{}]interface{}{
+						"spec": map[interface{}]interface{}{
+							"template": map[interface{}]interface{}{
+								"spec": map[interface{}]interface{}{
+									"some": "spec",
+								},
+							},
+						},
+					},
+				},
+			},
+			result: map[interface{}]interface{}{
+				"some": "spec",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Based on [feedback from previous PR](https://github.com/kubeapps/kubeapps/pull/1678#discussion_r411754535), this updates to handle both CronJobs and all resource list types.

Ref: #1617 