### PR TITLE
Generate and use secretsPerDomain.

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -167,16 +167,21 @@ func CreateRelease(cfg Config, w http.ResponseWriter, req *http.Request, params 
 		returnErrMessage(err, w)
 		return
 	}
+
 	ch := chartMulti.Helm3Chart
 	releaseName := chartDetails.ReleaseName
 	namespace := params[namespaceParam]
 	valuesString := chartDetails.Values
-	release, err := agent.CreateRelease(cfg.ActionConfig, releaseName, namespace, valuesString, ch)
+	release, err := agent.CreateRelease(cfg.ActionConfig, releaseName, namespace, valuesString, ch, cfg.ChartClient.RegistrySecretsPerDomain())
 	if err != nil {
 		returnErrMessage(err, w)
 		return
 	}
 	response.NewDataResponse(release).Write(w)
+}
+
+func getRegistrySecretsPerDomain(secretNames []string) (map[string]string, error) {
+	return nil, nil
 }
 
 // OperateRelease decides which method to call depending on the "action" query param.
@@ -200,8 +205,9 @@ func upgradeRelease(cfg Config, w http.ResponseWriter, req *http.Request, params
 		returnErrMessage(err, w)
 		return
 	}
+
 	ch := chartMulti.Helm3Chart
-	rel, err := agent.UpgradeRelease(cfg.ActionConfig, releaseName, chartDetails.Values, ch)
+	rel, err := agent.UpgradeRelease(cfg.ActionConfig, releaseName, chartDetails.Values, ch, cfg.ChartClient.RegistrySecretsPerDomain())
 	if err != nil {
 		returnErrMessage(err, w)
 		return

--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -180,10 +180,6 @@ func CreateRelease(cfg Config, w http.ResponseWriter, req *http.Request, params 
 	response.NewDataResponse(release).Write(w)
 }
 
-func getRegistrySecretsPerDomain(secretNames []string) (map[string]string, error) {
-	return nil, nil
-}
-
 // OperateRelease decides which method to call depending on the "action" query param.
 func OperateRelease(cfg Config, w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
 	switch req.FormValue("action") {

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	k8s.io/cli-runtime v0.17.2
 	k8s.io/client-go v0.17.2
 	k8s.io/helm v2.16.0+incompatible
+	k8s.io/kubernetes v1.13.0
 	rsc.io/letsencrypt v0.0.1 // indirect
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -795,6 +795,7 @@ k8s.io/kubectl v0.0.0-20191016120415-2ed914427d51 h1:RBkTKVMF+xsNsSOVc0+HdC0B5gD
 k8s.io/kubectl v0.0.0-20191016120415-2ed914427d51/go.mod h1:gL826ZTIfD4vXTGlmzgTbliCAT9NGiqpCqK2aNYv5MQ=
 k8s.io/kubectl v0.17.2 h1:QZR8Q6lWiVRjwKslekdbN5WPMp53dS/17j5e+oi5XVU=
 k8s.io/kubectl v0.17.2/go.mod h1:y4rfLV0n6aPmvbRCqZQjvOp3ezxsFgpqL+zF5jH/lxk=
+k8s.io/kubernetes v1.13.0 h1:qTfB+u5M92k2fCCCVP2iuhgwwSOv1EkAkvQY1tQODD8=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/metrics v0.0.0-20191016113814-3b1a734dba6e/go.mod h1:ve7/vMWeY5lEBkZf6Bt5TTbGS3b8wAxwGbdXAsufjRs=
 k8s.io/metrics v0.17.2/go.mod h1:3TkNHET4ROd+NfzNxkjoVfQ0Ob4iZnaHmSEA4vYpwLw=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -69,7 +69,7 @@ func ListReleases(actionConfig *action.Configuration, namespace string, listLimi
 }
 
 // CreateRelease creates a release.
-func CreateRelease(actionConfig *action.Configuration, name, namespace, valueString string, ch *chart.Chart) (*release.Release, error) {
+func CreateRelease(actionConfig *action.Configuration, name, namespace, valueString string, ch *chart.Chart, registrySecrets map[string]string) (*release.Release, error) {
 	// Check if the release already exists
 	_, err := GetRelease(actionConfig, name)
 	if err == nil {
@@ -78,10 +78,7 @@ func CreateRelease(actionConfig *action.Configuration, name, namespace, valueStr
 	cmd := action.NewInstall(actionConfig)
 	cmd.ReleaseName = name
 	cmd.Namespace = namespace
-	// TODO(#1617): the map of registry domains to secret names needs to be passed
-	// to both CreateRelease and UpgradeRelease.
-	var secrets map[string]string
-	cmd.PostRenderer, err = NewDockerSecretsPostRenderer(secrets)
+	cmd.PostRenderer, err = NewDockerSecretsPostRenderer(registrySecrets)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +99,7 @@ func CreateRelease(actionConfig *action.Configuration, name, namespace, valueStr
 }
 
 // UpgradeRelease upgrades a release.
-func UpgradeRelease(actionConfig *action.Configuration, name, valuesYaml string, ch *chart.Chart) (*release.Release, error) {
+func UpgradeRelease(actionConfig *action.Configuration, name, valuesYaml string, ch *chart.Chart, registrySecrets map[string]string) (*release.Release, error) {
 	// Check if the release already exists:
 	_, err := GetRelease(actionConfig, name)
 	if err != nil {
@@ -110,10 +107,8 @@ func UpgradeRelease(actionConfig *action.Configuration, name, valuesYaml string,
 	}
 	log.Printf("Upgrading release %s", name)
 	cmd := action.NewUpgrade(actionConfig)
-	// TODO(#1617): the map of registry domains to secret names needs to be passed
-	// to both CreateRelease and UpgradeRelease.
-	var secrets map[string]string
-	cmd.PostRenderer, err = NewDockerSecretsPostRenderer(secrets)
+
+	cmd.PostRenderer, err = NewDockerSecretsPostRenderer(registrySecrets)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -193,7 +193,7 @@ func TestCreateReleases(t *testing.T) {
 				ChartName: tc.chartName,
 			}, nil, false)
 			// Perform test
-			rls, err := CreateRelease(actionConfig, tc.chartName, tc.namespace, tc.values, ch.Helm3Chart)
+			rls, err := CreateRelease(actionConfig, tc.chartName, tc.namespace, tc.values, ch.Helm3Chart, nil)
 			// Check result
 			if tc.shouldFail && err == nil {
 				t.Errorf("Should fail with %v; instead got %s in %s", tc.desc, tc.releaseName, tc.namespace)
@@ -681,7 +681,7 @@ func TestUpgradeRelease(t *testing.T) {
 			ch, _ := fakechart.GetChart(&kubechart.Details{
 				ChartName: tc.chartName,
 			}, nil, false)
-			newRelease, err := UpgradeRelease(cfg, tc.release, tc.valuesYaml, ch.Helm3Chart)
+			newRelease, err := UpgradeRelease(cfg, tc.release, tc.valuesYaml, ch.Helm3Chart, nil)
 			// Check for errors
 			if got, want := err != nil, tc.shouldFail; got != want {
 				t.Errorf("Failure: got: %v, want: %v", got, want)

--- a/pkg/agent/docker_secrets_postrenderer.go
+++ b/pkg/agent/docker_secrets_postrenderer.go
@@ -166,6 +166,7 @@ func (r *DockerSecretsPostRenderer) updatePodSpecWithPullSecrets(podSpec map[int
 		}
 		// Only add the secret if it's not already included in the image pull secrets.
 		if _, ok := existingNames[secretName]; !ok {
+			log.Infof("appending imagePullSecret %q for fetching image %s", secretName, image)
 			imagePullSecrets = append(imagePullSecrets, map[string]interface{}{"name": secretName})
 			existingNames[secretName] = true
 		}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -37,6 +37,12 @@ import (
 	helm2loader "k8s.io/helm/pkg/chartutil"
 	helm2chart "k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/repo"
+	"k8s.io/kubernetes/pkg/credentialprovider"
+)
+
+const (
+	dockerConfigJSONType = "kubernetes.io/dockerconfigjson"
+	dockerConfigJSONKey  = ".dockerconfigjson"
 )
 
 type repoIndex struct {
@@ -85,14 +91,16 @@ type Resolver interface {
 	ParseDetails(data []byte) (*Details, error)
 	GetChart(details *Details, netClient kube.HTTPClient, requireV1Support bool) (*ChartMultiVersion, error)
 	InitNetClient(details *Details, userAuthToken string) (kube.HTTPClient, error)
+	RegistrySecretsPerDomain() (map[string]string, error)
 }
 
 // ChartClient struct contains the clients required to retrieve charts info
 type ChartClient struct {
-	appRepoHandler    kube.AuthHandler
-	userAgent         string
-	kubeappsNamespace string
-	appRepo           *appRepov1.AppRepository
+	appRepoHandler           kube.AuthHandler
+	userAgent                string
+	kubeappsNamespace        string
+	appRepo                  *appRepov1.AppRepository
+	registrySecretsPerDomain map[string]string
 }
 
 // NewChartClient returns a new ChartClient
@@ -312,6 +320,12 @@ func (c *ChartClient) InitNetClient(details *Details, userAuthToken string) (kub
 	if err != nil {
 		return nil, err
 	}
+
+	c.registrySecretsPerDomain, err = getRegistrySecretsPerDomain(c.appRepo.Spec.DockerRegistrySecrets, details.AppRepositoryResourceNamespace, c.appRepoHandler.AsUser(userAuthToken))
+	if err != nil {
+		return nil, err
+	}
+
 	return kube.InitNetClient(appRepo, caCertSecret, authSecret, http.Header{"User-Agent": []string{c.userAgent}})
 }
 
@@ -337,4 +351,40 @@ func (c *ChartClient) GetChart(details *Details, netClient kube.HTTPClient, requ
 	}
 
 	return chart, nil
+}
+
+// RegistrySecretsPerDomain checks the app repo and available secrets
+// to return the secret names per registry domain.
+func (c *ChartClient) RegistrySecretsPerDomain() map[string]string {
+	return c.registrySecretsPerDomain
+}
+
+func getRegistrySecretsPerDomain(appRepoSecrets []string, namespace string, client kube.Handler) (map[string]string, error) {
+	secretsPerDomain := map[string]string{}
+	for _, secretName := range appRepoSecrets {
+		secret, err := client.GetSecret(secretName, namespace)
+		if err != nil {
+			return nil, err
+		}
+
+		if secret.Type != dockerConfigJSONType {
+			return nil, fmt.Errorf("AppRepository secret must be of type %q. Secret %q had type %q", dockerConfigJSONType, secretName, secret.Type)
+		}
+
+		dockerConfigJSONBytes, ok := secret.Data[dockerConfigJSONKey]
+		if !ok {
+			return nil, fmt.Errorf("AppRepository secret must have a data map with a key %q. Secret %q did not", dockerConfigJSONKey, secretName)
+		}
+
+		dockerConfigJSON := credentialprovider.DockerConfigJson{}
+		if err := json.Unmarshal(dockerConfigJSONBytes, &dockerConfigJSON); err != nil {
+			return nil, err
+		}
+
+		for key, _ := range dockerConfigJSON.Auths {
+			secretsPerDomain[key] = secretName
+		}
+
+	}
+	return secretsPerDomain, nil
 }

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -355,6 +355,9 @@ func (c *ChartClient) GetChart(details *Details, netClient kube.HTTPClient, requ
 
 // RegistrySecretsPerDomain checks the app repo and available secrets
 // to return the secret names per registry domain.
+//
+// These are actually calculated during InitNetClient when we already have a
+// k8s client with the user token.
 func (c *ChartClient) RegistrySecretsPerDomain() map[string]string {
 	return c.registrySecretsPerDomain
 }

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -779,7 +779,7 @@ func TestGetRegistrySecretsPerDomain(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &kube.FakeHandler{Secrets: tc.existingSecrets}
 
-			secretsPerDomain, err := getRegistrySecretsPerDomain(tc.secretNames, namespace, client)
+			secretsPerDomain, err := getRegistrySecretsPerDomain(tc.secretNames, namespace, "token", client)
 			if got, want := err != nil, tc.expectError; !cmp.Equal(got, want) {
 				t.Fatalf("got: %t, want: %t, err was: %+v", got, want, err)
 			}

--- a/pkg/chart/fake/chart.go
+++ b/pkg/chart/fake/chart.go
@@ -70,3 +70,7 @@ func getValues(raw []byte) (map[string]interface{}, error) {
 func (f *FakeChart) InitNetClient(details *chartUtils.Details, userAuthToken string) (kube.HTTPClient, error) {
 	return &http.Client{}, nil
 }
+
+func (f *FakeChart) RegistrySecretsPerDomain() (map[string]string, error) {
+	return nil, nil
+}

--- a/pkg/chart/fake/chart.go
+++ b/pkg/chart/fake/chart.go
@@ -71,6 +71,6 @@ func (f *FakeChart) InitNetClient(details *chartUtils.Details, userAuthToken str
 	return &http.Client{}, nil
 }
 
-func (f *FakeChart) RegistrySecretsPerDomain() (map[string]string, error) {
-	return nil, nil
+func (f *FakeChart) RegistrySecretsPerDomain() map[string]string {
+	return nil
 }

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -37,12 +37,12 @@ type FakeHandler struct {
 }
 
 // AsUser fakes user auth
-func (c *FakeHandler) AsUser(token string) Handler {
+func (c *FakeHandler) AsUser(token string) handler {
 	return c
 }
 
 // AsSVC fakes using current svcaccount
-func (c *FakeHandler) AsSVC() Handler {
+func (c *FakeHandler) AsSVC() handler {
 	return c
 }
 

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -37,12 +37,12 @@ type FakeHandler struct {
 }
 
 // AsUser fakes user auth
-func (c *FakeHandler) AsUser(token string) handler {
+func (c *FakeHandler) AsUser(token string) Handler {
 	return c
 }
 
 // AsSVC fakes using current svcaccount
-func (c *FakeHandler) AsSVC() handler {
+func (c *FakeHandler) AsSVC() Handler {
 	return c
 }
 

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -93,7 +93,7 @@ type userHandler struct {
 	clientset combinedClientsetInterface
 }
 
-type handler interface {
+type Handler interface {
 	CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error)
 	DeleteAppRepository(name, namespace string) error
 	GetNamespaces() ([]corev1.Namespace, error)
@@ -103,13 +103,13 @@ type handler interface {
 	GetOperatorLogo(namespace, name string) ([]byte, error)
 }
 
-// AuthHandler exposes handler functionality as a user or the current serviceaccount
+// AuthHandler exposes Handler functionality as a user or the current serviceaccount
 type AuthHandler interface {
-	AsUser(token string) handler
-	AsSVC() handler
+	AsUser(token string) Handler
+	AsSVC() Handler
 }
 
-func (a *kubeHandler) AsUser(token string) handler {
+func (a *kubeHandler) AsUser(token string) Handler {
 	clientset, err := a.clientsetForConfig(a.configForToken(token))
 	if err != nil {
 		log.Errorf("unable to create clientset: %v", err)
@@ -121,7 +121,7 @@ func (a *kubeHandler) AsUser(token string) handler {
 	}
 }
 
-func (a *kubeHandler) AsSVC() handler {
+func (a *kubeHandler) AsSVC() Handler {
 	return &userHandler{
 		kubeappsNamespace: a.kubeappsNamespace,
 		svcClientset:      a.svcClientset,


### PR DESCRIPTION
Adds a function to create the map of docker registry servers to secret names and passes that in during Install and Upgrade functions.

I had to expose `kube.Handler`, but it was actually odd that it wasn't already exposed (it's an interface with public methods, and we use the public methods already). I haven't yet checked other uses of this, but will do. (I'll fix the errors).

With this, I hope to test deploying with a private repo tomorrow, which together with your UI work, might mean we can have a video demo or similar for the end of the week!

Ref: #1617