### PR TITLE
Avoid applying modifications when rendering

### DIFF
--- a/dashboard/src/components/UpgradeForm/__snapshots__/UpgradeForm.test.tsx.snap
+++ b/dashboard/src/components/UpgradeForm/__snapshots__/UpgradeForm.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`renders the full UpgradeForm 1`] = `
         chartID="my-repo/my-chart"
         chartNamespace="kubeapps"
         chartVersion="1.0.0"
-        deployedValues=""
         getChartVersion={[Function]}
         goBack={[Function]}
         namespace="default"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

In the upgrade form, we were recalculating the "deployed values" (the values stored in the release plus the comments) with every keystroke which caused a big delay when writing in the advanced form. This PR fixes that calculating that value just once.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1667 
