### PR TITLE
Minor fixes in the docker-credentials form 

### DIFF
--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
@@ -89,7 +89,7 @@ export class AppRepoAddDockerCreds extends React.Component<IAppRepoFormProps, IA
                   id="kubeapps-docker-cred-server"
                   value={this.state.server}
                   onChange={this.handleServerChange}
-                  placeholder="https://index.docker.io/v1"
+                  placeholder="https://index.docker.io/v1/"
                   required={true}
                 />
               </div>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
@@ -62,7 +62,7 @@ export class AppRepoAddDockerCreds extends React.Component<IAppRepoFormProps, IA
             );
           })
         ) : (
-          <span className="margin-b-small">No existing credentials found.</span>
+          <div className="margin-b-small">No existing credentials found.</div>
         )}
         {this.state.showSecretSubForm && (
           <div className="secondary-input margin-t-big">

--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
@@ -89,7 +89,7 @@ export class AppRepoAddDockerCreds extends React.Component<IAppRepoFormProps, IA
                   id="kubeapps-docker-cred-server"
                   value={this.state.server}
                   onChange={this.handleServerChange}
-                  placeholder="https://index.docker.io/v1/"
+                  placeholder="docker.io"
                   required={true}
                 />
               </div>


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

I learned the hard way that `https://index.docker.io/v1` is not valid (it requires the trailing `/`), should we enforce that?

