### PR TITLE
Added config for OAuth login/logout URIs

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -42,7 +42,7 @@ data:
       "namespace": "{{ .Release.Namespace }}",
       "appVersion": "{{ .Chart.AppVersion }}",
       "authProxyEnabled": {{ .Values.authProxy.enabled }},
-      "oauthLoginURI": "/oauth2/start",
-      "oauthLogoutURI": "/oauth2/sign_out",
+      "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
+      "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},
       "featureFlags": {{ .Values.featureFlags | toJson }}
     }

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -627,6 +627,11 @@ authProxy:
   ## OAuth2 Proxy containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
+  ## Overridable flags for OAuth URIs that Kubeapps uses, useful when serving
+  ## Kubeapps under a sub path
+  oauthLoginURI: /oauth2/start
+  oauthLogoutURI: /oauth2/sign_out
+  ##
   resources:
     ## Default values set based on usage data from running Kubeapps instances
     ## ref: https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
These changes allow overriding the OAuth Login and Logout URIs which is useful when deploying the chart under a sub path.  For my deployment, I set the ingress to rewrite urls and change a few other values to properly know about the sub path.  I've included some sample values below however the sample values would need extra configuration to fully configure the authProxy service.

- Relevant Sample Values:
```
authProxy:
  enabled: true
  additionalFlags:
  - -redirect-url=https://<hostname>/kubeapps/oauth2/callback
  - -cookie-path=/kubeapps
  oauthLoginURI: /kubeapps/oauth2/start?rd=/kubeapps/
  oauthLogoutURI: /kubeapps/oauth2/sign_out
ingress:
  enabled: true
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /$2
  extraHosts:
  - name: <hostname>
    path: /kubeapps(/|$)(.*)
  extraTls:
  - hosts:
    - <hostname>
    secretName: <hostname>-cert
```

### Benefits

<!-- What benefits will be realized by the code change? -->
- Allow configuring the locations that Kubeapps should redirect a user to when logging in or out with `authProxy.enabled=true`

### Possible drawbacks

<!-- Describe any known limitations with your change -->


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Partially related to #1579, would need more changes to allow an external auth proxy service

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
