### PR TITLE
Return json responses for proxied requests to API server.

### DIFF
--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -76,7 +76,7 @@ func CreateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, r
 		}
 		responseBody, err := json.Marshal(response)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.Write(responseBody)
@@ -134,7 +134,7 @@ func GetNamespaces(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, req
 		}
 		responseBody, err := json.Marshal(response)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.Write(responseBody)
@@ -148,7 +148,7 @@ func GetOperatorLogo(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, r
 		name := mux.Vars(req)["name"]
 		logo, err := kubeHandler.AsSVC().GetOperatorLogo(ns, name)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		ctype := http.DetectContentType(logo)

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -42,14 +42,21 @@ type appRepositoryResponse struct {
 	AppRepository v1alpha1.AppRepository `json:"appRepository"`
 }
 
+func JSONError(w http.ResponseWriter, err interface{}, code int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(err)
+}
+
 func returnK8sError(err error, w http.ResponseWriter) {
 	if statusErr, ok := err.(*k8sErrors.StatusError); ok {
 		status := statusErr.ErrStatus
 		log.Infof("unable to create app repo: %v", status.Reason)
-		http.Error(w, status.Message, int(status.Code))
+		JSONError(w, statusErr.ErrStatus, int(status.Code))
 	} else {
 		log.Errorf("unable to create app repo: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		JSONError(w, err.Error(), http.StatusInternalServerError)
 	}
 }
 


### PR DESCRIPTION
Fixes #1675 .

Without this change, the dashboard assumes the 403 response from the API server is from the auth proxy, since one of the ways we detect an api server response is via the json data and without this change the app repo creation (and other methods) are not returning the expected json data for errors:
![logout-on-403](https://user-images.githubusercontent.com/497518/80346464-1f5b8500-88ae-11ea-98dc-f9e7f23fbe01.png)

With this change, the expected error is shown with the required RBAC:
![add-app-repo-correct-error](https://user-images.githubusercontent.com/497518/80346492-2e423780-88ae-11ea-8200-2970d972936b.png)
