### PR TITLE
Default to postgres rather than mongodb.

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -513,7 +513,7 @@ dashboard:
 ##
 mongodb:
   ## Whether to deploy a mongodb server to satisfy the applications database requirements.
-  enabled: true
+  enabled: false
   ## Kubeapps uses MongoDB as a cache and persistence is not required
   ##
   persistence:
@@ -546,7 +546,7 @@ mongodb:
 ##
 postgresql:
   ## Whether to deploy a postgresql server to satisfy the applications database requirements.
-  enabled: false
+  enabled: true
   ## Enable replication for high availability
   replication:
     enabled: true


### PR DESCRIPTION
While thinking about roadmap goals, I realised this is IMO long overdue. We need to be able to start improving the asset svc as we add multi-cluster support and/or improve operator integration etc., and it's going to be painful if we have to continue doing so for both mongodb and postgres.