### PR TITLE
Enable modify button for app repositories

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -543,6 +543,10 @@ describe("updateRepo", () => {
         type: getType(repoActions.repoUpdated),
         payload: r,
       },
+      {
+        type: getType(repoActions.receiveReposSecrets),
+        payload: [],
+      },
     ];
 
     await store.dispatch(

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -530,10 +530,59 @@ describe("installRepo", () => {
 });
 
 describe("updateRepo", () => {
-  it("updates a repo", async () => {
+  it("updates a repo with an auth header", async () => {
     const r = {
       metadata: { name: "repo-abc" },
       spec: { auth: { header: { secretKeyRef: { name: "apprepo-repo-abc" } } } },
+    };
+    const secret = { metadata: { name: "apprepo-repo-abc" } };
+    AppRepository.update = jest.fn(() => {
+      return { appRepository: r };
+    });
+    Secret.get = jest.fn(() => {
+      return secret;
+    });
+    const expectedActions = [
+      {
+        type: getType(repoActions.requestRepoUpdate),
+      },
+      {
+        type: getType(repoActions.repoUpdated),
+        payload: r,
+      },
+      {
+        type: getType(repoActions.receiveReposSecret),
+        payload: secret,
+      },
+    ];
+
+    await store.dispatch(
+      repoActions.updateRepo(
+        "my-repo",
+        "my-namespace",
+        "http://foo.bar",
+        "foo",
+        "bar",
+        safeYAMLTemplate,
+        ["repo-1"],
+      ),
+    );
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(AppRepository.update).toHaveBeenCalledWith(
+      "my-repo",
+      "my-namespace",
+      "http://foo.bar",
+      "foo",
+      "bar",
+      { spec: { containers: [{ env: [{ name: "FOO", value: "BAR" }] }] } },
+      ["repo-1"],
+    );
+  });
+
+  it("updates a repo with an customCA", async () => {
+    const r = {
+      metadata: { name: "repo-abc" },
+      spec: { auth: { customCA: { secretKeyRef: { name: "apprepo-repo-abc" } } } },
     };
     const secret = { metadata: { name: "apprepo-repo-abc" } };
     AppRepository.update = jest.fn(() => {

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -531,9 +531,16 @@ describe("installRepo", () => {
 
 describe("updateRepo", () => {
   it("updates a repo", async () => {
-    const r = { metadata: { name: "repo-abc" } };
+    const r = {
+      metadata: { name: "repo-abc" },
+      spec: { auth: { header: { secretKeyRef: { name: "apprepo-repo-abc" } } } },
+    };
+    const secret = { metadata: { name: "apprepo-repo-abc" } };
     AppRepository.update = jest.fn(() => {
       return { appRepository: r };
+    });
+    Secret.get = jest.fn(() => {
+      return secret;
     });
     const expectedActions = [
       {
@@ -544,8 +551,8 @@ describe("updateRepo", () => {
         payload: r,
       },
       {
-        type: getType(repoActions.receiveReposSecrets),
-        payload: [],
+        type: getType(repoActions.receiveReposSecret),
+        payload: secret,
       },
     ];
 

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -274,8 +274,18 @@ export const updateRepo = (
       // Re-fetch the helm repo secret that could have been modified with the updated headers
       // so that if the user chooses to edit the app repo again, they will see the current value.
       if (data.appRepository.spec?.auth) {
-        const secretName = data.appRepository.spec.auth.header.secretKeyRef.name;
-        dispatch(fetchRepoSecret(namespace, secretName));
+        let secretName = "";
+        if (data.appRepository.spec.auth.header) {
+          secretName = data.appRepository.spec.auth.header.secretKeyRef.name;
+          dispatch(fetchRepoSecret(namespace, secretName));
+        }
+        if (
+          data.appRepository.spec.auth.customCA &&
+          secretName !== data.appRepository.spec.auth.customCA.secretKeyRef.name
+        ) {
+          secretName = data.appRepository.spec.auth.customCA.secretKeyRef.name;
+          dispatch(fetchRepoSecret(namespace, secretName));
+        }
       }
       return true;
     } catch (e) {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
@@ -85,23 +85,20 @@ export class AppRepoListItem extends React.Component<IAppRepoListItemProps, IApp
             Delete
           </button>
 
-          {/*TODO(andresmgot): Re-enable this component when the update endpoint is available */}
-          <div hidden={true}>
-            <AppRepoAddButton
-              errors={errors}
-              onSubmit={update}
-              validate={validate}
-              namespace={namespace}
-              kubeappsNamespace={kubeappsNamespace}
-              validating={validating}
-              text="Edit"
-              repo={repo}
-              secret={secret}
-              imagePullSecrets={imagePullSecrets}
-              fetchImagePullSecrets={fetchImagePullSecrets}
-              createDockerRegistrySecret={createDockerRegistrySecret}
-            />
-          </div>
+          <AppRepoAddButton
+            errors={errors}
+            onSubmit={update}
+            validate={validate}
+            namespace={namespace}
+            kubeappsNamespace={kubeappsNamespace}
+            validating={validating}
+            text="Edit"
+            repo={repo}
+            secret={secret}
+            imagePullSecrets={imagePullSecrets}
+            fetchImagePullSecrets={fetchImagePullSecrets}
+            createDockerRegistrySecret={createDockerRegistrySecret}
+          />
 
           <button
             className="button button-secondary"

--- a/dashboard/src/reducers/repos.test.ts
+++ b/dashboard/src/reducers/repos.test.ts
@@ -1,0 +1,183 @@
+import { getType } from "typesafe-actions";
+import actions from "../actions";
+
+import { IAppRepository } from "shared/types";
+import reposReducer from "./repos";
+import { IAppRepositoryState } from "./repos";
+
+describe("reposReducer", () => {
+  let initialState: IAppRepositoryState;
+
+  beforeEach(() => {
+    initialState = {
+      addingRepo: false,
+      errors: {},
+      form: {
+        name: "",
+        namespace: "",
+        show: false,
+        url: "",
+      },
+      isFetching: false,
+      isFetchingElem: {
+        repositories: false,
+        secrets: false,
+      },
+      validating: false,
+      repo: {} as IAppRepository,
+      repos: [],
+      repoSecrets: [],
+      imagePullSecrets: [],
+    };
+  });
+
+  describe("repos", () => {
+    const actionTypes = {
+      addRepo: getType(actions.repos.addRepo),
+      addedRepo: getType(actions.repos.addedRepo),
+      requestRepoUpdate: getType(actions.repos.requestRepoUpdate),
+      repoUpdated: getType(actions.repos.repoUpdated),
+      requestRepos: getType(actions.repos.requestRepos),
+      receiveRepos: getType(actions.repos.receiveRepos),
+      receiveReposSecrets: getType(actions.repos.receiveReposSecrets),
+      requestRepo: getType(actions.repos.requestRepo),
+      receiveRepo: getType(actions.repos.receiveRepo),
+      repoValidating: getType(actions.repos.repoValidating),
+      repoValidated: getType(actions.repos.repoValidated),
+      clearRepo: getType(actions.repos.clearRepo),
+      showForm: getType(actions.repos.showForm),
+      hideForm: getType(actions.repos.hideForm),
+      resetForm: getType(actions.repos.resetForm),
+      submitForm: getType(actions.repos.submitForm),
+      redirect: getType(actions.repos.redirect),
+      redirected: getType(actions.repos.redirected),
+      errorRepos: getType(actions.repos.errorRepos),
+      requestImagePullSecrets: getType(actions.repos.requestImagePullSecrets),
+      receiveImagePullSecrets: getType(actions.repos.receiveImagePullSecrets),
+      createImagePullSecret: getType(actions.repos.createImagePullSecret),
+    };
+
+    describe("reducer actions", () => {
+      it("sets isFetching when requesting repos", () => {
+        expect(
+          reposReducer(undefined, {
+            type: actionTypes.requestRepos as any,
+          }),
+        ).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { repositories: true, secrets: false },
+        });
+      });
+
+      it("unsets isFetching and receive repos", () => {
+        const repo = { metadata: { name: "foo" } };
+        const state = reposReducer(undefined, {
+          type: actionTypes.requestRepos as any,
+        });
+        expect(state).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { repositories: true, secrets: false },
+        });
+        expect(
+          reposReducer(state, {
+            type: actionTypes.receiveRepos as any,
+            payload: [repo],
+          }),
+        ).toEqual({ ...initialState, repos: [repo] });
+      });
+
+      it("unsets isFetching and receive repo", () => {
+        const repo = { metadata: { name: "foo" } };
+        const state = reposReducer(undefined, {
+          type: actionTypes.requestRepos as any,
+        });
+        expect(state).toEqual({
+          ...initialState,
+          isFetching: true,
+          isFetchingElem: { repositories: true, secrets: false },
+        });
+        expect(
+          reposReducer(state, {
+            type: actionTypes.receiveRepo as any,
+            payload: repo,
+          }),
+        ).toEqual({ ...initialState, repo });
+      });
+    });
+
+    it("receives repo secrets", () => {
+      const secret = { metadata: { name: "foo" } };
+      expect(
+        reposReducer(undefined, {
+          type: actionTypes.receiveReposSecrets as any,
+          payload: [secret],
+        }),
+      ).toEqual({ ...initialState, repoSecrets: [secret] });
+    });
+
+    it("adds a repo", () => {
+      const repo = { metadata: { name: "foo" } };
+      const state = reposReducer(undefined, {
+        type: actionTypes.addRepo as any,
+      });
+      expect(state).toEqual({
+        ...initialState,
+        addingRepo: true,
+      });
+      expect(
+        reposReducer(state, {
+          type: actionTypes.addedRepo as any,
+          payload: repo,
+        }),
+      ).toEqual({ ...initialState, lastAdded: repo, repos: [repo] });
+    });
+
+    it("updates a repo", () => {
+      const repo = { metadata: { name: "foo" } } as any;
+      expect(
+        reposReducer(
+          { ...initialState, repos: [repo] },
+          {
+            type: actionTypes.repoUpdated as any,
+            payload: { ...repo, spec: { a: "b" } },
+          },
+        ),
+      ).toEqual({ ...initialState, repos: [{ ...repo, spec: { a: "b" } }] });
+    });
+
+    it("validates a repo", () => {
+      const state = reposReducer(undefined, {
+        type: actionTypes.repoValidating as any,
+      });
+      expect(state).toEqual({
+        ...initialState,
+        validating: true,
+      });
+      expect(
+        reposReducer(state, {
+          type: actionTypes.repoValidated as any,
+        }),
+      ).toEqual({ ...initialState });
+    });
+
+    it("receives image pull secrets", () => {
+      const pullSecret = { metadata: { name: "foo" } } as any;
+      const state = reposReducer(undefined, {
+        type: actionTypes.requestImagePullSecrets as any,
+      });
+      expect(state).toEqual({
+        ...initialState,
+        isFetching: true,
+        isFetchingElem: { repositories: false, secrets: true },
+      });
+      expect(
+        reposReducer(state, {
+          type: actionTypes.receiveImagePullSecrets as any,
+          payload: [pullSecret],
+        }),
+      ).toEqual({ ...initialState, imagePullSecrets: [pullSecret] });
+    });
+  });
+});

--- a/dashboard/src/reducers/repos.test.ts
+++ b/dashboard/src/reducers/repos.test.ts
@@ -40,6 +40,7 @@ describe("reposReducer", () => {
       requestRepos: getType(actions.repos.requestRepos),
       receiveRepos: getType(actions.repos.receiveRepos),
       receiveReposSecrets: getType(actions.repos.receiveReposSecrets),
+      receiveReposSecret: getType(actions.repos.receiveReposSecret),
       requestRepo: getType(actions.repos.requestRepo),
       receiveRepo: getType(actions.repos.receiveRepo),
       repoValidating: getType(actions.repos.repoValidating),
@@ -115,6 +116,20 @@ describe("reposReducer", () => {
           payload: [secret],
         }),
       ).toEqual({ ...initialState, repoSecrets: [secret] });
+    });
+
+    it("receives a repo secret", () => {
+      const secret = { metadata: { name: "foo" } } as any;
+      const modifiedSecret = { ...secret, spec: { foo: "bar" } };
+      expect(
+        reposReducer(
+          { ...initialState, repoSecrets: [secret] },
+          {
+            type: actionTypes.receiveReposSecret as any,
+            payload: modifiedSecret,
+          },
+        ),
+      ).toEqual({ ...initialState, repoSecrets: [modifiedSecret] });
     });
 
     it("adds a repo", () => {

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -98,6 +98,15 @@ const reposReducer = (
         lastAdded: action.payload,
         repos: [...state.repos, action.payload],
       };
+    case getType(actions.repos.repoUpdated):
+      const updatedRepo = action.payload;
+      const repos = state.repos.map(r =>
+        r.metadata.name === updatedRepo.metadata.name &&
+        r.metadata.namespace === updatedRepo.metadata.namespace
+          ? updatedRepo
+          : r,
+      );
+      return { ...state, repos };
     case getType(actions.repos.repoValidating):
       return { ...state, validating: true };
     case getType(actions.repos.repoValidated):

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -87,6 +87,15 @@ const reposReducer = (
       };
     case getType(actions.repos.receiveReposSecrets):
       return { ...state, repoSecrets: action.payload };
+    case getType(actions.repos.receiveReposSecret):
+      const secret = action.payload;
+      const repoSecrets = state.repoSecrets.map(s =>
+        s.metadata.name === secret.metadata.name &&
+        s.metadata.namespace === secret.metadata.namespace
+          ? secret
+          : s,
+      );
+      return { ...state, repoSecrets };
     case getType(actions.repos.requestRepos):
       return { ...state, ...isFetching(state, "repositories", true) };
     case getType(actions.repos.addRepo):

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -407,7 +407,13 @@ export interface IAppRepository
       type: string;
       url: string;
       auth: {
-        header: {
+        header?: {
+          secretKeyRef: {
+            name: string;
+            key: string;
+          };
+        };
+        customCA?: {
           secretKeyRef: {
             name: string;
             key: string;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Requires #1705 

I have enabled the modify button which was mostly ready unless two minor things:

 - I needed to re-fetch secrets in case the modification modify any of the related app repo secrets
 - I have added the updatedRepo event in the reducer to update the updated app repo in the state.

Since the reducer for app repos didn't exist, I have covered part of that file with unit tests.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1666

