### PR TITLE
Fix operators test for GKE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ build_images: &build_images
         fi
         for IMAGE in "${IMG_ARRAY[@]}"; do
           make IMG_MODIFIER="$IMG_MODIFIER" IMAGE_TAG="${DEV_TAG}" $makeArgs kubeapps/${IMAGE}
-          if [[ -z "${CIRCLE_PULL_REQUEST}" && -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
+          if [[ -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
             docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
             docker push kubeapps/${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,7 @@ workflows:
             - build_go_images
             - build_dashboard
       - GKE_1_15_MASTER:
-          # <<: *build_on_master
-          <<: *build_always
+          <<: *build_on_master
           requires:
             - test_go
             - test_dashboard
@@ -79,8 +78,7 @@ workflows:
             - build_go_images
             - build_dashboard
       - GKE_1_14_MASTER:
-          # <<: *build_on_master
-          <<: *build_always
+          <<: *build_on_master
           requires:
             - test_go
             - test_dashboard

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,8 @@ workflows:
             - build_go_images
             - build_dashboard
       - GKE_1_15_MASTER:
-          <<: *build_on_master
+          # <<: *build_on_master
+          <<: *build_always
           requires:
             - test_go
             - test_dashboard
@@ -78,7 +79,8 @@ workflows:
             - build_go_images
             - build_dashboard
       - GKE_1_14_MASTER:
-          <<: *build_on_master
+          # <<: *build_on_master
+          <<: *build_always
           requires:
             - test_go
             - test_dashboard

--- a/integration/use-cases/operator-deployment.js
+++ b/integration/use-cases/operator-deployment.js
@@ -1,4 +1,9 @@
 test("Deploys an Operator", async () => {
+  if (process.env.GKE_BRANCH === "1.14") {
+    console.log("Operators are not supported in GKE 1.14, skipping test");
+    return;
+  }
+
   await page.goto(getUrl("/#/ns/kubeapps/operators"));
 
   await expect(page).toFillForm("form", {

--- a/integration/use-cases/operator-deployment.js
+++ b/integration/use-cases/operator-deployment.js
@@ -1,9 +1,4 @@
 test("Deploys an Operator", async () => {
-  if (process.env.GKE_BRANCH === "1.14") {
-    console.log("Operators are not supported in GKE 1.14, skipping test");
-    return;
-  }
-
   await page.goto(getUrl("/#/ns/kubeapps/operators"));
 
   await expect(page).toFillForm("form", {

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -92,7 +92,7 @@ installOLM() {
 
     kubectl apply -f ${url}/crds.yaml
 
-    if [[ -z "$GKE_ADMIN" ]]; then
+    if [[ -z "$GKE_BRANCH" ]]; then
       # The Pod that populates the catalog gets OOM Killed due to very low limits
       # This has been fixed here: https://github.com/operator-framework/operator-lifecycle-manager/pull/1389
       # But the fix has not been published yet. To workaround the issue we are using a newer image
@@ -121,9 +121,12 @@ installOperator() {
     kubectl create -f "https://operatorhub.io/install/${operator}.yaml"
 }
 
-installOLM 0.14.1
-# TODO(andresmgot): Switch to install the operator using the web form when ready
-installOperator prometheus
+# Operators are not supported in GKE 1.14, skipping test
+if [[ "$GKE_BRANCH" != "1.14" ]]; then
+  installOLM 0.14.1
+  # TODO(andresmgot): Switch to install the operator using the web form when ready
+  installOperator prometheus
+fi
 
 info "IMAGE TAG TO BE TESTED: $DEV_TAG"
 info "IMAGE_REPO_SUFFIX: $IMG_MODIFIER"

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -78,6 +78,16 @@ tiller-init-rbac() {
 }
 
 ########################
+# Check if the pod that populates de OperatorHub catalog is running
+# Globals: None
+# Arguments: None
+# Returns: None
+#########################
+isOperatorHubCatalogRunning() {
+  kubectl get pod -n olm -l olm.catalogSource=operatorhubio-catalog -o jsonpath='{.items[0].status.phase}' | grep Running
+}
+
+########################
 # Install OLM
 # Globals: None
 # Arguments:
@@ -269,6 +279,10 @@ if [[ -z "${TEST_LATEST_RELEASE:-}" ]]; then
   fi
   info "Helm tests succeded!!"
 fi
+
+## Wait for the Operator catalog to be populated
+info "Waiting for the OperatorHub Catalog to be ready ..."
+retry_while isOperatorHubCatalogRunning 24
 
 # Browser tests
 cd "${ROOT_DIR}/integration"

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 set -o errexit
-set -o nounset
 set -o pipefail
 
 # Constants

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -279,6 +279,10 @@ pod=$(kubectl get po -l run=integration -o jsonpath="{.items[0].metadata.name}")
 for f in *.js; do
   kubectl cp "./${f}" "${pod}:/app/"
 done
+## Operators are not supported for GKE 1.14, skip that test
+if [[ "${GKE_BRANCH:-}" == "1.14" ]]; then
+  rm use-cases/operator-deployment.js
+fi
 kubectl cp ./use-cases "${pod}:/app/"
 ## Create admin user
 kubectl create serviceaccount kubeapps-operator -n kubeapps

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -85,6 +85,8 @@ tiller-init-rbac() {
 #########################
 isOperatorHubCatalogRunning() {
   kubectl get pod -n olm -l olm.catalogSource=operatorhubio-catalog -o jsonpath='{.items[0].status.phase}' | grep Running
+  # Wait also for the catalog to be populated
+  kubectl get packagemanifests.packages.operators.coreos.com | grep prometheus
 }
 
 ########################
@@ -280,9 +282,11 @@ if [[ -z "${TEST_LATEST_RELEASE:-}" ]]; then
   info "Helm tests succeded!!"
 fi
 
-## Wait for the Operator catalog to be populated
-info "Waiting for the OperatorHub Catalog to be ready ..."
-retry_while isOperatorHubCatalogRunning 24
+if [[ "${GKE_BRANCH-}" != "1.14" ]]; then
+  ## Wait for the Operator catalog to be populated
+  info "Waiting for the OperatorHub Catalog to be ready ..."
+  retry_while isOperatorHubCatalogRunning 24
+fi
 
 # Browser tests
 cd "${ROOT_DIR}/integration"

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -188,8 +188,8 @@ pushChart() {
     pkill -f "kubectl port-forward $POD_NAME 8080:8080 --namespace kubeapps"
 }
 
-# Operators are not supported in GKE 1.14, skipping test
-if [[ -z "${GKE_BRANCH-}" != "1.14" ]]; then
+# Operators are not supported in GKE 1.14 and flaky in 1.15
+if [[ -z "${GKE_BRANCH-}" ]]; then
   installOLM 0.14.1
   # TODO(andresmgot): Switch to install the operator using the web form when ready
   installOperator prometheus
@@ -340,7 +340,8 @@ if [[ -z "${TEST_LATEST_RELEASE:-}" ]]; then
   info "Helm tests succeded!!"
 fi
 
-if [[ "${GKE_BRANCH-}" != "1.14" ]]; then
+# Operators are not supported in GKE 1.14 and flaky in 1.15
+if [[ -z "${GKE_BRANCH-}" ]]; then
   ## Wait for the Operator catalog to be populated
   info "Waiting for the OperatorHub Catalog to be ready ..."
   retry_while isOperatorHubCatalogRunning 24
@@ -356,8 +357,8 @@ for f in *.js; do
   kubectl cp "./${f}" "${pod}:/app/"
 done
 testsToIgnore=()
-## Operators are not supported for GKE 1.14, skip that test
-if [[ "${GKE_BRANCH:-}" == "1.14" ]]; then
+# Operators are not supported in GKE 1.14 and flaky in 1.15, skipping test
+if [[ -z "${GKE_BRANCH-}" ]]; then
   testsToIgnore=("operator-deployment" "${testsToIgnore[@]}")
 fi
 ## Support for Docker registry secrets are not supported for Helm2, skipping that test

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -122,7 +122,7 @@ installOperator() {
 }
 
 # Operators are not supported in GKE 1.14, skipping test
-if [[ "$GKE_BRANCH" != "1.14" ]]; then
+if [[ "${GKE_BRANCH-}" != "1.14" ]]; then
   installOLM 0.14.1
   # TODO(andresmgot): Switch to install the operator using the web form when ready
   installOperator prometheus

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -300,7 +300,7 @@ done
 testsToIgnore=()
 ## Operators are not supported for GKE 1.14, skip that test
 if [[ "${GKE_BRANCH:-}" == "1.14" ]]; then
-  testsToIgnore=("operator-deployment" "${testToIgnore[@]}")
+  testsToIgnore=("operator-deployment" "${testsToIgnore[@]}")
 fi
 ignoreFlag=""
 if [[ "${#testsToIgnore[@]}" > "0" ]]; then
@@ -332,7 +332,7 @@ view_token="$(kubectl get -n kubeapps secret "$(kubectl get -n kubeapps servicea
 edit_token="$(kubectl get -n kubeapps secret "$(kubectl get -n kubeapps serviceaccount kubeapps-edit -o jsonpath='{.secrets[].name}')" -o go-template='{{.data.token | base64decode}}' && echo)"
 ## Run tests
 info "Running Integration tests..."
-if ! kubectl exec -it "$pod" -- /bin/sh -c "INTEGRATION_ENTRYPOINT=http://kubeapps-ci.kubeapps ADMIN_TOKEN=${admin_token} VIEW_TOKEN=${view_token} EDIT_TOKEN=${edit_token} yarn start"; then
+if ! kubectl exec -it "$pod" -- /bin/sh -c "INTEGRATION_ENTRYPOINT=http://kubeapps-ci.kubeapps ADMIN_TOKEN=${admin_token} VIEW_TOKEN=${view_token} EDIT_TOKEN=${edit_token} yarn start ${ignoreFlag}"; then
   ## Integration tests failed, get report screenshot
   warn "PODS status on failure"
   kubectl cp "${pod}:/app/reports" ./reports

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -370,7 +370,7 @@ if [[ "${#testsToIgnore[@]}" > "0" ]]; then
   # Join tests to ignore
   testsToIgnore=$(printf "|%s" "${testsToIgnore[@]}")
   testsToIgnore=${testsToIgnore:1}
-  ignoreFlag="--testPathIgnorePatterns $testsToIgnore"
+  ignoreFlag="--testPathIgnorePatterns '$testsToIgnore'"
 fi
 kubectl cp ./use-cases "${pod}:/app/"
 ## Create admin user

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -103,17 +103,12 @@ installOLM() {
 
     kubectl apply -f ${url}/crds.yaml
 
-    if [[ "${GKE_BRANCH-}" != "1.15" ]]; then
-      # The Pod that populates the catalog gets OOM Killed due to very low limits
-      # This has been fixed here: https://github.com/operator-framework/operator-lifecycle-manager/pull/1389
-      # But the fix has not been published yet. To workaround the issue we are using a newer image
-      # This will be fixed in a version > 0.14.2
-      kubectl apply -f "${ROOT_DIR}/script/manifests/olm.yaml"
-    else
-      # The newer manifest doesn't work in k8s 1.15
-      # So we use the default manifest, the only problem is that it's way slower
-      kubectl apply -f ${url}/olm.yaml
-    fi
+    # The Pod that populates the catalog gets OOM Killed due to very low limits
+    # This has been fixed here: https://github.com/operator-framework/operator-lifecycle-manager/pull/1389
+    # But the fix has not been published yet. To workaround the issue we are using a newer image
+    # This will be fixed in a version > 0.14.2
+    kubectl apply -f "${ROOT_DIR}/script/manifests/olm.yaml"
+
     # wait for deployments to be ready
     kubectl rollout status -w deployment/olm-operator --namespace="${namespace}"
     kubectl rollout status -w deployment/catalog-operator --namespace="${namespace}"

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -92,7 +92,7 @@ installOLM() {
 
     kubectl apply -f ${url}/crds.yaml
 
-    if [[ -z "$GKE_BRANCH" ]]; then
+    if [[ -z "${GKE_BRANCH-}" ]]; then
       # The Pod that populates the catalog gets OOM Killed due to very low limits
       # This has been fixed here: https://github.com/operator-framework/operator-lifecycle-manager/pull/1389
       # But the fix has not been published yet. To workaround the issue we are using a newer image

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -358,8 +358,8 @@ for f in *.js; do
 done
 testsToIgnore=()
 # Operators are not supported in GKE 1.14 and flaky in 1.15, skipping test
-if [[ -z "${GKE_BRANCH-}" ]]; then
-  testsToIgnore=("operator-deployment" "${testsToIgnore[@]}")
+if [[ -n "${GKE_BRANCH-}" ]]; then
+  testsToIgnore=("operator-deployment.js" "${testsToIgnore[@]}")
 fi
 ## Support for Docker registry secrets are not supported for Helm2, skipping that test
 if [[ "${HELM_VERSION:-}" =~ "v2" ]]; then


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Fix the GKE tests in master. There are two problems for the Operator test:

 - The OLM cannot be installed in GKE 1.14, the manifest fails to be installed so we need to skip the test in this build.
 - The newer image that I am using to avoid the issue for limits too low doesn't work for GKE 1.15 so I need to use the default manifest and let the pod to be killed several times because of OOM until it populates the operator catalog (which is slow).

[EDIT]

At the end I had to disable the test also for GKE 1.15, it was too flaky because the operatorhub populator pod gets continuously restarted.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1708 
