### PR TITLE
Add support to multiple conditions to hide an element on basic forms

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
@@ -131,8 +131,17 @@ it("should hide an element if it depends on a param (object)", () => {
       path: "foo",
       type: "string",
       hidden: {
-        value: "bar",
-        condition: "enabled",
+        conditions: [
+          {
+            value: "bar",
+            reference: "enabled",
+          },
+          {
+            value: "baz",
+            reference: "disabled",
+          },
+        ],
+        operator: "and",
       },
     },
     {
@@ -140,7 +149,7 @@ it("should hide an element if it depends on a param (object)", () => {
       type: "string",
     },
   ] as IBasicFormParam[];
-  const appValues = "foo: 1\nbar: enabled";
+  const appValues = "foo: 1\nbar: enabled\nbaz: disabled";
   const wrapper = shallow(
     <BasicDeploymentForm {...defaultProps} params={params} appValues={appValues} />,
   );

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
@@ -125,7 +125,31 @@ it("should hide an element if it depends on a param (string)", () => {
   expect(hiddenParam).toExist();
 });
 
-it("should hide an element if it depends on a param (object)", () => {
+it("should hide an element if it depends on a single param (object)", () => {
+  const params = [
+    {
+      path: "foo",
+      type: "string",
+      hidden: {
+        value: "bar",
+        path: "enabled",
+      },
+    },
+    {
+      path: "bar",
+      type: "string",
+    },
+  ] as IBasicFormParam[];
+  const appValues = "foo: 1\nbar: enabled";
+  const wrapper = shallow(
+    <BasicDeploymentForm {...defaultProps} params={params} appValues={appValues} />,
+  );
+
+  const hiddenParam = wrapper.find("div").filterWhere(p => p.prop("hidden") === true);
+  expect(hiddenParam).toExist();
+});
+
+it("should hide an element if it depends on multiple params (object)", () => {
   const params = [
     {
       path: "foo",
@@ -134,11 +158,11 @@ it("should hide an element if it depends on a param (object)", () => {
         conditions: [
           {
             value: "bar",
-            reference: "enabled",
+            path: "enabled",
           },
           {
             value: "baz",
-            reference: "disabled",
+            path: "disabled",
           },
         ],
         operator: "and",

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
@@ -149,7 +149,7 @@ it("should hide an element if it depends on a single param (object)", () => {
   expect(hiddenParam).toExist();
 });
 
-it("should hide an element if it depends on multiple params (object)", () => {
+it("should hide an element if it depends on multiple params (AND) (object)", () => {
   const params = [
     {
       path: "foo",
@@ -174,6 +174,72 @@ it("should hide an element if it depends on multiple params (object)", () => {
     },
   ] as IBasicFormParam[];
   const appValues = "foo: 1\nbar: enabled\nbaz: disabled";
+  const wrapper = shallow(
+    <BasicDeploymentForm {...defaultProps} params={params} appValues={appValues} />,
+  );
+
+  const hiddenParam = wrapper.find("div").filterWhere(p => p.prop("hidden") === true);
+  expect(hiddenParam).toExist();
+});
+
+it("should hide an element if it depends on multiple params (OR) (object)", () => {
+  const params = [
+    {
+      path: "foo",
+      type: "string",
+      hidden: {
+        conditions: [
+          {
+            value: "enabled",
+            path: "bar",
+          },
+          {
+            value: "disabled",
+            path: "baz",
+          },
+        ],
+        operator: "or",
+      },
+    },
+    {
+      path: "bar",
+      type: "string",
+    },
+  ] as IBasicFormParam[];
+  const appValues = "foo: 1\nbar: enabled\nbaz: enabled";
+  const wrapper = shallow(
+    <BasicDeploymentForm {...defaultProps} params={params} appValues={appValues} />,
+  );
+
+  const hiddenParam = wrapper.find("div").filterWhere(p => p.prop("hidden") === true);
+  expect(hiddenParam).toExist();
+});
+
+it("should hide an element if it depends on multiple params (NOR) (object)", () => {
+  const params = [
+    {
+      path: "foo",
+      type: "string",
+      hidden: {
+        conditions: [
+          {
+            value: "enabled",
+            path: "bar",
+          },
+          {
+            value: "disabled",
+            path: "baz",
+          },
+        ],
+        operator: "nor",
+      },
+    },
+    {
+      path: "bar",
+      type: "string",
+    },
+  ] as IBasicFormParam[];
+  const appValues = "foo: 1\nbar: disabled\nbaz: enabled";
   const wrapper = shallow(
     <BasicDeploymentForm {...defaultProps} params={params} appValues={appValues} />,
   );

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
@@ -131,8 +131,8 @@ it("should hide an element if it depends on a single param (object)", () => {
       path: "foo",
       type: "string",
       hidden: {
-        value: "bar",
-        path: "enabled",
+        value: "enabled",
+        path: "bar",
       },
     },
     {
@@ -157,12 +157,12 @@ it("should hide an element if it depends on multiple params (object)", () => {
       hidden: {
         conditions: [
           {
-            value: "bar",
-            path: "enabled",
+            value: "enabled",
+            path: "bar",
           },
           {
-            value: "baz",
-            path: "disabled",
+            value: "disabled",
+            path: "baz",
           },
         ],
         operator: "and",

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -61,8 +61,17 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
               return hidden.conditions.some(
                 c => getValue(this.props.appValues, c.value) === c.path,
               );
+            case "nor":
+              // Every value mismatches the referenced
+              // value (via jsonpath) in any of the conditions
+              return hidden.conditions.every(
+                c => getValue(this.props.appValues, c.value) !== c.path,
+              );
             default:
-              return false;
+              // we consider 'and' as the default operator
+              return hidden.conditions.every(
+                c => getValue(this.props.appValues, c.value) === c.path,
+              );
           }
         } else {
           return getValue(this.props.appValues, hidden.value) === hidden.path;

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -42,8 +42,33 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
         // If hidden is a string, it points to the value that should be true
         return getValue(this.props.appValues, hidden) === true;
       case "object":
-        // If hidden is an object, inspect the value it points to
-        return getValue(this.props.appValues, hidden.value) === hidden.condition;
+        let isHiddenParam;
+        // If hidden is an object, a different logic should be applied
+        // based on the operator
+        switch (hidden.operator) {
+          case "and":
+            // Every value matches its reference in
+            // all the conditions
+            isHiddenParam = true;
+            hidden.conditions.forEach(c => {
+              if (getValue(this.props.appValues, c.value) !== c.reference) {
+                isHiddenParam = false;
+              }
+            });
+            return isHiddenParam;
+          case "or":
+            // It is enough if the value matches its reference in
+            // any of the conditions
+            isHiddenParam = false;
+            hidden.conditions.forEach(c => {
+              if (getValue(this.props.appValues, c.value) === c.reference) {
+                isHiddenParam = true;
+              }
+            });
+            return isHiddenParam;
+          default:
+            return false;
+        }
       case "undefined":
         return false;
     }

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -53,28 +53,28 @@ class BasicDeploymentForm extends React.Component<IBasicDeploymentFormProps> {
               // Every value matches the referenced
               // value (via jsonpath) in all the conditions
               return hidden.conditions.every(
-                c => getValue(this.props.appValues, c.value) === c.path,
+                c => getValue(this.props.appValues, c.path) === c.value,
               );
             case "or":
               // It is enough if the value matches the referenced
               // value (via jsonpath) in any of the conditions
               return hidden.conditions.some(
-                c => getValue(this.props.appValues, c.value) === c.path,
+                c => getValue(this.props.appValues, c.path) === c.value,
               );
             case "nor":
               // Every value mismatches the referenced
               // value (via jsonpath) in any of the conditions
               return hidden.conditions.every(
-                c => getValue(this.props.appValues, c.value) !== c.path,
+                c => getValue(this.props.appValues, c.path) !== c.value,
               );
             default:
               // we consider 'and' as the default operator
               return hidden.conditions.every(
-                c => getValue(this.props.appValues, c.value) === c.path,
+                c => getValue(this.props.appValues, c.path) === c.value,
               );
           }
         } else {
-          return getValue(this.props.appValues, hidden.value) === hidden.path;
+          return getValue(this.props.appValues, hidden.path) === hidden.value;
         }
       case "undefined":
         return false;

--- a/dashboard/src/shared/schema.ts
+++ b/dashboard/src/shared/schema.ts
@@ -76,7 +76,7 @@ function getDefinedPath(allElementsButTheLast: string[], doc: YAML.ast.Document)
 
 function splitPath(path: string): string[] {
   return (
-    path
+    (path ?? "")
       // ignore the first slash, if exists
       .replace(/^\//, "")
       // split by slashes

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -542,8 +542,10 @@ export interface IBasicFormParam {
   description?: string;
   hidden?:
     | {
+        path: any;
+        value: string;
         conditions: Array<{
-          reference: any;
+          path: any;
           value: string;
         }>;
         operator: string;

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -542,8 +542,11 @@ export interface IBasicFormParam {
   description?: string;
   hidden?:
     | {
-        condition: any;
-        value: string;
+        conditions: Array<{
+          reference: any;
+          value: string;
+        }>;
+        operator: string;
       }
     | string;
   children?: IBasicFormParam[];

--- a/docs/developer/basic-form-support.md
+++ b/docs/developer/basic-form-support.md
@@ -4,8 +4,8 @@
 
 Since Kubeapps 1.6.0, it's possible to include a JSON schema with a chart that defines the structure of the `values.yaml` file. This JSON schema is used with two goals:
 
- - Validate that the given values satisfy the schema defined. In case the submitted values are not valid, the installation or upgrade will fail. This has been introduced with Helm v3.
- - Present the user with a simpler so the chart is easier to deploy and configure.
+- Validate that the given values satisfy the schema defined. In case the submitted values are not valid, the installation or upgrade will fail. This has been introduced with Helm v3.
+- Present the user with a simpler so the chart is easier to deploy and configure.
 
 The goal of this feature is to present the user with the most common parameters which are typically modified before deploying a chart (like username and password) in a more user-friendly form.
 
@@ -36,9 +36,9 @@ With the definition above, we are marking the value `wordpressUsername` as a val
 
 In addition to the `type`, there are other tags that can be used to customize the way the parameter is represented:
 
- - `title` is used to render the title of the parameter. If it's not specified, Kubeapps will use the path of the value (i.e. `credentials.username`).
- - `description` is used to include additional information of the parameter.
- - `default` is used to set a default value. Note that this field will only be used if the `values.yaml` file doesn't have already a default value for the parameter.
+- `title` is used to render the title of the parameter. If it's not specified, Kubeapps will use the path of the value (i.e. `credentials.username`).
+- `description` is used to include additional information of the parameter.
+- `default` is used to set a default value. Note that this field will only be used if the `values.yaml` file doesn't have already a default value for the parameter.
 
 ### Custom type: Slider
 
@@ -48,11 +48,11 @@ It's possible to render a component as a slider, users can then drag and drop th
 
 In order to render a slider, there are some requirements and additional tags that you may need to set:
 
- - The only supported `type` for the moment is a string. Other types like `integer` will be transformed to a string.
- - It's necessary to specify the tag `render` and set it to `slider`.
- - The tag `sliderMin` identifies the minimum value the slider allows (this can be bypassed writting a smaller value in the input).
- - The tag `sliderMax` identifies the maximum value the slider allows (this can be bypassed writting a bigger value in the input).
- - The tag `sliderUnit` specifies the unit of the value to set. For example `Gi`.
+- The only supported `type` for the moment is a string. Other types like `integer` will be transformed to a string.
+- It's necessary to specify the tag `render` and set it to `slider`.
+- The tag `sliderMin` identifies the minimum value the slider allows (this can be bypassed writting a smaller value in the input).
+- The tag `sliderMax` identifies the maximum value the slider allows (this can be bypassed writting a bigger value in the input).
+- The tag `sliderUnit` specifies the unit of the value to set. For example `Gi`.
 
  This is an example of a slider param:
 
@@ -94,7 +94,26 @@ When a property of type `object` is set with a `form` identifier, it will be ren
 
 All the parameters within an `object` will be rendered in the subsection.
 
-Note that in some cases, a parameter cause that the rest of parameters are no longer relevant. For example, setting `ingress.enabled` to `false` makes the `ingress.hostname` irrelevant. To avoid confussion, you can hide that parameter setting the special tag `hidden`. The tag `hidden` can be a `string` pointing to the parameter that needs to be `true` to hide the element or an object to also set the value that the pointed value needs to match.
+Note that in some cases, a parameter cause that the rest of parameters are no longer relevant. For example, setting `ingress.enabled` to `false` makes the `ingress.hostname` irrelevant. To avoid confussion, you can hide that parameter setting the special tag `hidden`. The tag `hidden` can be a `string` pointing to the parameter that needs to be `true` to hide the element or an `object` to also set a group of values that need to match a given reference.
+
+When using an `object` to set the `hidden` tag, you can specify an array of conditions to match, and the conditional operator to use (currently supported: `and`, `or`). The format is shown below:
+
+```json
+{
+  "hidden": {
+    "conditions": [
+      {
+        "value": "foo",
+        "reference": "bar"
+      },
+      {
+        "value": "baz",
+        "reference": "qux"
+      }
+    ],
+    "operator": "or"
+}
+```
 
 This is an example for a subsection with a parameter that can be hidden:
 
@@ -115,8 +134,11 @@ This is an example for a subsection with a parameter that can be hidden:
           "form": "hostname",
           "title": "Hostname",
           "hidden": {
-            "value": "ingress.enabled",
-            "condition": false
+            "conditions": [{
+              "reference": false,
+              "value": "ingress/enabled"
+            }],
+            "operator": "and"
           }
         }
       }

--- a/docs/developer/basic-form-support.md
+++ b/docs/developer/basic-form-support.md
@@ -144,8 +144,8 @@ This is an example for a subsection with a parameter that can be hidden:
           "title": "Hostname",
           "hidden": {
             "conditions": [{
-              "path": false,
-              "value": "ingress/enabled"
+              "path": ingress/enabled,
+              "value": "false"
             }],
             "operator": "and"
           }
@@ -176,7 +176,7 @@ Note that the parameter that hides another parameter doesn't need to be within t
           "type": "string",
           "form": "externalDatabaseHost",
           "title": "Database Host",
-          "hidden": "mariadb.enabled"
+          "hidden": "mariadb/enabled"
         },
       }
     },

--- a/docs/developer/basic-form-support.md
+++ b/docs/developer/basic-form-support.md
@@ -94,9 +94,18 @@ When a property of type `object` is set with a `form` identifier, it will be ren
 
 All the parameters within an `object` will be rendered in the subsection.
 
-Note that in some cases, a parameter cause that the rest of parameters are no longer relevant. For example, setting `ingress.enabled` to `false` makes the `ingress.hostname` irrelevant. To avoid confussion, you can hide that parameter setting the special tag `hidden`. The tag `hidden` can be a `string` pointing to the parameter that needs to be `true` to hide the element or an `object` to also set a group of values that need to match a given reference.
+Note that in some cases, a parameter cause that the rest of parameters are no longer relevant. For example, setting `ingress.enabled` to `false` makes the `ingress.hostname` irrelevant. To avoid confussion, you can hide that parameter setting the special tag `hidden`. The tag `hidden` can be a `string` pointing to the parameter that needs to be `true` to hide the element, or an `object` to also set the value that the pointed value needs to match as shown below:
 
-When using an `object` to set the `hidden` tag, you can specify an array of conditions to match, and the conditional operator to use (currently supported: `and`, `or`). The format is shown below:
+```json
+{
+  "hidden": {
+    "value": "foo",
+    "path": "bar"
+  }
+}
+```
+
+When using an `object` to set the `hidden` tag, you can also specify an array of conditions to match, and the conditional operator to use (currently supported: `and`, `or`). The format is shown below:
 
 ```json
 {
@@ -104,11 +113,11 @@ When using an `object` to set the `hidden` tag, you can specify an array of cond
     "conditions": [
       {
         "value": "foo",
-        "reference": "bar"
+        "path": "bar"
       },
       {
         "value": "baz",
-        "reference": "qux"
+        "path": "qux"
       }
     ],
     "operator": "or"
@@ -135,7 +144,7 @@ This is an example for a subsection with a parameter that can be hidden:
           "title": "Hostname",
           "hidden": {
             "conditions": [{
-              "reference": false,
+              "path": false,
               "value": "ingress/enabled"
             }],
             "operator": "and"

--- a/docs/developer/basic-form-support.md
+++ b/docs/developer/basic-form-support.md
@@ -105,7 +105,7 @@ Note that in some cases, a parameter cause that the rest of parameters are no lo
 }
 ```
 
-When using an `object` to set the `hidden` tag, you can also specify an array of conditions to match, and the conditional operator to use (currently supported: `and`, `or`). The format is shown below:
+When using an `object` to set the `hidden` tag, you can also specify an array of conditions to match, and the conditional operator to use (currently supported: `and`, `or`, `nor`). The format is shown below:
 
 ```json
 {


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

### Description of the change

This PR adds support for multiple conditions to hide an element on basic forms.

As it's explained in the developer docs, developers will be able to use an array of conditions, and the conditional operator to consider an element to be hidden.

### Benefits

More possibilities for chart developers to create their values.schemas.json

### Possible drawbacks

None that I'm aware of

### Applicable issues

  - fixes https://github.com/kubeapps/kubeapps/issues/1336