### PR TITLE
Omit maintainers if they don't exist

### DIFF
--- a/dashboard/src/components/ChartView/ChartView.test.tsx
+++ b/dashboard/src/components/ChartView/ChartView.test.tsx
@@ -107,7 +107,7 @@ context("when fetching is true and chart is available", () => {
 describe("subcomponents", () => {
   const wrapper = shallow(<ChartView {...props} selected={{ version: testVersion }} />);
 
-  for (const component of [ChartHeader, ChartReadme, ChartVersionsList, ChartMaintainers]) {
+  for (const component of [ChartHeader, ChartReadme, ChartVersionsList]) {
     it(`renders ${component.name}`, () => {
       expect(wrapper.find(component).exists()).toBe(true);
     });
@@ -119,6 +119,7 @@ it("does not render the app version, home and sources sections if not set", () =
   expect(wrapper.contains(<h2>App Version</h2>)).toBe(false);
   expect(wrapper.contains(<h2>Home</h2>)).toBe(false);
   expect(wrapper.contains(<h2>Related</h2>)).toBe(false);
+  expect(wrapper.contains(<h2>Maintainers</h2>)).toBe(false);
 });
 
 it("renders the app version when set", () => {
@@ -149,22 +150,31 @@ describe("ChartMaintainers githubIDAsNames prop value", () => {
     expected: boolean;
     name: string;
     repoURL: string;
+    maintainers: Array<{ name: string; email?: string }>;
   }> = [
     {
       expected: true,
       name: "stable Helm repo",
+      maintainers: [{ name: "Bitnami" }],
       repoURL: "https://kubernetes-charts.storage.googleapis.com",
     },
     {
       expected: true,
       name: "incubator Helm repo",
+      maintainers: [{ name: "Bitnami", email: "email: containers@bitnami.com" }],
       repoURL: "https://kubernetes-charts-incubator.storage.googleapis.com",
     },
-    { name: "random Helm repo", repoURL: "https://examplerepo.com", expected: false },
+    {
+      expected: false,
+      name: "random Helm repo",
+      maintainers: [{ name: "Bitnami" }],
+      repoURL: "https://examplerepo.com",
+    },
   ];
 
   for (const t of tests) {
     it(`for ${t.name}`, () => {
+      v.relationships.chart.data.maintainers = [{ name: "John Smith" }];
       v.relationships.chart.data.repo.url = t.repoURL;
       const wrapper = shallow(<ChartView {...props} selected={{ version: v }} />);
       const chartMaintainers = wrapper.find(ChartMaintainers);

--- a/dashboard/src/components/ChartView/ChartView.tsx
+++ b/dashboard/src/components/ChartView/ChartView.tsx
@@ -103,13 +103,15 @@ class ChartView extends React.Component<IChartViewProps> {
                       </div>
                     </div>
                   )}
-                  <div className="ChartViewSidebar__section">
-                    <h2>Maintainers</h2>
-                    <ChartMaintainers
-                      maintainers={chartAttrs.maintainers}
-                      githubIDAsNames={this.isKubernetesCharts(chartAttrs.repo.url)}
-                    />
-                  </div>
+                  {chartAttrs.maintainers?.length > 0 && (
+                    <div className="ChartViewSidebar__section">
+                      <h2>Maintainers</h2>
+                      <ChartMaintainers
+                        maintainers={chartAttrs.maintainers}
+                        githubIDAsNames={this.isKubernetesCharts(chartAttrs.repo.url)}
+                      />
+                    </div>
+                  )}
                   {chartAttrs.sources?.length > 0 && (
                     <div className="ChartViewSidebar__section">
                       <h2>Related</h2>


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

### Description of the change

This PR ensure the "Maintainers" section is omitted ChartView when this field doesn't exist in the corresponding **Chart.yaml**.

Before these changes:

<img width="304" alt="Screenshot 2020-05-07 at 17 00 25" src="https://user-images.githubusercontent.com/6740773/81310404-54bd5b00-9084-11ea-82bb-9faec7fc5226.png">

After these changes:

<img width="326" alt="Screenshot 2020-05-07 at 16 58 41" src="https://user-images.githubusercontent.com/6740773/81310428-5be46900-9084-11ea-982f-c41961ecf24d.png">

### Possible drawbacks

None that I'm aware of

### Applicable issues

- Related to https://github.com/kubeapps/kubeapps/issues/1620