### PR TITLE
Disable "Deploy" button for deployed Operators

### DIFF
--- a/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
@@ -21,6 +21,7 @@ const defaultProps: IOperatorInstanceProps = {
   getResource: jest.fn(),
   deleteResource: jest.fn(),
   push: jest.fn(),
+  errors: {},
 };
 
 itBehavesLike("aLoadingComponent", {
@@ -47,7 +48,9 @@ it("gets a resource again if the namespace changes", () => {
 });
 
 it("renders an error", () => {
-  const wrapper = shallow(<OperatorInstance {...defaultProps} error={new Error("Boom!")} />);
+  const wrapper = shallow(
+    <OperatorInstance {...defaultProps} errors={{ fetch: new Error("Boom!") }} />,
+  );
   expect(wrapper.find(ErrorSelector)).toExist();
   expect(wrapper.find(AppNotes)).not.toExist();
 });

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -31,7 +31,11 @@ export interface IOperatorInstanceProps {
   ) => Promise<void>;
   deleteResource: (namespace: string, crdName: string, resource: IResource) => Promise<boolean>;
   push: (location: string) => RouterAction;
-  error?: Error;
+  errors: {
+    fetch?: Error;
+    delete?: Error;
+    update?: Error;
+  };
   resource?: IResource;
   csv?: IClusterServiceVersion;
 }
@@ -131,7 +135,7 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
   public render() {
     const {
       isFetching,
-      error,
+      errors,
       resource,
       csv,
       instanceName,
@@ -143,7 +147,7 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
     const { resources } = this.state;
     const onUpdateClick = () =>
       push(app.operatorInstances.update(namespace, csvName, crdName, instanceName));
-
+    const error = errors.fetch || errors.delete || errors.update;
     return (
       <section className="AppView padding-b-big">
         <main>

--- a/dashboard/src/components/OperatorNew/OperatorNew.test.tsx
+++ b/dashboard/src/components/OperatorNew/OperatorNew.test.tsx
@@ -11,6 +11,7 @@ const defaultProps = {
   namespace: "kubeapps",
   push: jest.fn(),
   createOperator: jest.fn(),
+  errors: {},
 };
 
 const defaultOperator = {
@@ -69,7 +70,9 @@ it("parses the default channel when receiving the operator", () => {
 });
 
 it("renders an error if present", () => {
-  const wrapper = shallow(<OperatorNew {...defaultProps} error={new NotFoundError()} />);
+  const wrapper = shallow(
+    <OperatorNew {...defaultProps} errors={{ fetch: new NotFoundError() }} />,
+  );
   expect(wrapper.html()).toContain("Operator foo not found");
 });
 

--- a/dashboard/src/components/OperatorView/OperatorHeader.test.tsx
+++ b/dashboard/src/components/OperatorView/OperatorHeader.test.tsx
@@ -22,3 +22,11 @@ it("omits the button", () => {
   const wrapper = shallow(<OperatorHeader {...defaultProps} hideButton={true} />);
   expect(wrapper.find("button")).not.toExist();
 });
+
+it("disables the button", () => {
+  const wrapper = shallow(<OperatorHeader {...defaultProps} disableButton={true} />);
+  const button = wrapper.find("button");
+  expect(button).toExist();
+  expect(button.prop("disabled")).toBe(true);
+  expect(button.text()).toBe("Deployed");
+});

--- a/dashboard/src/components/OperatorView/OperatorHeader.tsx
+++ b/dashboard/src/components/OperatorView/OperatorHeader.tsx
@@ -7,6 +7,7 @@ interface IOperatorHeaderProps {
   id: string;
   icon?: string;
   hideButton?: boolean;
+  disableButton?: boolean;
   description: string;
   namespace: string;
   version: string;
@@ -21,7 +22,16 @@ class OperatorHeader extends React.Component<IOperatorHeaderProps> {
   };
 
   public render() {
-    const { id, icon, description, namespace, version, provider, hideButton } = this.props;
+    const {
+      id,
+      icon,
+      description,
+      namespace,
+      version,
+      provider,
+      hideButton,
+      disableButton,
+    } = this.props;
     return (
       <header>
         <div className="ChartView__heading margin-normal row">
@@ -43,8 +53,12 @@ class OperatorHeader extends React.Component<IOperatorHeaderProps> {
           </div>
           {!hideButton && (
             <div className="col-2 ChartHeader__button">
-              <button className="button button-primary button-accent" onClick={this.redirect}>
-                Deploy
+              <button
+                className="button button-primary button-accent"
+                onClick={this.redirect}
+                disabled={disableButton}
+              >
+                {disableButton ? "Deployed" : "Deploy"}
               </button>
             </div>
           )}

--- a/dashboard/src/components/OperatorView/__snapshots__/OperatorView.test.tsx.snap
+++ b/dashboard/src/components/OperatorView/__snapshots__/OperatorView.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`renders a full OperatorView 1`] = `
 >
   <OperatorHeader
     description="Foo"
+    disableButton={false}
     icon="api/v1/namespaces/kubeapps/operator/foo/logo"
     id="foo"
     namespace="kubeapps"

--- a/dashboard/src/containers/OperatorInstanceCreateContainer/OperatorInstanceCreateContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceCreateContainer/OperatorInstanceCreateContainer.tsx
@@ -24,7 +24,10 @@ function mapStateToProps(
     namespace: namespace.current,
     isFetching: operators.isFetching,
     csv: operators.csv,
-    errors: operators.errors,
+    errors: {
+      fetch: operators.errors.csv.fetch,
+      create: operators.errors.resource.create,
+    },
     csvName: params.csv,
     crdName: params.crd,
   };

--- a/dashboard/src/containers/OperatorInstanceUpdateContainer/OperatorInstanceUpdateContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceUpdateContainer/OperatorInstanceUpdateContainer.tsx
@@ -25,7 +25,7 @@ function mapStateToProps(
     namespace: namespace.current,
     isFetching: operators.isFetching,
     csv: operators.csv,
-    errors: operators.errors,
+    errors: operators.errors.resource,
     csvName: params.csv,
     crdName: params.crd,
     resourceName: params.instanceName,

--- a/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
@@ -28,7 +28,7 @@ function mapStateToProps(
     isFetching: operators.isFetching,
     resource: operators.resource,
     csv: operators.csv,
-    error: operators.errors.fetch || operators.errors.delete,
+    errors: operators.errors.resource,
   };
 }
 

--- a/dashboard/src/containers/OperatorNewContainer/OperatorNewContainer.tsx
+++ b/dashboard/src/containers/OperatorNewContainer/OperatorNewContainer.tsx
@@ -23,7 +23,7 @@ function mapStateToProps(
     namespace: namespace.current,
     isFetching: operators.isFetching,
     operator: operators.operator,
-    error: operators.errors.fetch || operators.errors.create,
+    errors: operators.errors.operator,
     operatorName: params.operator,
   };
 }

--- a/dashboard/src/containers/OperatorViewContainer/OperatorViewContainer.tsx
+++ b/dashboard/src/containers/OperatorViewContainer/OperatorViewContainer.tsx
@@ -23,8 +23,9 @@ function mapStateToProps(
     namespace: namespace.current,
     isFetching: operators.isFetching,
     operator: operators.operator,
-    error: operators.errors.fetch,
+    error: operators.errors.operator.fetch,
     operatorName: params.operator,
+    csv: operators.csv,
   };
 }
 
@@ -33,6 +34,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     getOperator: (namespace: string, operatorName: string) =>
       dispatch(actions.operators.getOperator(namespace, operatorName)),
     push: (location: string) => dispatch(push(location)),
+    getCSV: (namespace: string, name: string) =>
+      dispatch(actions.operators.getCSV(namespace, name)),
   };
 }
 

--- a/dashboard/src/containers/OperatorsListContainer/OperatorsListContainer.tsx
+++ b/dashboard/src/containers/OperatorsListContainer/OperatorsListContainer.tsx
@@ -17,7 +17,7 @@ function mapStateToProps(
     isFetching: operators.isFetching,
     isOLMInstalled: operators.isOLMInstalled,
     operators: operators.operators,
-    error: operators.errors.fetch,
+    error: operators.errors.operator.fetch,
     csvs: operators.csvs,
     filter: qs.parse(location.search, { ignoreQueryPrefix: true }).q || "",
   };

--- a/dashboard/src/reducers/operators.test.ts
+++ b/dashboard/src/reducers/operators.test.ts
@@ -20,7 +20,7 @@ describe("catalogReducer", () => {
       isOLMInstalled: false,
       operators: [],
       csvs: [],
-      errors: {},
+      errors: { operator: {}, resource: {}, csv: {} },
       resources: [],
     };
   });
@@ -116,7 +116,11 @@ describe("catalogReducer", () => {
             type: actionTypes.errorOperators as any,
             payload: new Error("Boom!"),
           }),
-        ).toEqual({ ...initialState, isFetching: false, errors: { fetch: new Error("Boom!") } });
+        ).toEqual({
+          ...initialState,
+          isFetching: false,
+          errors: { ...initialState.errors, operator: { fetch: new Error("Boom!") } },
+        });
       });
 
       it("unsets an error when changing namespace", () => {
@@ -127,14 +131,14 @@ describe("catalogReducer", () => {
         expect(state).toEqual({
           ...initialState,
           isFetching: false,
-          errors: { fetch: new Error("Boom!") },
+          errors: { ...initialState.errors, operator: { fetch: new Error("Boom!") } },
         });
 
         expect(
           operatorReducer(undefined, {
             type: actionTypes.setNamespace as any,
           }),
-        ).toEqual({ ...initialState, error: undefined });
+        ).toEqual({ ...initialState });
       });
 
       it("sets the initial state when changing namespace", () => {
@@ -144,7 +148,7 @@ describe("catalogReducer", () => {
               ...initialState,
               isFetching: true,
               isFetchingElem: { OLM: true, operator: false, csv: false, resource: false },
-              errors: { fetch: new Error("Boom!") },
+              errors: { ...initialState.errors, operator: { fetch: new Error("Boom!") } },
               operators: [{} as any],
             },
             {
@@ -204,7 +208,11 @@ describe("catalogReducer", () => {
             type: actionTypes.errorCSVs as any,
             payload: new Error("Boom!"),
           }),
-        ).toEqual({ ...initialState, isFetching: false, errors: { fetch: new Error("Boom!") } });
+        ).toEqual({
+          ...initialState,
+          isFetching: false,
+          errors: { ...initialState.errors, csv: { fetch: new Error("Boom!") } },
+        });
       });
 
       it("sets receive csv", () => {
@@ -258,7 +266,11 @@ describe("catalogReducer", () => {
           type: actionTypes.errorResourceCreate as any,
           payload: new Error("Boom!"),
         }),
-      ).toEqual({ ...initialState, isFetching: false, errors: { create: new Error("Boom!") } });
+      ).toEqual({
+        ...initialState,
+        isFetching: false,
+        errors: { ...initialState.errors, resource: { create: new Error("Boom!") } },
+      });
     });
 
     it("sets receive resources", () => {
@@ -293,7 +305,11 @@ describe("catalogReducer", () => {
           type: actionTypes.errorCustomResource as any,
           payload: new Error("Boom!"),
         }),
-      ).toEqual({ ...initialState, isFetching: false, errors: { fetch: new Error("Boom!") } });
+      ).toEqual({
+        ...initialState,
+        isFetching: false,
+        errors: { ...initialState.errors, resource: { fetch: new Error("Boom!") } },
+      });
     });
 
     it("sets receive resource", () => {
@@ -370,7 +386,7 @@ describe("catalogReducer", () => {
       ).toEqual({ ...initialState, isFetching: false });
     });
 
-    it("sets an error creating a resource", () => {
+    it("sets an error creating an operator", () => {
       const state = operatorReducer(undefined, {
         type: actionTypes.creatingOperator as any,
       });
@@ -384,7 +400,11 @@ describe("catalogReducer", () => {
           type: actionTypes.errorOperatorCreate as any,
           payload: new Error("Boom!"),
         }),
-      ).toEqual({ ...initialState, isFetching: false, errors: { create: new Error("Boom!") } });
+      ).toEqual({
+        ...initialState,
+        isFetching: false,
+        errors: { ...initialState.errors, operator: { create: new Error("Boom!") } },
+      });
     });
   });
 });

--- a/dashboard/src/reducers/operators.ts
+++ b/dashboard/src/reducers/operators.ts
@@ -6,6 +6,13 @@ import actions from "../actions";
 import { NamespaceAction } from "../actions/namespace";
 import { IClusterServiceVersion, IPackageManifest, IResource } from "../shared/types";
 
+export interface IOperatorsStateError {
+  fetch?: Error;
+  create?: Error;
+  delete?: Error;
+  update?: Error;
+}
+
 export interface IOperatorsState {
   isFetching: boolean;
   isFetchingElem: {
@@ -18,10 +25,9 @@ export interface IOperatorsState {
   operators: IResource[];
   operator?: IPackageManifest;
   errors: {
-    fetch?: Error;
-    create?: Error;
-    delete?: Error;
-    update?: Error;
+    operator: IOperatorsStateError;
+    csv: IOperatorsStateError;
+    resource: IOperatorsStateError;
   };
   csvs: IClusterServiceVersion[];
   csv?: IClusterServiceVersion;
@@ -40,7 +46,11 @@ const initialState: IOperatorsState = {
   isOLMInstalled: false,
   operators: [],
   csvs: [],
-  errors: {},
+  errors: {
+    operator: {},
+    csv: {},
+    resource: {},
+  },
   resources: [],
 };
 
@@ -69,7 +79,7 @@ const catalogReducer = (
       return {
         ...state,
         ...isFetching(state, "OLM", false),
-        errors: { fetch: action.payload },
+        errors: { ...state.errors, operator: { fetch: action.payload } },
       };
     case getType(operators.requestOperators):
       return { ...state, ...isFetching(state, "operator", true) };
@@ -91,7 +101,8 @@ const catalogReducer = (
       return {
         ...state,
         ...isFetching(state, "operator", false),
-        errors: { fetch: action.payload },
+        operator: undefined,
+        errors: { ...state.errors, operator: { fetch: action.payload } },
       };
     case getType(operators.requestCSVs):
       return { ...state, ...isFetching(state, "csv", true) };
@@ -105,7 +116,8 @@ const catalogReducer = (
       return {
         ...state,
         ...isFetching(state, "csv", false),
-        errors: { fetch: action.payload },
+        csv: undefined,
+        errors: { ...state.errors, csv: { fetch: action.payload } },
       };
     case getType(operators.creatingResource):
       return { ...state, ...isFetching(state, "resource", true) };
@@ -123,19 +135,19 @@ const catalogReducer = (
       return {
         ...state,
         ...isFetching(state, "resource", false),
-        errors: { delete: action.payload },
+        errors: { ...state.errors, resource: { delete: action.payload } },
       };
     case getType(operators.errorResourceCreate):
       return {
         ...state,
         ...isFetching(state, "resource", false),
-        errors: { create: action.payload },
+        errors: { ...state.errors, resource: { create: action.payload } },
       };
     case getType(operators.errorResourceUpdate):
       return {
         ...state,
         ...isFetching(state, "resource", false),
-        errors: { update: action.payload },
+        errors: { ...state.errors, resource: { update: action.payload } },
       };
     case getType(operators.requestCustomResources):
       return { ...state, ...isFetching(state, "resource", true) };
@@ -149,7 +161,8 @@ const catalogReducer = (
       return {
         ...state,
         ...isFetching(state, "resource", false),
-        errors: { fetch: action.payload },
+        resource: undefined,
+        errors: { ...state.errors, resource: { fetch: action.payload } },
       };
     case getType(operators.requestCustomResource):
       return { ...state, ...isFetching(state, "resource", true) };
@@ -167,10 +180,14 @@ const catalogReducer = (
       return {
         ...state,
         ...isFetching(state, "operator", false),
-        errors: { create: action.payload },
+        errors: { ...state.errors, operator: { create: action.payload } },
       };
     case LOCATION_CHANGE:
-      return { ...state, isOLMInstalled: state.isOLMInstalled, errors: {} };
+      return {
+        ...state,
+        isOLMInstalled: state.isOLMInstalled,
+        errors: { operator: {}, csv: {}, resource: {} },
+      };
     case getType(actions.namespace.setNamespace):
       return { ...initialState, isOLMInstalled: state.isOLMInstalled };
     default:

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -256,3 +256,37 @@ it("creates only a subscription if the namespace is operators", async () => {
   expect(axiosWithAuth.get).not.toHaveBeenCalled();
   expect(axiosWithAuth.post).toHaveBeenCalledTimes(1);
 });
+
+it("finds a default channel", () => {
+  const operator = {
+    status: {
+      defaultChannel: "foo",
+      channels: [{ name: "foo" }, { name: "bar" }],
+    },
+  } as any;
+  expect(Operators.getDefaultChannel(operator)).toEqual({ name: "foo" });
+});
+
+describe("#global", () => {
+  [
+    {
+      description: "returns true if the channel support all namespaces",
+      channel: { currentCSVDesc: { installModes: [{ type: "AllNamespaces", supported: true }] } },
+      result: true,
+    },
+    {
+      description: "returns false if the channel support only namespaces",
+      channel: { currentCSVDesc: { installModes: [{ type: "AllNamespaces", supported: false }] } },
+      result: false,
+    },
+    {
+      description: "returns false if the channel is undefined",
+      channel: undefined,
+      result: false,
+    },
+  ].forEach(test => {
+    it(test.description, () => {
+      expect(Operators.global(test.channel as any)).toBe(test.result);
+    });
+  });
+});

--- a/dashboard/src/shared/Operators.ts
+++ b/dashboard/src/shared/Operators.ts
@@ -1,6 +1,12 @@
 import * as urls from "../shared/url";
 import { axiosWithAuth } from "./AxiosInstance";
-import { IClusterServiceVersion, IK8sList, IPackageManifest, IResource } from "./types";
+import {
+  IClusterServiceVersion,
+  IK8sList,
+  IPackageManifest,
+  IPackageManifestChannel,
+  IResource,
+} from "./types";
 
 export class Operators {
   public static async isOLMInstalled(namespace: string) {
@@ -126,6 +132,14 @@ export class Operators {
       },
     );
     return result;
+  }
+
+  public static getDefaultChannel(operator: IPackageManifest) {
+    return operator.status.channels.find(ch => ch.name === operator.status.defaultChannel);
+  }
+
+  public static global(channel?: IPackageManifestChannel) {
+    return !!channel?.currentCSVDesc.installModes.find(m => m.type === "AllNamespaces")?.supported;
   }
 
   private static async createOperatorGroupIfNotExists(namespace: string) {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

If an Operator has been already deployed in a namespace, disable the "Deploy" button to avoid confusion.

![Screenshot from 2020-05-11 10-44-41](https://user-images.githubusercontent.com/4025665/81550997-6010cf00-9381-11ea-8fde-fca1d8fe57d9.png)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1703 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

There is a bigger change in the State for operators: before, the `errors` struct was shared between the different resource types (`errors.fetch` could be an error fetching operators or clusterserviceversions) so I had to expand it in order to ignore the missing error when requesting the CSV in the OperatorView.