### PR TITLE
Fix selfLink assumption

### DIFF
--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.test.tsx
@@ -7,6 +7,7 @@ import { IKubeItem, IResource } from "../../../../shared/types";
 import DeploymentItemRow from "./DeploymentItem/DeploymentItem";
 import OtherResourceItem from "./OtherResourceItem";
 import ResourceTableItem from "./ResourceTableItem";
+import SecretItem from "./SecretItem";
 
 const kubeItem: IKubeItem<IResource> = {
   isFetching: false,
@@ -158,5 +159,35 @@ context("when there is a valid resouce", () => {
       <ResourceTableItem {...defaultProps} resource={kubeItem} name={cm.metadata.name} />,
     );
     expect(wrapper.find(OtherResourceItem)).toExist();
+  });
+
+  it("ignores the namespace if it matches a known type", () => {
+    const deployment = {
+      metadata: {
+        name: "foo",
+        selfLink: "/api/v1/namespaces/deployments/secrets/kubernetes",
+      },
+      status: { replicas: 1, updatedReplicas: 1, availableReplicas: 1 },
+    } as IResource;
+    kubeItem.item = deployment;
+    const wrapper = shallow(
+      <ResourceTableItem {...defaultProps} resource={kubeItem} name={deployment.metadata.name} />,
+    );
+    expect(wrapper.find(SecretItem)).toExist();
+  });
+
+  it("ignores the resource name if it matches a known type", () => {
+    const deployment = {
+      metadata: {
+        name: "foo",
+        selfLink: "/api/v1/namespaces/default/secrets/services",
+      },
+      status: { replicas: 1, updatedReplicas: 1, availableReplicas: 1 },
+    } as IResource;
+    kubeItem.item = deployment;
+    const wrapper = shallow(
+      <ResourceTableItem {...defaultProps} resource={kubeItem} name={deployment.metadata.name} />,
+    );
+    expect(wrapper.find(SecretItem)).toExist();
   });
 });

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.test.tsx
@@ -161,7 +161,7 @@ context("when there is a valid resouce", () => {
     expect(wrapper.find(OtherResourceItem)).toExist();
   });
 
-  it("ignores the namespace if it matches a known type", () => {
+  it("it parses the type from the position in the self-link (it ignores the namespace)", () => {
     const deployment = {
       metadata: {
         name: "foo",
@@ -176,7 +176,7 @@ context("when there is a valid resouce", () => {
     expect(wrapper.find(SecretItem)).toExist();
   });
 
-  it("ignores the resource name if it matches a known type", () => {
+  it("it parses the type from the position in the self-link (it ignores the resource name)", () => {
     const deployment = {
       metadata: {
         name: "foo",

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.tsx
@@ -86,21 +86,34 @@ class WorkloadItem extends React.Component<IResourceItemProps> {
 
   private renderResource = (r: IResource | ISecret) => {
     const plainResource = r as IResource;
+    const type = this.typeFromSelfLink(r.metadata.selfLink);
     // resource kind may not be available for Lists
-    if (r.metadata.selfLink.match("deployments")) {
-      return <DeploymentItemRow resource={plainResource} />;
-    } else if (r.metadata.selfLink.match("statefulsets")) {
-      return <StatefulSetItemRow resource={plainResource} />;
-    } else if (r.metadata.selfLink.match("daemonsets")) {
-      return <DaemonSetItemRow resource={plainResource} />;
-    } else if (r.metadata.selfLink.match("services")) {
-      return <ServiceItem resource={plainResource} />;
-    } else if (r.metadata.selfLink.match("secrets")) {
-      return <SecretItem resource={r as ISecret} />;
-    } else {
-      return <OtherResourceItem resource={plainResource} />;
+    switch (type) {
+      case "deployments":
+        return <DeploymentItemRow resource={plainResource} />;
+      case "statefulsets":
+        return <StatefulSetItemRow resource={plainResource} />;
+      case "daemonsets":
+        return <DaemonSetItemRow resource={plainResource} />;
+      case "services":
+        return <ServiceItem resource={plainResource} />;
+      case "secrets":
+        return <SecretItem resource={r as ISecret} />;
+      default:
+        return <OtherResourceItem resource={plainResource} />;
     }
   };
+
+  private typeFromSelfLink(link: string) {
+    const parsedLink = link.split("/");
+    if (parsedLink.length < 2) {
+      // Unknown selflink
+      return "";
+    }
+    // For a single resource, the type is the second-to-last item
+    // e.g. /api/v1/namespaces/default/pods/foo
+    return parsedLink[parsedLink.length - 2];
+  }
 }
 
 export default WorkloadItem;

--- a/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceItem/ResourceTableItem.tsx
@@ -86,8 +86,16 @@ class WorkloadItem extends React.Component<IResourceItemProps> {
 
   private renderResource = (r: IResource | ISecret) => {
     const plainResource = r as IResource;
-    const type = this.typeFromSelfLink(r.metadata.selfLink);
-    // resource kind may not be available for Lists
+    // The resource kind may not be available for Lists
+    // so we need to infer it from the selfLink
+    const parsedLink = r.metadata.selfLink.split("/");
+    if (parsedLink.length < 2) {
+      // Unknown selflink
+      return "";
+    }
+    // For a single resource, the type is the second-to-last item
+    // e.g. /api/v1/namespaces/default/pods/foo
+    const type = parsedLink[parsedLink.length - 2];
     switch (type) {
       case "deployments":
         return <DeploymentItemRow resource={plainResource} />;
@@ -103,17 +111,6 @@ class WorkloadItem extends React.Component<IResourceItemProps> {
         return <OtherResourceItem resource={plainResource} />;
     }
   };
-
-  private typeFromSelfLink(link: string) {
-    const parsedLink = link.split("/");
-    if (parsedLink.length < 2) {
-      // Unknown selflink
-      return "";
-    }
-    // For a single resource, the type is the second-to-last item
-    // e.g. /api/v1/namespaces/default/pods/foo
-    return parsedLink[parsedLink.length - 2];
-  }
 }
 
 export default WorkloadItem;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

When the `kind` of a resource is not available (for example, when receiving an element of a list), we rely in the `selfLink` of the component to discover its type. We were looking in the whole `selfLink` which caused that if a resource is deployed in the namespace "services" or is called "services" it would be treated as a service. To fix that we just look for the place in which the type is located.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1695

