### PR TITLE
Use older tag for image builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ run_e2e_tests: &run_e2e_tests
     fi
 gke_test: &gke_test
   docker:
-    - image: circleci/golang:1.13
+    - image: circleci/golang:1.13.10
   steps:
     - checkout
     - run: |
@@ -268,7 +268,7 @@ jobs:
     environment:
       CGO_ENABLED: "0"
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.13.10
     steps:
       - checkout
       - <<: *exports
@@ -285,7 +285,7 @@ jobs:
     environment:
       HELM_VERSION: "v3.0.2"
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.13.10
     steps:
       - <<: *exports
       - checkout
@@ -293,7 +293,7 @@ jobs:
       - run: ./script/chart-template-test.sh
   build_go_images:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.13.10
     working_directory: /go/src/github.com/kubeapps/kubeapps
     environment:
       GOPATH: /home/circleci/.go_workspace
@@ -301,13 +301,13 @@ jobs:
     <<: *build_images
   build_dashboard:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.13.10
     environment:
       IMAGES: "dashboard"
     <<: *build_images
   release:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.13.10
     steps:
       - checkout
       - run: REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
@@ -363,7 +363,7 @@ jobs:
       TEST_LATEST_RELEASE: 1
   sync_chart:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.13.10
     steps:
       - checkout
       - add_ssh_keys:
@@ -378,7 +378,7 @@ jobs:
           ./script/chart_sync.sh kubernetes-bitnami kubernetes@bitnami.com
   push_images:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.13.10
     steps:
       - setup_remote_docker
       - <<: *exports


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

It seems that the latest circleci image has a docker cli that is too new. This was discovered today (https://github.com/kubeapps/kubeapps/pull/1731#issuecomment-630661622) so I changed the image to the previous build (5 days ago).
