### PR TITLE
Remove post-install annotation for apprepositories

### DIFF
--- a/chart/kubeapps/templates/apprepositories.yaml
+++ b/chart/kubeapps/templates/apprepositories.yaml
@@ -3,9 +3,6 @@ apiVersion: kubeapps.com/v1alpha1
 kind: AppRepository
 metadata:
   name: {{ .name }}
-  annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "10"
   labels:
     app: {{ template "kubeapps.apprepository.fullname" $ }}
     chart: {{ template "kubeapps.chart" $ }}


### PR DESCRIPTION
We had added this to ensure that during installation of Kubeapps, the
creation of the app repository resources wouldn't trigger a sync job
to run before the upgrade job updates the schema. But one case we did
not anticipate is that if the installation is held up (network issues
or similar) and the helm install fails, the resources won't be present.

I think it's better to ensure they are always present so that the sync
job can eventually sync them (and update to safely migrate the schema
rather than recreating it - as per #1560).

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
As above
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
If the helm install command fails because a post-install job cannot run (yet), all resources are still present on the cluster.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

AppRepository creation could trigger a sync job before the backend schema is recreated, which could mean another cycle until the repo is scanned (possibly).
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
