### PR TITLE
Add a shared k8s-api-proxy.conf and default cluster location.

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -8,6 +8,24 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+  k8s-api-proxy.conf: |-
+    # Disable buffering for log streaming
+    proxy_buffering off;
+    # Hide Www-Authenticate to prevent it triggering a basic auth prompt in
+    # the browser with some clusters
+    proxy_hide_header Www-Authenticate;
+
+    # Keep the connection open with the API server even if idle (the default is 60 seconds)
+    # Setting it to 1 hour which should be enough for our current use case of deploying/upgrading apps
+    # If we enable other use-cases in the future we might need to bump this value
+    # More info here https://github.com/kubeapps/kubeapps/issues/766
+    proxy_read_timeout 1h;
+
+    {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
+    # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
+    proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
+    {{- end }}
+
   vhost.conf: |-
     # Retain the default nginx handling of requests without a "Connection" header
     map $http_upgrade $connection_upgrade {
@@ -29,28 +47,23 @@ data:
         return 200 "healthy\n";
       }
 
+      # The default cluster running on the same cluster as Kubeapps.
+      location ~* /api/clusters/default {
+        rewrite /api/clusters/default/(.*) /$1 break;
+        rewrite /api/clusters/default / break;
+        proxy_pass https://kubernetes.default;
+        include "/opt/bitnami/nginx/conf/server_blocks/k8s-api-proxy.conf";
+      }
+
+      # TODO: The following location is left for backwards compat but will no longer
+      # be needed once clients are sending the cluster name.
       # Using regexp match instead of prefix one because the application can be
       # deployed under a specific path i.e /kubeapps
       location ~* /api/kube {
         rewrite /api/kube/(.*) /$1 break;
         rewrite /api/kube / break;
         proxy_pass https://kubernetes.default;
-        # Disable buffering for log streaming
-        proxy_buffering off;
-        # Hide Www-Authenticate to prevent it triggering a basic auth prompt in
-        # the browser with some clusters
-        proxy_hide_header Www-Authenticate;
-
-        # Keep the connection open with the API server even if idle (the default is 60 seconds)
-        # Setting it to 1 hour which should be enough for our current use case of deploying/upgrading apps
-        # If we enable other use-cases in the future we might need to bump this value
-        # More info here https://github.com/kubeapps/kubeapps/issues/766
-        proxy_read_timeout 1h;
-
-        {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
-        # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
-        proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
-        {{- end }}
+        include "/opt/bitnami/nginx/conf/server_blocks/k8s-api-proxy.conf";
       }
 
       location ~* /api/assetsvc {

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -52,7 +52,7 @@ data:
         rewrite /api/clusters/default/(.*) /$1 break;
         rewrite /api/clusters/default / break;
         proxy_pass https://kubernetes.default;
-        include "/opt/bitnami/nginx/conf/server_blocks/k8s-api-proxy.conf";
+        include "./server_blocks/k8s-api-proxy.conf";
       }
 
       # TODO: The following location is left for backwards compat but will no longer
@@ -63,7 +63,7 @@ data:
         rewrite /api/kube/(.*) /$1 break;
         rewrite /api/kube / break;
         proxy_pass https://kubernetes.default;
-        include "/opt/bitnami/nginx/conf/server_blocks/k8s-api-proxy.conf";
+        include "./server_blocks/k8s-api-proxy.conf";
       }
 
       location ~* /api/assetsvc {


### PR DESCRIPTION
Prep work so that we can soon route /api/clusters/cluster-name/ from
configuration to the correct k8s cluster. Adds a default cluster which
uses the local api server (to the pod), while leaving the existing
location for temporary backwards compat.

Ref: #1752 
