### PR TITLE
Update dashboard to use /api/clusters/default instead of /api/kube.

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -8,6 +8,24 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+  k8s-api-proxy.conf: |-
+    # Disable buffering for log streaming
+    proxy_buffering off;
+    # Hide Www-Authenticate to prevent it triggering a basic auth prompt in
+    # the browser with some clusters
+    proxy_hide_header Www-Authenticate;
+
+    # Keep the connection open with the API server even if idle (the default is 60 seconds)
+    # Setting it to 1 hour which should be enough for our current use case of deploying/upgrading apps
+    # If we enable other use-cases in the future we might need to bump this value
+    # More info here https://github.com/kubeapps/kubeapps/issues/766
+    proxy_read_timeout 1h;
+
+    {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
+    # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
+    proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
+    {{- end }}
+
   vhost.conf: |-
     # Retain the default nginx handling of requests without a "Connection" header
     map $http_upgrade $connection_upgrade {
@@ -29,28 +47,23 @@ data:
         return 200 "healthy\n";
       }
 
+      # The default cluster running on the same cluster as Kubeapps.
+      location ~* /api/clusters/default {
+        rewrite /api/clusters/default/(.*) /$1 break;
+        rewrite /api/clusters/default / break;
+        proxy_pass https://kubernetes.default;
+        include "/opt/bitnami/nginx/conf/server_blocks/k8s-api-proxy.conf";
+      }
+
+      # TODO: The following location is left for backwards compat but will no longer
+      # be needed once clients are sending the cluster name.
       # Using regexp match instead of prefix one because the application can be
       # deployed under a specific path i.e /kubeapps
       location ~* /api/kube {
         rewrite /api/kube/(.*) /$1 break;
         rewrite /api/kube / break;
         proxy_pass https://kubernetes.default;
-        # Disable buffering for log streaming
-        proxy_buffering off;
-        # Hide Www-Authenticate to prevent it triggering a basic auth prompt in
-        # the browser with some clusters
-        proxy_hide_header Www-Authenticate;
-
-        # Keep the connection open with the API server even if idle (the default is 60 seconds)
-        # Setting it to 1 hour which should be enough for our current use case of deploying/upgrading apps
-        # If we enable other use-cases in the future we might need to bump this value
-        # More info here https://github.com/kubeapps/kubeapps/issues/766
-        proxy_read_timeout 1h;
-
-        {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
-        # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
-        proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
-        {{- end }}
+        include "/opt/bitnami/nginx/conf/server_blocks/k8s-api-proxy.conf";
       }
 
       location ~* /api/assetsvc {

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -52,7 +52,7 @@ data:
         rewrite /api/clusters/default/(.*) /$1 break;
         rewrite /api/clusters/default / break;
         proxy_pass https://kubernetes.default;
-        include "/opt/bitnami/nginx/conf/server_blocks/k8s-api-proxy.conf";
+        include "./server_blocks/k8s-api-proxy.conf";
       }
 
       # TODO: The following location is left for backwards compat but will no longer
@@ -63,7 +63,7 @@ data:
         rewrite /api/kube/(.*) /$1 break;
         rewrite /api/kube / break;
         proxy_pass https://kubernetes.default;
-        include "/opt/bitnami/nginx/conf/server_blocks/k8s-api-proxy.conf";
+        include "./server_blocks/k8s-api-proxy.conf";
       }
 
       location ~* /api/assetsvc {

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -35,12 +35,12 @@ describe("getResource", () => {
     const expectedActions = [
       {
         type: getType(actions.kube.requestResource),
-        payload: "api/kube/api/v1/namespaces/default/services/foo",
+        payload: "api/clusters/default/api/v1/namespaces/default/services/foo",
       },
       {
         type: getType(actions.kube.receiveResource),
         payload: {
-          key: "api/kube/api/v1/namespaces/default/services/foo",
+          key: "api/clusters/default/api/v1/namespaces/default/services/foo",
           resource: [],
         },
       },
@@ -65,7 +65,7 @@ describe("getResource", () => {
     store = mockStore({
       kube: {
         items: {
-          "api/kube/api/v1/namespaces/default/services/foo": { isFetching: true },
+          "api/clusters/default/api/v1/namespaces/default/services/foo": { isFetching: true },
         },
       },
     });
@@ -103,7 +103,7 @@ describe("getAndWatchResource", () => {
     const expectedActions = [
       {
         type: getType(actions.kube.requestResource),
-        payload: "api/kube/api/v1/namespaces/default/services/foo",
+        payload: "api/clusters/default/api/v1/namespaces/default/services/foo",
       },
       {
         type: getType(actions.kube.openWatchResource),
@@ -140,7 +140,7 @@ describe("getAndWatchResource", () => {
     const expectedActions = [
       {
         type: getType(actions.kube.requestResource),
-        payload: "api/kube/api/v1/namespaces/default/services",
+        payload: "api/clusters/default/api/v1/namespaces/default/services",
       },
       {
         type: getType(actions.kube.openWatchResource),
@@ -162,7 +162,7 @@ describe("getAndWatchResource", () => {
     const newAction = {
       type: getType(actions.kube.receiveResourceFromList),
       payload: {
-        key: "api/kube/api/v1/namespaces/default/services",
+        key: "api/clusters/default/api/v1/namespaces/default/services",
         resource: svc,
       },
     };

--- a/dashboard/src/components/AppView/ResourceTable/__snapshots__/ResourceTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/ResourceTable/__snapshots__/ResourceTable.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`renders a ResourceItem 1`] = `
     </thead>
     <tbody>
       <Connect(WorkloadItem)
-        key="api/kube/apis/undefined/namespaces/default/deployments/foo"
+        key="api/clusters/default/apis/undefined/namespaces/default/deployments/foo"
         resourceRef={
           ResourceRef {
             "apiVersion": undefined,

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
@@ -31,8 +31,8 @@ describe("AccessURLTableContainer", () => {
       item: { metadata: { name: `${name}-ingress` } } as IResource,
     };
     const store = makeStore({
-      "api/kube/api/v1/namespaces/wee/services/foo-service": service,
-      "api/kube/api/v1/namespaces/wee/ingresses/foo-ingress": ingress,
+      "api/clusters/default/api/v1/namespaces/wee/services/foo-service": service,
+      "api/clusters/default/api/v1/namespaces/wee/ingresses/foo-ingress": ingress,
     });
     const serviceRef = new ResourceRef({
       apiVersion: "v1",

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
@@ -24,7 +24,7 @@ describe("ApplicationStatusContainer", () => {
     const name = "foo";
     const item = { isFetching: false, item: { metadata: { name } } as IResource };
     const store = makeStore({
-      "api/kube/apis/apps/v1/namespaces/wee/deployments/foo": item,
+      "api/clusters/default/apis/apps/v1/namespaces/wee/deployments/foo": item,
     });
     const ref = new ResourceRef({
       apiVersion: "apps/v1",

--- a/dashboard/src/containers/ResourceItemContainer/ResourceItemContainer.test.tsx
+++ b/dashboard/src/containers/ResourceItemContainer/ResourceItemContainer.test.tsx
@@ -24,7 +24,7 @@ describe("ResourceItemContainer", () => {
     const name = "foo";
     const item = { isFetching: false, item: { metadata: { name } } as IResource };
     const store = makeStore({
-      "api/kube/apis/apps/v1/namespaces/wee/statefulsets/foo": item,
+      "api/clusters/default/apis/apps/v1/namespaces/wee/statefulsets/foo": item,
     });
     const ref = new ResourceRef({
       apiVersion: "apps/v1",

--- a/dashboard/src/containers/helpers/index.test.ts
+++ b/dashboard/src/containers/helpers/index.test.ts
@@ -20,9 +20,9 @@ describe("filterByResourceRefs", () => {
   } as IResource;
 
   const items: IKubeState["items"] = {
-    "api/kube/api/v1/namespaces/foo/services/bar": { item: svc1 } as IKubeItem<IResource>,
-    "api/kube/api/v1/namespaces/foo1/services/bar": { item: svc2 } as IKubeItem<IResource>,
-    "api/kube/apis/apps/v1/namespaces/foo1/deployments/bar": { item: deploy } as IKubeItem<
+    "api/clusters/default/api/v1/namespaces/foo/services/bar": { item: svc1 } as IKubeItem<IResource>,
+    "api/clusters/default/api/v1/namespaces/foo1/services/bar": { item: svc2 } as IKubeItem<IResource>,
+    "api/clusters/default/apis/apps/v1/namespaces/foo1/deployments/bar": { item: deploy } as IKubeItem<
       IResource
     >,
   };

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -14,7 +14,7 @@ describe("Auth", () => {
     const mock = jest.fn();
     Axios.get = mock;
     await Auth.validateToken("foo");
-    expect(mock.mock.calls[0]).toEqual(["api/kube/", { headers: { Authorization: "Bearer foo" } }]);
+    expect(mock.mock.calls[0]).toEqual(["api/clusters/default/", { headers: { Authorization: "Bearer foo" } }]);
   });
 
   describe("when there is an error", () => {

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -4,7 +4,7 @@ import { ResourceKindsWithAPIVersions } from "./ResourceAPIVersion";
 import { ResourceKind, ResourceKindsWithPlurals } from "./ResourceKinds";
 import { IK8sList, IResource } from "./types";
 
-export const APIBase = "api/kube";
+export const APIBase = "api/clusters/default";
 export let WebSocketAPIBase: string;
 if (location.protocol === "https:") {
   WebSocketAPIBase = `wss://${window.location.host}${window.location.pathname}`;

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -9,7 +9,7 @@ it("check if the OLM has been installed", async () => {
   expect(await Operators.isOLMInstalled("ns")).toBe(true);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
-    "api/kube/apis/packages.operators.coreos.com/v1/namespaces/ns/packagemanifests",
+    "api/clusters/default/apis/packages.operators.coreos.com/v1/namespaces/ns/packagemanifests",
   );
 });
 
@@ -36,7 +36,7 @@ it("get operators", async () => {
   expect(await Operators.getOperators(ns)).toEqual([operator]);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
-    `api/kube/apis/packages.operators.coreos.com/v1/namespaces/${ns}/packagemanifests`,
+    `api/clusters/default/apis/packages.operators.coreos.com/v1/namespaces/${ns}/packagemanifests`,
   );
 });
 
@@ -50,7 +50,7 @@ it("get operator", async () => {
   expect(await Operators.getOperator(ns, opName)).toEqual(operator);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
-    `api/kube/apis/packages.operators.coreos.com/v1/namespaces/${ns}/packagemanifests/${opName}`,
+    `api/clusters/default/apis/packages.operators.coreos.com/v1/namespaces/${ns}/packagemanifests/${opName}`,
   );
 });
 
@@ -63,7 +63,7 @@ it("get csvs", async () => {
   expect(await Operators.getCSVs(ns)).toEqual([csv]);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
-    `api/kube/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions`,
+    `api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions`,
   );
 });
 
@@ -76,7 +76,7 @@ it("get global csvs", async () => {
   expect(await Operators.getCSVs(ns)).toEqual([csv]);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
-    "api/kube/apis/operators.coreos.com/v1alpha1/namespaces/operators/clusterserviceversions",
+    "api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/operators/clusterserviceversions",
   );
 });
 
@@ -89,7 +89,7 @@ it("get csv", async () => {
   expect(await Operators.getCSV(ns, "foo")).toEqual(csv);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
-    `api/kube/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions/foo`,
+    `api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions/foo`,
   );
 });
 
@@ -102,7 +102,7 @@ it("creates a resource", async () => {
   expect(await Operators.createResource(ns, "v1", "pods", resource)).toEqual(resource);
   expect(axiosWithAuth.post).toHaveBeenCalled();
   expect((axiosWithAuth.post as jest.Mock).mock.calls[0]).toEqual([
-    `api/kube/apis/v1/namespaces/${ns}/pods`,
+    `api/clusters/default/apis/v1/namespaces/${ns}/pods`,
     resource,
   ]);
 });
@@ -116,7 +116,7 @@ it("list resources", async () => {
   expect(await Operators.listResources(ns, "v1", "pods")).toEqual({ items: [resource] });
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0]).toEqual([
-    `api/kube/apis/v1/namespaces/${ns}/pods`,
+    `api/clusters/default/apis/v1/namespaces/${ns}/pods`,
   ]);
 });
 
@@ -129,7 +129,7 @@ it("get a resource", async () => {
   expect(await Operators.getResource(ns, "v1", "pods", "foo")).toEqual(resource);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0]).toEqual([
-    `api/kube/apis/v1/namespaces/${ns}/pods/foo`,
+    `api/clusters/default/apis/v1/namespaces/${ns}/pods/foo`,
   ]);
 });
 
@@ -142,7 +142,7 @@ it("deletes a resource", async () => {
   expect(await Operators.deleteResource(ns, "v1", "pods", "foo")).toEqual(resource);
   expect(axiosWithAuth.delete).toHaveBeenCalled();
   expect((axiosWithAuth.delete as jest.Mock).mock.calls[0]).toEqual([
-    `api/kube/apis/v1/namespaces/${ns}/pods/foo`,
+    `api/clusters/default/apis/v1/namespaces/${ns}/pods/foo`,
   ]);
 });
 
@@ -157,7 +157,7 @@ it("updates a resource", async () => {
   ).toEqual(resource);
   expect(axiosWithAuth.post).toHaveBeenCalled();
   expect((axiosWithAuth.post as jest.Mock).mock.calls[0]).toEqual([
-    `api/kube/apis/v1/namespaces/${ns}/pods`,
+    `api/clusters/default/apis/v1/namespaces/${ns}/pods`,
     resource,
   ]);
 });
@@ -205,15 +205,15 @@ it("creates an operatorgroup and a subscription", async () => {
   );
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0]).toEqual([
-    `api/kube/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
+    `api/clusters/default/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
   ]);
   expect(axiosWithAuth.post).toHaveBeenCalledTimes(2);
   expect((axiosWithAuth.post as jest.Mock).mock.calls[0]).toEqual([
-    `api/kube/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
+    `api/clusters/default/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
     operatorgroup,
   ]);
   expect((axiosWithAuth.post as jest.Mock).mock.calls[1]).toEqual([
-    `api/kube/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/foo`,
+    `api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/foo`,
     subscription,
   ]);
 });
@@ -232,11 +232,11 @@ it("creates only a subscription if the operator group already exists", async () 
   );
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0]).toEqual([
-    `api/kube/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
+    `api/clusters/default/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
   ]);
   expect(axiosWithAuth.post).toHaveBeenCalledTimes(1);
   expect((axiosWithAuth.post as jest.Mock).mock.calls[0]).toEqual([
-    `api/kube/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/foo`,
+    `api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/foo`,
     subscription,
   ]);
 });

--- a/dashboard/src/shared/Secret.test.ts
+++ b/dashboard/src/shared/Secret.test.ts
@@ -14,7 +14,7 @@ it("creates a secret", async () => {
   const name = "secret";
   const namespace = "default";
   expect(await Secret.create(name, secrets, owner, namespace)).toEqual("ok");
-  expect(axiosWithAuth.post).toHaveBeenCalledWith("api/kube/api/v1/namespaces/default/secrets", {
+  expect(axiosWithAuth.post).toHaveBeenCalledWith("api/clusters/default/api/v1/namespaces/default/secrets", {
     apiVersion: "v1",
     data: secrets,
     kind: "Secret",
@@ -26,7 +26,7 @@ it("creates a secret", async () => {
 it("deletes a secret", async () => {
   axiosWithAuth.delete = jest.fn();
   await Secret.delete("foo", "bar");
-  expect(axiosWithAuth.delete).toHaveBeenCalledWith("api/kube/api/v1/namespaces/bar/secrets/foo");
+  expect(axiosWithAuth.delete).toHaveBeenCalledWith("api/clusters/default/api/v1/namespaces/bar/secrets/foo");
 });
 
 it("gets a secret", async () => {
@@ -34,7 +34,7 @@ it("gets a secret", async () => {
     return { data: "ok" };
   });
   await Secret.get("foo", "bar");
-  expect(axiosWithAuth.get).toHaveBeenCalledWith("api/kube/api/v1/namespaces/bar/secrets/foo");
+  expect(axiosWithAuth.get).toHaveBeenCalledWith("api/clusters/default/api/v1/namespaces/bar/secrets/foo");
 });
 
 it("lists secrets", async () => {
@@ -42,7 +42,7 @@ it("lists secrets", async () => {
     return { data: "ok" };
   });
   await Secret.list("foo");
-  expect(axiosWithAuth.get).toHaveBeenCalledWith("api/kube/api/v1/namespaces/foo/secrets");
+  expect(axiosWithAuth.get).toHaveBeenCalledWith("api/clusters/default/api/v1/namespaces/foo/secrets");
 });
 
 it("creates a pull secret", async () => {
@@ -56,7 +56,7 @@ it("creates a pull secret", async () => {
   const server = "docker.io";
   const namespace = "default";
   expect(await Secret.createPullSecret(name, user, password, email, server, namespace)).toBe("ok");
-  expect(axiosWithAuth.post).toHaveBeenCalledWith("api/kube/api/v1/namespaces/default/secrets", {
+  expect(axiosWithAuth.post).toHaveBeenCalledWith("api/clusters/default/api/v1/namespaces/default/secrets", {
     apiVersion: "v1",
     stringData: {
       ".dockerconfigjson":

--- a/integration/use-cases/create-private-registry.js
+++ b/integration/use-cases/create-private-registry.js
@@ -75,7 +75,7 @@ test("Creates a private registry", async () => {
   // Now that the deployment has been created, we check that the imagePullSecret
   // has been added. For doing so, we query the kubernetes API to get info of the
   // deployment
-  const URL = getUrl("/api/kube/apis/apps/v1/namespaces/default/deployments");
+  const URL = getUrl("/api/clusters/default/apis/apps/v1/namespaces/default/deployments");
   const response = await axios.get(URL, {
     headers: { Authorization: `Bearer ${process.env.ADMIN_TOKEN}` },
   });


### PR DESCRIPTION
Ref #1752, follows #1757 

Updates the dashboard to use a named cluster endpoint for the k8s api (currently just using the default cluster).