### PR TITLE
Update kubeops service to include arg for additonal cluster config.

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -35,12 +35,20 @@ const isV1SupportRequired = false
 // This approach practically eliminates that risk; it is much easier to use WithHandlerConfig to create a handler guaranteed to use a valid handler config.
 type dependentHandler func(cfg Config, w http.ResponseWriter, req *http.Request, params handlerutil.Params)
 
+// AdditionalClusterConfig contains required info to talk to additional clusters.
+type AdditionalClusterConfig struct {
+	Name                     string `json:"name"`
+	ApiServiceURL            string `json:"apiServiceURL"`
+	CertificateAuthorityData string `json:"certificateAuthorityData,omitempty"`
+}
+
 // Options represents options that can be created without a bearer token, i.e. once at application startup.
 type Options struct {
-	ListLimit         int
-	Timeout           int64
-	UserAgent         string
-	KubeappsNamespace string
+	ListLimit          int
+	Timeout            int64
+	UserAgent          string
+	KubeappsNamespace  string
+	AdditionalClusters map[string]AdditionalClusterConfig
 }
 
 // Config represents data needed by each handler to be able to create Helm 3 actions.

--- a/cmd/kubeops/main_test.go
+++ b/cmd/kubeops/main_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kubeapps/kubeapps/cmd/kubeops/internal/handler"
+)
+
+func TestParseAdditionalClusterConfig(t *testing.T) {
+	testCases := []struct {
+		name           string
+		configJSON     string
+		expectedErr    bool
+		expectedConfig map[string]handler.AdditionalClusterConfig
+	}{
+		{
+			name:       "parses a single additional cluster",
+			configJSON: `[{"name": "cluster-2", "apiServiceURL": "https://example.com", "certificateAuthorityData": "abcd"}]`,
+			expectedConfig: map[string]handler.AdditionalClusterConfig{
+				"cluster-2": handler.AdditionalClusterConfig{
+					Name:                     "cluster-2",
+					ApiServiceURL:            "https://example.com",
+					CertificateAuthorityData: "abcd",
+				},
+			},
+		},
+		{
+			name: "parses multiple additional clusters",
+			configJSON: `[
+	{"name": "cluster-2", "apiServiceURL": "https://example.com/cluster-2", "certificateAuthorityData": "abcd"},
+	{"name": "cluster-3", "apiServiceURL": "https://example.com/cluster-3", "certificateAuthorityData": "efgh"}
+]`,
+			expectedConfig: map[string]handler.AdditionalClusterConfig{
+				"cluster-2": handler.AdditionalClusterConfig{
+					Name:                     "cluster-2",
+					ApiServiceURL:            "https://example.com/cluster-2",
+					CertificateAuthorityData: "abcd",
+				},
+				"cluster-3": handler.AdditionalClusterConfig{
+					Name:                     "cluster-3",
+					ApiServiceURL:            "https://example.com/cluster-3",
+					CertificateAuthorityData: "efgh",
+				},
+			},
+		},
+		{
+			name:        "errors if the cluster configs cannot be parsed",
+			configJSON:  `[{"name": "cluster-2", "apiServiceURL": "https://example.com", "certificateAuthorityData": "extracomma",}]`,
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := createConfigFile(t, tc.configJSON)
+			defer os.Remove(path)
+
+			config, err := parseAdditionalClusterConfig(path)
+			if got, want := err != nil, tc.expectedErr; got != want {
+				t.Errorf("got: %t, want: %t", got, want)
+			}
+
+			if got, want := config, tc.expectedConfig; !cmp.Equal(want, got) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func createConfigFile(t *testing.T, content string) string {
+	tmpfile, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	return tmpfile.Name()
+}


### PR DESCRIPTION
First part of #1761 . Follow up will enable adding the mounted file to the pod when additional clusters defined.