### PR TITLE
Enable kubeops to talk to other configured clusters.

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -92,8 +92,10 @@ func NewClusterConfig(inClusterConfig *rest.Config, token string, cluster string
 func WithHandlerConfig(storageForDriver agent.StorageForDriver, options Options) func(f dependentHandler) handlerutil.WithParams {
 	return func(f dependentHandler) handlerutil.WithParams {
 		return func(w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
-			cluster := params[clusterParam]
-			if cluster == "" {
+			// Don't assume the cluster name was in the url for backwards compatability
+			// for now.
+			cluster, ok := params[clusterParam]
+			if !ok {
 				cluster = defaultClusterName
 			}
 			namespace := params[namespaceParam]

--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -41,7 +41,7 @@ type dependentHandler func(cfg Config, w http.ResponseWriter, req *http.Request,
 // AdditionalClusterConfig contains required info to talk to additional clusters.
 type AdditionalClusterConfig struct {
 	Name                     string `json:"name"`
-	ApiServiceURL            string `json:"apiServiceURL"`
+	APIServiceURL            string `json:"apiServiceURL"`
 	CertificateAuthorityData string `json:"certificateAuthorityData,omitempty"`
 }
 
@@ -72,15 +72,15 @@ func NewClusterConfig(inClusterConfig *rest.Config, token string, cluster string
 		return config, nil
 	}
 
-	clusterConfig, ok := additionalClusters[cluster]
+	additionalCluster, ok := additionalClusters[cluster]
 	if !ok {
 		return nil, fmt.Errorf("cluster %q has no configuration", cluster)
 	}
 
-	config.Host = clusterConfig.ApiServiceURL
-	if clusterConfig.CertificateAuthorityData != "" {
+	config.Host = additionalCluster.APIServiceURL
+	if additionalCluster.CertificateAuthorityData != "" {
 		config.TLSClientConfig = rest.TLSClientConfig{
-			CAData: []byte(clusterConfig.CertificateAuthorityData),
+			CAData: []byte(additionalCluster.CertificateAuthorityData),
 		}
 	}
 	return config, nil

--- a/cmd/kubeops/internal/handler/handler_test.go
+++ b/cmd/kubeops/internal/handler/handler_test.go
@@ -26,9 +26,7 @@ import (
 )
 
 const (
-	defaultListLimit        = 256
-	KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST"
-	KUBERNETES_SERVICE_PORT = "KUBERNETES_SERVICE_PORT"
+	defaultListLimit = 256
 )
 
 var (
@@ -556,8 +554,8 @@ func TestNewClusterConfig(t *testing.T) {
 			token:   "token-1",
 			cluster: "cluster-1",
 			additionalClusters: map[string]AdditionalClusterConfig{
-				"cluster-1": AdditionalClusterConfig{
-					ApiServiceURL:            "https://cluster-1.example.com:7890",
+				"cluster-1": {
+					APIServiceURL:            "https://cluster-1.example.com:7890",
 					CertificateAuthorityData: "ca-file-data",
 				},
 			},

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -90,12 +90,19 @@ func main() {
 	// Routes
 	// Auth not necessary here with Helm 3 because it's done by Kubernetes.
 	addRoute := handler.AddRouteWith(r.PathPrefix("/v1").Subrouter(), withHandlerConfig)
+	// Deprecate non-cluster-aware URIs.
 	addRoute("GET", "/releases", handler.ListAllReleases)
 	addRoute("GET", "/namespaces/{namespace}/releases", handler.ListReleases)
 	addRoute("POST", "/namespaces/{namespace}/releases", handler.CreateRelease)
 	addRoute("GET", "/namespaces/{namespace}/releases/{releaseName}", handler.GetRelease)
 	addRoute("PUT", "/namespaces/{namespace}/releases/{releaseName}", handler.OperateRelease)
 	addRoute("DELETE", "/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
+	addRoute("GET", "/clusters/{cluster}/releases", handler.ListAllReleases)
+	addRoute("GET", "/clusters/{cluster}/namespaces/{namespace}/releases", handler.ListReleases)
+	addRoute("POST", "/clusters/{cluster}/namespaces/{namespace}/releases", handler.CreateRelease)
+	addRoute("GET", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.GetRelease)
+	addRoute("PUT", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.OperateRelease)
+	addRoute("DELETE", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
 
 	// Backend routes unrelated to kubeops functionality.
 	err := backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter())

--- a/cmd/kubeops/main_test.go
+++ b/cmd/kubeops/main_test.go
@@ -22,7 +22,7 @@ func TestParseAdditionalClusterConfig(t *testing.T) {
 			expectedConfig: map[string]handler.AdditionalClusterConfig{
 				"cluster-2": handler.AdditionalClusterConfig{
 					Name:                     "cluster-2",
-					ApiServiceURL:            "https://example.com",
+					APIServiceURL:            "https://example.com",
 					CertificateAuthorityData: "abcd",
 				},
 			},
@@ -36,12 +36,12 @@ func TestParseAdditionalClusterConfig(t *testing.T) {
 			expectedConfig: map[string]handler.AdditionalClusterConfig{
 				"cluster-2": handler.AdditionalClusterConfig{
 					Name:                     "cluster-2",
-					ApiServiceURL:            "https://example.com/cluster-2",
+					APIServiceURL:            "https://example.com/cluster-2",
 					CertificateAuthorityData: "abcd",
 				},
 				"cluster-3": handler.AdditionalClusterConfig{
 					Name:                     "cluster-3",
-					ApiServiceURL:            "https://example.com/cluster-3",
+					APIServiceURL:            "https://example.com/cluster-3",
 					CertificateAuthorityData: "efgh",
 				},
 			},


### PR DESCRIPTION
Not yet tested IRL, I still need to check that the `kubehandler` here
works as expected or requires a separate in cluster config etc., but
this should maintain the current behaviour for non-multi-cluster.