### PR TITLE
Fix bug -> chart version link

### DIFF
--- a/dashboard/src/components/ChartView/ChartVersionsList.test.tsx
+++ b/dashboard/src/components/ChartView/ChartVersionsList.test.tsx
@@ -10,6 +10,7 @@ const testChart: IChartVersion["relationships"]["chart"] = {
     name: "test",
     repo: {
       name: "testrepo",
+      namespace: "kubeapps",
     },
   },
 } as IChartVersion["relationships"]["chart"];
@@ -72,12 +73,10 @@ it("renders the list of versions", () => {
   const wrapper = shallow(<ChartVersionsList versions={testVersions} selected={testVersions[1]} />);
   const items = wrapper.find("li");
   expect(items).toHaveLength(4);
-  expect(
-    items
-      .at(1)
-      .find(Link)
-      .props().className,
-  ).toBe("type-bold type-color-action");
+  const link = items.at(1).find(Link);
+  expect(link.prop("className")).toBe("type-bold type-color-action");
+  // The link include the namespace
+  expect(link.prop("to")).toBe("/ns/kubeapps/charts/testrepo/test/versions/1.2.2");
 });
 
 it("does not render a the Show All link when there are 5 or less versions", () => {

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -5,7 +5,7 @@ import { IChartVersion } from "./types";
 export const app = {
   charts: {
     version: (cv: IChartVersion) =>
-      `/charts/${cv.relationships.chart.data.repo.name}/${cv.relationships.chart.data.name}/versions/${cv.attributes.version}`,
+      `/ns/${cv.relationships.chart.data.repo.namespace}/charts/${cv.relationships.chart.data.repo.name}/${cv.relationships.chart.data.name}/versions/${cv.attributes.version}`,
   },
   operators: {
     view: (namespace: string, name: string) => `/ns/${namespace}/operators/${name}`,


### PR DESCRIPTION
Signed-off-by: sayaoailun <guojianwei007@126.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
change the dashboard to fix bug `chart version link`

When I click on the Chart Versions, I get 404.

I check the code, and find this:

https://github.com/kubeapps/kubeapps/blob/ea227231b7701594bf43b60c94fee51d3d7d55af/dashboard/src/shared/url.ts#L6-L9

So I made this change.