### PR TITLE
Update kube package handlers to be multi-cluster aware.

### DIFF
--- a/cmd/kubeops/internal/handler/handler_test.go
+++ b/cmd/kubeops/internal/handler/handler_test.go
@@ -20,7 +20,6 @@ import (
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	helmTime "helm.sh/helm/v3/pkg/time"
-	"k8s.io/client-go/rest"
 
 	"helm.sh/helm/v3/pkg/release"
 )
@@ -521,78 +520,6 @@ func TestUpgradeAction(t *testing.T) {
 
 			if got, want := actualReleases, tc.expectedReleases; !cmp.Equal(want, got, releaseComparer) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, releaseComparer))
-			}
-		})
-	}
-}
-
-func TestNewClusterConfig(t *testing.T) {
-	testCases := []struct {
-		name               string
-		token              string
-		cluster            string
-		additionalClusters map[string]AdditionalClusterConfig
-		inClusterConfig    *rest.Config
-		expectedConfig     *rest.Config
-		errorExpected      bool
-	}{
-		{
-			name:    "returns an in-cluster with explicit token for the default cluster",
-			token:   "token-1",
-			cluster: "default",
-			inClusterConfig: &rest.Config{
-				BearerToken:     "something-else",
-				BearerTokenFile: "/foo/bar",
-			},
-			expectedConfig: &rest.Config{
-				BearerToken:     "token-1",
-				BearerTokenFile: "",
-			},
-		},
-		{
-			name:    "returns a config setup for an additional cluster",
-			token:   "token-1",
-			cluster: "cluster-1",
-			additionalClusters: map[string]AdditionalClusterConfig{
-				"cluster-1": {
-					APIServiceURL:            "https://cluster-1.example.com:7890",
-					CertificateAuthorityData: "ca-file-data",
-				},
-			},
-			inClusterConfig: &rest.Config{
-				Host:            "https://something-else.example.com:6443",
-				BearerToken:     "something-else",
-				BearerTokenFile: "/foo/bar",
-				TLSClientConfig: rest.TLSClientConfig{
-					CAFile: "/var/run/whatever/ca.crt",
-				},
-			},
-			expectedConfig: &rest.Config{
-				Host:            "https://cluster-1.example.com:7890",
-				BearerToken:     "token-1",
-				BearerTokenFile: "",
-				TLSClientConfig: rest.TLSClientConfig{
-					CAData: []byte("ca-file-data"),
-				},
-			},
-		},
-		{
-			name:            "returns an error if the cluster does not exist",
-			cluster:         "cluster-1",
-			inClusterConfig: &rest.Config{},
-			errorExpected:   true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			config, err := NewClusterConfig(tc.inClusterConfig, tc.token, tc.cluster, tc.additionalClusters)
-			if got, want := err != nil, tc.errorExpected; got != want {
-				t.Fatalf("got: %t, want: %t. err: %+v", got, want, err)
-			}
-
-			if got, want := config, tc.expectedConfig; !cmp.Equal(want, got) {
-				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}
 		})
 	}

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/agent"
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	backendHandlers "github.com/kubeapps/kubeapps/pkg/http-handler"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/urfave/negroni"
@@ -54,7 +55,7 @@ func main() {
 		log.Fatal("POD_NAMESPACE should be defined")
 	}
 
-	var additionalClusters map[string]handler.AdditionalClusterConfig
+	var additionalClusters map[string]kube.AdditionalClusterConfig
 	if additionalClustersConfigPath != "" {
 		var err error
 		additionalClusters, err = parseAdditionalClusterConfig(additionalClustersConfigPath)
@@ -171,18 +172,18 @@ func main() {
 	os.Exit(0)
 }
 
-func parseAdditionalClusterConfig(path string) (map[string]handler.AdditionalClusterConfig, error) {
+func parseAdditionalClusterConfig(path string) (kube.AdditionalClustersConfig, error) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	var clusterConfigs []handler.AdditionalClusterConfig
+	var clusterConfigs []kube.AdditionalClusterConfig
 	if err = json.Unmarshal(content, &clusterConfigs); err != nil {
 		return nil, err
 	}
 
-	configs := map[string]handler.AdditionalClusterConfig{}
+	configs := kube.AdditionalClustersConfig{}
 	for _, c := range clusterConfigs {
 		configs[c.Name] = c
 	}

--- a/cmd/kubeops/main_test.go
+++ b/cmd/kubeops/main_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/cmd/kubeops/internal/handler"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 )
 
 func TestParseAdditionalClusterConfig(t *testing.T) {
@@ -14,13 +14,13 @@ func TestParseAdditionalClusterConfig(t *testing.T) {
 		name           string
 		configJSON     string
 		expectedErr    bool
-		expectedConfig map[string]handler.AdditionalClusterConfig
+		expectedConfig kube.AdditionalClustersConfig
 	}{
 		{
 			name:       "parses a single additional cluster",
 			configJSON: `[{"name": "cluster-2", "apiServiceURL": "https://example.com", "certificateAuthorityData": "abcd"}]`,
-			expectedConfig: map[string]handler.AdditionalClusterConfig{
-				"cluster-2": handler.AdditionalClusterConfig{
+			expectedConfig: kube.AdditionalClustersConfig{
+				"cluster-2": {
 					Name:                     "cluster-2",
 					APIServiceURL:            "https://example.com",
 					CertificateAuthorityData: "abcd",
@@ -33,13 +33,13 @@ func TestParseAdditionalClusterConfig(t *testing.T) {
 	{"name": "cluster-2", "apiServiceURL": "https://example.com/cluster-2", "certificateAuthorityData": "abcd"},
 	{"name": "cluster-3", "apiServiceURL": "https://example.com/cluster-3", "certificateAuthorityData": "efgh"}
 ]`,
-			expectedConfig: map[string]handler.AdditionalClusterConfig{
-				"cluster-2": handler.AdditionalClusterConfig{
+			expectedConfig: kube.AdditionalClustersConfig{
+				"cluster-2": {
 					Name:                     "cluster-2",
 					APIServiceURL:            "https://example.com/cluster-2",
 					CertificateAuthorityData: "abcd",
 				},
-				"cluster-3": handler.AdditionalClusterConfig{
+				"cluster-3": {
 					Name:                     "cluster-3",
 					APIServiceURL:            "https://example.com/cluster-3",
 					CertificateAuthorityData: "efgh",

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -280,7 +280,7 @@ func (c *ChartClient) ParseDetails(data []byte) (*Details, error) {
 func (c *ChartClient) parseDetailsForHTTPClient(details *Details, userAuthToken string) (*appRepov1.AppRepository, *corev1.Secret, *corev1.Secret, error) {
 	// We grab the specified app repository (for later access to the repo URL, as well as any specified
 	// auth).
-	client := c.appRepoHandler.AsUser(userAuthToken)
+	client := c.appRepoHandler.AsUser(userAuthToken, kube.DefaultClusterName)
 	if details.AppRepositoryResourceNamespace == c.kubeappsNamespace {
 		// If we're parsing a global repository (from the kubeappsNamespace), use a service client.
 		client = c.appRepoHandler.AsSVC()
@@ -364,7 +364,7 @@ func (c *ChartClient) RegistrySecretsPerDomain() map[string]string {
 
 func getRegistrySecretsPerDomain(appRepoSecrets []string, namespace, token string, authHandler kube.AuthHandler) (map[string]string, error) {
 	secretsPerDomain := map[string]string{}
-	client := authHandler.AsUser(token)
+	client := authHandler.AsUser(token, kube.DefaultClusterName)
 	for _, secretName := range appRepoSecrets {
 		secret, err := client.GetSecret(secretName, namespace)
 		if err != nil {

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -60,12 +60,21 @@ func returnK8sError(err error, w http.ResponseWriter) {
 	}
 }
 
+func getNamespaceAndCluster(req *http.Request) (string, string) {
+	requestNamespace := mux.Vars(req)["namespace"]
+	requestCluster, ok := mux.Vars(req)["cluster"]
+	if !ok {
+		requestCluster = kube.DefaultClusterName
+	}
+	return requestNamespace, requestCluster
+}
+
 // CreateAppRepository creates App Repository
 func CreateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		requestNamespace := mux.Vars(req)["namespace"]
+		requestNamespace, requestCluster := getNamespaceAndCluster(req)
 		token := auth.ExtractToken(req.Header.Get("Authorization"))
-		appRepo, err := handler.AsUser(token).CreateAppRepository(req.Body, requestNamespace)
+		appRepo, err := handler.AsUser(token, requestCluster).CreateAppRepository(req.Body, requestNamespace)
 		if err != nil {
 			returnK8sError(err, w)
 			return
@@ -86,9 +95,9 @@ func CreateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, r
 // UpdateAppRepository updates an App Repository
 func UpdateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		requestNamespace := mux.Vars(req)["namespace"]
+		requestNamespace, requestCluster := getNamespaceAndCluster(req)
 		token := auth.ExtractToken(req.Header.Get("Authorization"))
-		appRepo, err := handler.AsUser(token).UpdateAppRepository(req.Body, requestNamespace)
+		appRepo, err := handler.AsUser(token, requestCluster).UpdateAppRepository(req.Body, requestNamespace)
 		if err != nil {
 			returnK8sError(err, w)
 			return
@@ -109,8 +118,9 @@ func UpdateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, r
 // ValidateAppRepository returns a 200 if the connection to the AppRepo can be established
 func ValidateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
+		requestNamespace, requestCluster := getNamespaceAndCluster(req)
 		token := auth.ExtractToken(req.Header.Get("Authorization"))
-		res, err := handler.AsUser(token).ValidateAppRepository(req.Body, mux.Vars(req)["namespace"])
+		res, err := handler.AsUser(token, requestCluster).ValidateAppRepository(req.Body, requestNamespace)
 		if err != nil {
 			returnK8sError(err, w)
 			return
@@ -127,11 +137,11 @@ func ValidateAppRepository(handler kube.AuthHandler) func(w http.ResponseWriter,
 // DeleteAppRepository deletes an App Repository
 func DeleteAppRepository(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		repoNamespace := mux.Vars(req)["namespace"]
+		requestNamespace, requestCluster := getNamespaceAndCluster(req)
 		repoName := mux.Vars(req)["name"]
 		token := auth.ExtractToken(req.Header.Get("Authorization"))
 
-		err := kubeHandler.AsUser(token).DeleteAppRepository(repoName, repoNamespace)
+		err := kubeHandler.AsUser(token, requestCluster).DeleteAppRepository(repoName, requestNamespace)
 
 		if err != nil {
 			returnK8sError(err, w)
@@ -143,7 +153,8 @@ func DeleteAppRepository(kubeHandler kube.AuthHandler) func(w http.ResponseWrite
 func GetNamespaces(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		token := auth.ExtractToken(req.Header.Get("Authorization"))
-		namespaces, err := kubeHandler.AsUser(token).GetNamespaces()
+		_, requestCluster := getNamespaceAndCluster(req)
+		namespaces, err := kubeHandler.AsUser(token, requestCluster).GetNamespaces()
 		if err != nil {
 			returnK8sError(err, w)
 		}

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -196,11 +196,18 @@ func SetupDefaultRoutes(r *mux.Router) error {
 	if err != nil {
 		return err
 	}
+	// Deprecate non-cluster-aware URIs.
 	r.Methods("GET").Path("/namespaces").Handler(http.HandlerFunc(GetNamespaces(backendHandler)))
 	r.Methods("POST").Path("/namespaces/{namespace}/apprepositories").Handler(http.HandlerFunc(CreateAppRepository(backendHandler)))
 	r.Methods("POST").Path("/namespaces/{namespace}/apprepositories/validate").Handler(http.HandlerFunc(ValidateAppRepository(backendHandler)))
 	r.Methods("PUT").Path("/namespaces/{namespace}/apprepositories/{name}").Handler(http.HandlerFunc(UpdateAppRepository(backendHandler)))
 	r.Methods("DELETE").Path("/namespaces/{namespace}/apprepositories/{name}").Handler(http.HandlerFunc(DeleteAppRepository(backendHandler)))
 	r.Methods("GET").Path("/namespaces/{namespace}/operator/{name}/logo").Handler(http.HandlerFunc(GetOperatorLogo(backendHandler)))
+	r.Methods("GET").Path("/clusters/{cluster}/namespaces").Handler(http.HandlerFunc(GetNamespaces(backendHandler)))
+	r.Methods("POST").Path("/clusters/{cluster}/namespaces/{namespace}/apprepositories").Handler(http.HandlerFunc(CreateAppRepository(backendHandler)))
+	r.Methods("POST").Path("/clusters/{cluster}/namespaces/{namespace}/apprepositories/validate").Handler(http.HandlerFunc(ValidateAppRepository(backendHandler)))
+	r.Methods("PUT").Path("/clusters/{cluster}/namespaces/{namespace}/apprepositories/{name}").Handler(http.HandlerFunc(UpdateAppRepository(backendHandler)))
+	r.Methods("DELETE").Path("/clusters/{cluster}/namespaces/{namespace}/apprepositories/{name}").Handler(http.HandlerFunc(DeleteAppRepository(backendHandler)))
+	r.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/operator/{name}/logo").Handler(http.HandlerFunc(GetOperatorLogo(backendHandler)))
 	return nil
 }

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -36,7 +36,7 @@ type FakeHandler struct {
 }
 
 // AsUser fakes user auth
-func (c *FakeHandler) AsUser(token string) handler {
+func (c *FakeHandler) AsUser(token, cluster string) handler {
 	return c
 }
 


### PR DESCRIPTION
Moves NewClusterConfig (and tests) into the shared kube package so that
it can be used by other packages. Updates the AsUser helper (which
returns clientsets) to use NewClusterConfig, requiring a call-signature
change.

Also updates NewClusterConfig so as to not re-use default clusters TLS config if none configured for the selected cluster.

I'll followup with a related small fix to ensure we don't swallow errors
in AsUser.

Ref: #1761 
