### PR TITLE
Move AppListView route to be cluster-aware.

### DIFF
--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -14,6 +14,7 @@ import CustomResourceListItem from "./CustomResourceListItem";
 interface IAppListProps {
   apps: IAppState;
   fetchAppsWithUpdateInfo: (ns: string, all: boolean) => void;
+  cluster: string;
   namespace: string;
   pushSearchFilter: (filter: string) => any;
   filter: string;

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -1,8 +1,9 @@
 import { shallow } from "enzyme";
 import * as React from "react";
-
 import { INamespaceState } from "../../reducers/namespace";
+import { app } from "../../shared/url";
 import Header from "./Header";
+
 
 const defaultProps = {
   authenticated: true,
@@ -24,13 +25,14 @@ it("renders the header links and titles", () => {
   const menubar = wrapper.find(".header__nav__menu").first();
   const items = menubar.children().map(p => p.props().children.props);
   const expectedItems = [
-    { children: "Applications", to: "apps" },
-    { children: "Catalog", to: "catalog" },
-    { children: "Service Instances (alpha)", to: "services/instances" },
+    { children: "Applications", to: app.apps.list("default") },
+    { children: "Catalog", to: app.catalog("default") },
+    { children: "Service Instances (alpha)", to: app.servicesInstances("default") },
   ];
-  items.forEach((item, index) => {
-    expect(item.children).toBe(expectedItems[index].children);
-    expect(item.to).toBe(expectedItems[index].to);
+  expect(items.length).toEqual(expectedItems.length);
+  expectedItems.forEach((expectedItem, index) => {
+    expect(expectedItem.children).toBe(items[index].children);
+    expect(expectedItem.to).toBe(items[index].to);
   });
 });
 

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -109,6 +109,7 @@ it("call setNamespace and getNamespace when selecting a namespace", () => {
   const createNamespace = jest.fn();
   const getNamespace = jest.fn();
   const namespace = {
+    cluster: "default",
     current: "foo",
     namespaces: ["foo", "bar"],
   };
@@ -136,6 +137,7 @@ it("doesn't call getNamespace when selecting all namespaces", () => {
   const setNamespace = jest.fn();
   const getNamespace = jest.fn();
   const namespace = {
+    cluster: "defalut",
     current: "foo",
     namespaces: ["foo", "bar"],
   };

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -42,17 +42,17 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
     {
       children: "Applications",
       exact: true,
-      namespaced: true,
+      clustered: true,
       to: "apps",
     },
     {
       children: "Catalog",
-      namespaced: true,
+      clustered: false,
       to: "catalog",
     },
     {
       children: "Service Instances (alpha)",
-      namespaced: true,
+      clustered: false,
       to: "services/instances",
     },
   ];
@@ -117,7 +117,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                 <ul className="header__nav__menu" role="menubar">
                   {this.links.map(link => (
                     <li key={link.to}>
-                      <HeaderLink {...link} currentNamespace={namespace.current} />
+                      <HeaderLink {...link} currentCluster={namespace.cluster} currentNamespace={namespace.current} />
                     </li>
                   ))}
                 </ul>

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -1,17 +1,14 @@
 import * as React from "react";
+import { LogOut, Settings } from "react-feather";
 import { NavLink } from "react-router-dom";
+import "react-select/dist/react-select.css";
 import logo from "../../logo.svg";
-
 import { INamespaceState } from "../../reducers/namespace";
 import { definedNamespaces } from "../../shared/Namespace";
-import HeaderLink, { IHeaderLinkProps } from "./HeaderLink";
-import NamespaceSelector from "./NamespaceSelector";
-
-// Icons
-import { LogOut, Settings } from "react-feather";
-
-import "react-select/dist/react-select.css";
+import { app } from "../../shared/url";
 import "./Header.css";
+import HeaderLink from "./HeaderLink";
+import NamespaceSelector from "./NamespaceSelector";
 
 interface IHeaderProps {
   authenticated: boolean;
@@ -36,26 +33,6 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   public static defaultProps = {
     featureFlags: { reposPerNamespace: false, operators: false },
   };
-
-  // Defines the route
-  private readonly links: IHeaderLinkProps[] = [
-    {
-      children: "Applications",
-      exact: true,
-      clustered: true,
-      to: "apps",
-    },
-    {
-      children: "Catalog",
-      clustered: false,
-      to: "catalog",
-    },
-    {
-      children: "Service Instances (alpha)",
-      clustered: false,
-      to: "services/instances",
-    },
-  ];
 
   constructor(props: any) {
     super(props);
@@ -115,11 +92,15 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                   <div />
                 </button>
                 <ul className="header__nav__menu" role="menubar">
-                  {this.links.map(link => (
-                    <li key={link.to}>
-                      <HeaderLink {...link} currentCluster={namespace.cluster} currentNamespace={namespace.current} />
-                    </li>
-                  ))}
+                  <li>
+                    <HeaderLink to={app.apps.list(namespace.current, namespace.cluster)} exact={true}>Applications</HeaderLink>
+                  </li>
+                  <li>
+                    <HeaderLink to={app.catalog(namespace.current)}>Catalog</HeaderLink>
+                  </li>
+                  <li>
+                    <HeaderLink to={app.servicesInstances(namespace.current)}>Service Instances (alpha)</HeaderLink>
+                  </li>
                 </ul>
               </nav>
             )}

--- a/dashboard/src/components/Header/HeaderLink.tsx
+++ b/dashboard/src/components/Header/HeaderLink.tsx
@@ -5,28 +5,20 @@ import { NavLink } from "react-router-dom";
 export interface IHeaderLinkProps {
   to: string;
   exact?: boolean;
-  external?: boolean;
   children?: React.ReactChildren | React.ReactNode | string;
-  currentNamespace?: string | null;
-  currentCluster?: string;
-  // clustered enables some menu items to include a cluster prefix while transitioning.
-  clustered?: boolean;
 }
 
 class HeaderLink extends React.Component<IHeaderLinkProps> {
   public static defaultProps: Partial<IHeaderLinkProps> = {
     exact: false,
-    external: false,
   };
 
-  public renderInternalLink() {
-    const { currentCluster, currentNamespace, clustered, to } = this.props;
+  public render() {
+    const { to } = this.props;
 
-    let link = currentNamespace ? `/ns/${currentNamespace}/${to}` : to;
-    link = clustered ? `/c/${currentCluster}${link}` : link;
     return (
       <NavLink
-        to={link}
+        to={to}
         activeClassName="header__nav__menu__item-active"
         className="header__nav__menu__item"
         exact={this.props.exact}
@@ -34,18 +26,6 @@ class HeaderLink extends React.Component<IHeaderLinkProps> {
         {this.props.children}
       </NavLink>
     );
-  }
-
-  public renderExternalLink() {
-    return (
-      <a href={this.props.to} className="header__nav__menu__item">
-        {this.props.children}
-      </a>
-    );
-  }
-
-  public render() {
-    return this.props.external ? this.renderExternalLink() : this.renderInternalLink();
   }
 }
 

--- a/dashboard/src/components/Header/HeaderLink.tsx
+++ b/dashboard/src/components/Header/HeaderLink.tsx
@@ -8,7 +8,9 @@ export interface IHeaderLinkProps {
   external?: boolean;
   children?: React.ReactChildren | React.ReactNode | string;
   currentNamespace?: string | null;
-  namespaced?: boolean;
+  currentCluster?: string;
+  // clustered enables some menu items to include a cluster prefix while transitioning.
+  clustered?: boolean;
 }
 
 class HeaderLink extends React.Component<IHeaderLinkProps> {
@@ -18,8 +20,10 @@ class HeaderLink extends React.Component<IHeaderLinkProps> {
   };
 
   public renderInternalLink() {
-    const { currentNamespace, namespaced, to } = this.props;
-    const link = currentNamespace && namespaced ? `/ns/${currentNamespace}/${to}` : to;
+    const { currentCluster, currentNamespace, clustered, to } = this.props;
+
+    let link = currentNamespace ? `/ns/${currentNamespace}/${to}` : to;
+    link = clustered ? `/c/${currentCluster}${link}` : link;
     return (
       <NavLink
         to={link}

--- a/dashboard/src/components/Header/NamespaceSelector.test.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.test.tsx
@@ -88,7 +88,7 @@ it("fetches namespaces and retrive the current namespace", () => {
       {...defaultProps}
       fetchNamespaces={fetchNamespaces}
       getNamespace={getNamespace}
-      namespace={{ current: "foo", namespaces: [] }}
+      namespace={{ cluster: "default", current: "foo", namespaces: [] }}
     />,
   );
   expect(fetchNamespaces).toHaveBeenCalled();
@@ -103,7 +103,7 @@ it("doesnt' get the current namespace if all namespaces is selected", () => {
       {...defaultProps}
       fetchNamespaces={fetchNamespaces}
       getNamespace={getNamespace}
-      namespace={{ current: "_all", namespaces: [] }}
+      namespace={{ cluster: "default", current: "_all", namespaces: [] }}
     />,
   );
   expect(fetchNamespaces).toHaveBeenCalled();

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
@@ -107,7 +107,7 @@ describe("renders a resource", () => {
     expect(deleteResource).toHaveBeenCalledWith(defaultProps.namespace, "foo", resource);
     // wait async calls
     await new Promise(r => r());
-    expect(push).toHaveBeenCalledWith(`/ns/${defaultProps.namespace}/apps`);
+    expect(push).toHaveBeenCalledWith(`/c/default/ns/${defaultProps.namespace}/apps`);
   });
 
   it("updates the state with the CRD resources", () => {

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
@@ -5,6 +5,7 @@ import * as ReactModal from "react-modal";
 import AccessURLTable from "../../containers/AccessURLTableContainer";
 import ApplicationStatus from "../../containers/ApplicationStatusContainer";
 import itBehavesLike from "../../shared/specs";
+import { app } from "../../shared/url";
 import AppNotes from "../AppView/AppNotes";
 import AppValues from "../AppView/AppValues";
 import ResourceTable from "../AppView/ResourceTable";
@@ -107,7 +108,7 @@ describe("renders a resource", () => {
     expect(deleteResource).toHaveBeenCalledWith(defaultProps.namespace, "foo", resource);
     // wait async calls
     await new Promise(r => r());
-    expect(push).toHaveBeenCalledWith(`/c/default/ns/${defaultProps.namespace}/apps`);
+    expect(push).toHaveBeenCalledWith(app.apps.list(defaultProps.namespace));
   });
 
   it("updates the state with the CRD resources", () => {

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -266,7 +266,7 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
     const deleted = await this.props.deleteResource(namespace, crd!.name.split(".")[0], resource!);
     this.closeModal();
     if (deleted) {
-      this.props.push(`/ns/${namespace}/apps`);
+      this.props.push(`/c/default/ns/${namespace}/apps`);
     }
   };
 }

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -266,7 +266,7 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
     const deleted = await this.props.deleteResource(namespace, crd!.name.split(".")[0], resource!);
     this.closeModal();
     if (deleted) {
-      this.props.push(`/c/default/ns/${namespace}/apps`);
+      this.props.push(app.apps.list(namespace));
     }
   };
 }

--- a/dashboard/src/containers/AppListContainer/AppListContainer.tsx
+++ b/dashboard/src/containers/AppListContainer/AppListContainer.tsx
@@ -15,6 +15,7 @@ function mapStateToProps(
   return {
     apps,
     filter: qs.parse(location.search, { ignoreQueryPrefix: true }).q || "",
+    cluster: namespace.cluster,
     namespace: namespace.current,
     customResources: operators.resources,
     isFetchingResources: operators.isFetching,

--- a/dashboard/src/containers/ErrorBoundaryContainer/ErrorBoundaryContainer.test.tsx
+++ b/dashboard/src/containers/ErrorBoundaryContainer/ErrorBoundaryContainer.test.tsx
@@ -9,6 +9,7 @@ import UnexpectedErrorPage from "../../components/ErrorAlert/UnexpectedErrorAler
 const mockStore = configureMockStore([thunk]);
 const makeStore = (error?: { action: string; error: Error }) => {
   const state: INamespaceState = {
+    cluster: "default",
     current: "default",
     namespaces: ["default"],
     error,

--- a/dashboard/src/containers/RoutesContainer/Routes.test.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.test.tsx
@@ -5,6 +5,7 @@ import { StaticRouter } from "react-router";
 import { Redirect, RouteComponentProps } from "react-router-dom";
 
 import NotFound from "../../components/NotFound";
+import { app } from "../../shared/url";
 import RepoListContainer from "../../containers/RepoListContainer";
 import Routes from "./Routes";
 
@@ -41,7 +42,7 @@ it("should render a redirect to the default cluster and namespace", () => {
     </StaticRouter>,
   );
   expect(wrapper.find(NotFound)).not.toExist();
-  expect(wrapper.find(Redirect).prop("to")).toEqual("/c/default/ns/default/apps");
+  expect(wrapper.find(Redirect).prop("to")).toEqual(app.apps.list("default"));
 });
 
 it("should render a redirect to the login page", () => {

--- a/dashboard/src/containers/RoutesContainer/Routes.test.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.test.tsx
@@ -3,11 +3,11 @@ import { createMemoryHistory } from "history";
 import * as React from "react";
 import { StaticRouter } from "react-router";
 import { Redirect, RouteComponentProps } from "react-router-dom";
-
 import NotFound from "../../components/NotFound";
-import { app } from "../../shared/url";
 import RepoListContainer from "../../containers/RepoListContainer";
+import { app } from "../../shared/url";
 import Routes from "./Routes";
+
 
 const emptyRouteComponentProps: RouteComponentProps<{}> = {
   history: createMemoryHistory(),

--- a/dashboard/src/containers/RoutesContainer/Routes.test.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.test.tsx
@@ -27,27 +27,27 @@ const emptyRouteComponentProps: RouteComponentProps<{}> = {
 it("invalid path should show a 404 error", () => {
   const wrapper = mount(
     <StaticRouter location="/random" context={{}}>
-      <Routes {...emptyRouteComponentProps} namespace={"default"} authenticated={true} />
+      <Routes {...emptyRouteComponentProps} cluster={"default"} namespace={"default"} authenticated={true} />
     </StaticRouter>,
   );
   expect(wrapper.find(NotFound)).toExist();
   expect(wrapper.text()).toContain("The page you are looking for can't be found.");
 });
 
-it("should render a redirect to the default namespace", () => {
+it("should render a redirect to the default cluster and namespace", () => {
   const wrapper = mount(
     <StaticRouter location="/" context={{}}>
-      <Routes {...emptyRouteComponentProps} namespace={"default"} authenticated={true} />
+      <Routes {...emptyRouteComponentProps} cluster={"default"} namespace={"default"} authenticated={true} />
     </StaticRouter>,
   );
   expect(wrapper.find(NotFound)).not.toExist();
-  expect(wrapper.find(Redirect).prop("to")).toEqual("/ns/default/apps");
+  expect(wrapper.find(Redirect).prop("to")).toEqual("/c/default/ns/default/apps");
 });
 
 it("should render a redirect to the login page", () => {
   const wrapper = mount(
     <StaticRouter location="/" context={{}}>
-      <Routes {...emptyRouteComponentProps} namespace={""} authenticated={true} />
+      <Routes {...emptyRouteComponentProps} cluster={"default"} namespace={""} authenticated={true} />
     </StaticRouter>,
   );
   expect(wrapper.find(NotFound)).not.toExist();
@@ -57,7 +57,7 @@ it("should render a redirect to the login page", () => {
 it("should render a redirect to the login page (when not authenticated)", () => {
   const wrapper = mount(
     <StaticRouter location="/" context={{}}>
-      <Routes {...emptyRouteComponentProps} namespace={"default"} authenticated={false} />
+      <Routes {...emptyRouteComponentProps} cluster={"default"} namespace={"default"} authenticated={false} />
     </StaticRouter>,
   );
   expect(wrapper.find(NotFound)).not.toExist();
@@ -65,6 +65,7 @@ it("should render a redirect to the login page (when not authenticated)", () => 
 });
 
 describe("Routes depending on feature flags", () => {
+  const cluster = "default";
   const namespace = "default";
   const perNamespacePath = "/config/ns/:namespace/repos";
   const nonNamespacedPath = "/config/repos";
@@ -74,6 +75,7 @@ describe("Routes depending on feature flags", () => {
       <StaticRouter location="/config/repos" context={{}}>
         <Routes
           {...emptyRouteComponentProps}
+          cluster={cluster}
           namespace={namespace}
           authenticated={true}
           featureFlags={{ reposPerNamespace: false, operators: false }}
@@ -95,6 +97,7 @@ describe("Routes depending on feature flags", () => {
       <StaticRouter location="/config/repos" context={{}}>
         <Routes
           {...emptyRouteComponentProps}
+          cluster={cluster}
           namespace={namespace}
           authenticated={true}
           featureFlags={{ reposPerNamespace: true, operators: false }}

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -26,7 +26,7 @@ import ServiceInstanceViewContainer from "../../containers/ServiceInstanceViewCo
 type IRouteComponentPropsAndRouteProps = RouteProps & RouteComponentProps<any>;
 
 const privateRoutes = {
-  "/ns/:namespace/apps": AppListContainer,
+  "/c/:cluster/ns/:namespace/apps": AppListContainer,
   "/ns/:namespace/apps/:releaseName": AppViewContainer,
   "/ns/:namespace/apps/:releaseName/upgrade": AppUpgradeContainer,
   "/ns/:namespace/apps/new/:repo/:id/versions/:version": AppNewContainer,
@@ -51,6 +51,7 @@ const routes = {
 
 interface IRoutesProps extends IRouteComponentPropsAndRouteProps {
   namespace: string;
+  cluster: string;
   authenticated: boolean;
   featureFlags: {
     reposPerNamespace: boolean;
@@ -101,7 +102,7 @@ class Routes extends React.Component<IRoutesProps> {
   }
   private rootNamespacedRedirect = () => {
     if (this.props.namespace && this.props.authenticated) {
-      return <Redirect to={`/ns/${this.props.namespace}/apps`} />;
+      return <Redirect to={`/c/${this.props.cluster}/ns/${this.props.namespace}/apps`} />;
     }
     // There is not a default namespace, redirect to login page
     return <Redirect to={"/login"} />;

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -22,6 +22,7 @@ import ServiceClassListContainer from "../../containers/ServiceClassListContaine
 import ServiceClassViewContainer from "../../containers/ServiceClassViewContainer";
 import ServiceInstanceListContainer from "../../containers/ServiceInstanceListContainer";
 import ServiceInstanceViewContainer from "../../containers/ServiceInstanceViewContainer";
+import { app } from "../../shared/url";
 
 type IRouteComponentPropsAndRouteProps = RouteProps & RouteComponentProps<any>;
 
@@ -102,7 +103,7 @@ class Routes extends React.Component<IRoutesProps> {
   }
   private rootNamespacedRedirect = () => {
     if (this.props.namespace && this.props.authenticated) {
-      return <Redirect to={`/c/${this.props.cluster}/ns/${this.props.namespace}/apps`} />;
+      return <Redirect to={app.apps.list(this.props.namespace, this.props.cluster)} />;
     }
     // There is not a default namespace, redirect to login page
     return <Redirect to={"/login"} />;

--- a/dashboard/src/containers/RoutesContainer/RoutesContainer.tsx
+++ b/dashboard/src/containers/RoutesContainer/RoutesContainer.tsx
@@ -6,6 +6,7 @@ import Routes from "./Routes";
 
 function mapStateToProps({ auth, namespace, config }: IStoreState) {
   return {
+    cluster: namespace.cluster,
     namespace: namespace.current || auth.defaultNamespace,
     authenticated: auth.authenticated,
     featureFlags: config.featureFlags,

--- a/dashboard/src/reducers/namespace.test.ts
+++ b/dashboard/src/reducers/namespace.test.ts
@@ -8,6 +8,7 @@ import namespaceReducer from "./namespace";
 
 describe("namespaceReducer", () => {
   const initialState = {
+    cluster: "default",
     current: "initial-current",
     namespaces: ["default", "initial-current"],
   };
@@ -65,6 +66,7 @@ describe("namespaceReducer", () => {
   context("when CLEAR_NAMESPACES", () => {
     it("returns to the initial state", () => {
       const dirtyState = {
+        cluster: "default",
         current: "some-other-namespace",
         namespaces: ["namespace-one", "namespace-two"],
       };
@@ -72,7 +74,7 @@ describe("namespaceReducer", () => {
         namespaceReducer(dirtyState, {
           type: getType(actions.namespace.clearNamespaces),
         }),
-      ).toEqual({ current: "_all", namespaces: [] });
+      ).toEqual({ cluster: "default", current: "_all", namespaces: [] });
     });
   });
 
@@ -80,13 +82,13 @@ describe("namespaceReducer", () => {
     it("sets the current namespace to the users default", () => {
       expect(
         namespaceReducer(
-          { current: "default", namespaces: [] },
+          { cluster: "default", current: "default", namespaces: [] },
           {
             type: getType(actions.auth.setAuthenticated),
             payload: { authenticated: true, oidc: false, defaultNamespace: "foo-bar" },
           },
         ),
-      ).toEqual({ current: "foo-bar", namespaces: [] });
+      ).toEqual({ cluster: "default", current: "foo-bar", namespaces: [] });
     });
   });
 
@@ -95,6 +97,7 @@ describe("namespaceReducer", () => {
       expect(
         namespaceReducer(
           {
+            cluster: "default",
             current: "error",
             namespaces: [],
             error: { action: "create", error: new Error("boom") },
@@ -104,7 +107,7 @@ describe("namespaceReducer", () => {
             payload: "default",
           },
         ),
-      ).toEqual({ current: "default", namespaces: [], error: undefined });
+      ).toEqual({ cluster: "default", current: "default", namespaces: [], error: undefined });
     });
   });
 
@@ -113,6 +116,7 @@ describe("namespaceReducer", () => {
       expect(
         namespaceReducer(
           {
+            cluster: "default",
             current: "",
             namespaces: ["default"],
             error: { action: "create", error: new Error("boom") },
@@ -122,7 +126,7 @@ describe("namespaceReducer", () => {
             payload: { metadata: { name: "bar" } } as IResource,
           },
         ),
-      ).toEqual({ current: "", namespaces: ["bar", "default"], error: undefined });
+      ).toEqual({ cluster: "default", current: "", namespaces: ["bar", "default"], error: undefined });
     });
   });
 });

--- a/dashboard/src/reducers/namespace.ts
+++ b/dashboard/src/reducers/namespace.ts
@@ -7,6 +7,7 @@ import { NamespaceAction } from "../actions/namespace";
 import { Auth } from "../shared/Auth";
 
 export interface INamespaceState {
+  cluster: string;
   current: string;
   namespaces: string[];
   error?: { action: string; error: Error };
@@ -15,6 +16,7 @@ export interface INamespaceState {
 const getInitialState: () => INamespaceState = (): INamespaceState => {
   const token = Auth.getAuthToken() || "";
   return {
+    cluster: "default",
     current: Auth.defaultNamespaceFromToken(token),
     namespaces: [],
   };

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -9,6 +9,7 @@ export const app = {
       const newSegment = repoNamespace === namespace ? "new" : "new-from-global";
       return `/ns/${namespace}/apps/${newSegment}/${cv.relationships.chart.data.repo.name}/${cv.relationships.chart.data.name}/versions/${version}`;
     },
+    list: (namespace: string, cluster: string = 'default') => `/c/${cluster}/ns/${namespace}/apps`,
   },
   charts: {
     version: (cv: IChartVersion) =>

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -9,8 +9,10 @@ export const app = {
       const newSegment = repoNamespace === namespace ? "new" : "new-from-global";
       return `/ns/${namespace}/apps/${newSegment}/${cv.relationships.chart.data.repo.name}/${cv.relationships.chart.data.name}/versions/${version}`;
     },
-    list: (namespace: string, cluster: string = 'default') => `/c/${cluster}/ns/${namespace}/apps`,
+    list: (namespace: string, cluster: string = "default") => `/c/${cluster}/ns/${namespace}/apps`,
   },
+  catalog: (namespace: string) => `/ns/${namespace}/catalog`,
+  servicesInstances: (namespace: string) => `/ns/${namespace}/services/instances`,
   charts: {
     version: (cv: IChartVersion) =>
       `/ns/${cv.relationships.chart.data.repo.namespace}/charts/${cv.relationships.chart.data.repo.name}/${cv.relationships.chart.data.name}/versions/${cv.attributes.version}`,


### PR DESCRIPTION
First of several PRs which will transition existing relevant routes in the UI to
be cluster-aware, defaulting to the "default" cluster so as to not break
the existing experience.

Ref: #1762 
