### PR TITLE
Remove reposPerNamespace feature flag.

### DIFF
--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -65,9 +65,7 @@ spec:
             {{- if .Values.apprepository.crontab }}
             - --crontab={{ .Values.apprepository.crontab }}
             {{- end }}
-            {{- if .Values.featureFlags.reposPerNamespace }}
             - --repos-per-namespace
-            {{- end }}
           {{- if .Values.apprepository.resources }}
           resources: {{- toYaml .Values.apprepository.resources | nindent 12 }}
           {{- end }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -691,7 +691,6 @@ authProxy:
 ## Feature flags
 ## These are used to switch on in development features or new features which are ready to be released.
 featureFlags:
-  reposPerNamespace: true
   invalidateCache: true
   operators: false
   # additionalClusters is a WIP feature for multi-cluster support.

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -57,7 +57,9 @@ const (
 	// existing.
 	ErrResourceExists = "ErrResourceExists"
 
-	LabelRepoName      = "apprepositories.kubeapps.com/repo-name"
+	// LabelRepoName is the label used to identify the repository name.
+	LabelRepoName = "apprepositories.kubeapps.com/repo-name"
+	// LabelRepoNamespace is the label used to identify the repository namespace.
 	LabelRepoNamespace = "apprepositories.kubeapps.com/repo-namespace"
 
 	// MessageResourceExists is the message used for Events when a resource

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -25,6 +25,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd" // Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	log "github.com/sirupsen/logrus"
 )
@@ -69,13 +70,7 @@ func main() {
 
 	// We're interested in being informed about cronjobs in kubeapps namespace only, currently.
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(namespace))
-	// Depending on the flag, we may be interested in AppRepository resources across the cluster.
-	var apprepoInformerFactory informers.SharedInformerFactory
-	if reposPerNamespace {
-		apprepoInformerFactory = informers.NewSharedInformerFactory(apprepoClient, 0)
-	} else {
-		apprepoInformerFactory = informers.NewFilteredSharedInformerFactory(apprepoClient, 0, namespace, nil)
-	}
+	apprepoInformerFactory := informers.NewSharedInformerFactory(apprepoClient, 0)
 
 	controller := NewController(kubeClient, apprepoClient, kubeInformerFactory, apprepoInformerFactory, namespace)
 
@@ -93,7 +88,7 @@ func init() {
 	flag.StringVar(&repoSyncImage, "repo-sync-image", "quay.io/helmpack/chart-repo:latest", "container repo/image to use in CronJobs")
 	flag.StringVar(&repoSyncCommand, "repo-sync-cmd", "/chart-repo", "command used to sync/delete repos for repo-sync-image")
 	flag.StringVar(&namespace, "namespace", "kubeapps", "Namespace to discover AppRepository resources")
-	flag.BoolVar(&reposPerNamespace, "repos-per-namespace", false, "Enables syncing app repositories across all namespaces.")
+	flag.BoolVar(&reposPerNamespace, "repos-per-namespace", true, "UNUSED: This flag will be removed in a future release.")
 	flag.StringVar(&dbType, "database-type", "mongodb", "Database type. Allowed values: mongodb, postgresql")
 	flag.StringVar(&dbURL, "database-url", "localhost", "Database URL")
 	flag.StringVar(&dbUser, "database-user", "root", "Database user")

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -5,7 +5,6 @@
   "oauthLoginURI": "/oauth2/start",
   "oauthLogoutURI": "/oauth2/sign_out",
   "featureFlags": {
-    "reposPerNamespace": true,
     "operators": true
   }
 }

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -98,35 +98,8 @@ actionTestCases.forEach(tc => {
 describe("deleteRepo", () => {
   context("dispatches requestRepos and receivedRepos after deletion if no error", async () => {
     const currentNamespace = "current-namespace";
-    it("dispatches requestRepos with kubeapps namespace when reposPerNamespace is not set", async () => {
+    it("dispatches requestRepos with current namespace", async () => {
       const storeWithFlag: any = mockStore({
-        config: {
-          namespace: kubeappsNamespace,
-          featureFlags: { reposPerNamespace: false },
-        },
-        namespace: { current: currentNamespace },
-      });
-      const expectedActions = [
-        {
-          type: getType(repoActions.requestRepos),
-          payload: kubeappsNamespace,
-        },
-        {
-          type: getType(repoActions.receiveRepos),
-          payload: { foo: "bar" },
-        },
-      ];
-
-      await storeWithFlag.dispatch(repoActions.deleteRepo("foo", "my-namespace"));
-      expect(storeWithFlag.getActions()).toEqual(expectedActions);
-    });
-
-    it("dispatches requestRepos with current namespace when reposPerNamespace is set", async () => {
-      const storeWithFlag: any = mockStore({
-        config: {
-          namespace: kubeappsNamespace,
-          featureFlags: { reposPerNamespace: true },
-        },
         namespace: { current: currentNamespace },
       });
       const expectedActions = [

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -5,15 +5,15 @@ import { AppRepository } from "../shared/AppRepository";
 import Chart from "../shared/Chart";
 import { definedNamespaces } from "../shared/Namespace";
 import Secret from "../shared/Secret";
-import { errorChart } from "./charts";
-
 import {
   IAppRepository,
   IAppRepositoryKey,
   ISecret,
   IStoreState,
-  NotFoundError,
+  NotFoundError
 } from "../shared/types";
+import { errorChart } from "./charts";
+
 
 export const addRepo = createAction("ADD_REPO");
 export const addedRepo = createAction("ADDED_REPO", resolve => {
@@ -115,14 +115,10 @@ export const deleteRepo = (
   return async (dispatch, getState) => {
     const {
       namespace: { current },
-      config: { namespace: kubeappsNamespace, featureFlags },
     } = getState();
     try {
       await AppRepository.delete(name, namespace);
-      const fetchFromNamespace: string = featureFlags.reposPerNamespace
-        ? current
-        : kubeappsNamespace;
-      dispatch(fetchRepos(fetchFromNamespace));
+      dispatch(fetchRepos(current));
       return true;
     } catch (e) {
       dispatch(errorRepos(e, "delete"));

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -1,8 +1,8 @@
 import { shallow } from "enzyme";
 import * as React from "react";
-
 import { INamespaceState } from "../../reducers/namespace";
 import Header from "./Header";
+
 
 const defaultProps = {
   authenticated: true,
@@ -35,23 +35,9 @@ it("renders the header links and titles", () => {
 });
 
 describe("settings", () => {
-  it("renders settings without reposPerNamespace", () => {
-    const wrapper = shallow(<Header {...defaultProps} />);
-    const settingsbar = wrapper.find(".header__nav__submenu").first();
-    const items = settingsbar.find("NavLink").map(p => p.props());
-    const expectedItems = [
-      { children: "App Repositories", to: "/config/repos" },
-      { children: "Service Brokers", to: "/config/brokers" },
-    ];
-    items.forEach((item, index) => {
-      expect(item.children).toBe(expectedItems[index].children);
-      expect(item.to).toBe(expectedItems[index].to);
-    });
-  });
-
-  it("renders settings with reposPerNamespace", () => {
+  it("renders settings", () => {
     const wrapper = shallow(
-      <Header {...defaultProps} featureFlags={{ reposPerNamespace: true, operators: false }} />,
+      <Header {...defaultProps} featureFlags={{ operators: false }} />,
     );
     const settingsbar = wrapper.find(".header__nav__submenu").first();
     const items = settingsbar.find("NavLink").map(p => p.props());
@@ -67,7 +53,7 @@ describe("settings", () => {
 
   it("renders operators link", () => {
     const wrapper = shallow(
-      <Header {...defaultProps} featureFlags={{ reposPerNamespace: true, operators: true }} />,
+      <Header {...defaultProps} featureFlags={{ operators: true }} />,
     );
     const settingsbar = wrapper.find(".header__nav__submenu").first();
     const items = settingsbar.find("NavLink").map(p => p.props());

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -1,17 +1,17 @@
 import * as React from "react";
+// Icons
+import { LogOut, Settings } from "react-feather";
 import { NavLink } from "react-router-dom";
+import "react-select/dist/react-select.css";
 import logo from "../../logo.svg";
-
 import { INamespaceState } from "../../reducers/namespace";
 import { definedNamespaces } from "../../shared/Namespace";
+import "./Header.css";
 import HeaderLink, { IHeaderLinkProps } from "./HeaderLink";
 import NamespaceSelector from "./NamespaceSelector";
 
-// Icons
-import { LogOut, Settings } from "react-feather";
 
-import "react-select/dist/react-select.css";
-import "./Header.css";
+
 
 interface IHeaderProps {
   authenticated: boolean;
@@ -24,7 +24,7 @@ interface IHeaderProps {
   setNamespace: (ns: string) => void;
   createNamespace: (ns: string) => Promise<boolean>;
   getNamespace: (ns: string) => void;
-  featureFlags: { reposPerNamespace: boolean; operators: boolean };
+  featureFlags: { operators: boolean };
 }
 
 interface IHeaderState {
@@ -34,7 +34,7 @@ interface IHeaderState {
 
 class Header extends React.Component<IHeaderProps, IHeaderState> {
   public static defaultProps = {
-    featureFlags: { reposPerNamespace: false, operators: false },
+    featureFlags: { operators: false },
   };
 
   // Defines the route
@@ -89,9 +89,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
       this.state.configOpen ? "header__nav__submenu-open" : ""
     }`;
 
-    const reposPath = this.props.featureFlags.reposPerNamespace
-      ? `/config/ns/${namespace.current}/repos`
-      : "/config/repos";
+    const reposPath = `/config/ns/${namespace.current}/repos`;
     return (
       <section className="gradient-135-brand type-color-reverse type-color-reverse-anchor-reset">
         <div className="container">

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.test.tsx
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.test.tsx
@@ -25,7 +25,7 @@ const defaultState = {
   auth: defaultAuthState,
   router: { location: emptyLocation },
   config: {
-    featureFlags: { reposPerNamespace: true },
+    featureFlags: { operators: true },
   },
 };
 
@@ -43,7 +43,7 @@ describe("HeaderContainer props", () => {
     const store = mockStore({
       ...defaultState,
       config: {
-        featureFlags: { reposPerNamespace: true },
+        featureFlags: { operators: true },
       },
     });
 
@@ -51,7 +51,7 @@ describe("HeaderContainer props", () => {
 
     const form = wrapper.find("Header");
     expect(form).toHaveProp({
-      featureFlags: { reposPerNamespace: true },
+      featureFlags: { operators: true },
     });
   });
 });

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -34,7 +34,7 @@ const makeStore = (
     namespace: "",
     appVersion: "",
     oauthLogoutURI: "",
-    featureFlags: { reposPerNamespace: false, operators: false },
+    featureFlags: { operators: false },
   };
   return mockStore({ auth, config });
 };

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.test.tsx
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.test.tsx
@@ -2,9 +2,9 @@ import { shallow } from "enzyme";
 import * as React from "react";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
-
 import RepoListContainer from ".";
 import { definedNamespaces } from "../../shared/Namespace";
+
 
 const mockStore = configureMockStore([thunk]);
 const currentNamespace = "current-namespace";
@@ -12,7 +12,6 @@ const kubeappsNamespace = "kubeapps-namespace";
 
 const defaultState = {
   config: {
-    featureFlags: { reposPerNamespace: false },
     namespace: kubeappsNamespace,
   },
   namespace: { current: currentNamespace },
@@ -21,24 +20,9 @@ const defaultState = {
 };
 
 describe("RepoListContainer props", () => {
-  it("uses kubeapps namespace when reposPerNamespace false", () => {
-    const store = mockStore(defaultState);
-    const wrapper = shallow(<RepoListContainer store={store} />);
-
-    const component = wrapper.find("AppRepoList");
-
-    expect(component).toHaveProp({
-      namespace: kubeappsNamespace,
-      displayReposPerNamespaceMsg: false,
-    });
-  });
-
-  it("uses the current namespace when reposPerNamespace is true", () => {
+  it("uses the current namespace", () => {
     const store = mockStore({
       ...defaultState,
-      config: {
-        featureFlags: { reposPerNamespace: true },
-      },
     });
     const wrapper = shallow(<RepoListContainer store={store} />);
 
@@ -50,11 +34,10 @@ describe("RepoListContainer props", () => {
     });
   });
 
-  it("passes _all through as a normal namespace when reposPerNamespaces is true, to be handled by the component", () => {
+  it("passes _all through as a normal namespace to be handled by the component", () => {
     const store = mockStore({
       ...defaultState,
       config: {
-        featureFlags: { reposPerNamespace: true },
         namespace: kubeappsNamespace,
       },
       namespace: { current: definedNamespaces.all },

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -1,20 +1,17 @@
 import { connect } from "react-redux";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
-
 import actions from "../../actions";
 import AppRepoList from "../../components/Config/AppRepoList";
 import { definedNamespaces } from "../../shared/Namespace";
 import { IAppRepositoryKey, IStoreState } from "../../shared/types";
 
+
 function mapStateToProps({ config, namespace, repos }: IStoreState) {
-  let repoNamespace = config.namespace;
+  const repoNamespace = namespace.current;
   let displayReposPerNamespaceMsg = false;
-  if (config.featureFlags.reposPerNamespace) {
-    repoNamespace = namespace.current;
-    if (repoNamespace !== definedNamespaces.all) {
-      displayReposPerNamespaceMsg = true;
-    }
+  if (repoNamespace !== definedNamespaces.all) {
+    displayReposPerNamespaceMsg = true;
   }
   return {
     errors: repos.errors,

--- a/dashboard/src/containers/RoutesContainer/Routes.test.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.test.tsx
@@ -3,10 +3,10 @@ import { createMemoryHistory } from "history";
 import * as React from "react";
 import { StaticRouter } from "react-router";
 import { Redirect, RouteComponentProps } from "react-router-dom";
-
 import NotFound from "../../components/NotFound";
 import RepoListContainer from "../../containers/RepoListContainer";
 import Routes from "./Routes";
+
 
 const emptyRouteComponentProps: RouteComponentProps<{}> = {
   history: createMemoryHistory(),
@@ -67,37 +67,14 @@ it("should render a redirect to the login page (when not authenticated)", () => 
 describe("Routes depending on feature flags", () => {
   const namespace = "default";
   const perNamespacePath = "/config/ns/:namespace/repos";
-  const nonNamespacedPath = "/config/repos";
 
-  it("should use a non-namespaced route for app repos without feature flag", () => {
+  it("uses a namespaced route for app repos", () => {
     const wrapper = shallow(
       <StaticRouter location="/config/repos" context={{}}>
         <Routes
           {...emptyRouteComponentProps}
           namespace={namespace}
           authenticated={true}
-          featureFlags={{ reposPerNamespace: false, operators: false }}
-        />
-      </StaticRouter>,
-    )
-      .dive()
-      .dive()
-      .dive();
-
-    const component = wrapper.find({ component: RepoListContainer });
-
-    expect(component.length).toBe(1);
-    expect(component.props().path).toEqual(nonNamespacedPath);
-  });
-
-  it("should use a namespaced route for app repos when feature flag set", () => {
-    const wrapper = shallow(
-      <StaticRouter location="/config/repos" context={{}}>
-        <Routes
-          {...emptyRouteComponentProps}
-          namespace={namespace}
-          authenticated={true}
-          featureFlags={{ reposPerNamespace: true, operators: false }}
         />
       </StaticRouter>,
     )

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -62,8 +62,6 @@ class Routes extends React.Component<IRoutesProps> {
     featureFlags: { operators: false },
   };
   public render() {
-    // The path used for AppRepository list depends on a feature flag.
-    // TODO(mnelson, #1256) Remove when feature becomes default.
     const reposPath = "/config/ns/:namespace/repos";
     if (this.props.featureFlags.operators) {
       // Add routes related to operators

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Redirect, Route, RouteComponentProps, RouteProps, Switch } from "react-router";
-
 import NotFound from "../../components/NotFound";
 import AppListContainer from "../../containers/AppListContainer";
 import AppNewContainer from "../../containers/AppNewContainer";
@@ -22,6 +21,7 @@ import ServiceClassListContainer from "../../containers/ServiceClassListContaine
 import ServiceClassViewContainer from "../../containers/ServiceClassViewContainer";
 import ServiceInstanceListContainer from "../../containers/ServiceInstanceListContainer";
 import ServiceInstanceViewContainer from "../../containers/ServiceInstanceViewContainer";
+
 
 type IRouteComponentPropsAndRouteProps = RouteProps & RouteComponentProps<any>;
 
@@ -53,21 +53,18 @@ interface IRoutesProps extends IRouteComponentPropsAndRouteProps {
   namespace: string;
   authenticated: boolean;
   featureFlags: {
-    reposPerNamespace: boolean;
     operators: boolean;
   };
 }
 
 class Routes extends React.Component<IRoutesProps> {
   public static defaultProps = {
-    featureFlags: { reposPerNamespace: false, operators: false },
+    featureFlags: { operators: false },
   };
   public render() {
     // The path used for AppRepository list depends on a feature flag.
     // TODO(mnelson, #1256) Remove when feature becomes default.
-    const reposPath = this.props.featureFlags.reposPerNamespace
-      ? "/config/ns/:namespace/repos"
-      : "/config/repos";
+    const reposPath = "/config/ns/:namespace/repos";
     if (this.props.featureFlags.operators) {
       // Add routes related to operators
       Object.assign(privateRoutes, {

--- a/dashboard/src/reducers/config.ts
+++ b/dashboard/src/reducers/config.ts
@@ -1,8 +1,8 @@
 import { getType } from "typesafe-actions";
-
 import actions from "../actions";
 import { ConfigAction } from "../actions/config";
 import { IConfig } from "../shared/Config";
+
 
 export interface IConfigState extends IConfig {
   loaded: boolean;
@@ -15,7 +15,7 @@ const initialState: IConfigState = {
   authProxyEnabled: false,
   oauthLoginURI: "",
   oauthLogoutURI: "",
-  featureFlags: { reposPerNamespace: true, operators: true },
+  featureFlags: { operators: true },
 };
 
 const configReducer = (state: IConfigState = initialState, action: ConfigAction): IConfigState => {

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -171,7 +171,7 @@ describe("Auth", () => {
         oauthLogoutURI,
         namespace: "ns",
         appVersion: "2",
-        featureFlags: { reposPerNamespace: false, operators: false },
+        featureFlags: { operators: false },
       });
 
       expect(mockedAssign).toBeCalledWith(oauthLogoutURI);
@@ -185,7 +185,7 @@ describe("Auth", () => {
         oauthLogoutURI: "",
         namespace: "ns",
         appVersion: "2",
-        featureFlags: { reposPerNamespace: false, operators: false },
+        featureFlags: { operators: false },
       });
 
       expect(mockedAssign).toBeCalledWith("/oauth2/sign_out");

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -9,7 +9,6 @@ export interface IConfig {
   oauthLogoutURI: string;
   error?: Error;
   featureFlags: {
-    reposPerNamespace: boolean;
     operators: boolean;
   };
 }


### PR DESCRIPTION
### Description of the change
Removes the reposPerNamespace feature flag.

### Benefits
Removes related redundant code now that we've released the feature.

### Additional information
Leaves the flag available for the apprepository controller binary though
it does nothing (and can be removed later when people have upgraded).
