### PR TITLE
Fix non-namespaced calls during release upgrade.

### DIFF
--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -104,6 +104,7 @@ export function getApp(
 }
 
 function getAppUpdateInfo(
+  namespace: string,
   releaseName: string,
   chartName: string,
   currentVersion: string,
@@ -111,9 +112,6 @@ function getAppUpdateInfo(
 ): ThunkAction<Promise<void>, IStoreState, null, AppsAction> {
   return async (dispatch, getState) => {
     dispatch(requestAppUpdateInfo());
-    const {
-      config: { namespace },
-    } = getState();
     try {
       const chartsInfo = await Chart.listWithFilters(
         namespace,
@@ -175,6 +173,7 @@ export function getAppWithUpdateInfo(
       ) {
         dispatch(
           getAppUpdateInfo(
+            namespace,
             app.name,
             app.chart.metadata.name,
             app.chart.metadata.version,
@@ -228,14 +227,15 @@ export function fetchApps(
 }
 
 export function fetchAppsWithUpdateInfo(
-  ns?: string,
+  namespace: string,
   all: boolean = false,
 ): ThunkAction<Promise<void>, IStoreState, null, AppsAction> {
   return async dispatch => {
-    const apps = await dispatch(fetchApps(ns, all));
+    const apps = await dispatch(fetchApps(namespace, all));
     apps.forEach(app =>
       dispatch(
         getAppUpdateInfo(
+          namespace,
           app.releaseName,
           app.chartMetadata.name,
           app.chartMetadata.version,

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -657,9 +657,9 @@ describe("checkChart", () => {
       },
     ];
 
-    await store.dispatch(repoActions.checkChart(kubeappsNamespace, "my-repo", "my-chart"));
+    await store.dispatch(repoActions.checkChart("other-namespace", "my-repo", "my-chart"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(Chart.fetchChartVersions).toBeCalledWith("kubeapps-namespace", "my-repo/my-chart");
+    expect(Chart.fetchChartVersions).toBeCalledWith("other-namespace", "my-repo/my-chart");
   });
 
   it("dispatches requestRepo and errorChart if error fetching", async () => {
@@ -677,9 +677,9 @@ describe("checkChart", () => {
       },
     ];
 
-    await store.dispatch(repoActions.checkChart(kubeappsNamespace, "my-repo", "my-chart"));
+    await store.dispatch(repoActions.checkChart("other-namespace", "my-repo", "my-chart"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(Chart.fetchChartVersions).toBeCalledWith("kubeapps-namespace", "my-repo/my-chart");
+    expect(Chart.fetchChartVersions).toBeCalledWith("other-namespace", "my-repo/my-chart");
   });
 });
 

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -324,13 +324,10 @@ export function checkChart(
   chartName: string,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> {
   return async (dispatch, getState) => {
-    const {
-      config: { namespace },
-    } = getState();
     dispatch(requestRepo());
-    const appRepository = await AppRepository.get(repo, namespace);
+    const appRepository = await AppRepository.get(repo, repoNamespace);
     try {
-      await Chart.fetchChartVersions(namespace, `${repo}/${chartName}`);
+      await Chart.fetchChartVersions(repoNamespace, `${repo}/${chartName}`);
       dispatch(receiveRepo(appRepository));
       return true;
     } catch (e) {

--- a/script/cluster-kind.mk
+++ b/script/cluster-kind.mk
@@ -41,5 +41,6 @@ delete-cluster-kind:
 	kind delete cluster --name ${ADDITIONAL_CLUSTER_NAME} || true
 	rm ${CLUSTER_CONFIG}
 	rm ${ADDITIONAL_CLUSTER_CONFIG} || true
+	rm devel/dex.*
 
 .PHONY: additional-cluster-kind cluster-kind cluster-kind-delete


### PR DESCRIPTION
As per #1815, the call used to getAppUpdateInfo was still using the
kubeapps namespace. Similarly, although the checkChart function was
passed the repo namespace, it was not used.

Fixes #1815.

I'll follow-up with the CI change.