### PR TITLE
Fix flaky chart tests

### DIFF
--- a/chart/kubeapps/templates/tests/test-assetsvc.yaml
+++ b/chart/kubeapps/templates/tests/test-assetsvc.yaml
@@ -14,7 +14,17 @@ spec:
         - name: ASSETSVC_PORT
           value: "{{ .Values.assetsvc.service.port }}"
       command:
-        - sh
+        - bash
         - -c
-        - curl -o /tmp/output $ASSETSVC_HOST:$ASSETSVC_PORT/v1/ns/{{ .Release.Namespace }}/charts && cat /tmp/output && cat /tmp/output | grep wordpress
+        - |
+            n=0
+            until [ "$n" -ge 5 ]; do
+              if curl -o /tmp/output $ASSETSVC_HOST:$ASSETSVC_PORT/v1/ns/{{ .Release.Namespace }}/charts && cat /tmp/output && cat /tmp/output | grep wordpress; then
+                break
+              fi
+              sleep 10
+            done
+            if [ "$n" -eq 5 ]; then
+              exit 1
+            fi
   restartPolicy: Never

--- a/chart/kubeapps/templates/tests/test-assetsvc.yaml
+++ b/chart/kubeapps/templates/tests/test-assetsvc.yaml
@@ -16,6 +16,8 @@ spec:
       command:
         - bash
         - -c
+        # We are requesting the "wordpress" chart to the chartsvc to check that everything works as expected
+        # Also, we retry several times in case the repository is being populated at the time of executing this test
         - |
             n=0
             until [ "$n" -ge 5 ]; do
@@ -23,6 +25,7 @@ spec:
                 break
               fi
               sleep 10
+              ((n+=1))
             done
             if [ "$n" -eq 5 ]; then
               exit 1

--- a/integration/use-cases/default-deployment.js
+++ b/integration/use-cases/default-deployment.js
@@ -2,14 +2,14 @@ test("Deploys an application with the values by default", async () => {
   await page.goto(getUrl("/#/login"));
 
   await expect(page).toFillForm("form", {
-    token: process.env.ADMIN_TOKEN
+    token: process.env.ADMIN_TOKEN,
   });
 
   await expect(page).toClick("button", { text: "Login" });
 
   await expect(page).toClick("a", { text: "Catalog" });
 
-  await expect(page).toClick("a", { text: "aerospike", timeout: 60000 });
+  await expect(page).toClick("a", { text: "apache", timeout: 60000 });
 
   await expect(page).toClick("button", { text: "Deploy" });
 

--- a/integration/use-cases/missing-permissions.js
+++ b/integration/use-cases/missing-permissions.js
@@ -2,14 +2,14 @@ test("Fails to deploy an application due to missing permissions", async () => {
   await page.goto(getUrl("/#/login"));
 
   await expect(page).toFillForm("form", {
-    token: process.env.VIEW_TOKEN
+    token: process.env.VIEW_TOKEN,
   });
 
   await expect(page).toClick("button", { text: "Login" });
 
   await expect(page).toClick("a", { text: "Catalog" });
 
-  await expect(page).toClick("a", { text: "aerospike", timeout: 60000 });
+  await expect(page).toClick("a", { text: "apache", timeout: 60000 });
 
   await expect(page).toClick("button", { text: "Deploy" });
 

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -288,8 +288,12 @@ else
 fi
 
 # Wait for Kubeapps Jobs
-k8s_wait_for_job_completed kubeapps apprepositories.kubeapps.com/repo-name=stable
-info "Job apprepositories.kubeapps.com/repo-name=stable ready"
+# Clean up existing jobs
+kubectl delete jobs -n kubeapps --all
+# Trigger update of the bitnami repository
+kubectl patch apprepositories.kubeapps.com -n kubeapps bitnami -p='[{"op": "replace", "path": "/spec/resyncRequests", "value":1}]' --type=json
+k8s_wait_for_job_completed kubeapps apprepositories.kubeapps.com/repo-name=bitnami
+info "Job apprepositories.kubeapps.com/repo-name=bitnami ready"
 
 info "All deployments ready. PODs:"
 kubectl get pods -n kubeapps -o wide


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

After adding the `upgrade` test, the scenario in which that test is run (helm3+pg) fails many times. After a bit of investigation I noticed that since we are running the install plus the upgrade in a short time, the `upgrade` hook may finish after the repos are populated. This causes that the catalog doesn't include the chart required for the tests.

This PR, adds:
 - A retry for the assetsvc test so if the populate job are still running, we retry a few times.
 - Use `bitnami` charts rather than `stable` (which is being deprecated).
 - Ensure that the sync job is run and finishes after the upgrade.

