### PR TITLE
Update url.app.apps.{get|upgrade} with required cluster arg.

### DIFF
--- a/chart/kubeapps/requirements.lock
+++ b/chart/kubeapps/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 7.11.1
+  version: 7.14.8
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 8.9.1
-digest: sha256:bec1eb6964d077d775be68be65a04a46a7244d426091b6179acf2df9076a76f2
-generated: "2020-04-22T10:21:48.840081009Z"
+  version: 8.10.11
+digest: sha256:ab1c99273fd342dce2879dece3c38eb0d525a1df870758e873ca293cdd857a25
+generated: "2020-07-01T14:11:29.916518817+10:00"

--- a/chart/kubeapps/requirements.yaml
+++ b/chart/kubeapps/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: mongodb
-    version: "> 7.10.2"
+    version: "~ 7.14.2"
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
   - name: postgresql

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -129,6 +129,7 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
   public appListItems() {
     const {
       apps: { listOverview },
+      cluster,
       customResources,
     } = this.props;
     const filteredReleases = this.filteredReleases(listOverview || [], this.state.filter);
@@ -148,7 +149,7 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
       <div>
         <CardGrid>
           {filteredReleases.map(r => {
-            return <AppListItem key={r.releaseName} app={r} />;
+            return <AppListItem key={r.releaseName} app={r} cluster={cluster} />;
           })}
           {filteredCRs.map(r => {
             const csv = this.props.csvs.find(c =>

--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -1,26 +1,26 @@
 import { shallow } from "enzyme";
 import * as React from "react";
 import { Link } from "react-router-dom";
-import { IAppOverview } from "../../shared/types";
 import * as url from "../../shared/url";
 import InfoCard from "../InfoCard";
-import AppListItem from "./AppListItem";
+import AppListItem, { IAppListItemProps } from "./AppListItem";
+
+const defaultProps = {
+  app: {
+    namespace: "default",
+    releaseName: "foo",
+    status: "DEPLOYED",
+    version: "1.0.0",
+    chart: "myapp",
+    chartMetadata: {
+      appVersion: "1.0.0",
+    },
+  },
+  cluster: "default",
+} as IAppListItemProps;
 
 it("renders an app item", () => {
-  const wrapper = shallow(
-    <AppListItem
-      app={
-        {
-          namespace: "default",
-          releaseName: "foo",
-          status: "DEPLOYED",
-          version: "1.0.0",
-          chart: "myapp",
-        } as IAppOverview
-      }
-      cluster={"default"}
-    />,
-  );
+  const wrapper = shallow(<AppListItem {...defaultProps} />);
   const card = wrapper.find(InfoCard).shallow();
   expect(
     card
@@ -41,80 +41,65 @@ it("renders an app item", () => {
 });
 
 it("should set a banner if there are chart updates available", () => {
-  const wrapper = shallow(
-    <AppListItem
-      app={
-        {
-          namespace: "default",
-          releaseName: "foo",
-          status: "DEPLOYED",
-          version: "1.0.0",
-          chart: "myapp",
-          chartMetadata: {
-            appVersion: "1.1.0",
-          },
-          updateInfo: {
-            upToDate: false,
-            chartLatestVersion: "1.1.0",
-            appLatestVersion: "1.1.0",
-            repository: { name: "", url: "" },
-          },
-        } as IAppOverview
-      }
-    />,
-  );
+  const props = {
+    ...defaultProps,
+    app: {
+      ...defaultProps.app,
+      chartMetadata: {
+        appVersion: "1.1.0",
+      },
+      updateInfo: {
+        upToDate: false,
+        chartLatestVersion: "1.1.0",
+        appLatestVersion: "1.1.0",
+        repository: { name: "", url: "" },
+      },
+    },
+  } as IAppListItemProps;
+  const wrapper = shallow(<AppListItem {...props} />);
   const card = wrapper.find(InfoCard);
   expect(card.prop("banner")).toBe("Update available");
 });
 
 it("should set a banner if there are app updates available", () => {
-  const wrapper = shallow(
-    <AppListItem
-      app={
-        {
-          namespace: "default",
-          releaseName: "foo",
-          status: "DEPLOYED",
-          version: "1.0.0",
-          chart: "myapp",
-          chartMetadata: {
-            appVersion: "1.0.0",
-          },
-          updateInfo: {
-            upToDate: false,
-            chartLatestVersion: "1.1.0",
-            appLatestVersion: "1.1.0",
-            repository: { name: "", url: "" },
-          },
-        } as IAppOverview
-      }
-    />,
-  );
+  const props = {
+    ...defaultProps,
+    app: {
+      ...defaultProps.app,
+      chartMetadata: {
+        appVersion: "1.0.0",
+      },
+      updateInfo: {
+        upToDate: false,
+        chartLatestVersion: "1.0.0",
+        appLatestVersion: "1.1.0",
+        repository: { name: "", url: "" },
+      },
+    },
+  } as IAppListItemProps;
+  const wrapper = shallow(<AppListItem {...props} />);
   const card = wrapper.find(InfoCard);
   expect(card.prop("banner")).toBe("Update available");
 });
 
 it("should not set a banner if there are errors in the update info", () => {
-  const wrapper = shallow(
-    <AppListItem
-      app={
-        {
-          namespace: "default",
-          releaseName: "foo",
-          status: "DEPLOYED",
-          version: "1.0.0",
-          chart: "myapp",
-          updateInfo: {
-            error: new Error("Boom!"),
-            upToDate: false,
-            chartLatestVersion: "",
-            appLatestVersion: "",
-            repository: { name: "", url: "" },
-          },
-        } as IAppOverview
-      }
-    />,
-  );
+  const props = {
+    ...defaultProps,
+    app: {
+      ...defaultProps.app,
+      chartMetadata: {
+        appVersion: "1.0.0",
+      },
+      updateInfo: {
+        upToDate: false,
+        error: new Error("Boom!"),
+        chartLatestVersion: "1.0.0",
+        appLatestVersion: "1.1.0",
+        repository: { name: "", url: "" },
+      },
+    },
+  } as IAppListItemProps;
+  const wrapper = shallow(<AppListItem {...props} />);
   const card = wrapper.find(InfoCard);
   expect(card.prop("banner")).toBe(undefined);
 });

--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -18,6 +18,7 @@ it("renders an app item", () => {
           chart: "myapp",
         } as IAppOverview
       }
+      cluster={"default"}
     />,
   );
   const card = wrapper.find(InfoCard).shallow();
@@ -32,7 +33,7 @@ it("renders an app item", () => {
       .find(Link)
       .at(0)
       .props().to,
-  ).toBe(url.app.apps.get("foo", "default"));
+  ).toBe(url.app.apps.get("default", "default", "foo"));
   expect(card.find(".type-color-light-blue").text()).toBe("myapp v1.0.0");
   expect(card.find(".deployed").exists()).toBe(true);
   expect(card.find(".ListItem__content__info_tag-1").text()).toBe("default");

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -8,11 +8,12 @@ import "./AppListItem.css";
 
 interface IAppListItemProps {
   app: IAppOverview;
+  cluster: string;
 }
 
 class AppListItem extends React.Component<IAppListItemProps> {
   public render() {
-    const { app } = this.props;
+    const { app, cluster } = this.props;
     const icon = app.icon ? app.icon : placeholder;
     const banner =
       app.updateInfo && !app.updateInfo.error && !app.updateInfo.upToDate
@@ -21,7 +22,7 @@ class AppListItem extends React.Component<IAppListItemProps> {
     return (
       <InfoCard
         key={app.releaseName}
-        link={url.app.apps.get(app.releaseName, app.namespace)}
+        link={url.app.apps.get(cluster, app.namespace, app.releaseName)}
         title={app.releaseName}
         icon={icon}
         info={`${app.chart} v${app.version || "-"}`}

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -6,7 +6,7 @@ import * as url from "../../shared/url";
 import InfoCard from "../InfoCard";
 import "./AppListItem.css";
 
-interface IAppListItemProps {
+export interface IAppListItemProps {
   app: IAppOverview;
   cluster: string;
 }

--- a/dashboard/src/components/AppView/AppControls/AppControls.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/AppControls.test.tsx
@@ -60,7 +60,7 @@ it("calls delete function without purge when clicking the button", done => {
     push,
   };
   const wrapper = getWrapper(store, props);
-  const appControls = wrapper.find(".AppControls");
+  const appControls = wrapper.find(AppControls);
   const button = appControls.children().find(".button-danger");
   expect(button.exists()).toBe(true);
   expect(button.text()).toBe("Delete");
@@ -69,6 +69,8 @@ it("calls delete function without purge when clicking the button", done => {
   const confirm = appControls.children().find(ConfirmDialog);
   expect(confirm.exists()).toBe(true);
   confirm.props().onConfirm(); // Simulate confirmation
+
+  expect(appControls.state("deleting")).toBe(true);
 
   // Wait for the async action to finish
   setTimeout(() => {
@@ -87,7 +89,7 @@ it("calls delete function with additional purge", () => {
   const store = mockStore(initialState);
   const wrapper = getWrapper(store, props);
   Modal.setAppElement(document.createElement("div"));
-  const appControls = wrapper.find(".AppControls");
+  const appControls = wrapper.find(AppControls);
   const button = appControls.children().find(".button-danger");
   expect(button.exists()).toBe(true);
   expect(button.text()).toBe("Delete");
@@ -98,7 +100,9 @@ it("calls delete function with additional purge", () => {
   expect(confirm.exists()).toBe(true);
   const checkbox = wrapper.find('input[type="checkbox"]');
   expect(checkbox.exists()).toBe(true);
+  expect(appControls.state("purge")).toBe(false);
   checkbox.simulate("change");
+  expect(appControls.state("purge")).toBe(true);
 
   // Check that the "purge" state is forwarded to deleteApp
   confirm.props().onConfirm(); // Simulate confirmation

--- a/dashboard/src/components/AppView/AppControls/AppControls.tsx
+++ b/dashboard/src/components/AppView/AppControls/AppControls.tsx
@@ -1,6 +1,5 @@
 import { RouterAction } from "connected-react-router";
 import * as React from "react";
-import { Redirect } from "react-router";
 
 import { IRelease } from "shared/types";
 import RollbackButtonContainer from "../../../containers/RollbackButtonContainer";
@@ -85,7 +84,7 @@ class AppControls extends React.Component<IAppControlsProps, IAppControlsState> 
             )
           }
         />
-        {this.state.redirectToAppList && <Redirect to={url.app.apps.list(cluster, namespace)} />}
+        {this.state.redirectToAppList && push(url.app.apps.list(cluster, namespace))}
       </div>
     );
   }

--- a/dashboard/src/components/AppView/AppControls/UpgradeButton.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/UpgradeButton.test.tsx
@@ -1,30 +1,64 @@
-import { mount, shallow } from "enzyme";
+import { mount } from "enzyme";
 import context from "jest-plugin-context";
 import * as React from "react";
 import { ArrowUpCircle } from "react-feather";
+import { Provider } from "react-redux";
 import { Redirect } from "react-router";
-import * as url from "../../../shared/url";
-import UpgradeButton from "./UpgradeButton";
+import configureMockStore, { MockStore } from "redux-mock-store";
+import thunk from "redux-thunk";
+import { IStoreState } from "shared/types";
+import * as url from "shared/url";
+import UpgradeButton, { IUpgradeButtonProps } from "./UpgradeButton";
+
+const mockStore = configureMockStore([thunk]);
+
+// TODO(absoludity): As we move to function components with (redux) hooks we'll need to
+// be including state in tests, so we may want to put things like initialState
+// and a generalized getWrapper in a test helpers or similar package?
+const initialState = {
+  apps: {},
+  auth: {},
+  catalog: {},
+  charts: {},
+  config: {},
+  kube: {},
+  clusters: {
+    currentCluster: "default-cluster",
+  },
+  repos: {},
+  operators: {},
+} as IStoreState;
+
+const getWrapper = (store: MockStore, props: IUpgradeButtonProps) =>
+  mount(
+    <Provider store={store}>
+      <UpgradeButton {...props} />
+    </Provider>,
+  );
+
+const defaultProps = {
+  releaseName: "foo",
+  releaseNamespace: "default",
+  push: jest.fn(),
+} as IUpgradeButtonProps;
 
 it("renders a redirect when clicking upgrade", () => {
   const push = jest.fn();
-  const wrapper = shallow(
-    <UpgradeButton releaseName="foo" releaseNamespace="default" push={push} />,
-  );
+  const store = mockStore(initialState);
+  const wrapper = getWrapper(store, { ...defaultProps, push });
   const button = wrapper.find(".button").filterWhere(i => i.text() === "Upgrade");
   expect(button.exists()).toBe(true);
   expect(wrapper.find(Redirect).exists()).toBe(false);
 
   button.simulate("click");
   expect(push.mock.calls.length).toBe(1);
-  expect(push.mock.calls[0]).toEqual([url.app.apps.upgrade("foo", "default")]);
+  expect(push.mock.calls[0]).toEqual([url.app.apps.upgrade("default-cluster", "default", "foo")]);
 });
 
 context("when a new version is available", () => {
   it("should show a modify the style", () => {
-    const wrapper = mount(
-      <UpgradeButton newVersion={true} releaseName="" releaseNamespace="" push={jest.fn()} />,
-    );
+    const store = mockStore(initialState);
+    const wrapper = getWrapper(store, { ...defaultProps, newVersion: true });
     const icon = wrapper.find(ArrowUpCircle);
     expect(icon).toExist();
   });

--- a/dashboard/src/components/AppView/AppControls/UpgradeButton.tsx
+++ b/dashboard/src/components/AppView/AppControls/UpgradeButton.tsx
@@ -1,9 +1,11 @@
 import { RouterAction } from "connected-react-router";
 import * as React from "react";
 import { ArrowUpCircle } from "react-feather";
+import { useSelector } from "react-redux";
+import { IStoreState } from "shared/types";
 import * as url from "../../../shared/url";
 
-interface IUpgradeButtonProps {
+export interface IUpgradeButtonProps {
   newVersion?: boolean;
   releaseName: string;
   releaseNamespace: string;
@@ -12,7 +14,8 @@ interface IUpgradeButtonProps {
 
 const UpgradeButton: React.SFC<IUpgradeButtonProps> = props => {
   const { newVersion, push, releaseName, releaseNamespace } = props;
-  const onClick = () => push(url.app.apps.upgrade(releaseName, releaseNamespace));
+  const cluster = useSelector((state: IStoreState) => state.clusters.currentCluster);
+  const onClick = () => push(url.app.apps.upgrade(cluster, releaseNamespace, releaseName));
   let upgradeButton = (
     <button className="button" onClick={onClick}>
       Upgrade

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -155,7 +155,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
             )}
             <div className="row collapse-b-tablet">
               <div className="col-3">
-                <ChartInfo app={app} />
+                <ChartInfo app={app} cluster={cluster} />
               </div>
               <div className="col-9">
                 <div className="row padding-t-bigger">

--- a/dashboard/src/components/AppView/ChartInfo.test.tsx
+++ b/dashboard/src/components/AppView/ChartInfo.test.tsx
@@ -20,6 +20,7 @@ const defaultProps = {
     },
     name: "foo",
   } as hapi.release.Release,
+  cluster: "default",
 };
 
 it("renders a app item", () => {

--- a/dashboard/src/components/AppView/ChartInfo.tsx
+++ b/dashboard/src/components/AppView/ChartInfo.tsx
@@ -9,6 +9,7 @@ import "./ChartInfo.css";
 
 interface IChartInfoProps {
   app: IRelease;
+  cluster: string;
 }
 
 class ChartInfo extends React.Component<IChartInfoProps> {
@@ -47,7 +48,7 @@ class ChartInfo extends React.Component<IChartInfoProps> {
   }
 
   private updateStatusInfo() {
-    const { app } = this.props;
+    const { app, cluster } = this.props;
     // If update is not set yet we cannot know if there is
     // an update available or not
     if (app.updateInfo) {
@@ -98,8 +99,8 @@ class ChartInfo extends React.Component<IChartInfoProps> {
               {update}
               <br />
               <span>
-                Click <Link to={url.app.apps.upgrade(app.name, app.namespace)}>here</Link> to
-                upgrade.
+                Click <Link to={url.app.apps.upgrade(cluster, app.namespace, app.name)}>here</Link>{" "}
+                to upgrade.
               </span>
             </React.Fragment>
           );

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -194,7 +194,7 @@ it("triggers a deployment when submitting the form", done => {
     schema,
   );
   setTimeout(() => {
-    expect(push).toHaveBeenCalledWith(url.app.apps.get("my-release", "default"));
+    expect(push).toHaveBeenCalledWith(url.app.apps.get("default", "default", "my-release"));
     done();
   }, 1);
 });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -165,7 +165,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
 
   public handleDeploy = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const { chartNamespace, selected, deployChart, push, namespace } = this.props;
+    const { chartNamespace, cluster, selected, deployChart, push, namespace } = this.props;
     const { releaseName, appValues } = this.state;
 
     this.setState({ isDeploying: true, latestSubmittedReleaseName: releaseName });
@@ -180,7 +180,7 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
       );
       this.setState({ isDeploying: false });
       if (deployed) {
-        push(url.app.apps.get(releaseName, namespace));
+        push(url.app.apps.get(cluster, namespace, releaseName));
       }
     }
   };

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -122,7 +122,9 @@ it("triggers an upgrade when submitting the form", done => {
     schema,
   );
   setTimeout(() => {
-    expect(push).toHaveBeenCalledWith(url.app.apps.get(defaultProps.cluster, namespace, releaseName));
+    expect(push).toHaveBeenCalledWith(
+      url.app.apps.get(defaultProps.cluster, namespace, releaseName),
+    );
     done();
   }, 1);
 });

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -97,8 +97,7 @@ it("forwards the appValues when modified", () => {
 });
 
 it("triggers an upgrade when submitting the form", done => {
-  const releaseName = "my-release";
-  const namespace = "default";
+  const { namespace, releaseName } = defaultProps;
   const appValues = "foo: bar";
   const schema = { properties: { foo: { type: "string" } } };
   const upgradeApp = jest.fn().mockReturnValue(true);
@@ -123,7 +122,7 @@ it("triggers an upgrade when submitting the form", done => {
     schema,
   );
   setTimeout(() => {
-    expect(push).toHaveBeenCalledWith(url.app.apps.get(releaseName, namespace));
+    expect(push).toHaveBeenCalledWith(url.app.apps.get(defaultProps.cluster, namespace, releaseName));
     done();
   }, 1);
 });

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -149,7 +149,7 @@ class UpgradeForm extends React.Component<IUpgradeFormProps, IUpgradeFormState> 
 
   public handleDeploy = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const { selected, push, upgradeApp, releaseName, namespace, repoNamespace } = this.props;
+    const { selected, push, upgradeApp, releaseName, cluster, namespace, repoNamespace } = this.props;
     const { appValues } = this.state;
 
     this.setState({ isDeploying: true });
@@ -164,7 +164,7 @@ class UpgradeForm extends React.Component<IUpgradeFormProps, IUpgradeFormState> 
       );
       this.setState({ isDeploying: false });
       if (deployed) {
-        push(url.app.apps.get(releaseName, namespace));
+        push(url.app.apps.get(cluster, namespace, releaseName));
       }
     }
   };

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -149,7 +149,15 @@ class UpgradeForm extends React.Component<IUpgradeFormProps, IUpgradeFormState> 
 
   public handleDeploy = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const { selected, push, upgradeApp, releaseName, cluster, namespace, repoNamespace } = this.props;
+    const {
+      selected,
+      push,
+      upgradeApp,
+      releaseName,
+      cluster,
+      namespace,
+      repoNamespace,
+    } = this.props;
     const { appValues } = this.state;
 
     this.setState({ isDeploying: true });

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -10,10 +10,10 @@ export const app = {
       return `/c/${cluster}/ns/${namespace}/apps/${newSegment}/${cv.relationships.chart.data.repo.name}/${cv.relationships.chart.data.name}/versions/${version}`;
     },
     list: (cluster: string, namespace: string) => `/c/${cluster}/ns/${namespace}/apps`,
-    get: (releaseName: string, namespace: string, cluster: string = "default") =>
+    get: (cluster: string, namespace: string, releaseName: string) =>
       `${app.apps.list(cluster, namespace)}/${releaseName}`,
     upgrade: (releaseName: string, namespace: string, cluster: string = "default") =>
-      `${app.apps.get(releaseName, namespace, cluster)}/upgrade`,
+      `${app.apps.get(cluster, namespace, releaseName)}/upgrade`,
   },
   catalog: (namespace: string, cluster: string = "default") =>
     `/c/${cluster}/ns/${namespace}/catalog`,

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -12,7 +12,7 @@ export const app = {
     list: (cluster: string, namespace: string) => `/c/${cluster}/ns/${namespace}/apps`,
     get: (cluster: string, namespace: string, releaseName: string) =>
       `${app.apps.list(cluster, namespace)}/${releaseName}`,
-    upgrade: (releaseName: string, namespace: string, cluster: string = "default") =>
+    upgrade: (cluster: string, namespace: string, releaseName: string) =>
       `${app.apps.get(cluster, namespace, releaseName)}/upgrade`,
   },
   catalog: (namespace: string, cluster: string = "default") =>

--- a/script/libtest.sh
+++ b/script/libtest.sh
@@ -43,6 +43,11 @@ k8s_wait_for_deployment() {
     # Avoid to exit the function if the rollout fails
     silence kubectl rollout status --namespace "$namespace" deployment "$deployment" || exit_code=$?
     debug "Rollout exit code: '${exit_code}'"
+    if [ ${exit_code} -ne 0 ]
+    then
+      info "Rollout exit code: '${exit_code}'"
+      kubectl get pods --namespace "$namespace"
+    fi
     return $exit_code
 }
 


### PR DESCRIPTION
Continues url updates for cluster requirement. Ref #1762 .

Starting to get some duplication of test setup, as the function components which use state need providers etc. I looked at options for creating the shared code, but `react-scripts` doesn't support the jest `setupFiles` option, so it might just be a separate `src/helpers.test.tsx` exporting some functions like `getWrapper(state, component, props)`? What do you think? (not for this PR, but I will cleanup the dups once decided).

The other thing that I had to wrangle here is that once wrapped in a provider, it seems that even our class-based components are no longer classes after wrapping - at least, I had to remove calls to `wrapper.state()` (also tried `wrapper.find(ComponentName).state()`) as jest kept failing saying that `state()` is only available on class-based components.