### PR TITLE
Updates url.app.{catalog|repo} to require the cluster arg.

### DIFF
--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -205,6 +205,11 @@ it("filters apps", () => {
 });
 
 it("clicking 'List All' checkbox should trigger toggleListAll", () => {
+  const mockFetchAppsWithUpdateInfo = jest.fn();
+  const updatedProps: IAppListProps = {
+    ...defaultProps,
+    fetchAppsWithUpdateInfo: mockFetchAppsWithUpdateInfo,
+  };
   const apps = {
     isFetching: false,
     items: [],
@@ -220,12 +225,12 @@ it("clicking 'List All' checkbox should trigger toggleListAll", () => {
     ],
     listingAll: false,
   } as IAppState;
-  const wrapper = shallow(<AppList {...defaultProps} apps={apps} />);
+  const wrapper = shallow(<AppList {...updatedProps} apps={apps} />);
   const checkbox = wrapper.find('input[type="checkbox"]');
   expect(apps.listingAll).toBe(false);
   checkbox.simulate("change");
   // The last call to fetchApps should list all the apps
-  const fetchCalls = (defaultProps.fetchAppsWithUpdateInfo as jest.Mock).mock.calls;
+  const fetchCalls = mockFetchAppsWithUpdateInfo.mock.calls;
   expect(fetchCalls[fetchCalls.length - 1]).toEqual(["default", true]);
 });
 

--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -21,6 +21,7 @@ const defaultProps: IAppListProps = {
   pushSearchFilter: jest.fn(),
   fetchAppsWithUpdateInfo: jest.fn(),
   getCustomResources: jest.fn(),
+  isFetchingResources: false,
   customResources: [],
   csvs: [],
   featureFlags: { operators: true, additionalClusters: [], ui: "hex" },
@@ -219,20 +220,12 @@ it("clicking 'List All' checkbox should trigger toggleListAll", () => {
     ],
     listingAll: false,
   } as IAppState;
-  const wrapper = shallow(
-    <AppList
-      {...defaultProps}
-      apps={apps}
-      toggleListAll={jest.fn((toggle: boolean) => {
-        apps.listingAll = toggle;
-      })}
-    />,
-  );
+  const wrapper = shallow(<AppList {...defaultProps} apps={apps} />);
   const checkbox = wrapper.find('input[type="checkbox"]');
   expect(apps.listingAll).toBe(false);
   checkbox.simulate("change");
   // The last call to fetchApps should list all the apps
-  const fetchCalls = defaultProps.fetchAppsWithUpdateInfo.mock.calls;
+  const fetchCalls = (defaultProps.fetchAppsWithUpdateInfo as jest.Mock).mock.calls;
   expect(fetchCalls[fetchCalls.length - 1]).toEqual(["default", true]);
 });
 

--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -7,17 +7,17 @@ import { IAppOverview, IAppState } from "../../shared/types";
 import { CardGrid } from "../Card";
 import { ErrorSelector } from "../ErrorAlert";
 import { genericMessage } from "../ErrorAlert/UnexpectedErrorAlert";
-import AppList from "./AppList";
+import AppList, { IAppListProps } from "./AppList";
 import AppListItem from "./AppListItem";
 import CustomResourceListItem from "./CustomResourceListItem";
 
 let props = {} as any;
 
-const defaultProps: any = {
+const defaultProps: IAppListProps = {
   apps: {} as IAppState,
-  fetchApps: jest.fn(),
   filter: "",
   namespace: "default",
+  cluster: "defaultc",
   pushSearchFilter: jest.fn(),
   fetchAppsWithUpdateInfo: jest.fn(),
   getCustomResources: jest.fn(),

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -13,7 +13,7 @@ import SearchFilter from "../SearchFilter";
 import AppListItem from "./AppListItem";
 import CustomResourceListItem from "./CustomResourceListItem";
 
-interface IAppListProps {
+export interface IAppListProps {
   apps: IAppState;
   fetchAppsWithUpdateInfo: (ns: string, all: boolean) => void;
   cluster: string;

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -65,6 +65,7 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
   public render() {
     const {
       apps: { error, isFetching },
+      cluster,
       isFetchingResources,
       namespace,
     } = this.props;
@@ -79,7 +80,7 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
           </div>
           <div className="col-3 text-r align-center">
             {!error && (
-              <Link to={url.app.catalog(namespace)}>
+              <Link to={url.app.catalog(cluster, namespace)}>
                 <button className="deploy-button button button-accent">Deploy App</button>
               </Link>
             )}

--- a/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
+++ b/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`when apps available matches the snapshot 1`] = `
       className="col-3 text-r align-center"
     >
       <Link
-        to="/c/default/ns/default/catalog"
+        to="/c/defaultc/ns/default/catalog"
       >
         <button
           className="deploy-button button button-accent"
@@ -68,6 +68,7 @@ exports[`when apps available matches the snapshot 1`] = `
                 "releaseName": "foo",
               }
             }
+            cluster="defaultc"
             key="foo"
           />
         </CardGrid>
@@ -117,7 +118,7 @@ exports[`when custom resources available matches the snapshot 1`] = `
       className="col-3 text-r align-center"
     >
       <Link
-        to="/c/default/ns/default/catalog"
+        to="/c/defaultc/ns/default/catalog"
       >
         <button
           className="deploy-button button button-accent"
@@ -277,7 +278,7 @@ exports[`when fetched but not apps available matches the snapshot 1`] = `
       className="col-3 text-r align-center"
     >
       <Link
-        to="/c/default/ns/default/catalog"
+        to="/c/defaultc/ns/default/catalog"
       >
         <button
           className="deploy-button button button-accent"
@@ -348,7 +349,7 @@ exports[`while fetching apps loading spinner matches the snapshot 1`] = `
       className="col-3 text-r align-center"
     >
       <Link
-        to="/c/default/ns/default/catalog"
+        to="/c/defaultc/ns/default/catalog"
       >
         <button
           className="deploy-button button button-accent"
@@ -419,7 +420,7 @@ exports[`while fetching apps loading spinner matches the snapshot 2`] = `
       className="col-3 text-r align-center"
     >
       <Link
-        to="/c/default/ns/default/catalog"
+        to="/c/defaultc/ns/default/catalog"
       >
         <button
           className="deploy-button button button-accent"
@@ -490,7 +491,7 @@ exports[`while fetching apps matches the snapshot 1`] = `
       className="col-3 text-r align-center"
     >
       <Link
-        to="/c/default/ns/default/catalog"
+        to="/c/defaultc/ns/default/catalog"
       >
         <button
           className="deploy-button button button-accent"

--- a/dashboard/src/components/Catalog/CatalogItem.tsx
+++ b/dashboard/src/components/Catalog/CatalogItem.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
+import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import helmIcon from "../../icons/helm.svg";
 import operatorIcon from "../../icons/operator-framework.svg";
 import placeholder from "../../placeholder.png";
-import { IRepo } from "../../shared/types";
+import { IRepo, IStoreState } from "../../shared/types";
 import * as url from "../../shared/url";
 import InfoCard from "../InfoCard";
 import "./CatalogItem.css";
@@ -80,8 +81,12 @@ const OperatorCatalogItem: React.SFC<IOperatorCatalogItem> = props => {
 const ChartCatalogItem: React.SFC<IChartCatalogItem> = props => {
   const { icon, name, repo, version, description, namespace, id } = props;
   const iconSrc = icon || placeholder;
+  const cluster = useSelector((state: IStoreState) => state.clusters.currentCluster);
   const tag1 = (
-    <Link className="ListItem__content__info_tag_link" to={url.app.repo(repo.name, namespace)}>
+    <Link
+      className="ListItem__content__info_tag_link"
+      to={url.app.repo(cluster, namespace, repo.name)}
+    >
       {repo.name}
     </Link>
   );

--- a/dashboard/src/components/Catalog/__snapshots__/CatalogItem.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/CatalogItem.test.tsx.snap
@@ -18,13 +18,135 @@ exports[`should render a chart item in a namespace 1`] = `
   tag1Content={
     <ForwardRef
       className="ListItem__content__info_tag_link"
-      to="/c/default/ns/repo-namespace/catalog/repo-name"
+      to="/c/default-cluster/ns/repo-namespace/catalog/repo-name"
     >
       repo-name
     </ForwardRef>
   }
   title="foo"
-/>
+>
+  <Card
+    className="ListItem"
+    responsive={true}
+  >
+    <article
+      className="Card ListItem Card-responsive"
+    >
+      <div
+        className="Card__inner bg-white elevation-1"
+      >
+        <Link
+          className="ListItem__header"
+          title="foo"
+          to="/c/default/ns/repo-namespace/charts/repo-name/foo"
+        >
+          <LinkAnchor
+            className="ListItem__header"
+            href="/c/default/ns/repo-namespace/charts/repo-name/foo"
+            navigate={[Function]}
+            title="foo"
+          >
+            <a
+              className="ListItem__header"
+              href="/c/default/ns/repo-namespace/charts/repo-name/foo"
+              onClick={[Function]}
+              title="foo"
+            >
+              <CardIcon
+                icon="icon.png"
+              >
+                <div
+                  className="Card__icon bg-light text-c"
+                >
+                  <img
+                    alt="icon"
+                    src="icon.png"
+                  />
+                </div>
+              </CardIcon>
+              <div
+                className="Card__subIcon bg-light text-r"
+              >
+                <img
+                  alt="icon"
+                  src="helm.svg"
+                />
+              </div>
+            </a>
+          </LinkAnchor>
+        </Link>
+        <CardContent>
+          <div
+            className="Card__content padding-normal "
+          >
+            <div
+              className="ListItem__content"
+            >
+              <Link
+                title="foo"
+                to="/c/default/ns/repo-namespace/charts/repo-name/foo"
+              >
+                <LinkAnchor
+                  href="/c/default/ns/repo-namespace/charts/repo-name/foo"
+                  navigate={[Function]}
+                  title="foo"
+                >
+                  <a
+                    href="/c/default/ns/repo-namespace/charts/repo-name/foo"
+                    onClick={[Function]}
+                    title="foo"
+                  >
+                    <h3
+                      className="ListItem__content__title type-big"
+                    >
+                      foo
+                    </h3>
+                  </a>
+                </LinkAnchor>
+              </Link>
+              <div
+                className="ListItem__content__description"
+              />
+              <div
+                className="ListItem__content__info"
+              >
+                <p
+                  className="margin-reset type-small padding-t-tiny type-color-light-blue"
+                >
+                  1.0.0
+                </p>
+                <div>
+                  <span
+                    className="ListItem__content__info_tag ListItem__content__info_tag-1 type-small type-color-white padding-t-tiny padding-h-normal repo-name"
+                  >
+                    <Link
+                      className="ListItem__content__info_tag_link"
+                      to="/c/default-cluster/ns/repo-namespace/catalog/repo-name"
+                    >
+                      <LinkAnchor
+                        className="ListItem__content__info_tag_link"
+                        href="/c/default-cluster/ns/repo-namespace/catalog/repo-name"
+                        navigate={[Function]}
+                      >
+                        <a
+                          className="ListItem__content__info_tag_link"
+                          href="/c/default-cluster/ns/repo-namespace/catalog/repo-name"
+                          onClick={[Function]}
+                        >
+                          repo-name
+                        </a>
+                      </LinkAnchor>
+                    </Link>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </div>
+    </article>
+  </Card>
+</InfoCard>
 `;
 
 exports[`should render a global chart item in a namespace 1`] = `
@@ -45,11 +167,133 @@ exports[`should render a global chart item in a namespace 1`] = `
   tag1Content={
     <ForwardRef
       className="ListItem__content__info_tag_link"
-      to="/c/default/ns/repo-namespace/catalog/repo-name"
+      to="/c/default-cluster/ns/repo-namespace/catalog/repo-name"
     >
       repo-name
     </ForwardRef>
   }
   title="foo"
-/>
+>
+  <Card
+    className="ListItem"
+    responsive={true}
+  >
+    <article
+      className="Card ListItem Card-responsive"
+    >
+      <div
+        className="Card__inner bg-white elevation-1"
+      >
+        <Link
+          className="ListItem__header"
+          title="foo"
+          to="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+        >
+          <LinkAnchor
+            className="ListItem__header"
+            href="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+            navigate={[Function]}
+            title="foo"
+          >
+            <a
+              className="ListItem__header"
+              href="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+              onClick={[Function]}
+              title="foo"
+            >
+              <CardIcon
+                icon="icon.png"
+              >
+                <div
+                  className="Card__icon bg-light text-c"
+                >
+                  <img
+                    alt="icon"
+                    src="icon.png"
+                  />
+                </div>
+              </CardIcon>
+              <div
+                className="Card__subIcon bg-light text-r"
+              >
+                <img
+                  alt="icon"
+                  src="helm.svg"
+                />
+              </div>
+            </a>
+          </LinkAnchor>
+        </Link>
+        <CardContent>
+          <div
+            className="Card__content padding-normal "
+          >
+            <div
+              className="ListItem__content"
+            >
+              <Link
+                title="foo"
+                to="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+              >
+                <LinkAnchor
+                  href="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+                  navigate={[Function]}
+                  title="foo"
+                >
+                  <a
+                    href="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+                    onClick={[Function]}
+                    title="foo"
+                  >
+                    <h3
+                      className="ListItem__content__title type-big"
+                    >
+                      foo
+                    </h3>
+                  </a>
+                </LinkAnchor>
+              </Link>
+              <div
+                className="ListItem__content__description"
+              />
+              <div
+                className="ListItem__content__info"
+              >
+                <p
+                  className="margin-reset type-small padding-t-tiny type-color-light-blue"
+                >
+                  1.0.0
+                </p>
+                <div>
+                  <span
+                    className="ListItem__content__info_tag ListItem__content__info_tag-1 type-small type-color-white padding-t-tiny padding-h-normal repo-name"
+                  >
+                    <Link
+                      className="ListItem__content__info_tag_link"
+                      to="/c/default-cluster/ns/repo-namespace/catalog/repo-name"
+                    >
+                      <LinkAnchor
+                        className="ListItem__content__info_tag_link"
+                        href="/c/default-cluster/ns/repo-namespace/catalog/repo-name"
+                        navigate={[Function]}
+                      >
+                        <a
+                          className="ListItem__content__info_tag_link"
+                          href="/c/default-cluster/ns/repo-namespace/catalog/repo-name"
+                          onClick={[Function]}
+                        >
+                          repo-name
+                        </a>
+                      </LinkAnchor>
+                    </Link>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </div>
+    </article>
+  </Card>
+</InfoCard>
 `;

--- a/dashboard/src/components/ChartView/ChartHeader.test.tsx
+++ b/dashboard/src/components/ChartView/ChartHeader.test.tsx
@@ -15,6 +15,7 @@ const testProps: any = {
     },
   },
   namespace: "kubeapps",
+  cluster: "default",
 };
 
 it("renders a header for the chart", () => {
@@ -24,7 +25,7 @@ it("renders a header for the chart", () => {
   const repoLink = wrapper.find(Link);
   expect(repoLink.exists()).toBe(true);
   expect(repoLink.props()).toMatchObject({
-    to: url.app.repo("testrepo", "kubeapps"),
+    to: url.app.repo("default", "kubeapps", "testrepo"),
     children: "testrepo",
   });
   expect(wrapper.find(ChartIcon).exists()).toBe(true);

--- a/dashboard/src/components/ChartView/ChartHeader.tsx
+++ b/dashboard/src/components/ChartView/ChartHeader.tsx
@@ -13,11 +13,12 @@ interface IChartHeaderProps {
   description: string;
   version: IChartVersion;
   namespace: string;
+  cluster: string;
 }
 
 class ChartHeader extends React.Component<IChartHeaderProps> {
   public render() {
-    const { id, icon, repo, description, version, namespace } = this.props;
+    const { id, icon, repo, description, version, cluster, namespace } = this.props;
     const appVersion = version.attributes.app_version;
     return (
       <header>
@@ -30,7 +31,7 @@ class ChartHeader extends React.Component<IChartHeaderProps> {
               <h1 className="margin-t-reset">{id}</h1>
               <h5 className="subtitle margin-b-normal">
                 {appVersion && <span>{appVersion} - </span>}
-                <Link to={url.app.repo(repo, namespace)}>{repo}</Link>
+                <Link to={url.app.repo(cluster, namespace, repo)}>{repo}</Link>
               </h5>
               <h5 className="subtitle margin-b-reset">{description}</h5>
             </div>

--- a/dashboard/src/components/ChartView/ChartView.tsx
+++ b/dashboard/src/components/ChartView/ChartView.tsx
@@ -9,7 +9,7 @@ import ChartReadme from "./ChartReadme";
 import ChartVersionsList from "./ChartVersionsList";
 import "./ChartView.css";
 
-interface IChartViewProps {
+export interface IChartViewProps {
   chartID: string;
   chartNamespace: string;
   fetchChartVersionsAndSelectVersion: (namespace: string, id: string, version?: string) => void;
@@ -19,6 +19,7 @@ interface IChartViewProps {
   resetChartVersion: () => any;
   getChartReadme: (namespace: string, version: string) => any;
   namespace: string;
+  cluster: string;
   version: string | undefined;
 }
 
@@ -46,7 +47,7 @@ class ChartView extends React.Component<IChartViewProps> {
   }
 
   public render() {
-    const { isFetching, getChartReadme, namespace, chartID, chartNamespace } = this.props;
+    const { isFetching, getChartReadme, cluster, namespace, chartID, chartNamespace } = this.props;
     const { version, readme, error, readmeError, versions } = this.props.selected;
     if (error) {
       return <ErrorSelector error={error} resource={`Chart ${chartID}`} />;
@@ -64,6 +65,7 @@ class ChartView extends React.Component<IChartViewProps> {
           repo={chartAttrs.repo.name}
           version={version}
           namespace={namespace}
+          cluster={cluster}
         />
         <main>
           <div className="container container-fluid">

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -16,6 +16,7 @@ const defaultProps = {
   update: jest.fn(),
   validate: jest.fn(),
   namespace: defaultNamespace,
+  cluster: "default",
   kubeappsNamespace: "kubeapps",
   displayReposPerNamespaceMsg: false,
   validating: false,

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -42,6 +42,7 @@ export interface IAppRepoListProps {
   ) => Promise<boolean>;
   validating: boolean;
   validate: (url: string, authHeader: string, customCA: string) => Promise<any>;
+  cluster: string;
   namespace: string;
   kubeappsNamespace: string;
   displayReposPerNamespaceMsg: boolean;
@@ -108,6 +109,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
       repos,
       install,
       update,
+      cluster,
       namespace,
       kubeappsNamespace,
       displayReposPerNamespaceMsg,
@@ -149,6 +151,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
                       resyncRepo={resyncRepo}
                       repo={repo}
                       renderNamespace={renderNamespace}
+                      cluster={cluster}
                       namespace={namespace}
                       kubeappsNamespace={kubeappsNamespace}
                       errors={errors}

--- a/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
@@ -73,7 +73,7 @@ export class AppRepoListItem extends React.Component<IAppRepoListItemProps, IApp
     return (
       <tr key={repo.metadata.name}>
         <td>
-          <Link to={url.app.repo(cluster, repo.metadata.name, namespace)}>
+          <Link to={url.app.repo(cluster, namespace, repo.metadata.name)}>
             {repo.metadata.name}
           </Link>
         </td>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoListItem.tsx
@@ -28,6 +28,7 @@ interface IAppRepoListItemProps {
   repo: IAppRepository;
   secret?: ISecret;
   renderNamespace: boolean;
+  cluster: string;
   namespace: string;
   kubeappsNamespace: string;
   deleteRepo: (name: string, namespace: string) => Promise<boolean>;
@@ -55,6 +56,7 @@ export class AppRepoListItem extends React.Component<IAppRepoListItemProps, IApp
 
   public render() {
     const {
+      cluster,
       namespace,
       renderNamespace,
       repo,
@@ -71,7 +73,9 @@ export class AppRepoListItem extends React.Component<IAppRepoListItemProps, IApp
     return (
       <tr key={repo.metadata.name}>
         <td>
-          <Link to={url.app.repo(repo.metadata.name, namespace)}>{repo.metadata.name}</Link>
+          <Link to={url.app.repo(cluster, repo.metadata.name, namespace)}>
+            {repo.metadata.name}
+          </Link>
         </td>
         {renderNamespace && <td>{repo.metadata.namespace}</td>}
         <td>{repo.spec && repo.spec.url}</td>

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -31,7 +31,7 @@ it("renders the header links and titles", () => {
   const items = menubar.children().map(p => p.props().children.props);
   const expectedItems = [
     { children: "Applications", to: app.apps.list("default", "default") },
-    { children: "Catalog", to: app.catalog("default") },
+    { children: "Catalog", to: app.catalog("default", "default") },
     { children: "Service Instances (alpha)", to: app.servicesInstances("default") },
   ];
   expect(items.length).toEqual(expectedItems.length);

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -97,7 +97,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                     </HeaderLink>
                   </li>
                   <li>
-                    <HeaderLink to={app.catalog(cluster.currentNamespace)}>Catalog</HeaderLink>
+                    <HeaderLink to={app.catalog(clusters.currentCluster, cluster.currentNamespace)}>Catalog</HeaderLink>
                   </li>
                   <li>
                     <HeaderLink to={app.servicesInstances(cluster.currentNamespace)}>

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -97,7 +97,9 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                     </HeaderLink>
                   </li>
                   <li>
-                    <HeaderLink to={app.catalog(clusters.currentCluster, cluster.currentNamespace)}>Catalog</HeaderLink>
+                    <HeaderLink to={app.catalog(clusters.currentCluster, cluster.currentNamespace)}>
+                      Catalog
+                    </HeaderLink>
                   </li>
                   <li>
                     <HeaderLink to={app.servicesInstances(cluster.currentNamespace)}>

--- a/dashboard/src/containers/ChartViewContainer/ChartViewContainer.tsx
+++ b/dashboard/src/containers/ChartViewContainer/ChartViewContainer.tsx
@@ -9,6 +9,7 @@ import { IChartVersion, IStoreState } from "../../shared/types";
 interface IRouteProps {
   match: {
     params: {
+      cluster: string;
       namespace: string;
       repo: string;
       global: string;
@@ -23,6 +24,7 @@ function mapStateToProps({ charts, config }: IStoreState, { match: { params } }:
     chartID: chartID(params),
     chartNamespace: params.global === "global" ? config.namespace : params.namespace,
     isFetching: charts.isFetching,
+    cluster: params.cluster,
     namespace: params.namespace,
     selected: charts.selected,
     version: params.version,

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -15,6 +15,7 @@ function mapStateToProps({ config, clusters: { currentCluster, clusters }, repos
   return {
     errors: repos.errors,
     namespace: repoNamespace,
+    cluster: currentCluster,
     repos: repos.repos,
     displayReposPerNamespaceMsg,
     isFetching: repos.isFetching,

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -15,9 +15,8 @@ export const app = {
     upgrade: (cluster: string, namespace: string, releaseName: string) =>
       `${app.apps.get(cluster, namespace, releaseName)}/upgrade`,
   },
-  catalog: (cluster: string, namespace: string) =>
-    `/c/${cluster}/ns/${namespace}/catalog`,
-  repo: (repo: string, namespace: string, cluster: string = "default") =>
+  catalog: (cluster: string, namespace: string) => `/c/${cluster}/ns/${namespace}/catalog`,
+  repo: (cluster: string, namespace: string, repo: string) =>
     `${app.catalog(cluster, namespace)}/${repo}`,
   servicesInstances: (namespace: string) => `/ns/${namespace}/services/instances`,
   charts: {

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -15,10 +15,10 @@ export const app = {
     upgrade: (cluster: string, namespace: string, releaseName: string) =>
       `${app.apps.get(cluster, namespace, releaseName)}/upgrade`,
   },
-  catalog: (namespace: string, cluster: string = "default") =>
+  catalog: (cluster: string, namespace: string) =>
     `/c/${cluster}/ns/${namespace}/catalog`,
   repo: (repo: string, namespace: string, cluster: string = "default") =>
-    `${app.catalog(namespace, cluster)}/${repo}`,
+    `${app.catalog(cluster, namespace)}/${repo}`,
   servicesInstances: (namespace: string) => `/ns/${namespace}/services/instances`,
   charts: {
     get: (chartName: string, repo: IRepo, namespace: string, cluster: string = "default") => {


### PR DESCRIPTION
Follows #1833 . Ref #1762 .

Only unexpected here was the lack of ability to use `shallow` when rendering a connected component, and hence unable to do a small targeted snapshot.

A few fly-by fixes for non-typed data.