### PR TITLE
Ensure that image building fails if typescript check fails.

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /app/src
 RUN curl -L https://unpkg.com/@bitnami/hex@3.2.0/dist/hex.min.css > /app/src/hex.min.css
 RUN curl -L https://unpkg.com/@clr/ui@3.1.4/clr-ui.min.css > /app/src/clr-ui.min.css
 COPY . /app
-RUN yarn run prettier-check
+RUN yarn run prettier-check && yarn run ts-compile-check
 RUN yarn run build
 
 FROM bitnami/nginx:1.18.0-debian-10-r38

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -40,6 +40,7 @@ describe("AppViewComponent", () => {
     error: undefined,
     getAppWithUpdateInfo: jest.fn(),
     namespace: "my-happy-place",
+    cluster: "default",
     releaseName: "mr-sunshine",
     push: jest.fn(),
   };

--- a/dashboard/src/components/ConfigLoader/ConfigLoader.tsx
+++ b/dashboard/src/components/ConfigLoader/ConfigLoader.tsx
@@ -6,7 +6,7 @@ import LoadingWrapper, {
 } from "../../components/LoadingWrapper/LoadingWrapper";
 
 interface IConfigLoaderProps extends ILoadingWrapperProps {
-  children: JSX.Element;
+  children?: JSX.Element;
   getConfig: () => void;
   error?: Error;
 }

--- a/dashboard/src/containers/AppUpgradeContainer/AppUpgradeContainer.test.tsx
+++ b/dashboard/src/containers/AppUpgradeContainer/AppUpgradeContainer.test.tsx
@@ -23,18 +23,24 @@ const makeStore = (apps: any, repos: any) => {
   });
 };
 
+const defaultMatch = {
+  params: {
+    cluster: "default",
+    namespace: "default",
+    releaseName: "foo",
+  },
+};
+
 describe("LoginFormContainer props", () => {
   it("repoName is empty if no apps nor repos are available", () => {
     const store = makeStore({}, { errors: {}, repo: {} });
-    const match = { params: { namespace: "default", releaseName: "foo" } };
-    const wrapper = shallow(<Upgrade store={store} match={match} />);
+    const wrapper = shallow(<Upgrade store={store} match={defaultMatch} />);
     expect(wrapper.find(AppUpgrade).prop("repoName")).toBe(undefined);
   });
 
   it("repoName is set using the selected repo", () => {
     const store = makeStore({}, { errors: {}, repo: { metadata: { name: "stable" } } });
-    const match = { params: { namespace: "default", releaseName: "foo" } };
-    const wrapper = shallow(<Upgrade store={store} match={match} />);
+    const wrapper = shallow(<Upgrade store={store} match={defaultMatch} />);
     expect(wrapper.find(AppUpgrade).prop("repoName")).toBe("stable");
   });
 
@@ -43,8 +49,7 @@ describe("LoginFormContainer props", () => {
       { selected: { updateInfo: { repository: { name: "bitnami" } } } },
       { errors: {}, repo: {} },
     );
-    const match = { params: { namespace: "default", releaseName: "foo" } };
-    const wrapper = shallow(<Upgrade store={store} match={match} />);
+    const wrapper = shallow(<Upgrade store={store} match={defaultMatch} />);
     expect(wrapper.find(AppUpgrade).prop("repoName")).toBe("bitnami");
   });
 });

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -38,6 +38,7 @@ describe("clusterReducer", () => {
               payload: {
                 location: { ...location, pathname: tc.path },
                 action: "PUSH" as RouterActionType,
+                isFirstRendering: true,
               },
             }),
           ).toEqual({


### PR DESCRIPTION
The build (and hence CI) was still able to pass even though there were typescript errors (compile-time type checking) because although we'd updated to check prettier during the build, I missed the ts-compile-check.

Now the build fails if a typescript check fails - independently of an individual contributors setup (ie. it's not dependent on whether or not we run husky pre-commit hooks).