### PR TITLE
Update url.app.charts.{get|version} to require cluster arg.

### DIFF
--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -221,11 +221,18 @@ describe("deploy chart", () => {
 
   it("returns true if namespace is correct and deployment is successful", async () => {
     const res = await store.dispatch(
-      actions.apps.deployChart("my-version" as any, "chart-namespace", "default", "my-release"),
+      actions.apps.deployChart(
+        "target-cluster",
+        "target-namespace",
+        "my-version" as any,
+        "chart-namespace",
+        "my-release",
+      ),
     );
     expect(res).toBe(true);
     expect(App.create).toHaveBeenCalledWith(
-      "default",
+      "target-cluster",
+      "target-namespace",
       "my-release",
       "chart-namespace",
       "my-version",
@@ -241,9 +248,10 @@ describe("deploy chart", () => {
   it("returns false and dispatches UnprocessableEntity if the namespace is _all", async () => {
     const res = await store.dispatch(
       actions.apps.deployChart(
+        "target-cluster",
+        definedNamespaces.all,
         "my-version" as any,
         "chart-namespace",
-        definedNamespaces.all,
         "my-release",
       ),
     );
@@ -262,9 +270,10 @@ describe("deploy chart", () => {
   it("returns false and dispatches UnprocessableEntity if the given values don't satisfy the schema ", async () => {
     const res = await store.dispatch(
       actions.apps.deployChart(
+        "target-cluster",
+        "default",
         "my-version" as any,
         "chart-namespace",
-        "default",
         "my-release",
         "foo: 1",
         {

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -247,9 +247,10 @@ export function fetchAppsWithUpdateInfo(
 }
 
 export function deployChart(
+  targetCluster: string,
+  targetNamespace: string,
   chartVersion: IChartVersion,
   chartNamespace: string,
-  namespace: string,
   releaseName: string,
   values?: string,
   schema?: JSONSchema4,
@@ -258,7 +259,7 @@ export function deployChart(
     dispatch(requestDeployApp());
     try {
       // You can not deploy applications unless the namespace is set
-      if (namespace === definedNamespaces.all) {
+      if (targetNamespace === definedNamespaces.all) {
         throw new UnprocessableEntity(
           "Namespace not selected. Please select a namespace using the selector in the top right corner.",
         );
@@ -274,7 +275,14 @@ export function deployChart(
           );
         }
       }
-      await App.create(namespace, releaseName, chartNamespace, chartVersion, values);
+      await App.create(
+        targetCluster,
+        targetNamespace,
+        releaseName,
+        chartNamespace,
+        chartVersion,
+        values,
+      );
       dispatch(receiveDeployApp());
       return true;
     } catch (e) {

--- a/dashboard/src/components/Catalog/CatalogItem.tsx
+++ b/dashboard/src/components/Catalog/CatalogItem.tsx
@@ -90,7 +90,7 @@ const ChartCatalogItem: React.SFC<IChartCatalogItem> = props => {
       {repo.name}
     </Link>
   );
-  const link = url.app.charts.get(name, repo || ({} as IRepo), namespace);
+  const link = url.app.charts.get(cluster, namespace, name, repo || ({} as IRepo));
   const subIcon = helmIcon;
 
   const descriptionC = (

--- a/dashboard/src/components/Catalog/__snapshots__/CatalogItem.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/CatalogItem.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`should render a chart item in a namespace 1`] = `
   icon="icon.png"
   info="1.0.0"
   key="foo1"
-  link="/c/default/ns/repo-namespace/charts/repo-name/foo"
+  link="/c/default-cluster/ns/repo-namespace/charts/repo-name/foo"
   subIcon="helm.svg"
   tag1Class="repo-name"
   tag1Content={
@@ -38,17 +38,17 @@ exports[`should render a chart item in a namespace 1`] = `
         <Link
           className="ListItem__header"
           title="foo"
-          to="/c/default/ns/repo-namespace/charts/repo-name/foo"
+          to="/c/default-cluster/ns/repo-namespace/charts/repo-name/foo"
         >
           <LinkAnchor
             className="ListItem__header"
-            href="/c/default/ns/repo-namespace/charts/repo-name/foo"
+            href="/c/default-cluster/ns/repo-namespace/charts/repo-name/foo"
             navigate={[Function]}
             title="foo"
           >
             <a
               className="ListItem__header"
-              href="/c/default/ns/repo-namespace/charts/repo-name/foo"
+              href="/c/default-cluster/ns/repo-namespace/charts/repo-name/foo"
               onClick={[Function]}
               title="foo"
             >
@@ -84,15 +84,15 @@ exports[`should render a chart item in a namespace 1`] = `
             >
               <Link
                 title="foo"
-                to="/c/default/ns/repo-namespace/charts/repo-name/foo"
+                to="/c/default-cluster/ns/repo-namespace/charts/repo-name/foo"
               >
                 <LinkAnchor
-                  href="/c/default/ns/repo-namespace/charts/repo-name/foo"
+                  href="/c/default-cluster/ns/repo-namespace/charts/repo-name/foo"
                   navigate={[Function]}
                   title="foo"
                 >
                   <a
-                    href="/c/default/ns/repo-namespace/charts/repo-name/foo"
+                    href="/c/default-cluster/ns/repo-namespace/charts/repo-name/foo"
                     onClick={[Function]}
                     title="foo"
                   >
@@ -161,7 +161,7 @@ exports[`should render a global chart item in a namespace 1`] = `
   icon="icon.png"
   info="1.0.0"
   key="foo1"
-  link="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+  link="/c/default-cluster/ns/repo-namespace/global-charts/repo-name/foo"
   subIcon="helm.svg"
   tag1Class="repo-name"
   tag1Content={
@@ -187,17 +187,17 @@ exports[`should render a global chart item in a namespace 1`] = `
         <Link
           className="ListItem__header"
           title="foo"
-          to="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+          to="/c/default-cluster/ns/repo-namespace/global-charts/repo-name/foo"
         >
           <LinkAnchor
             className="ListItem__header"
-            href="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+            href="/c/default-cluster/ns/repo-namespace/global-charts/repo-name/foo"
             navigate={[Function]}
             title="foo"
           >
             <a
               className="ListItem__header"
-              href="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+              href="/c/default-cluster/ns/repo-namespace/global-charts/repo-name/foo"
               onClick={[Function]}
               title="foo"
             >
@@ -233,15 +233,15 @@ exports[`should render a global chart item in a namespace 1`] = `
             >
               <Link
                 title="foo"
-                to="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+                to="/c/default-cluster/ns/repo-namespace/global-charts/repo-name/foo"
               >
                 <LinkAnchor
-                  href="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+                  href="/c/default-cluster/ns/repo-namespace/global-charts/repo-name/foo"
                   navigate={[Function]}
                   title="foo"
                 >
                   <a
-                    href="/c/default/ns/repo-namespace/global-charts/repo-name/foo"
+                    href="/c/default-cluster/ns/repo-namespace/global-charts/repo-name/foo"
                     onClick={[Function]}
                     title="foo"
                   >

--- a/dashboard/src/components/ChartView/ChartVersionsList.test.tsx
+++ b/dashboard/src/components/ChartView/ChartVersionsList.test.tsx
@@ -76,6 +76,7 @@ it("renders the list of versions", () => {
       versions={testVersions}
       selected={testVersions[1]}
       targetNamespace="targetNamespace"
+      cluster="default"
     />,
   );
   const items = wrapper.find("li");
@@ -84,7 +85,7 @@ it("renders the list of versions", () => {
   expect(link.prop("className")).toBe("type-bold type-color-action");
   // The link include the namespace
   expect(link.prop("to")).toBe(
-    url.app.charts.version("test", "1.2.2", testChart.data.repo, "targetNamespace"),
+    url.app.charts.version("default", "targetNamespace", "test", "1.2.2", testChart.data.repo),
   );
 });
 
@@ -94,6 +95,7 @@ it("does not render a the Show All link when there are 5 or less versions", () =
       versions={testVersions}
       selected={testVersions[1]}
       targetNamespace="targetNamespace"
+      cluster="default"
     />,
   );
   expect(wrapper.find("a").exists()).toBe(false);
@@ -116,6 +118,7 @@ it("renders a the Show All link when there are more than 5 versions", () => {
       versions={extendedVersions}
       selected={extendedVersions[1]}
       targetNamespace="targetNamespace"
+      cluster="default"
     />,
   );
   const showAllLink = wrapper.find("button");
@@ -131,6 +134,7 @@ it("shows all the versions when the Show All link is clicked", () => {
       versions={extendedVersions}
       selected={extendedVersions[1]}
       targetNamespace="targetNamespace"
+      cluster="default"
     />,
   );
   expect(wrapper.find("li")).toHaveLength(5);

--- a/dashboard/src/components/ChartView/ChartVersionsList.tsx
+++ b/dashboard/src/components/ChartView/ChartVersionsList.tsx
@@ -8,6 +8,7 @@ interface IChartVersionsListProps {
   selected: IChartVersion;
   versions: IChartVersion[];
   targetNamespace: string;
+  cluster: string;
 }
 
 interface IChartVersionsListState {
@@ -32,10 +33,11 @@ class ChartVersionsList extends React.Component<IChartVersionsListProps, IChartV
           <Link
             className={selectedClass}
             to={url.app.charts.version(
+              this.props.cluster,
+              this.props.targetNamespace,
               chartData.name,
               v.attributes.version,
               chartData.repo,
-              this.props.targetNamespace,
             )}
           >
             {v.attributes.version} - {this.formatDate(v.attributes.created)}

--- a/dashboard/src/components/ChartView/ChartView.tsx
+++ b/dashboard/src/components/ChartView/ChartView.tsx
@@ -87,6 +87,7 @@ class ChartView extends React.Component<IChartViewProps> {
                       selected={version}
                       versions={versions}
                       targetNamespace={namespace}
+                      cluster={cluster}
                     />
                   </div>
                   {version.attributes.app_version && (

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -186,9 +186,10 @@ it("triggers a deployment when submitting the form", done => {
   wrapper.setState({ appValues });
   wrapper.find("form").simulate("submit");
   expect(deployChart).toHaveBeenCalledWith(
+    defaultProps.cluster,
+    defaultProps.namespace,
     versions[0],
     defaultProps.chartNamespace,
-    namespace,
     releaseName,
     appValues,
     schema,

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -26,9 +26,10 @@ export interface IDeploymentFormProps {
   chartsIsFetching: boolean;
   selected: IChartState["selected"];
   deployChart: (
+    targetCluster: string,
+    targetNamespace: string,
     version: IChartVersion,
     chartNamespace: string,
-    namespace: string,
     releaseName: string,
     values?: string,
     schema?: JSONSchema4,
@@ -171,9 +172,10 @@ class DeploymentForm extends React.Component<IDeploymentFormProps, IDeploymentFo
     this.setState({ isDeploying: true, latestSubmittedReleaseName: releaseName });
     if (selected.version) {
       const deployed = await deployChart(
+        cluster,
+        namespace,
         selected.version,
         chartNamespace,
-        namespace,
         releaseName,
         appValues,
         selected.schema,

--- a/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -41,15 +41,24 @@ function mapStateToProps(
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
     deployChart: (
+      targetCluster: string,
+      targetNamespace: string,
       version: IChartVersion,
       chartNamespace: string,
-      namespace: string,
       releaseName: string,
       values?: string,
       schema?: JSONSchema4,
     ) =>
       dispatch(
-        actions.apps.deployChart(version, chartNamespace, namespace, releaseName, values, schema),
+        actions.apps.deployChart(
+          targetCluster,
+          targetNamespace,
+          version,
+          chartNamespace,
+          releaseName,
+          values,
+          schema,
+        ),
       ),
     fetchChartVersions: (namespace: string, id: string) =>
       dispatch(actions.charts.fetchChartVersions(namespace, id)),

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -1,5 +1,5 @@
 import * as moxios from "moxios";
-import { App, TILLER_PROXY_ROOT_URL } from "./App";
+import { App, KUBEOPS_ROOT_URL } from "./App";
 import { axiosWithAuth } from "./AxiosInstance";
 import { IAppOverview, IChartVersion } from "./types";
 
@@ -11,35 +11,6 @@ describe("App", () => {
   afterEach(() => {
     moxios.uninstall(axiosWithAuth as any);
     jest.resetAllMocks();
-  });
-  describe("getResourceURL", () => {
-    [
-      {
-        description: "returns the root API URL if no params are given",
-        result: `${TILLER_PROXY_ROOT_URL}/releases`,
-      },
-      {
-        description: "returns namespaced URLs",
-        namespace: "default",
-        result: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases`,
-      },
-      {
-        description: "returns a single release URL",
-        namespace: "default",
-        resourceName: "foo",
-        result: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases/foo`,
-      },
-      {
-        description: "returns a URL with a query",
-        namespace: "default",
-        query: "statuses=foo",
-        result: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases?statuses=foo`,
-      },
-    ].forEach(t => {
-      it(t.description, () => {
-        expect(App.getResourceURL(t.namespace, t.resourceName, t.query)).toBe(t.result);
-      });
-    });
   });
 
   describe("listApps", () => {
@@ -53,17 +24,17 @@ describe("App", () => {
     [
       {
         description: "should request all the releases if no namespace is given",
-        expectedURL: `${TILLER_PROXY_ROOT_URL}/releases`,
+        expectedURL: `${KUBEOPS_ROOT_URL}/releases`,
       },
       {
         description: "should request the releases of a namespace",
-        expectedURL: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases`,
+        expectedURL: `${KUBEOPS_ROOT_URL}/namespaces/default/releases`,
         namespace: "default",
       },
       {
         all: true,
         description: "should request the releases of a namespace with any status",
-        expectedURL: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases?statuses=all`,
+        expectedURL: `${KUBEOPS_ROOT_URL}/namespaces/default/releases?statuses=all`,
         namespace: "default",
       },
     ].forEach(t => {
@@ -75,7 +46,7 @@ describe("App", () => {
   });
 
   describe("create", () => {
-    const expectedURL = `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases`;
+    const expectedURL = `${KUBEOPS_ROOT_URL}/namespaces/defaultns/releases`;
     const testChartVersion: IChartVersion = {
       attributes: {
         version: "1.2.3",
@@ -94,7 +65,9 @@ describe("App", () => {
     } as IChartVersion;
     it("creates an app in a namespace", async () => {
       moxios.stubRequest(/.*/, { response: "ok", status: 200 });
-      expect(await App.create("default", "absent-ant", "kubeapps", testChartVersion)).toBe("ok");
+      expect(
+        await App.create("defaultc", "defaultns", "absent-ant", "kubeapps", testChartVersion),
+      ).toBe("ok");
       const request = moxios.requests.mostRecent();
       expect(request.url).toBe(expectedURL);
       expect(request.config.data).toEqual(
@@ -110,7 +83,7 @@ describe("App", () => {
   });
 
   describe("upgrade", () => {
-    const expectedURL = `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases/absent-ant`;
+    const expectedURL = `${KUBEOPS_ROOT_URL}/namespaces/default/releases/absent-ant`;
     const testChartVersion: IChartVersion = {
       attributes: {
         version: "1.2.3",
@@ -147,12 +120,12 @@ describe("App", () => {
     [
       {
         description: "should delete an app in a namespace",
-        expectedURL: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases/foo`,
+        expectedURL: `${KUBEOPS_ROOT_URL}/namespaces/default/releases/foo`,
         purge: false,
       },
       {
         description: "should delete and purge an app in a namespace",
-        expectedURL: `${TILLER_PROXY_ROOT_URL}/namespaces/default/releases/foo?purge=true`,
+        expectedURL: `${KUBEOPS_ROOT_URL}/namespaces/default/releases/foo?purge=true`,
         purge: true,
       },
     ].forEach(t => {

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -48,8 +48,12 @@ function withNS(namespace: string) {
 }
 
 export const backend = {
+  namespaces: {
+    base: "api/v1/namespaces",
+    list: () => `${backend.namespaces.base}`,
+  },
   apprepositories: {
-    base: (namespace: string) => `api/v1/namespaces/${namespace}/apprepositories`,
+    base: (namespace: string) => `${backend.namespaces.base}/${namespace}/apprepositories`,
     create: (namespace: string) => backend.apprepositories.base(namespace),
     validate: () => `${backend.apprepositories.base("kubeapps")}/validate`,
     delete: (name: string, namespace: string) =>
@@ -57,9 +61,13 @@ export const backend = {
     update: (namespace: string, name: string) =>
       `${backend.apprepositories.base(namespace)}/${name}`,
   },
-  namespaces: {
-    base: "api/v1/namespaces",
-    list: () => `${backend.namespaces.base}`,
+};
+
+export const kubeops = {
+  releases: {
+    list: (namespace: string) => `api/tiller-deploy/v1/namespaces/${namespace}/releases`,
+    listAll: () => "api/tiller-deploy/v1/releases",
+    get: (namespace: string, name: string) => `${kubeops.releases.list(namespace)}/${name}`,
   },
 };
 

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -20,17 +20,17 @@ export const app = {
     `${app.catalog(cluster, namespace)}/${repo}`,
   servicesInstances: (namespace: string) => `/ns/${namespace}/services/instances`,
   charts: {
-    get: (chartName: string, repo: IRepo, namespace: string, cluster: string = "default") => {
+    get: (cluster: string, namespace: string, chartName: string, repo: IRepo) => {
       const chartsSegment = namespace !== repo?.namespace ? "global-charts" : "charts";
       return `/c/${cluster}/ns/${namespace}/${chartsSegment}/${repo.name}/${chartName}`;
     },
     version: (
+      cluster: string,
+      namespace: string,
       chartName: string,
       chartVersion: string,
       repo: IRepo,
-      namespace: string,
-      cluster: string = "default",
-    ) => `${app.charts.get(chartName, repo, namespace, cluster)}/versions/${chartVersion}`,
+    ) => `${app.charts.get(cluster, namespace, chartName, repo)}/versions/${chartVersion}`,
   },
   operators: {
     view: (namespace: string, name: string) => `/ns/${namespace}/operators/${name}`,

--- a/script/cluster-kind.mk
+++ b/script/cluster-kind.mk
@@ -41,6 +41,6 @@ delete-cluster-kind:
 	kind delete cluster --name ${ADDITIONAL_CLUSTER_NAME} || true
 	rm ${CLUSTER_CONFIG}
 	rm ${ADDITIONAL_CLUSTER_CONFIG} || true
-	rm devel/dex.*
+	rm devel/dex.* || true
 
 .PHONY: additional-cluster-kind cluster-kind cluster-kind-delete


### PR DESCRIPTION
Also then begins updating the backend url helpers - starting with `shared/App.create` to require cluster, (though I'm not yet using it in the URL, since the tests in this PR verify that the new `url.kubeops.releases` helper maintains the same endpoints.

Follows #1835, Ref: #1762 