### PR TITLE
Update backend url for namespaces to require cluster.

### DIFF
--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -67,7 +67,7 @@ describe("fetchNamespaces", () => {
       },
     ];
 
-    await store.dispatch(fetchNamespaces());
+    await store.dispatch(fetchNamespaces("default-c"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -81,7 +81,7 @@ describe("fetchNamespaces", () => {
       },
     ];
 
-    await store.dispatch(fetchNamespaces());
+    await store.dispatch(fetchNamespaces("default-c"));
 
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -106,7 +106,7 @@ describe("createNamespace", () => {
       },
     ];
 
-    const res = await store.dispatch(createNamespace("overlook-hotel"));
+    const res = await store.dispatch(createNamespace("default-c", "overlook-hotel"));
     expect(res).toBe(true);
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -121,7 +121,7 @@ describe("createNamespace", () => {
       },
     ];
 
-    const res = await store.dispatch(createNamespace("foo"));
+    const res = await store.dispatch(createNamespace("default-c", "foo"));
     expect(res).toBe(false);
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -134,14 +134,14 @@ describe("getNamespace", () => {
     const expectedActions = [
       {
         type: getType(requestNamespace),
-        payload: "default",
+        payload: "default-ns",
       },
       {
         type: getType(receiveNamespace),
         payload: ns,
       },
     ];
-    const r = await store.dispatch(getNamespace("default"));
+    const r = await store.dispatch(getNamespace("default-c", "default-ns"));
     expect(r).toBe(true);
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -152,14 +152,14 @@ describe("getNamespace", () => {
     const expectedActions = [
       {
         type: getType(requestNamespace),
-        payload: "default",
+        payload: "default-ns",
       },
       {
         type: getType(errorNamespaces),
         payload: { err, op: "get" },
       },
     ];
-    const r = await store.dispatch(getNamespace("default"));
+    const r = await store.dispatch(getNamespace("default-c", "default-ns"));
     expect(r).toBe(false);
     expect(store.getActions()).toEqual(expectedActions);
   });

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -41,10 +41,12 @@ const allActions = [
 ];
 export type NamespaceAction = ActionType<typeof allActions[number]>;
 
-export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
+export function fetchNamespaces(
+  cluster: string,
+): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
   return async dispatch => {
     try {
-      const namespaceList = await Namespace.list();
+      const namespaceList = await Namespace.list(cluster);
       const namespaceStrings = namespaceList.namespaces.map((n: IResource) => n.metadata.name);
       dispatch(receiveNamespaces(namespaceStrings));
     } catch (e) {
@@ -55,13 +57,14 @@ export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null,
 }
 
 export function createNamespace(
+  cluster: string,
   ns: string,
 ): ThunkAction<Promise<boolean>, IStoreState, null, NamespaceAction> {
   return async dispatch => {
     try {
-      await Namespace.create(ns);
+      await Namespace.create(cluster, ns);
       dispatch(postNamespace(ns));
-      dispatch(fetchNamespaces());
+      dispatch(fetchNamespaces(cluster));
       return true;
     } catch (e) {
       dispatch(errorNamespaces(e, "create"));
@@ -71,12 +74,13 @@ export function createNamespace(
 }
 
 export function getNamespace(
+  cluster: string,
   ns: string,
 ): ThunkAction<Promise<boolean>, IStoreState, null, NamespaceAction> {
   return async dispatch => {
     try {
       dispatch(requestNamespace(ns));
-      const namespace = await Namespace.get(ns);
+      const namespace = await Namespace.get(cluster, ns);
       dispatch(receiveNamespace(namespace));
       return true;
     } catch (e) {

--- a/dashboard/src/components/Header/ContextSelector.test.tsx
+++ b/dashboard/src/components/Header/ContextSelector.test.tsx
@@ -45,6 +45,7 @@ it("fetches namespaces", () => {
 
   expect(fetchNamespaces).toHaveBeenCalled();
   expect(getNamespace).toHaveBeenCalledWith(
+    defaultProps.clusters.currentCluster,
     defaultProps.clusters.clusters.default.currentNamespace,
   );
 });

--- a/dashboard/src/components/Header/ContextSelector.tsx
+++ b/dashboard/src/components/Header/ContextSelector.tsx
@@ -18,9 +18,9 @@ ClarityIcons.addIcons(clusterIcon, fileGroupIcon, angleIcon);
 export interface IContextSelectorProps {
   clusters: IClustersState;
   defaultNamespace: string;
-  fetchNamespaces: () => void;
-  createNamespace: (ns: string) => Promise<boolean>;
-  getNamespace: (ns: string) => void;
+  fetchNamespaces: (cluster: string) => void;
+  createNamespace: (cluster: string, ns: string) => Promise<boolean>;
+  getNamespace: (cluster: string, ns: string) => void;
   setNamespace: (ns: string) => void;
 }
 
@@ -43,9 +43,9 @@ function ContextSelector({
   useOutsideClick(setOpen, [ref], open);
 
   useEffect(() => {
-    fetchNamespaces();
+    fetchNamespaces(clusters.currentCluster);
     if (namespaceSelected !== definedNamespaces.all) {
-      getNamespace(namespaceSelected);
+      getNamespace(clusters.currentCluster, namespaceSelected);
     }
   }, [fetchNamespaces, namespaceSelected, getNamespace]);
 

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -96,7 +96,7 @@ it("renders the namespace switcher", () => {
   expect(namespaceSelector.props()).toEqual(
     expect.objectContaining({
       defaultNamespace: defaultProps.defaultNamespace,
-      cluster: defaultProps.clusters.clusters.default,
+      clusters: defaultProps.clusters,
     }),
   );
 });
@@ -130,7 +130,7 @@ it("call setNamespace and getNamespace when selecting a namespace", () => {
   onChange("bar");
 
   expect(setNamespace).toHaveBeenCalledWith("bar");
-  expect(getNamespace).toHaveBeenCalledWith("bar");
+  expect(getNamespace).toHaveBeenCalledWith("default", "bar");
   expect(createNamespace).not.toHaveBeenCalled();
 });
 

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -14,15 +14,15 @@ import NamespaceSelector from "./NamespaceSelector";
 export interface IHeaderProps {
   appVersion: string;
   authenticated: boolean;
-  fetchNamespaces: () => void;
+  fetchNamespaces: (cluster: string) => void;
   logout: () => void;
   clusters: IClustersState;
   defaultNamespace: string;
   pathname: string;
   push: (path: string) => void;
   setNamespace: (ns: string) => void;
-  createNamespace: (ns: string) => Promise<boolean>;
-  getNamespace: (ns: string) => void;
+  createNamespace: (cluster: string, ns: string) => Promise<boolean>;
+  getNamespace: (cluster: string, ns: string) => void;
   featureFlags: IFeatureFlags;
 }
 
@@ -113,7 +113,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
             {showNav && (
               <div className="header__nav header__nav-config">
                 <NamespaceSelector
-                  cluster={cluster}
+                  clusters={clusters}
                   defaultNamespace={defaultNamespace}
                   onChange={this.handleNamespaceChange}
                   fetchNamespaces={fetchNamespaces}
@@ -189,11 +189,17 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   };
 
   private handleNamespaceChange = (ns: string) => {
-    const { pathname, push, setNamespace, getNamespace } = this.props;
+    const {
+      clusters: { currentCluster },
+      pathname,
+      push,
+      setNamespace,
+      getNamespace,
+    } = this.props;
     const to = pathname.replace(/\/ns\/[^/]*/, `/ns/${ns}`);
     setNamespace(ns);
     if (ns !== definedNamespaces.all) {
-      getNamespace(ns);
+      getNamespace(currentCluster, ns);
     }
     if (to !== pathname) {
       push(to);

--- a/dashboard/src/components/Header/Header.v2.tsx
+++ b/dashboard/src/components/Header/Header.v2.tsx
@@ -10,15 +10,15 @@ import Menu from "./Menu";
 
 interface IHeaderProps {
   authenticated: boolean;
-  fetchNamespaces: () => void;
+  fetchNamespaces: (cluster: string) => void;
   logout: () => void;
   clusters: IClustersState;
   defaultNamespace: string;
   appVersion: string;
   push: (path: string) => void;
   setNamespace: (ns: string) => void;
-  createNamespace: (ns: string) => Promise<boolean>;
-  getNamespace: (ns: string) => void;
+  createNamespace: (cluster: string, ns: string) => Promise<boolean>;
+  getNamespace: (cluster: string, ns: string) => void;
 }
 
 function Header(props: IHeaderProps) {

--- a/dashboard/src/components/Header/NamespaceSelector.test.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.test.tsx
@@ -9,10 +9,15 @@ import NewNamespace from "./NewNamespace";
 
 const defaultProps = {
   fetchNamespaces: jest.fn(),
-  cluster: {
-    currentNamespace: "namespace-two",
-    namespaces: ["namespace-one", "namespace-two"],
-  } as IClusterState,
+  clusters: {
+    currentCluster: "default",
+    clusters: {
+      default: {
+        currentNamespace: "namespace-two",
+        namespaces: ["namespace-one", "namespace-two"],
+      } as IClusterState,
+    },
+  },
   defaultNamespace: "kubeapps-user",
   onChange: jest.fn(),
   createNamespace: jest.fn(),
@@ -24,8 +29,8 @@ it("renders the given namespaces with current selection", () => {
   const select = wrapper.find(".NamespaceSelector__select").first();
 
   const expectedValue = {
-    label: defaultProps.cluster.currentNamespace,
-    value: defaultProps.cluster.currentNamespace,
+    label: defaultProps.clusters.clusters.default.currentNamespace,
+    value: defaultProps.clusters.clusters.default.currentNamespace,
   };
   expect(select.props()).toMatchObject({
     value: expectedValue,
@@ -41,9 +46,15 @@ it("renders the given namespaces with current selection", () => {
 it("render with the default namespace selected if no current selection", () => {
   const props = {
     ...defaultProps,
-    cluster: {
-      ...defaultProps.cluster,
-      currentNamespace: "",
+    clusters: {
+      ...defaultProps.clusters,
+      clusters: {
+        ...defaultProps.clusters.clusters,
+        default: {
+          currentNamespace: "",
+          namespaces: [],
+        },
+      },
     },
   } as INamespaceSelectorProps;
   const wrapper = shallow(<NamespaceSelector {...props} />);
@@ -69,7 +80,7 @@ it("opens the modal to add a new namespace and creates it", async () => {
   wrapper.update();
 
   wrapper.find(".button-primary").simulate("click");
-  expect(createNamespace).toHaveBeenCalledWith("test");
+  expect(createNamespace).toHaveBeenCalledWith("default", "test");
   // hack to wait for the state to be updated
   await new Promise(res =>
     setTimeout(() => {
@@ -83,29 +94,45 @@ it("opens the modal to add a new namespace and creates it", async () => {
 it("fetches namespaces and retrive the current namespace", () => {
   const fetchNamespaces = jest.fn();
   const getNamespace = jest.fn();
-  shallow(
-    <NamespaceSelector
-      {...defaultProps}
-      fetchNamespaces={fetchNamespaces}
-      getNamespace={getNamespace}
-      cluster={{ currentNamespace: "foo", namespaces: [] }}
-    />,
-  );
+  const props = {
+    ...defaultProps,
+    fetchNamespaces,
+    getNamespace,
+    clusters: {
+      ...defaultProps.clusters,
+      clusters: {
+        ...defaultProps.clusters.clusters,
+        default: {
+          currentNamespace: "foo",
+          namespaces: [],
+        },
+      },
+    },
+  };
+  shallow(<NamespaceSelector {...props} />);
   expect(fetchNamespaces).toHaveBeenCalled();
-  expect(getNamespace).toHaveBeenCalledWith("foo");
+  expect(getNamespace).toHaveBeenCalledWith("default", "foo");
 });
 
 it("doesnt' get the current namespace if all namespaces is selected", () => {
   const fetchNamespaces = jest.fn();
   const getNamespace = jest.fn();
-  shallow(
-    <NamespaceSelector
-      {...defaultProps}
-      fetchNamespaces={fetchNamespaces}
-      getNamespace={getNamespace}
-      cluster={{ currentNamespace: "_all", namespaces: [] }}
-    />,
-  );
+  const props = {
+    ...defaultProps,
+    fetchNamespaces,
+    getNamespace,
+    clusters: {
+      ...defaultProps.clusters,
+      clusters: {
+        ...defaultProps.clusters.clusters,
+        default: {
+          currentNamespace: "_all",
+          namespaces: [],
+        },
+      },
+    },
+  };
+  shallow(<NamespaceSelector {...props} />);
   expect(fetchNamespaces).toHaveBeenCalled();
   expect(getNamespace).not.toHaveBeenCalled();
 });

--- a/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -65,7 +65,6 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     getChartVersion: (namespace: string, id: string, version: string) =>
       dispatch(actions.charts.getChartVersion(namespace, id, version)),
     push: (location: string) => dispatch(push(location)),
-    getNamespace: (ns: string) => dispatch(actions.namespace.getNamespace(ns)),
   };
 }
 

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -28,12 +28,14 @@ function mapStateToProps({
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    fetchNamespaces: () => dispatch(actions.namespace.fetchNamespaces()),
-    createNamespace: (ns: string) => dispatch(actions.namespace.createNamespace(ns)),
+    fetchNamespaces: (cluster: string) => dispatch(actions.namespace.fetchNamespaces(cluster)),
+    createNamespace: (cluster: string, ns: string) =>
+      dispatch(actions.namespace.createNamespace(cluster, ns)),
     logout: () => dispatch(actions.auth.logout()),
     push: (path: string) => dispatch(push(path)),
     setNamespace: (ns: string) => dispatch(actions.namespace.setNamespace(ns)),
-    getNamespace: (ns: string) => dispatch(actions.namespace.getNamespace(ns)),
+    getNamespace: (cluster: string, ns: string) =>
+      dispatch(actions.namespace.getNamespace(cluster, ns)),
   };
 }
 

--- a/dashboard/src/containers/RoutesContainer/Routes.test.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.test.tsx
@@ -1,10 +1,9 @@
-import { mount, shallow } from "enzyme";
+import { mount } from "enzyme";
 import { createMemoryHistory } from "history";
 import * as React from "react";
 import { StaticRouter } from "react-router";
 import { Redirect, RouteComponentProps } from "react-router-dom";
 import NotFound from "../../components/NotFound";
-import RepoListContainer from "../../containers/RepoListContainer";
 import { app } from "../../shared/url";
 import Routes from "./Routes";
 
@@ -82,31 +81,4 @@ it("should render a redirect to the login page (when not authenticated)", () => 
   );
   expect(wrapper.find(NotFound)).not.toExist();
   expect(wrapper.find(Redirect).prop("to")).toEqual("/login");
-});
-
-describe("Routes depending on feature flags", () => {
-  const cluster = "default";
-  const namespace = "default";
-  const perNamespacePath = "/config/ns/:namespace/repos";
-
-  it("uses a namespaced route for app repos", () => {
-    const wrapper = shallow(
-      <StaticRouter location="/config/repos" context={{}}>
-        <Routes
-          {...emptyRouteComponentProps}
-          cluster={cluster}
-          namespace={namespace}
-          authenticated={true}
-        />
-      </StaticRouter>,
-    )
-      .dive()
-      .dive()
-      .dive()
-      .dive();
-    const component = wrapper.find({ component: RepoListContainer });
-
-    expect(component.length).toBe(1);
-    expect(component.props().path).toEqual(perNamespacePath);
-  });
 });

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -1,31 +1,38 @@
 import { axiosWithAuth } from "./AxiosInstance";
-import { APIBase } from "./Kube";
 import * as url from "./url";
 
 import { ForbiddenError, IResource, NotFoundError } from "./types";
 
 export default class Namespace {
-  public static async list() {
+  public static async list(cluster: string) {
+    // This call is hitting an actual backend endpoint (see pkg/http-handler.go)
+    // while the other calls (create, get) are hitting the k8s API via the
+    // frountend nginx.
     const { data } = await axiosWithAuth.get<{ namespaces: IResource[] }>(
-      url.backend.namespaces.list(),
+      url.backend.namespaces.list(cluster),
     );
     return data;
   }
 
-  public static async create(name: string) {
-    const { data } = await axiosWithAuth.post<IResource>(`${APIBase}/api/v1/namespaces/`, {
-      apiVersion: "v1",
-      kind: "Namespace",
-      metadata: {
-        name,
+  public static async create(cluster: string, name: string) {
+    const { data } = await axiosWithAuth.post<IResource>(
+      `api/clusters/${cluster}/api/v1/namespaces/`,
+      {
+        apiVersion: "v1",
+        kind: "Namespace",
+        metadata: {
+          name,
+        },
       },
-    });
+    );
     return data;
   }
 
-  public static async get(name: string) {
+  public static async get(cluster: string, name: string) {
     try {
-      const { data } = await axiosWithAuth.get<IResource>(`${APIBase}/api/v1/namespaces/${name}`);
+      const { data } = await axiosWithAuth.get<IResource>(
+        `api/clusters/${cluster}/api/v1/namespaces/${name}`,
+      );
       return data;
     } catch (err) {
       switch (err.constructor) {

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -57,7 +57,7 @@ function withNS(namespace: string) {
 
 export const backend = {
   namespaces: {
-    list: (cluster: string) => `api/v1/clusters${cluster}/namespaces`,
+    list: (cluster: string) => `api/v1/clusters/${cluster}/namespaces`,
   },
   apprepositories: {
     base: (namespace: string) => `api/v1/namespaces/${namespace}/apprepositories`,

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -57,11 +57,10 @@ function withNS(namespace: string) {
 
 export const backend = {
   namespaces: {
-    base: "api/v1/namespaces",
-    list: () => `${backend.namespaces.base}`,
+    list: (cluster: string) => `api/v1/clusters${cluster}/namespaces`,
   },
   apprepositories: {
-    base: (namespace: string) => `${backend.namespaces.base}/${namespace}/apprepositories`,
+    base: (namespace: string) => `api/v1/namespaces/${namespace}/apprepositories`,
     create: (namespace: string) => backend.apprepositories.base(namespace),
     validate: () => `${backend.apprepositories.base("kubeapps")}/validate`,
     delete: (name: string, namespace: string) =>


### PR DESCRIPTION
Updates `url.backend.namespaces.list()` to require the cluster arg, and all affected call-sites/dependencies.

Ref #1762 