### PR TITLE
1762 add select cluster component

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	authHeader     = "Authorization"
-	clusterParam   = "clusters"
+	clusterParam   = "cluster"
 	namespaceParam = "namespace"
 	nameParam      = "releaseName"
 	authUserError  = "Unexpected error while configuring authentication"
@@ -94,7 +94,7 @@ func WithHandlerConfig(storageForDriver agent.StorageForDriver, options Options)
 				return
 			}
 
-			kubeHandler, err := kube.NewHandler(options.KubeappsNamespace)
+			kubeHandler, err := kube.NewHandler(options.KubeappsNamespace, options.AdditionalClusters)
 			if err != nil {
 				log.Errorf("Failed to create handler: %v", err)
 				response.NewErrorResponse(http.StatusInternalServerError, authUserError).Write(w)

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -59,6 +59,7 @@ func main() {
 	if additionalClustersConfigPath != "" {
 		var err error
 		additionalClusters, err = parseAdditionalClusterConfig(additionalClustersConfigPath)
+		log.Infof("additional clusters: %+v", additionalClusters)
 		if err != nil {
 			log.Fatalf("unable to parse additional clusters config: %+v", err)
 		}
@@ -106,7 +107,7 @@ func main() {
 	addRoute("DELETE", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
 
 	// Backend routes unrelated to kubeops functionality.
-	err := backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter())
+	err := backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), additionalClusters)
 	if err != nil {
 		log.Fatalf("Unable to setup backend routes: %+v", err)
 	}

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -133,7 +133,7 @@ func main() {
 		log.Fatalf("POD_NAMESPACE should be defined")
 	}
 
-	kubeHandler, err := kube.NewHandler(kubeappsNamespace)
+	kubeHandler, err := kube.NewHandler(kubeappsNamespace, kube.AdditionalClustersConfig{})
 	if err != nil {
 		log.Fatalf("Failed to create handler: %v", err)
 	}
@@ -172,7 +172,7 @@ func main() {
 	apiv1.Methods("DELETE").Path("/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}").Handler(handlerutil.WithParams(h.DeleteRelease))
 
 	// Backend routes unrelated to tiller-proxy functionality.
-	err = backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter())
+	err = backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), kube.AdditionalClustersConfig{})
 	if err != nil {
 		log.Fatalf("Unable to setup backend routes: %+v", err)
 	}

--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -54,7 +54,7 @@ describe("authenticate", () => {
       },
     ];
 
-    return store.dispatch(actions.auth.authenticate(token, false)).then(() => {
+    return store.dispatch(actions.auth.authenticate("default", token, false)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
@@ -71,9 +71,9 @@ describe("authenticate", () => {
       },
     ];
 
-    return store.dispatch(actions.auth.authenticate(token, false)).then(() => {
+    return store.dispatch(actions.auth.authenticate("default", token, false)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
-      expect(Auth.validateToken).toHaveBeenCalledWith(token);
+      expect(Auth.validateToken).toHaveBeenCalledWith("default", token);
     });
   });
 
@@ -93,7 +93,7 @@ describe("authenticate", () => {
       },
     ];
 
-    return store.dispatch(actions.auth.authenticate("ignored", true)).then(() => {
+    return store.dispatch(actions.auth.authenticate("default", "ignored", true)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
       expect(Auth.validateToken).not.toHaveBeenCalled();
     });
@@ -120,7 +120,7 @@ describe("OIDC authentication", () => {
       },
     ];
 
-    return store.dispatch(actions.auth.checkCookieAuthentication()).then(() => {
+    return store.dispatch(actions.auth.checkCookieAuthentication("default")).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -25,6 +25,7 @@ const allActions = [setAuthenticated, authenticating, authenticationError, setSe
 export type AuthAction = ActionType<typeof allActions[number]>;
 
 export function authenticate(
+  cluster: string,
   token: string,
   oidc: boolean,
 ): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
@@ -32,7 +33,7 @@ export function authenticate(
     dispatch(authenticating());
     try {
       if (!oidc) {
-        await Auth.validateToken(token);
+        await Auth.validateToken(cluster, token);
       }
       Auth.setAuthToken(token, oidc);
       dispatch(setAuthenticated(true, oidc, Auth.defaultNamespaceFromToken(token)));
@@ -74,20 +75,17 @@ export function expireSession(): ThunkAction<Promise<void>, IStoreState, null, A
   };
 }
 
-export function checkCookieAuthentication(): ThunkAction<
-  Promise<void>,
-  IStoreState,
-  null,
-  AuthAction
-> {
+export function checkCookieAuthentication(
+  cluster: string,
+): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
   return async dispatch => {
     // The call to authenticate below will also dispatch authenticating,
     // but we dispatch it early so that the login screen is shown as
     // loading while we query isAuthenticatedWithCookie().
     dispatch(authenticating());
-    const isAuthed = await Auth.isAuthenticatedWithCookie();
+    const isAuthed = await Auth.isAuthenticatedWithCookie(cluster);
     if (isAuthed) {
-      dispatch(authenticate("", true));
+      dispatch(authenticate(cluster, "", true));
     } else {
       dispatch(setAuthenticated(false, false, ""));
     }

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -46,6 +46,7 @@ describe("getResource", () => {
       },
     ];
     const r = {
+      cluster: "default",
       apiVersion: "v1",
       kind: "Service",
       metadata: {
@@ -58,7 +59,7 @@ describe("getResource", () => {
 
     await store.dispatch(actions.kube.getResource(ref));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(getResourceMock).toHaveBeenCalledWith("v1", "services", "default", "foo");
+    expect(getResourceMock).toHaveBeenCalledWith("default", "v1", "services", "default", "foo");
   });
 
   it("does not fetch a resource that is already being fetched", async () => {
@@ -71,6 +72,7 @@ describe("getResource", () => {
     });
 
     const r = {
+      cluster: "default",
       apiVersion: "v1",
       kind: "Service",
       metadata: {
@@ -90,6 +92,7 @@ describe("getResource", () => {
 describe("getAndWatchResource", () => {
   it("dispatches a getResource and openWatchResource action", () => {
     const r = {
+      cluster: "default",
       apiVersion: "v1",
       kind: "Service",
       metadata: {
@@ -117,7 +120,7 @@ describe("getAndWatchResource", () => {
 
     store.dispatch(actions.kube.getAndWatchResource(ref));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(getResourceMock).toHaveBeenCalledWith("v1", "services", "default", "foo");
+    expect(getResourceMock).toHaveBeenCalledWith("default", "v1", "services", "default", "foo");
   });
 
   it("dispatches a getResource and openWatchResource action for a list", () => {
@@ -127,6 +130,7 @@ describe("getAndWatchResource", () => {
       version: "v1",
     } as IClusterServiceVersionCRD;
     const svc = {
+      cluster: "default",
       apiVersion: "v1",
       kind: "Service",
       metadata: {
@@ -155,7 +159,7 @@ describe("getAndWatchResource", () => {
     store.dispatch(actions.kube.getAndWatchResource(r));
     const testActions = store.getActions();
     expect(testActions).toEqual(expectedActions);
-    expect(getResourceMock).toHaveBeenCalledWith("v1", "services", "default", undefined);
+    expect(getResourceMock).toHaveBeenCalledWith("default", "v1", "services", "default", undefined);
 
     const watchFunction = (testActions[1].payload as any).handler as (e: any) => void;
     watchFunction({ data: `{"object": ${JSON.stringify(svc)}}` });

--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -67,7 +67,7 @@ describe("fetchNamespaces", () => {
       },
     ];
 
-    await store.dispatch(fetchNamespaces());
+    await store.dispatch(fetchNamespaces("default-c"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -81,7 +81,7 @@ describe("fetchNamespaces", () => {
       },
     ];
 
-    await store.dispatch(fetchNamespaces());
+    await store.dispatch(fetchNamespaces("default-c"));
 
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -106,7 +106,7 @@ describe("createNamespace", () => {
       },
     ];
 
-    const res = await store.dispatch(createNamespace("overlook-hotel"));
+    const res = await store.dispatch(createNamespace("default-c", "overlook-hotel"));
     expect(res).toBe(true);
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -121,7 +121,7 @@ describe("createNamespace", () => {
       },
     ];
 
-    const res = await store.dispatch(createNamespace("foo"));
+    const res = await store.dispatch(createNamespace("default-c", "foo"));
     expect(res).toBe(false);
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -134,14 +134,14 @@ describe("getNamespace", () => {
     const expectedActions = [
       {
         type: getType(requestNamespace),
-        payload: "default",
+        payload: "default-ns",
       },
       {
         type: getType(receiveNamespace),
         payload: ns,
       },
     ];
-    const r = await store.dispatch(getNamespace("default"));
+    const r = await store.dispatch(getNamespace("default-c", "default-ns"));
     expect(r).toBe(true);
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -152,14 +152,14 @@ describe("getNamespace", () => {
     const expectedActions = [
       {
         type: getType(requestNamespace),
-        payload: "default",
+        payload: "default-ns",
       },
       {
         type: getType(errorNamespaces),
         payload: { err, op: "get" },
       },
     ];
-    const r = await store.dispatch(getNamespace("default"));
+    const r = await store.dispatch(getNamespace("default-c", "default-ns"));
     expect(r).toBe(false);
     expect(store.getActions()).toEqual(expectedActions);
   });

--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -32,19 +32,19 @@ interface ITestCase {
 }
 
 const actionTestCases: ITestCase[] = [
-  { name: "setNamespace", action: setNamespace, args: "jack", payload: "jack" },
+  { name: "setNamespace", action: setNamespace, args: ["jack"], payload: "jack" },
   {
     name: "receiveNamespces",
     action: receiveNamespaces,
-    args: ["jack", "danny"],
-    payload: ["jack", "danny"],
+    args: ["default", ["jack", "danny"]],
+    payload: { cluster: "default", namespaces: ["jack", "danny"] },
   },
 ];
 
 actionTestCases.forEach(tc => {
   describe(tc.name, () => {
     it("has expected structure", () => {
-      expect(tc.action.call(null, tc.args)).toEqual({
+      expect(tc.action.call(null, ...tc.args)).toEqual({
         type: getType(tc.action),
         payload: tc.payload,
       });
@@ -63,7 +63,7 @@ describe("fetchNamespaces", () => {
     const expectedActions = [
       {
         type: getType(receiveNamespaces),
-        payload: ["overlook-hotel", "room-217"],
+        payload: { cluster: "default-c", namespaces: ["overlook-hotel", "room-217"] },
       },
     ];
 
@@ -102,7 +102,7 @@ describe("createNamespace", () => {
       },
       {
         type: getType(receiveNamespaces),
-        payload: ["overlook-hotel", "room-217"],
+        payload: { cluster: "default-c", namespaces: ["overlook-hotel", "room-217"] },
       },
     ];
 
@@ -129,8 +129,9 @@ describe("createNamespace", () => {
 
 describe("getNamespace", () => {
   it("dispatches requested namespace", async () => {
-    const ns = { metadata: { name: "default" } };
-    Namespace.get = jest.fn().mockReturnValue(ns);
+    const namespace = { metadata: { name: "default-ns" } };
+    const cluster = "default-c";
+    Namespace.get = jest.fn().mockReturnValue(namespace);
     const expectedActions = [
       {
         type: getType(requestNamespace),
@@ -138,10 +139,10 @@ describe("getNamespace", () => {
       },
       {
         type: getType(receiveNamespace),
-        payload: ns,
+        payload: { cluster, namespace },
       },
     ];
-    const r = await store.dispatch(getNamespace("default-c", "default-ns"));
+    const r = await store.dispatch(getNamespace(cluster, "default-ns"));
     expect(r).toBe(true);
     expect(store.getActions()).toEqual(expectedActions);
   });

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -41,10 +41,12 @@ const allActions = [
 ];
 export type NamespaceAction = ActionType<typeof allActions[number]>;
 
-export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
+export function fetchNamespaces(
+  cluster: string,
+): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
   return async dispatch => {
     try {
-      const namespaceList = await Namespace.list();
+      const namespaceList = await Namespace.list(cluster);
       const namespaceStrings = namespaceList.namespaces.map((n: IResource) => n.metadata.name);
       dispatch(receiveNamespaces(namespaceStrings));
     } catch (e) {
@@ -55,13 +57,14 @@ export function fetchNamespaces(): ThunkAction<Promise<void>, IStoreState, null,
 }
 
 export function createNamespace(
+  cluster: string,
   ns: string,
 ): ThunkAction<Promise<boolean>, IStoreState, null, NamespaceAction> {
   return async dispatch => {
     try {
-      await Namespace.create(ns);
+      await Namespace.create(cluster, ns);
       dispatch(postNamespace(ns));
-      dispatch(fetchNamespaces());
+      dispatch(fetchNamespaces(cluster));
       return true;
     } catch (e) {
       dispatch(errorNamespaces(e, "create"));
@@ -71,12 +74,13 @@ export function createNamespace(
 }
 
 export function getNamespace(
+  cluster: string,
   ns: string,
 ): ThunkAction<Promise<boolean>, IStoreState, null, NamespaceAction> {
   return async dispatch => {
     try {
       dispatch(requestNamespace(ns));
-      const namespace = await Namespace.get(ns);
+      const namespace = await Namespace.get(cluster, ns);
       dispatch(receiveNamespace(namespace));
       return true;
     } catch (e) {

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -9,7 +9,7 @@ export const requestNamespace = createAction("REQUEST_NAMESPACE", resolve => {
   return (namespace: string) => resolve(namespace);
 });
 export const receiveNamespace = createAction("RECEIVE_NAMESPACE", resolve => {
-  return (namespace: IResource) => resolve(namespace);
+  return (cluster: string, namespace: IResource) => resolve({ cluster, namespace });
 });
 
 export const setNamespace = createAction("SET_NAMESPACE", resolve => {
@@ -21,7 +21,7 @@ export const postNamespace = createAction("CREATE_NAMESPACE", resolve => {
 });
 
 export const receiveNamespaces = createAction("RECEIVE_NAMESPACES", resolve => {
-  return (namespaces: string[]) => resolve(namespaces);
+  return (cluster: string, namespaces: string[]) => resolve({ cluster, namespaces });
 });
 
 export const errorNamespaces = createAction("ERROR_NAMESPACES", resolve => {
@@ -48,7 +48,7 @@ export function fetchNamespaces(
     try {
       const namespaceList = await Namespace.list(cluster);
       const namespaceStrings = namespaceList.namespaces.map((n: IResource) => n.metadata.name);
-      dispatch(receiveNamespaces(namespaceStrings));
+      dispatch(receiveNamespaces(cluster, namespaceStrings));
     } catch (e) {
       dispatch(errorNamespaces(e, "list"));
       return;
@@ -81,7 +81,7 @@ export function getNamespace(
     try {
       dispatch(requestNamespace(ns));
       const namespace = await Namespace.get(cluster, ns);
-      dispatch(receiveNamespace(namespace));
+      dispatch(receiveNamespace(cluster, namespace));
       return true;
     } catch (e) {
       dispatch(errorNamespaces(e, "get"));

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -59,7 +59,11 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
       namespace,
     } = this.props;
     // refetch if new namespace or error removed due to location change
-    if (prevProps.namespace !== namespace || (!error && prevProps.apps.error)) {
+    if (
+      prevProps.namespace !== namespace ||
+      prevProps.cluster !== cluster ||
+      (!error && prevProps.apps.error)
+    ) {
       fetchAppsWithUpdateInfo(cluster, namespace, listingAll);
       if (this.props.featureFlags.operators) {
         getCustomResources(namespace);

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -104,17 +104,25 @@ describe("AppViewComponent", () => {
       // setProps again so we trigger componentWillReceiveProps
       wrapper.setProps(validProps);
 
+      const expectedDeployment = Object.assign({}, resources.deployment);
+      expectedDeployment.cluster = "default";
       expect(wrapper.state("deployRefs")).toEqual([
-        new ResourceRef(resources.deployment, appRelease.namespace),
+        new ResourceRef(expectedDeployment, appRelease.namespace),
       ]);
+      const expectedService = Object.assign({}, resources.service);
+      expectedService.cluster = "default";
       expect(wrapper.state("serviceRefs")).toEqual([
-        new ResourceRef(resources.service, appRelease.namespace),
+        new ResourceRef(expectedService, appRelease.namespace),
       ]);
+      const expectedIngress = Object.assign({}, resources.ingress);
+      expectedIngress.cluster = "default";
       expect(wrapper.state("ingressRefs")).toEqual([
-        new ResourceRef(resources.ingress, appRelease.namespace),
+        new ResourceRef(expectedIngress, appRelease.namespace),
       ]);
+      const expectedSecret = Object.assign({}, resources.secret);
+      expectedSecret.cluster = "default";
       expect(wrapper.state("secretRefs")).toEqual([
-        new ResourceRef(resources.secret, appRelease.namespace),
+        new ResourceRef(expectedSecret, appRelease.namespace),
       ]);
     });
 
@@ -382,9 +390,11 @@ describe("AppViewComponent", () => {
     // setProps again so we trigger componentWillReceiveProps
     wrapper.setProps(validProps);
 
+    const expectedService = Object.assign({}, resources.service);
+    expectedService.cluster = "default";
     expect(wrapper.state()).toMatchObject({
       deployRefs: [new ResourceRef(resources.deployment, appRelease.namespace)],
-      serviceRefs: [new ResourceRef(resources.service, appRelease.namespace)],
+      serviceRefs: [new ResourceRef(expectedService, appRelease.namespace)],
       otherResources: [new ResourceRef(obj, appRelease.namespace)],
     });
   });
@@ -402,9 +412,11 @@ describe("AppViewComponent", () => {
     // setProps again so we trigger componentWillReceiveProps
     wrapper.setProps(validProps);
 
+    const expectedService = Object.assign({}, resources.service);
+    expectedService.cluster = "default";
     expect(wrapper.state()).toMatchObject({
       deployRefs: [new ResourceRef(resources.deployment, appRelease.namespace)],
-      serviceRefs: [new ResourceRef(resources.service, appRelease.namespace)],
+      serviceRefs: [new ResourceRef(expectedService, appRelease.namespace)],
       otherResources: [new ResourceRef(obj, appRelease.namespace)],
     });
   });
@@ -420,11 +432,15 @@ describe("AppViewComponent", () => {
     const applicationStatus = wrapper.find(ApplicationStatusContainer);
     expect(applicationStatus).toExist();
 
+    const expectedStatefulSet = Object.assign({}, resources.statefulset);
+    expectedStatefulSet.cluster = "default";
     expect(applicationStatus.prop("statefulsetRefs")).toEqual([
-      new ResourceRef(resources.statefulset, appRelease.namespace),
+      new ResourceRef(expectedStatefulSet, appRelease.namespace),
     ]);
+    const expectedDaemonSet = Object.assign({}, resources.daemonset);
+    expectedDaemonSet.cluster = "default";
     expect(applicationStatus.prop("daemonsetRefs")).toEqual([
-      new ResourceRef(resources.daemonset, appRelease.namespace),
+      new ResourceRef(expectedDaemonSet, appRelease.namespace),
     ]);
   });
 });

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -104,6 +104,11 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
     // Filter out elements in the manifest that does not comply
     // with { kind: foo }
     manifest = manifest.filter(r => r && r.kind);
+    // TODO: don't add cluster like this.
+    manifest = manifest.map((r: IResource) => {
+      r.cluster = this.props.cluster;
+      return r;
+    });
     if (!isEqual(manifest, this.state.manifest)) {
       this.setState({ manifest });
     } else {

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
@@ -15,7 +15,10 @@ it("skips the element if there are no resources", () => {
 
 it("renders a ResourceItem", () => {
   const resourceRefs = [
-    new ResourceRef({ kind: "Deployment", metadata: { name: "foo" } } as IResource, "default"),
+    new ResourceRef(
+      { cluster: "default", kind: "Deployment", metadata: { name: "foo" } } as IResource,
+      "default",
+    ),
   ];
   const wrapper = shallow(<ResourceTable resourceRefs={resourceRefs} title={""} />);
   expect(wrapper).toMatchSnapshot();

--- a/dashboard/src/components/AppView/ResourceTable/__snapshots__/ResourceTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/ResourceTable/__snapshots__/ResourceTable.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`renders a ResourceItem 1`] = `
         resourceRef={
           ResourceRef {
             "apiVersion": undefined,
+            "cluster": "default",
             "filter": undefined,
             "kind": "Deployment",
             "name": "foo",

--- a/dashboard/src/components/Header/ClusterSelector.tsx
+++ b/dashboard/src/components/Header/ClusterSelector.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { useDispatch } from "react-redux";
+import Select from "react-select";
+
+import actions from "actions";
+import { IClustersState } from "reducers/cluster";
+
+interface IClusterSelectorProps {
+  clusters: IClustersState;
+  onChange: (cluster: string) => void;
+}
+
+const ClusterSelector: React.FC<IClusterSelectorProps> = props => {
+  const clusters = Object.keys(props.clusters.clusters);
+  const options = clusters.length > 0 ? clusters.map(c => ({ value: c, label: c })) : [];
+  const dispatch = useDispatch();
+  const handleClusterChange = (option: any) => {
+    dispatch(actions.namespace.fetchNamespaces(option.value));
+    props.onChange(option.value);
+  };
+
+  // TODO: Currently just re-using namespace selector styles.
+  return (
+    <div className="NamespaceSelector margin-r-normal">
+      <label className="NamespaceSelector__label type-tiny">CLUSTER</label>
+      <Select
+        className="NamespaceSelector__select type-small"
+        value={props.clusters.currentCluster}
+        options={options}
+        multi={false}
+        onChange={handleClusterChange}
+        clearable={false}
+      />
+    </div>
+  );
+};
+
+export default ClusterSelector;

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -95,7 +95,7 @@ it("renders the namespace switcher", () => {
   expect(namespaceSelector.props()).toEqual(
     expect.objectContaining({
       defaultNamespace: defaultProps.defaultNamespace,
-      cluster: defaultProps.clusters.clusters.default,
+      clusters: defaultProps.clusters,
     }),
   );
 });
@@ -129,7 +129,7 @@ it("call setNamespace and getNamespace when selecting a namespace", () => {
   onChange("bar");
 
   expect(setNamespace).toHaveBeenCalledWith("bar");
-  expect(getNamespace).toHaveBeenCalledWith("bar");
+  expect(getNamespace).toHaveBeenCalledWith("default", "bar");
   expect(createNamespace).not.toHaveBeenCalled();
 });
 

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -7,6 +7,7 @@ import logo from "../../logo.svg";
 import { IClustersState } from "../../reducers/cluster";
 import { definedNamespaces } from "../../shared/Namespace";
 import { app } from "../../shared/url";
+import ClusterSelector from "./ClusterSelector";
 import "./Header.css";
 import HeaderLink from "./HeaderLink";
 import NamespaceSelector from "./NamespaceSelector";
@@ -111,6 +112,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
             )}
             {showNav && (
               <div className="header__nav header__nav-config">
+                <ClusterSelector clusters={clusters} onChange={this.handleClusterChange} />
                 <NamespaceSelector
                   clusters={clusters}
                   defaultNamespace={defaultNamespace}
@@ -200,6 +202,14 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
     if (ns !== definedNamespaces.all) {
       getNamespace(currentCluster, ns);
     }
+    if (to !== pathname) {
+      push(to);
+    }
+  };
+
+  private handleClusterChange = (cluster: string) => {
+    const { pathname, push } = this.props;
+    const to = pathname.replace(/\/c\/[^/]*/, `/c/${cluster}`);
     if (to !== pathname) {
       push(to);
     }

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -13,15 +13,15 @@ import NamespaceSelector from "./NamespaceSelector";
 
 export interface IHeaderProps {
   authenticated: boolean;
-  fetchNamespaces: () => void;
+  fetchNamespaces: (cluster: string) => void;
   logout: () => void;
   clusters: IClustersState;
   defaultNamespace: string;
   pathname: string;
   push: (path: string) => void;
   setNamespace: (ns: string) => void;
-  createNamespace: (ns: string) => Promise<boolean>;
-  getNamespace: (ns: string) => void;
+  createNamespace: (cluster: string, ns: string) => Promise<boolean>;
+  getNamespace: (cluster: string, ns: string) => void;
   featureFlags: IFeatureFlags;
 }
 
@@ -112,7 +112,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
             {showNav && (
               <div className="header__nav header__nav-config">
                 <NamespaceSelector
-                  cluster={cluster}
+                  clusters={clusters}
                   defaultNamespace={defaultNamespace}
                   onChange={this.handleNamespaceChange}
                   fetchNamespaces={fetchNamespaces}
@@ -188,11 +188,17 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
   };
 
   private handleNamespaceChange = (ns: string) => {
-    const { pathname, push, setNamespace, getNamespace } = this.props;
+    const {
+      clusters: { currentCluster },
+      pathname,
+      push,
+      setNamespace,
+      getNamespace,
+    } = this.props;
     const to = pathname.replace(/\/ns\/[^/]*/, `/ns/${ns}`);
     setNamespace(ns);
     if (ns !== definedNamespaces.all) {
-      getNamespace(ns);
+      getNamespace(currentCluster, ns);
     }
     if (to !== pathname) {
       push(to);

--- a/dashboard/src/components/Header/Header.v2.tsx
+++ b/dashboard/src/components/Header/Header.v2.tsx
@@ -18,14 +18,14 @@ ClarityIcons.addIcons(applicationsIcon, clusterIcon, fileGroupIcon, angleIcon);
 
 interface IHeaderProps {
   authenticated: boolean;
-  fetchNamespaces: () => void;
+  fetchNamespaces: (cluster: string) => void;
   logout: () => void;
   clusters: IClustersState;
   defaultNamespace: string;
   push: (path: string) => void;
   setNamespace: (ns: string) => void;
-  createNamespace: (ns: string) => Promise<boolean>;
-  getNamespace: (ns: string) => void;
+  createNamespace: (cluster: string, ns: string) => Promise<boolean>;
+  getNamespace: (cluster: string, ns: string) => void;
 }
 
 function Header(props: IHeaderProps) {

--- a/dashboard/src/components/Header/NamespaceSelector.test.tsx
+++ b/dashboard/src/components/Header/NamespaceSelector.test.tsx
@@ -9,10 +9,15 @@ import NewNamespace from "./NewNamespace";
 
 const defaultProps = {
   fetchNamespaces: jest.fn(),
-  cluster: {
-    currentNamespace: "namespace-two",
-    namespaces: ["namespace-one", "namespace-two"],
-  } as IClusterState,
+  clusters: {
+    currentCluster: "default",
+    clusters: {
+      default: {
+        currentNamespace: "namespace-two",
+        namespaces: ["namespace-one", "namespace-two"],
+      } as IClusterState,
+    },
+  },
   defaultNamespace: "kubeapps-user",
   onChange: jest.fn(),
   createNamespace: jest.fn(),
@@ -24,8 +29,8 @@ it("renders the given namespaces with current selection", () => {
   const select = wrapper.find(".NamespaceSelector__select").first();
 
   const expectedValue = {
-    label: defaultProps.cluster.currentNamespace,
-    value: defaultProps.cluster.currentNamespace,
+    label: defaultProps.clusters.clusters.default.currentNamespace,
+    value: defaultProps.clusters.clusters.default.currentNamespace,
   };
   expect(select.props()).toMatchObject({
     value: expectedValue,
@@ -41,9 +46,15 @@ it("renders the given namespaces with current selection", () => {
 it("render with the default namespace selected if no current selection", () => {
   const props = {
     ...defaultProps,
-    cluster: {
-      ...defaultProps.cluster,
-      currentNamespace: "",
+    clusters: {
+      ...defaultProps.clusters,
+      clusters: {
+        ...defaultProps.clusters.clusters,
+        default: {
+          currentNamespace: "",
+          namespaces: [],
+        },
+      },
     },
   } as INamespaceSelectorProps;
   const wrapper = shallow(<NamespaceSelector {...props} />);
@@ -69,7 +80,7 @@ it("opens the modal to add a new namespace and creates it", async () => {
   wrapper.update();
 
   wrapper.find(".button-primary").simulate("click");
-  expect(createNamespace).toHaveBeenCalledWith("test");
+  expect(createNamespace).toHaveBeenCalledWith("default", "test");
   // hack to wait for the state to be updated
   await new Promise(res =>
     setTimeout(() => {
@@ -83,29 +94,45 @@ it("opens the modal to add a new namespace and creates it", async () => {
 it("fetches namespaces and retrive the current namespace", () => {
   const fetchNamespaces = jest.fn();
   const getNamespace = jest.fn();
-  shallow(
-    <NamespaceSelector
-      {...defaultProps}
-      fetchNamespaces={fetchNamespaces}
-      getNamespace={getNamespace}
-      cluster={{ currentNamespace: "foo", namespaces: [] }}
-    />,
-  );
+  const props = {
+    ...defaultProps,
+    fetchNamespaces,
+    getNamespace,
+    clusters: {
+      ...defaultProps.clusters,
+      clusters: {
+        ...defaultProps.clusters.clusters,
+        default: {
+          currentNamespace: "foo",
+          namespaces: [],
+        },
+      },
+    },
+  };
+  shallow(<NamespaceSelector {...props} />);
   expect(fetchNamespaces).toHaveBeenCalled();
-  expect(getNamespace).toHaveBeenCalledWith("foo");
+  expect(getNamespace).toHaveBeenCalledWith("default", "foo");
 });
 
 it("doesnt' get the current namespace if all namespaces is selected", () => {
   const fetchNamespaces = jest.fn();
   const getNamespace = jest.fn();
-  shallow(
-    <NamespaceSelector
-      {...defaultProps}
-      fetchNamespaces={fetchNamespaces}
-      getNamespace={getNamespace}
-      cluster={{ currentNamespace: "_all", namespaces: [] }}
-    />,
-  );
+  const props = {
+    ...defaultProps,
+    fetchNamespaces,
+    getNamespace,
+    clusters: {
+      ...defaultProps.clusters,
+      clusters: {
+        ...defaultProps.clusters.clusters,
+        default: {
+          currentNamespace: "_all",
+          namespaces: [],
+        },
+      },
+    },
+  };
+  shallow(<NamespaceSelector {...props} />);
   expect(fetchNamespaces).toHaveBeenCalled();
   expect(getNamespace).not.toHaveBeenCalled();
 });

--- a/dashboard/src/components/LoginForm/LoginForm.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.test.tsx
@@ -15,6 +15,7 @@ const emptyLocation: Location = {
 };
 
 const defaultProps = {
+  cluster: "default",
   authenticate: jest.fn(),
   authenticated: false,
   authenticating: false,
@@ -95,7 +96,7 @@ describe("token login form", () => {
     const wrapper = shallow(<LoginForm {...defaultProps} />);
     wrapper.find("input#token").simulate("change", { currentTarget: { value: "f00b4r" } });
     wrapper.find("form").simulate("submit", { preventDefault: jest.fn() });
-    expect(defaultProps.authenticate).toBeCalledWith("f00b4r");
+    expect(defaultProps.authenticate).toBeCalledWith("default", "f00b4r");
   });
 
   it("displays an error if the authentication error is passed", () => {

--- a/dashboard/src/components/LoginForm/LoginForm.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.tsx
@@ -7,12 +7,13 @@ import LoadingWrapper from "../../components/LoadingWrapper";
 import "./LoginForm.css";
 
 interface ILoginFormProps {
+  cluster: string;
   authenticated: boolean;
   authenticating: boolean;
   authenticationError: string | undefined;
   oauthLoginURI: string;
-  authenticate: (token: string) => any;
-  checkCookieAuthentication: () => void;
+  authenticate: (cluster: string, token: string) => any;
+  checkCookieAuthentication: (cluster: string) => void;
   location: Location;
 }
 
@@ -25,7 +26,7 @@ class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
 
   public componentDidMount() {
     if (this.props.oauthLoginURI) {
-      this.props.checkCookieAuthentication();
+      this.props.checkCookieAuthentication(this.props.cluster);
     }
   }
 
@@ -65,7 +66,7 @@ class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
   private handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const { token } = this.state;
-    return token && (await this.props.authenticate(token));
+    return token && (await this.props.authenticate(this.props.cluster, token));
   };
 
   private handleTokenChange = (e: React.FormEvent<HTMLInputElement>) => {

--- a/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
+++ b/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
                   Array [
                     ResourceRef {
                       "apiVersion": "apps/v1",
+                      "cluster": "default",
                       "filter": Object {
                         "metadata": Object {
                           "ownerReferences": Array [
@@ -132,6 +133,7 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
               Array [
                 ResourceRef {
                   "apiVersion": "apps/v1",
+                  "cluster": "default",
                   "filter": Object {
                     "metadata": Object {
                       "ownerReferences": Array [

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
@@ -35,6 +35,7 @@ describe("AccessURLTableContainer", () => {
       "api/clusters/default/api/v1/namespaces/wee/ingresses/foo-ingress": ingress,
     });
     const serviceRef = new ResourceRef({
+      cluster: "default",
       apiVersion: "v1",
       kind: "Service",
       metadata: {
@@ -43,6 +44,7 @@ describe("AccessURLTableContainer", () => {
       },
     } as IResource);
     const ingressRef = new ResourceRef({
+      cluster: "default",
       apiVersion: "v1",
       kind: "Ingress",
       metadata: {

--- a/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/dashboard/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -65,7 +65,6 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     getChartVersion: (namespace: string, id: string, version: string) =>
       dispatch(actions.charts.getChartVersion(namespace, id, version)),
     push: (location: string) => dispatch(push(location)),
-    getNamespace: (ns: string) => dispatch(actions.namespace.getNamespace(ns)),
   };
 }
 

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
@@ -27,6 +27,7 @@ describe("ApplicationStatusContainer", () => {
       "api/clusters/default/apis/apps/v1/namespaces/wee/deployments/foo": item,
     });
     const ref = new ResourceRef({
+      cluster: "default",
       apiVersion: "apps/v1",
       kind: "Deployment",
       metadata: {

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -27,12 +27,14 @@ function mapStateToProps({
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    fetchNamespaces: () => dispatch(actions.namespace.fetchNamespaces()),
-    createNamespace: (ns: string) => dispatch(actions.namespace.createNamespace(ns)),
+    fetchNamespaces: (cluster: string) => dispatch(actions.namespace.fetchNamespaces(cluster)),
+    createNamespace: (cluster: string, ns: string) =>
+      dispatch(actions.namespace.createNamespace(cluster, ns)),
     logout: () => dispatch(actions.auth.logout()),
     push: (path: string) => dispatch(push(path)),
     setNamespace: (ns: string) => dispatch(actions.namespace.setNamespace(ns)),
-    getNamespace: (ns: string) => dispatch(actions.namespace.getNamespace(ns)),
+    getNamespace: (cluster: string, ns: string) =>
+      dispatch(actions.namespace.getNamespace(cluster, ns)),
   };
 }
 

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -2,6 +2,7 @@ import { shallow } from "enzyme";
 import { Location } from "history";
 import * as React from "react";
 import { IAuthState } from "reducers/auth";
+import { IClustersState } from "reducers/cluster";
 import { IConfigState } from "reducers/config";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
@@ -36,7 +37,16 @@ const makeStore = (
     oauthLogoutURI: "",
     featureFlags: { operators: false, additionalClusters: [], ui: "hex" },
   };
-  return mockStore({ auth, config });
+  const clusters: IClustersState = {
+    currentCluster: "default",
+    clusters: {
+      default: {
+        currentNamespace: "default",
+        namespaces: [],
+      },
+    },
+  };
+  return mockStore({ auth, config, clusters });
 };
 
 const emptyLocation: Location = {

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
@@ -9,8 +9,10 @@ import { IStoreState } from "../../shared/types";
 function mapStateToProps({
   auth: { authenticated, authenticating, authenticationError },
   config: { authProxyEnabled, oauthLoginURI },
+  clusters,
 }: IStoreState) {
   return {
+    cluster: clusters.currentCluster,
     authenticated,
     authenticating,
     authenticationError,
@@ -20,8 +22,10 @@ function mapStateToProps({
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    authenticate: (token: string) => dispatch(actions.auth.authenticate(token, false)),
-    checkCookieAuthentication: () => dispatch(actions.auth.checkCookieAuthentication()),
+    authenticate: (cluster: string, token: string) =>
+      dispatch(actions.auth.authenticate(cluster, token, false)),
+    checkCookieAuthentication: (cluster: string) =>
+      dispatch(actions.auth.checkCookieAuthentication(cluster)),
   };
 }
 

--- a/dashboard/src/containers/ResourceItemContainer/ResourceItemContainer.test.tsx
+++ b/dashboard/src/containers/ResourceItemContainer/ResourceItemContainer.test.tsx
@@ -27,6 +27,7 @@ describe("ResourceItemContainer", () => {
       "api/clusters/default/apis/apps/v1/namespaces/wee/statefulsets/foo": item,
     });
     const ref = new ResourceRef({
+      cluster: "default",
       apiVersion: "apps/v1",
       kind: "StatefulSet",
       metadata: {

--- a/dashboard/src/containers/RoutesContainer/Routes.test.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.test.tsx
@@ -1,10 +1,9 @@
-import { mount, shallow } from "enzyme";
+import { mount } from "enzyme";
 import { createMemoryHistory } from "history";
 import * as React from "react";
 import { StaticRouter } from "react-router";
 import { Redirect, RouteComponentProps } from "react-router-dom";
 import NotFound from "../../components/NotFound";
-import RepoListContainer from "../../containers/RepoListContainer";
 import { app } from "../../shared/url";
 import Routes from "./Routes";
 
@@ -82,31 +81,4 @@ it("should render a redirect to the login page (when not authenticated)", () => 
   );
   expect(wrapper.find(NotFound)).not.toExist();
   expect(wrapper.find(Redirect).prop("to")).toEqual("/login");
-});
-
-describe("Routes depending on feature flags", () => {
-  const cluster = "default";
-  const namespace = "default";
-  const perNamespacePath = "/config/ns/:namespace/repos";
-
-  it("uses a namespaced route for app repos", () => {
-    const wrapper = shallow(
-      <StaticRouter location="/config/repos" context={{}}>
-        <Routes
-          {...emptyRouteComponentProps}
-          cluster={cluster}
-          namespace={namespace}
-          authenticated={true}
-        />
-      </StaticRouter>,
-    )
-      .dive()
-      .dive()
-      .dive()
-      .dive();
-    const component = wrapper.find({ component: RepoListContainer });
-
-    expect(component.length).toBe(1);
-    expect(component.props().path).toEqual(perNamespacePath);
-  });
 });

--- a/dashboard/src/containers/helpers/index.test.ts
+++ b/dashboard/src/containers/helpers/index.test.ts
@@ -4,16 +4,19 @@ import { IKubeItem, IKubeState, IResource } from "../../shared/types";
 
 describe("filterByResourceRefs", () => {
   const svc1 = {
+    cluster: "default",
     apiVersion: "v1",
     kind: "Service",
     metadata: { name: "bar", namespace: "foo" },
   } as IResource;
   const svc2 = {
+    cluster: "default",
     apiVersion: "v1",
     kind: "Service",
     metadata: { name: "bar", namespace: "foo1" },
   } as IResource;
   const deploy = {
+    cluster: "default",
     apiVersion: "apps/v1",
     kind: "Deployment",
     metadata: { name: "bar", namespace: "foo1" },

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -9,11 +9,15 @@ import clusterReducer, { IClustersState } from "./cluster";
 
 describe("clusterReducer", () => {
   const initialState: IClustersState = {
-    currentCluster: "default",
+    currentCluster: "initial-cluster",
     clusters: {
       default: {
-        currentNamespace: "initial-current",
-        namespaces: ["default", "initial-current"],
+        currentNamespace: "default",
+        namespaces: ["default"],
+      },
+      "initial-cluster": {
+        currentNamespace: "initial-namespace",
+        namespaces: ["default", "initial-namespace"],
       },
     },
   };
@@ -26,9 +30,21 @@ describe("clusterReducer", () => {
 
     describe("changes the current stored namespace if it is in the URL", () => {
       const testCases = [
-        { path: "/c/default/ns/cyberdyne/apps", current: "cyberdyne" },
-        { path: "/cyberdyne/apps", current: "initial-current" },
-        { path: "/c/barcluster/ns/T-600/charts", current: "T-600" },
+        {
+          path: "/c/default/ns/cyberdyne/apps",
+          currentNamespace: "cyberdyne",
+          currentCluster: "default",
+        },
+        {
+          path: "/cyberdyne/apps",
+          currentNamespace: "initial-namespace",
+          currentCluster: "initial-cluster",
+        },
+        {
+          path: "/c/barcluster/ns/T-600/charts",
+          currentNamespace: "T-600",
+          currentCluster: "barcluster",
+        },
       ];
       testCases.forEach(tc => {
         it(tc.path, () =>
@@ -43,10 +59,12 @@ describe("clusterReducer", () => {
             }),
           ).toEqual({
             ...initialState,
+            currentCluster: tc.currentCluster,
             clusters: {
-              default: {
-                ...initialState.clusters.default,
-                currentNamespace: tc.current,
+              ...initialState.clusters,
+              [tc.currentCluster]: {
+                ...initialState.clusters[tc.currentCluster],
+                currentNamespace: tc.currentNamespace,
               },
             },
           } as IClustersState),
@@ -67,8 +85,9 @@ describe("clusterReducer", () => {
       ).toEqual({
         ...initialState,
         clusters: {
-          default: {
-            ...initialState.clusters.default,
+          ...initialState.clusters,
+          "initial-cluster": {
+            ...initialState.clusters["initial-cluster"],
             error: undefined,
           },
         },
@@ -84,6 +103,7 @@ describe("clusterReducer", () => {
       ).toEqual({
         ...initialState,
         clusters: {
+          ...initialState.clusters,
           default: { ...initialState.clusters.default, error: { action: "create", error: err } },
         },
       } as IClustersState);
@@ -98,7 +118,10 @@ describe("clusterReducer", () => {
         }),
       ).toEqual({
         ...initialState,
-        clusters: { default: { currentNamespace: "_all", namespaces: [] } },
+        clusters: {
+          ...initialState.clusters,
+          default: { currentNamespace: "_all", namespaces: [] },
+        },
       } as IClustersState);
     });
   });
@@ -113,6 +136,7 @@ describe("clusterReducer", () => {
       ).toEqual({
         ...initialState,
         clusters: {
+          ...initialState.clusters,
           default: { ...initialState.clusters.default, currentNamespace: "foo-bar" },
         },
       } as IClustersState);
@@ -126,6 +150,7 @@ describe("clusterReducer", () => {
           {
             ...initialState,
             clusters: {
+              ...initialState.clusters,
               default: {
                 ...initialState.clusters.default,
                 currentNamespace: "other",
@@ -141,6 +166,7 @@ describe("clusterReducer", () => {
       ).toEqual({
         ...initialState,
         clusters: {
+          ...initialState.clusters,
           default: {
             ...initialState.clusters.default,
             currentNamespace: "default",
@@ -161,13 +187,20 @@ describe("clusterReducer", () => {
               default: {
                 currentNamespace: "",
                 namespaces: ["default"],
+              },
+              other: {
+                currentNamespace: "",
+                namespaces: ["othernamespace"],
                 error: { action: "create", error: new Error("boom") },
               },
             },
           } as IClustersState,
           {
             type: getType(actions.namespace.receiveNamespace),
-            payload: { metadata: { name: "bar" } } as IResource,
+            payload: {
+              cluster: "other",
+              namespace: { metadata: { name: "bar" } } as IResource,
+            },
           },
         ),
       ).toEqual({
@@ -175,7 +208,11 @@ describe("clusterReducer", () => {
         clusters: {
           default: {
             currentNamespace: "",
-            namespaces: ["bar", "default"],
+            namespaces: ["default"],
+          },
+          other: {
+            currentNamespace: "",
+            namespaces: ["bar", "othernamespace"],
             error: undefined,
           },
         },
@@ -183,6 +220,48 @@ describe("clusterReducer", () => {
     });
   });
 
+  context("when RECEIVE_NAMESPACES", () => {
+    it("updates the namespace list and clears error", () => {
+      expect(
+        clusterReducer(
+          {
+            ...initialState,
+            clusters: {
+              default: {
+                currentNamespace: "",
+                namespaces: ["default"],
+              },
+              other: {
+                currentNamespace: "",
+                namespaces: ["othernamespace"],
+                error: { action: "create", error: new Error("boom") },
+              },
+            },
+          } as IClustersState,
+          {
+            type: getType(actions.namespace.receiveNamespaces),
+            payload: {
+              cluster: "other",
+              namespaces: ["one", "two", "three"],
+            },
+          },
+        ),
+      ).toEqual({
+        ...initialState,
+        clusters: {
+          default: {
+            currentNamespace: "",
+            namespaces: ["default"],
+          },
+          other: {
+            currentNamespace: "",
+            namespaces: ["one", "two", "three"],
+            error: undefined,
+          },
+        },
+      } as IClustersState);
+    });
+  });
   context("when RECEIVE_CONFIG", () => {
     const config = {
       namespace: "kubeapps",

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -13,7 +13,7 @@ describe("Auth", () => {
   it("should get an URL with the given token", async () => {
     const mock = jest.fn();
     Axios.get = mock;
-    await Auth.validateToken("foo");
+    await Auth.validateToken("default", "foo");
     expect(mock.mock.calls[0]).toEqual([
       "api/clusters/default/",
       { headers: { Authorization: "Bearer foo" } },
@@ -52,7 +52,7 @@ describe("Auth", () => {
         // to upgrade jest for `toThrow()` to work with async.
         let err = null;
         try {
-          await Auth.validateToken("foo");
+          await Auth.validateToken("default", "foo");
         } catch (e) {
           err = e;
         } finally {
@@ -65,9 +65,9 @@ describe("Auth", () => {
   describe("isAuthenticatedWithCookie", () => {
     it("returns true if request to API root succeeds", async () => {
       Axios.get = jest.fn().mockReturnValue(Promise.resolve({ headers: { status: 200 } }));
-      const isAuthed = await Auth.isAuthenticatedWithCookie();
+      const isAuthed = await Auth.isAuthenticatedWithCookie("default");
 
-      expect(Axios.get).toBeCalledWith(APIBase + "/");
+      expect(Axios.get).toBeCalledWith(APIBase + "/clusters/default/");
       expect(isAuthed).toBe(true);
     });
     it("returns false if the request to api root results in a 403 for an anonymous request", async () => {
@@ -79,7 +79,7 @@ describe("Auth", () => {
           },
         });
       });
-      const isAuthed = await Auth.isAuthenticatedWithCookie();
+      const isAuthed = await Auth.isAuthenticatedWithCookie("default");
       expect(isAuthed).toBe(false);
     });
     it("returns false if the request to api root results in a non-json response (ie. without data.message)", async () => {
@@ -90,7 +90,7 @@ describe("Auth", () => {
           },
         });
       });
-      const isAuthed = await Auth.isAuthenticatedWithCookie();
+      const isAuthed = await Auth.isAuthenticatedWithCookie("default");
       expect(isAuthed).toBe(false);
     });
     it("returns true if the request to api root results in a 403 (but not anonymous)", async () => {
@@ -102,14 +102,14 @@ describe("Auth", () => {
           },
         });
       });
-      const isAuthed = await Auth.isAuthenticatedWithCookie();
+      const isAuthed = await Auth.isAuthenticatedWithCookie("default");
       expect(isAuthed).toBe(true);
     });
     it("should return false if the request results in a 401", async () => {
       Axios.get = jest.fn(() => {
         return Promise.reject({ response: { status: 401 } });
       });
-      const isAuthed = await Auth.isAuthenticatedWithCookie();
+      const isAuthed = await Auth.isAuthenticatedWithCookie("default");
       expect(isAuthed).toBe(false);
     });
   });

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -57,9 +57,11 @@ export class Auth {
   }
 
   // Throws an error if the token is invalid
-  public static async validateToken(token: string) {
+  public static async validateToken(cluster: string, token: string) {
     try {
-      await Axios.get(APIBase + "/", { headers: { Authorization: `Bearer ${token}` } });
+      await Axios.get(APIBase + `/clusters/${cluster}/`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
     } catch (e) {
       const res = e.response as AxiosResponse;
       if (res.status === 401) {
@@ -96,9 +98,9 @@ export class Auth {
   // isAuthenticatedWithCookie() does an anonymous GET request to determine if
   // the request is authenticated with an http-only cookie (there is, by design,
   // no way to determine via client JS whether an http-only cookie is present).
-  public static async isAuthenticatedWithCookie(): Promise<boolean> {
+  public static async isAuthenticatedWithCookie(cluster: string): Promise<boolean> {
     try {
-      await Axios.get(APIBase + "/");
+      await Axios.get(APIBase + `/clusters/${cluster}/`);
     } catch (e) {
       const response = e.response as AxiosResponse;
       // The only error response which can possibly mean we did authenticate is

--- a/dashboard/src/shared/Kube.test.ts
+++ b/dashboard/src/shared/Kube.test.ts
@@ -14,29 +14,29 @@ describe("App", () => {
     [
       {
         description: "returns the version and resource",
-        args: ["v1", "pods"],
-        result: `${APIBase}/api/v1/pods`,
+        args: ["default", "v1", "pods"],
+        result: `${APIBase}/clusters/default/api/v1/pods`,
       },
       {
         description: "returns the version, resource in a namespace",
-        args: ["v1", "pods", "default"],
-        result: `${APIBase}/api/v1/namespaces/default/pods`,
+        args: ["mycluster", "v1", "pods", "default"],
+        result: `${APIBase}/clusters/mycluster/api/v1/namespaces/default/pods`,
       },
       {
         description: "returns the version, resource in a namespace with a name",
-        args: ["v1", "pods", "default", "foo"],
-        result: `${APIBase}/api/v1/namespaces/default/pods/foo`,
+        args: ["default", "v1", "pods", "default", "foo"],
+        result: `${APIBase}/clusters/default/api/v1/namespaces/default/pods/foo`,
       },
       {
         description: "returns the version, resource in a namespace with a name and a query",
-        args: ["v1", "pods", "default", "foo", "label=bar"],
-        result: `${APIBase}/api/v1/namespaces/default/pods/foo?label=bar`,
+        args: ["default", "v1", "pods", "default", "foo", "label=bar"],
+        result: `${APIBase}/clusters/default/api/v1/namespaces/default/pods/foo?label=bar`,
       },
     ].forEach(t => {
       it(t.description, () => {
-        expect(Kube.getResourceURL(t.args[0], t.args[1], t.args[2], t.args[3], t.args[4])).toBe(
-          t.result,
-        );
+        expect(
+          Kube.getResourceURL(t.args[0], t.args[1], t.args[2], t.args[3], t.args[4], t.args[5]),
+        ).toBe(t.result);
       });
     });
   });
@@ -45,29 +45,29 @@ describe("App", () => {
     [
       {
         description: "returns the version and resource",
-        args: ["v1", "pods"],
-        result: `${WebSocketAPIBase}${APIBase}/api/v1/pods?watch=true`,
+        args: ["default", "v1", "pods"],
+        result: `${WebSocketAPIBase}${APIBase}/clusters/default/api/v1/pods?watch=true`,
       },
       {
         description: "returns the version, resource in a namespace",
-        args: ["v1", "pods", "default"],
-        result: `${WebSocketAPIBase}${APIBase}/api/v1/namespaces/default/pods?watch=true`,
+        args: ["default", "v1", "pods", "default"],
+        result: `${WebSocketAPIBase}${APIBase}/clusters/default/api/v1/namespaces/default/pods?watch=true`,
       },
       {
         description: "returns the version, resource in a namespace with a name",
-        args: ["v1", "pods", "default", "foo"],
-        result: `${WebSocketAPIBase}${APIBase}/api/v1/namespaces/default/pods?watch=true&fieldSelector=metadata.name%3Dfoo`,
+        args: ["default", "v1", "pods", "default", "foo"],
+        result: `${WebSocketAPIBase}${APIBase}/clusters/default/api/v1/namespaces/default/pods?watch=true&fieldSelector=metadata.name%3Dfoo`,
       },
       {
         description: "returns the version, resource in a namespace with a name and a query",
-        args: ["v1", "pods", "default", "foo", "label=bar"],
-        result: `${WebSocketAPIBase}${APIBase}/api/v1/namespaces/default/pods?watch=true&fieldSelector=metadata.name%3Dfoo&label=bar`,
+        args: ["default", "v1", "pods", "default", "foo", "label=bar"],
+        result: `${WebSocketAPIBase}${APIBase}/clusters/default/api/v1/namespaces/default/pods?watch=true&fieldSelector=metadata.name%3Dfoo&label=bar`,
       },
     ].forEach(t => {
       it(t.description, () => {
-        expect(Kube.watchResourceURL(t.args[0], t.args[1], t.args[2], t.args[3], t.args[4])).toBe(
-          t.result,
-        );
+        expect(
+          Kube.watchResourceURL(t.args[0], t.args[1], t.args[2], t.args[3], t.args[4], t.args[5]),
+        ).toBe(t.result);
       });
     });
   });
@@ -81,20 +81,22 @@ describe("App", () => {
       });
     });
     it("should request a resource", async () => {
-      expect(await Kube.getResource("v1", "pods", "default", "foo", "label=bar")).toEqual({
+      expect(
+        await Kube.getResource("default", "v1", "pods", "default", "foo", "label=bar"),
+      ).toEqual({
         data: resource,
       });
       expect(moxios.requests.mostRecent().url).toBe(
-        `${APIBase}/api/v1/namespaces/default/pods/foo?label=bar`,
+        `${APIBase}/clusters/default/api/v1/namespaces/default/pods/foo?label=bar`,
       );
     });
   });
 
   describe("watchResource", () => {
     it("should open a socket", async () => {
-      const socket = Kube.watchResource("v1", "pods", "default", "foo");
+      const socket = Kube.watchResource("default", "v1", "pods", "default", "foo");
       expect(socket.url).toBe(
-        `${WebSocketAPIBase}${APIBase}/api/v1/namespaces/default/pods?watch=true&fieldSelector=metadata.name%3Dfoo`,
+        `${WebSocketAPIBase}${APIBase}/clusters/default/api/v1/namespaces/default/pods?watch=true&fieldSelector=metadata.name%3Dfoo`,
       );
       // it's a mock socket, so doesn't actually need to be closed
       socket.close();

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -4,7 +4,7 @@ import { ResourceKindsWithAPIVersions } from "./ResourceAPIVersion";
 import { ResourceKind, ResourceKindsWithPlurals } from "./ResourceKinds";
 import { IK8sList, IResource } from "./types";
 
-export const APIBase = "api/clusters/default";
+export const APIBase = "api";
 export let WebSocketAPIBase: string;
 if (window.location.protocol === "https:") {
   WebSocketAPIBase = `wss://${window.location.host}${window.location.pathname}`;
@@ -17,13 +17,16 @@ if (window.location.protocol === "https:") {
 // directly.
 export class Kube {
   public static getResourceURL(
+    cluster: string,
     apiVersion: string,
     resource: string,
     namespace?: string,
     name?: string,
     query?: string,
   ) {
-    let url = `${APIBase}/${apiVersion === "v1" ? "api/v1" : `apis/${apiVersion}`}`;
+    let url = `${APIBase}/clusters/${cluster}/${
+      apiVersion === "v1" ? "api/v1" : `apis/${apiVersion}`
+    }`;
     if (namespace) {
       url += `/namespaces/${namespace}`;
     }
@@ -38,13 +41,14 @@ export class Kube {
   }
 
   public static watchResourceURL(
+    cluster: string,
     apiVersion: string,
     resource: string,
     namespace?: string,
     name?: string,
     query?: string,
   ) {
-    let url = this.getResourceURL(apiVersion, resource, namespace);
+    let url = this.getResourceURL(cluster, apiVersion, resource, namespace);
     url = `${WebSocketAPIBase}${url}?watch=true`;
     if (name) {
       url += `&fieldSelector=metadata.name%3D${name}`;
@@ -56,6 +60,7 @@ export class Kube {
   }
 
   public static async getResource(
+    cluster: string,
     apiVersion: string,
     resource: string,
     namespace?: string,
@@ -63,7 +68,7 @@ export class Kube {
     query?: string,
   ) {
     const { data } = await axiosWithAuth.get<IResource | IK8sList<IResource, {}>>(
-      this.getResourceURL(apiVersion, resource, namespace, name, query),
+      this.getResourceURL(cluster, apiVersion, resource, namespace, name, query),
     );
     return data;
   }
@@ -73,6 +78,7 @@ export class Kube {
   // returned WebSocket can be attached to an event listener to read data from
   // the socket.
   public static watchResource(
+    cluster: string,
     apiVersion: string,
     resource: string,
     namespace?: string,
@@ -80,7 +86,7 @@ export class Kube {
     query?: string,
   ) {
     return new WebSocket(
-      this.watchResourceURL(apiVersion, resource, namespace, name, query),
+      this.watchResourceURL(cluster, apiVersion, resource, namespace, name, query),
       Auth.wsProtocols(),
     );
   }

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -1,31 +1,38 @@
 import { axiosWithAuth } from "./AxiosInstance";
-import { APIBase } from "./Kube";
 import * as url from "./url";
 
 import { ForbiddenError, IResource, NotFoundError } from "./types";
 
 export default class Namespace {
-  public static async list() {
+  public static async list(cluster: string) {
+    // This call is hitting an actual backend endpoint (see pkg/http-handler.go)
+    // while the other calls (create, get) are hitting the k8s API via the
+    // frountend nginx.
     const { data } = await axiosWithAuth.get<{ namespaces: IResource[] }>(
-      url.backend.namespaces.list(),
+      url.backend.namespaces.list(cluster),
     );
     return data;
   }
 
-  public static async create(name: string) {
-    const { data } = await axiosWithAuth.post<IResource>(`${APIBase}/api/v1/namespaces/`, {
-      apiVersion: "v1",
-      kind: "Namespace",
-      metadata: {
-        name,
+  public static async create(cluster: string, name: string) {
+    const { data } = await axiosWithAuth.post<IResource>(
+      `api/clusters/${cluster}/api/v1/namespaces/`,
+      {
+        apiVersion: "v1",
+        kind: "Namespace",
+        metadata: {
+          name,
+        },
       },
-    });
+    );
     return data;
   }
 
-  public static async get(name: string) {
+  public static async get(cluster: string, name: string) {
     try {
-      const { data } = await axiosWithAuth.get<IResource>(`${APIBase}/api/v1/namespaces/${name}`);
+      const { data } = await axiosWithAuth.get<IResource>(
+        `api/clusters/${cluster}/api/v1/namespaces/${name}`,
+      );
       return data;
     } catch (err) {
       switch (err.constructor) {

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -191,7 +191,7 @@ it("creates an operatorgroup and a subscription", async () => {
 it("creates only a subscription if the operator group already exists", async () => {
   const operatorGroups = { items: [{ metadata: { name: "foo" } }] };
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: operatorGroups });
-  const resource = { metadata: { name: "foo" } } as IResource;
+  const resource = { cluster: "default", metadata: { name: "foo" } } as IResource;
   axiosWithAuth.post = jest.fn().mockReturnValue({ data: resource });
   expect(await Operators.createOperator(namespace, "foo", "alpha", "Manual", "foo.1.0.0")).toEqual(
     resource,

--- a/dashboard/src/shared/ResourceRef.test.ts
+++ b/dashboard/src/shared/ResourceRef.test.ts
@@ -6,6 +6,7 @@ describe("ResourceRef", () => {
   describe("constructor", () => {
     it("it returns a ResourceRef with the correct details", () => {
       const r = {
+        cluster: "default",
         apiVersion: "apps/v1",
         kind: "Deployment",
         metadata: {
@@ -17,6 +18,7 @@ describe("ResourceRef", () => {
       const ref = new ResourceRef(r);
       expect(ref).toBeInstanceOf(ResourceRef);
       expect(ref).toEqual({
+        cluster: r.cluster,
         apiVersion: r.apiVersion,
         kind: r.kind,
         name: r.metadata.name,
@@ -26,6 +28,7 @@ describe("ResourceRef", () => {
 
     it("sets a default namespace if not in the resource", () => {
       const r = {
+        cluster: "default",
         apiVersion: "apps/v1",
         kind: "Deployment",
         metadata: {
@@ -39,6 +42,7 @@ describe("ResourceRef", () => {
 
     it("allows the default namespace to be provided", () => {
       const r = {
+        cluster: "default",
         apiVersion: "apps/v1",
         kind: "Deployment",
         metadata: {
@@ -53,6 +57,7 @@ describe("ResourceRef", () => {
     describe("fromCRD", () => {
       it("creates a resource ref with ownerReference", () => {
         const r = {
+          cluster: "default",
           kind: "Deployment",
           name: "",
           version: "",
@@ -106,6 +111,7 @@ describe("ResourceRef", () => {
     });
     it("calls Kube.getResourceURL with the correct arguments", () => {
       const r = {
+        cluster: "default",
         apiVersion: "v1",
         kind: "Service",
         metadata: {
@@ -117,7 +123,7 @@ describe("ResourceRef", () => {
       const ref = new ResourceRef(r);
 
       ref.getResourceURL();
-      expect(kubeGetResourceURLMock).toBeCalledWith("v1", "services", "bar", "foo");
+      expect(kubeGetResourceURLMock).toBeCalledWith("default", "v1", "services", "bar", "foo");
     });
   });
 
@@ -132,6 +138,7 @@ describe("ResourceRef", () => {
     });
     it("calls Kube.watchResourceURL with the correct arguments", () => {
       const r = {
+        cluster: "default",
         apiVersion: "v1",
         kind: "Service",
         metadata: {
@@ -143,7 +150,7 @@ describe("ResourceRef", () => {
       const ref = new ResourceRef(r);
 
       ref.watchResourceURL();
-      expect(kubeWatchResourceURLMock).toBeCalledWith("v1", "services", "bar", "foo");
+      expect(kubeWatchResourceURLMock).toBeCalledWith("default", "v1", "services", "bar", "foo");
     });
   });
 
@@ -160,6 +167,7 @@ describe("ResourceRef", () => {
     });
     it("calls Kube.getResource with the correct arguments", () => {
       const r = {
+        cluster: "default",
         apiVersion: "v1",
         kind: "Service",
         metadata: {
@@ -171,7 +179,7 @@ describe("ResourceRef", () => {
       const ref = new ResourceRef(r);
 
       ref.getResource();
-      expect(kubeGetResourceMock).toBeCalledWith("v1", "services", "bar", "foo");
+      expect(kubeGetResourceMock).toBeCalledWith("default", "v1", "services", "bar", "foo");
     });
 
     it("filters out the result when receiving a list", async () => {

--- a/dashboard/src/shared/ResourceRef.ts
+++ b/dashboard/src/shared/ResourceRef.ts
@@ -9,6 +9,7 @@ export function fromCRD(
   ownerReference: any,
 ) {
   const resource = {
+    cluster: "default",
     apiVersion: Kube.resourceAPIVersion(r.kind as ResourceKind),
     kind: r.kind,
     metadata: {},
@@ -25,6 +26,7 @@ export function fromCRD(
 // ResourceRef defines a reference to a namespaced Kubernetes API Object and
 // provides helpers to retrieve the resource URL
 class ResourceRef {
+  public cluster: string;
   public apiVersion: string;
   public kind: ResourceKind;
   public name: string;
@@ -36,6 +38,7 @@ class ResourceRef {
   // TODO: add support for cluster-scoped resources, or add a ClusterResourceRef
   // class.
   constructor(r: IResource, defaultNamespace?: string, defaultFilter?: any) {
+    this.cluster = r.cluster;
     this.apiVersion = r.apiVersion;
     this.kind = r.kind;
     this.name = r.metadata.name;
@@ -47,6 +50,7 @@ class ResourceRef {
   // Gets a full resource URL for the referenced resource
   public getResourceURL() {
     return Kube.getResourceURL(
+      this.cluster,
       this.apiVersion,
       Kube.resourcePlural(this.kind),
       this.namespace,
@@ -56,6 +60,7 @@ class ResourceRef {
 
   public watchResourceURL() {
     return Kube.watchResourceURL(
+      this.cluster,
       this.apiVersion,
       Kube.resourcePlural(this.kind),
       this.namespace,
@@ -65,6 +70,7 @@ class ResourceRef {
 
   public async getResource() {
     const resource = await Kube.getResource(
+      this.cluster,
       this.apiVersion,
       Kube.resourcePlural(this.kind),
       this.namespace,

--- a/dashboard/src/shared/Secret.test.ts
+++ b/dashboard/src/shared/Secret.test.ts
@@ -11,7 +11,7 @@ it("creates a secret", async () => {
   } as any;
   const name = "secret";
   const namespace = "default";
-  expect(await Secret.create(name, secrets, owner, namespace)).toEqual("ok");
+  expect(await Secret.create(name, secrets, owner, namespace, "default")).toEqual("ok");
   expect(axiosWithAuth.post).toHaveBeenCalledWith(
     "api/clusters/default/api/v1/namespaces/default/secrets",
     {

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -8,6 +8,7 @@ export default class Secret {
     secrets: { [s: string]: string },
     owner: IOwnerReference | undefined,
     namespace: string,
+    cluster: string,
   ) {
     const url = Secret.getLink(namespace);
     const { data } = await axiosWithAuth.post<ISecret>(url, {
@@ -74,6 +75,9 @@ export default class Secret {
   }
 
   private static getLink(namespace: string, name?: string): string {
-    return `${APIBase}/api/v1/namespaces/${namespace}/secrets${name ? `/${name}` : ""}`;
+    // TODO: update to be cluster aware.
+    return `${APIBase}/clusters/default/api/v1/namespaces/${namespace}/secrets${
+      name ? `/${name}` : ""
+    }`;
   }
 }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -176,6 +176,9 @@ export interface IResourceMetadata {
 }
 
 export interface IResource {
+  // TODO: In retrospect, having the cluster attribute here isn't great
+  // as the interface is otherwise an actual k8s resource.
+  cluster: string;
   apiVersion: string;
   kind: ResourceKind;
   type: string;

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -49,7 +49,7 @@ function withNS(namespace: string) {
 
 export const backend = {
   namespaces: {
-    list: (cluster: string) => `api/v1/clusters${cluster}/namespaces`,
+    list: (cluster: string) => `api/v1/clusters/${cluster}/namespaces`,
   },
   apprepositories: {
     base: (namespace: string) => `api/v1/namespaces/${namespace}/apprepositories`,
@@ -115,22 +115,26 @@ export const api = {
 
   operators: {
     operators: (namespace: string) =>
-      `${APIBase}/apis/packages.operators.coreos.com/v1/${withNS(namespace)}packagemanifests`,
+      `${APIBase}/clusters/default/apis/packages.operators.coreos.com/v1/${withNS(
+        namespace,
+      )}packagemanifests`,
     operator: (namespace: string, name: string) =>
-      `${APIBase}/apis/packages.operators.coreos.com/v1/namespaces/${namespace}/packagemanifests/${name}`,
+      `${APIBase}/clusters/default/apis/packages.operators.coreos.com/v1/namespaces/${namespace}/packagemanifests/${name}`,
     clusterServiceVersions: (namespace: string) =>
-      `${APIBase}/apis/operators.coreos.com/v1alpha1/${withNS(namespace)}clusterserviceversions`,
+      `${APIBase}/clusters/default/apis/operators.coreos.com/v1alpha1/${withNS(
+        namespace,
+      )}clusterserviceversions`,
     clusterServiceVersion: (namespace: string, name: string) =>
-      `${APIBase}/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/clusterserviceversions/${name}`,
+      `${APIBase}/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/clusterserviceversions/${name}`,
     operatorIcon: (namespace: string, name: string) =>
       `api/v1/namespaces/${namespace}/operator/${name}/logo`,
     resources: (namespace: string, apiVersion: string, resource: string) =>
-      `${APIBase}/apis/${apiVersion}/${withNS(namespace)}${resource}`,
+      `${APIBase}/clusters/default/apis/${apiVersion}/${withNS(namespace)}${resource}`,
     resource: (namespace: string, apiVersion: string, resource: string, name: string) =>
-      `${APIBase}/apis/${apiVersion}/namespaces/${namespace}/${resource}/${name}`,
+      `${APIBase}/clusters/default/apis/${apiVersion}/namespaces/${namespace}/${resource}/${name}`,
     operatorGroups: (namespace: string) =>
-      `${APIBase}/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
+      `${APIBase}/clusters/default/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
     subscription: (namespace: string, name: string) =>
-      `${APIBase}/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/${name}`,
+      `${APIBase}/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/${name}`,
   },
 };

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -49,11 +49,10 @@ function withNS(namespace: string) {
 
 export const backend = {
   namespaces: {
-    base: "api/v1/namespaces",
-    list: () => `${backend.namespaces.base}`,
+    list: (cluster: string) => `api/v1/clusters${cluster}/namespaces`,
   },
   apprepositories: {
-    base: (namespace: string) => `${backend.namespaces.base}/${namespace}/apprepositories`,
+    base: (namespace: string) => `api/v1/namespaces/${namespace}/apprepositories`,
     create: (namespace: string) => backend.apprepositories.base(namespace),
     validate: () => `${backend.apprepositories.base("kubeapps")}/validate`,
     delete: (name: string, namespace: string) =>

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -47,6 +47,7 @@ func StorageForMemory(_ string, _ *kubernetes.Clientset) *storage.Storage {
 // ListReleases lists releases in the specified namespace, or all namespaces if the empty string is given.
 func ListReleases(actionConfig *action.Configuration, namespace string, listLimit int, status string) ([]proxy.AppOverview, error) {
 	allNamespaces := namespace == ""
+	log.Infof("Creating NewList action")
 	cmd := action.NewList(actionConfig)
 	if allNamespaces {
 		cmd.AllNamespaces = true
@@ -57,6 +58,7 @@ func ListReleases(actionConfig *action.Configuration, namespace string, listLimi
 	}
 	releases, err := cmd.Run()
 	if err != nil {
+		log.Infof("Error when running NewList action: %+v", err)
 		return nil, err
 	}
 	appOverviews := make([]proxy.AppOverview, 0)
@@ -174,7 +176,9 @@ func NewActionConfig(storageForDriver StorageForDriver, config *rest.Config, cli
 // NewConfigFlagsFromCluster returns ConfigFlags with default values set from within cluster.
 func NewConfigFlagsFromCluster(namespace string, clusterConfig *rest.Config) *genericclioptions.ConfigFlags {
 	impersonateGroup := []string{}
-	insecure := false
+	// TODO: Change back once figured out why CAData isn't working.
+	// Using condition to only set insecure if it's an additional cluster (where we won't have a cafile)
+	insecure := clusterConfig.CAFile == ""
 
 	// CertFile and KeyFile must be nil for the BearerToken to be used for authentication and authorization instead of the pod's service account.
 	return &genericclioptions.ConfigFlags{

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -224,8 +224,8 @@ func GetOperatorLogo(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, r
 }
 
 // SetupDefaultRoutes enables call-sites to use the backend api's default routes with minimal setup.
-func SetupDefaultRoutes(r *mux.Router) error {
-	backendHandler, err := kube.NewHandler(os.Getenv("POD_NAMESPACE"))
+func SetupDefaultRoutes(r *mux.Router, additionalClusters kube.AdditionalClustersConfig) error {
+	backendHandler, err := kube.NewHandler(os.Getenv("POD_NAMESPACE"), additionalClusters)
 	if err != nil {
 		return err
 	}

--- a/script/cluster-kind.mk
+++ b/script/cluster-kind.mk
@@ -32,7 +32,7 @@ ${ADDITIONAL_CLUSTER_CONFIG}: devel/dex.crt
 		--name ${ADDITIONAL_CLUSTER_NAME} \
 		--config=./docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.json \
 		--retain
-	kubectl apply --kubeconfig=$ADDITIONAL_CLUSTER_CONFIG -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
+	kubectl apply --kubeconfig ${ADDITIONAL_CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
 
 additional-cluster-kind: ${ADDITIONAL_CLUSTER_CONFIG}
 

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -23,6 +23,7 @@ deploy-dev: deploy-dex deploy-openldap
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
 		--set useHelm3=true
+	kubectl apply --kubeconfig=${CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
 	@echo "\nYou can now simply open your browser at http://172.18.0.2:30000 to access Kubeapps!"
 	@echo "When logging in, you will be redirected to dex (with a self-signed cert) and can login with email as either of"
 	@echo "  kubeapps-operator@example.com:password"


### PR DESCRIPTION
The intent was to add the select cluster component and then test the multi-cluster integration.

As expected, there were quite a few adjustments needed to demo end-to-end. This PR isn't to review/land (lots of TODOs, insecure comms etc. which I did to demo rather than debugging), but just as a record for me to work from when I return in 2 weeks :)

Note to self: Instead of updating the IResource with a `cluster` attribute, add it to the `ResourceRef` (like we do with the release namespace).

jfyi @andresmgot (I'll double check that there's no bug-fixes here which need to land before a release).

Ref #1762 
