### PR TITLE
Added namespace field to intialRepos which changes the namespace of t…

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 3.7.2
+version: 3.7.3
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/apprepositories.yaml
+++ b/chart/kubeapps/templates/apprepositories.yaml
@@ -3,6 +3,9 @@ apiVersion: kubeapps.com/v1alpha1
 kind: AppRepository
 metadata:
   name: {{ .name }}
+{{- if .namespace }}
+  namespace: {{ .namespace }}
+{{- end }}
   annotations:
     "helm.sh/hook": post-install
   labels:{{ include "kubeapps.extraAppLabels" $ | nindent 4 }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -240,7 +240,7 @@ apprepository:
   #   # It should start with -----BEGIN CERTIFICATE----- or
   #   # -----BEGIN RSA PRIVATE KEY-----
   #   caCert:
-  #   # Create this apprepository in some other namespace
+  #   # Create this apprepository in a custom namespace
   #   namespace:
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
   ## AppRepository Controller containers' resource requests and limits

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -240,6 +240,8 @@ apprepository:
   #   # It should start with -----BEGIN CERTIFICATE----- or
   #   # -----BEGIN RSA PRIVATE KEY-----
   #   caCert:
+  #   # Create this apprepository in some other namespace
+  #   namespace:
   # https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
   ## AppRepository Controller containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
…he created AppRepository

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Added optional namespace field to `apprepository.intialRepos` to allow users to specify the namespace of the apprepository.

### Benefits

<!-- What benefits will be realized by the code change? -->

Currently RBAC prevents apprepositories from being read across namespaces. However, there is currently no way to create intial apprepositories via the values.yaml in a namespace other than default/kubeapps. This will allow for users to create these apprepositories on startup in a specific namespace.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

Things that need to be addressed before this PR goes in (that I'm not entirely sure how to do):
- Update the version number
- It appears that when an apprepository is created in another namespace, it's not cleaned up by `helm uninstall ...`. I'm not entirely familiar with helm, so I could use help on this
- I'm not acquainted with the codebase, so I'd like a maintainer to verify that this namespace change isn't breaking anything I'm unaware of

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Please feel free to reach out to me, I'll be as responsive as possible. I'm also in the #kubeapps channel of the kubernetes slack.