### PR TITLE
Pass additionalClusters to NewHandler and SetupDefaultRoutes.

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	authHeader     = "Authorization"
-	clusterParam   = "clusters"
+	clusterParam   = "cluster"
 	namespaceParam = "namespace"
 	nameParam      = "releaseName"
 	authUserError  = "Unexpected error while configuring authentication"
@@ -94,7 +94,7 @@ func WithHandlerConfig(storageForDriver agent.StorageForDriver, options Options)
 				return
 			}
 
-			kubeHandler, err := kube.NewHandler(options.KubeappsNamespace)
+			kubeHandler, err := kube.NewHandler(options.KubeappsNamespace, options.AdditionalClusters)
 			if err != nil {
 				log.Errorf("Failed to create handler: %v", err)
 				response.NewErrorResponse(http.StatusInternalServerError, authUserError).Write(w)

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -106,7 +106,7 @@ func main() {
 	addRoute("DELETE", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
 
 	// Backend routes unrelated to kubeops functionality.
-	err := backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter())
+	err := backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), additionalClusters)
 	if err != nil {
 		log.Fatalf("Unable to setup backend routes: %+v", err)
 	}

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -133,7 +133,7 @@ func main() {
 		log.Fatalf("POD_NAMESPACE should be defined")
 	}
 
-	kubeHandler, err := kube.NewHandler(kubeappsNamespace)
+	kubeHandler, err := kube.NewHandler(kubeappsNamespace, kube.AdditionalClustersConfig{})
 	if err != nil {
 		log.Fatalf("Failed to create handler: %v", err)
 	}
@@ -172,7 +172,7 @@ func main() {
 	apiv1.Methods("DELETE").Path("/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}").Handler(handlerutil.WithParams(h.DeleteRelease))
 
 	// Backend routes unrelated to tiller-proxy functionality.
-	err = backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter())
+	err = backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), kube.AdditionalClustersConfig{})
 	if err != nil {
 		log.Fatalf("Unable to setup backend routes: %+v", err)
 	}

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -224,8 +224,8 @@ func GetOperatorLogo(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, r
 }
 
 // SetupDefaultRoutes enables call-sites to use the backend api's default routes with minimal setup.
-func SetupDefaultRoutes(r *mux.Router) error {
-	backendHandler, err := kube.NewHandler(os.Getenv("POD_NAMESPACE"))
+func SetupDefaultRoutes(r *mux.Router, additionalClusters kube.AdditionalClustersConfig) error {
+	backendHandler, err := kube.NewHandler(os.Getenv("POD_NAMESPACE"), additionalClusters)
 	if err != nil {
 		return err
 	}

--- a/pkg/http-handler/http-handler_test.go
+++ b/pkg/http-handler/http-handler_test.go
@@ -213,7 +213,7 @@ func TestGetNamespaces(t *testing.T) {
 	}{
 		{
 			name:         "it should return the list of namespaces and a 200 if the repo is created",
-			namespaces:   []corev1.Namespace{corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			namespaces:   []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
 			expectedCode: 200,
 		},
 		{

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -212,7 +212,7 @@ var ErrGlobalRepositoryWithSecrets = fmt.Errorf("docker registry secrets cannot 
 
 // NewHandler returns a handler configured with a service account client set and a config
 // with a blank token to be copied when creating user client sets with specific tokens.
-func NewHandler(kubeappsNamespace string) (AuthHandler, error) {
+func NewHandler(kubeappsNamespace string, additionalClusters AdditionalClustersConfig) (AuthHandler, error) {
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{
@@ -244,8 +244,9 @@ func NewHandler(kubeappsNamespace string) (AuthHandler, error) {
 		config:            *config,
 		kubeappsNamespace: kubeappsNamespace,
 		// See comment in the struct defn above.
-		clientsetForConfig: clientsetForConfig,
-		svcClientset:       svcClientset,
+		clientsetForConfig:       clientsetForConfig,
+		svcClientset:             svcClientset,
+		additionalClustersConfig: additionalClusters,
 	}, nil
 }
 
@@ -518,7 +519,7 @@ func secretForRequest(appRepoRequest *appRepositoryRequest, appRepo *v1alpha1.Ap
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretNameForRepo(appRepo.Name),
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					APIVersion:         "kubeapps.com/v1alpha1",
 					Kind:               "AppRepository",
 					Name:               appRepo.ObjectMeta.Name,

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -275,7 +275,7 @@ func TestAppRepositoryCreate(t *testing.T) {
 			requestNamespace: kubeappsNamespace,
 			requestData:      `{"appRepository": {"name": "bitnami"}}`,
 			existingRepos: map[string][]repoStub{
-				"kubeapps": []repoStub{repoStub{name: "bitnami"}},
+				"kubeapps": {repoStub{name: "bitnami"}},
 			},
 			expectedError: fmt.Errorf(`apprepositories.kubeapps.com "bitnami" already exists`),
 		},
@@ -284,8 +284,8 @@ func TestAppRepositoryCreate(t *testing.T) {
 			requestNamespace: kubeappsNamespace,
 			requestData:      `{"appRepository": {"name": "bitnami"}}`,
 			existingRepos: map[string][]repoStub{
-				"kubeapps-other-ns-1": []repoStub{repoStub{name: "bitnami"}},
-				"kubeapps-other-ns-2": []repoStub{repoStub{name: "bitnami"}},
+				"kubeapps-other-ns-1": {repoStub{name: "bitnami"}},
+				"kubeapps-other-ns-2": {repoStub{name: "bitnami"}},
 			},
 		},
 		{
@@ -345,7 +345,7 @@ func TestAppRepositoryUpdate(t *testing.T) {
 			requestNamespace: kubeappsNamespace,
 			requestData:      `{"appRepository": {"name": "test-repo", "url": "http://example.com/test-repo"}}`,
 			existingRepos: map[string][]repoStub{
-				"kubeapps": []repoStub{repoStub{name: "test-repo"}},
+				"kubeapps": {repoStub{name: "test-repo"}},
 			},
 		},
 		{
@@ -359,14 +359,14 @@ func TestAppRepositoryUpdate(t *testing.T) {
 			requestNamespace: "default",
 			requestData:      `{"appRepository": {"name": "test-repo", "url": "http://example.com/test-repo"}}`,
 			existingRepos: map[string][]repoStub{
-				"default": []repoStub{repoStub{name: "test-repo"}},
+				"default": {repoStub{name: "test-repo"}},
 			},
 		},
 		{
 			name:             "it creates a secret if the auth header is set",
 			requestNamespace: kubeappsNamespace,
 			existingRepos: map[string][]repoStub{
-				"kubeapps": []repoStub{repoStub{name: "test-repo"}},
+				"kubeapps": {repoStub{name: "test-repo"}},
 			},
 			requestData: `{"appRepository": {"name": "test-repo", "url": "http://example.com/test-repo", "authHeader": "test-me"}}`,
 		},
@@ -374,8 +374,8 @@ func TestAppRepositoryUpdate(t *testing.T) {
 			name:             "it creates a secret if the auth header is set in different namespaces",
 			requestNamespace: "default",
 			existingRepos: map[string][]repoStub{
-				"kubeapps": []repoStub{repoStub{name: "test-repo"}},
-				"default":  []repoStub{repoStub{name: "test-repo"}},
+				"kubeapps": {repoStub{name: "test-repo"}},
+				"default":  {repoStub{name: "test-repo"}},
 			},
 			requestData: `{"appRepository": {"name": "test-repo", "url": "http://example.com/test-repo", "authHeader": "test-me"}}`,
 		},
@@ -383,10 +383,10 @@ func TestAppRepositoryUpdate(t *testing.T) {
 			name:             "it updates a secret if the auth header is set",
 			requestNamespace: kubeappsNamespace,
 			existingRepos: map[string][]repoStub{
-				"kubeapps": []repoStub{repoStub{name: "test-repo"}},
+				"kubeapps": {repoStub{name: "test-repo"}},
 			},
 			existingSecrets: map[string][]secretStub{
-				"kubeapps": []secretStub{secretStub{name: "apprepo-test-repo"}},
+				"kubeapps": {secretStub{name: "apprepo-test-repo"}},
 			},
 			requestData: `{"appRepository": {"name": "test-repo", "url": "http://example.com/test-repo", "authHeader": "test-me"}}`,
 		},
@@ -394,11 +394,11 @@ func TestAppRepositoryUpdate(t *testing.T) {
 			name:             "it updates a secret if the auth header is set in both default and kubeapps namespace",
 			requestNamespace: "default",
 			existingRepos: map[string][]repoStub{
-				"default": []repoStub{repoStub{name: "test-repo"}},
+				"default": {repoStub{name: "test-repo"}},
 			},
 			existingSecrets: map[string][]secretStub{
-				"kubeapps": []secretStub{secretStub{name: "default-apprepo-test-repo"}},
-				"default":  []secretStub{secretStub{name: "apprepo-test-repo"}},
+				"kubeapps": {secretStub{name: "default-apprepo-test-repo"}},
+				"default":  {secretStub{name: "apprepo-test-repo"}},
 			},
 			requestData: `{"appRepository": {"name": "test-repo", "url": "http://example.com/test-repo", "authHeader": "test-me"}}`,
 		},
@@ -441,26 +441,26 @@ func TestDeleteAppRepository(t *testing.T) {
 			name:             "it deletes an existing repo from a namespace",
 			repoName:         "my-repo",
 			requestNamespace: "my-namespace",
-			existingRepos:    map[string][]repoStub{"my-namespace": []repoStub{repoStub{name: "my-repo"}}},
+			existingRepos:    map[string][]repoStub{"my-namespace": {repoStub{name: "my-repo"}}},
 		},
 		{
 			name:             "it deletes an existing repo with credentials from a namespace",
 			repoName:         "my-repo",
 			requestNamespace: "my-namespace",
-			existingRepos:    map[string][]repoStub{"my-namespace": []repoStub{repoStub{name: "my-repo", private: true}}},
+			existingRepos:    map[string][]repoStub{"my-namespace": {repoStub{name: "my-repo", private: true}}},
 		},
 		{
 			name:              "it returns not found when repo does not exist in specified namespace",
 			repoName:          "my-repo",
 			requestNamespace:  "other-namespace",
-			existingRepos:     map[string][]repoStub{"my-namespace": []repoStub{repoStub{name: "my-repo"}}},
+			existingRepos:     map[string][]repoStub{"my-namespace": {repoStub{name: "my-repo"}}},
 			expectedErrorCode: 404,
 		},
 		{
 			name:             "it deletes an existing repo from kubeapps' namespace",
 			repoName:         "my-repo",
 			requestNamespace: kubeappsNamespace,
-			existingRepos:    map[string][]repoStub{kubeappsNamespace: []repoStub{repoStub{name: "my-repo"}}},
+			existingRepos:    map[string][]repoStub{kubeappsNamespace: {repoStub{name: "my-repo"}}},
 		},
 	}
 
@@ -661,7 +661,7 @@ func TestSecretForRequest(t *testing.T) {
 	// And the same owner references expectation.
 	blockOwnerDeletion := true
 	ownerRefs := []metav1.OwnerReference{
-		metav1.OwnerReference{
+		{
 			APIVersion:         "kubeapps.com/v1alpha1",
 			Kind:               "AppRepository",
 			Name:               "test-repo",
@@ -739,7 +739,7 @@ func TestGetNamespaces(t *testing.T) {
 			name:       "it list namespaces",
 			existingNS: []string{"foo"},
 			expectedResponse: []corev1.Namespace{
-				corev1.Namespace{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "foo",
 					},


### PR DESCRIPTION
When testing end-to-end, one of the issues I found in the backend was that we weren't using the `additionalClusters` configuration when setting up handlers and the default routes.

This change fixes that and removes some lint.

Ref: #1762 