### PR TITLE
Send cluster through to login form and actions.

### DIFF
--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -5,6 +5,7 @@ import { getType } from "typesafe-actions";
 import actions from ".";
 import { Auth } from "../shared/Auth";
 
+const defaultCluster = "default";
 const mockStore = configureMockStore([thunk]);
 const token = "abcd";
 const validationErrorMsg = "Validation error";
@@ -54,7 +55,7 @@ describe("authenticate", () => {
       },
     ];
 
-    return store.dispatch(actions.auth.authenticate(token, false)).then(() => {
+    return store.dispatch(actions.auth.authenticate("default", token, false)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
@@ -71,9 +72,9 @@ describe("authenticate", () => {
       },
     ];
 
-    return store.dispatch(actions.auth.authenticate(token, false)).then(() => {
+    return store.dispatch(actions.auth.authenticate(defaultCluster, token, false)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
-      expect(Auth.validateToken).toHaveBeenCalledWith(token);
+      expect(Auth.validateToken).toHaveBeenCalledWith(defaultCluster, token);
     });
   });
 
@@ -93,7 +94,7 @@ describe("authenticate", () => {
       },
     ];
 
-    return store.dispatch(actions.auth.authenticate("ignored", true)).then(() => {
+    return store.dispatch(actions.auth.authenticate(defaultCluster, "ignored", true)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
       expect(Auth.validateToken).not.toHaveBeenCalled();
     });

--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -121,7 +121,7 @@ describe("OIDC authentication", () => {
       },
     ];
 
-    return store.dispatch(actions.auth.checkCookieAuthentication()).then(() => {
+    return store.dispatch(actions.auth.checkCookieAuthentication("default")).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -75,12 +75,9 @@ export function expireSession(): ThunkAction<Promise<void>, IStoreState, null, A
   };
 }
 
-export function checkCookieAuthentication(cluster: string): ThunkAction<
-  Promise<void>,
-  IStoreState,
-  null,
-  AuthAction
-> {
+export function checkCookieAuthentication(
+  cluster: string,
+): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
   return async dispatch => {
     // The call to authenticate below will also dispatch authenticating,
     // but we dispatch it early so that the login screen is shown as

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -25,6 +25,7 @@ const allActions = [setAuthenticated, authenticating, authenticationError, setSe
 export type AuthAction = ActionType<typeof allActions[number]>;
 
 export function authenticate(
+  cluster: string,
   token: string,
   oidc: boolean,
 ): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
@@ -32,7 +33,7 @@ export function authenticate(
     dispatch(authenticating());
     try {
       if (!oidc) {
-        await Auth.validateToken(token);
+        await Auth.validateToken(cluster, token);
       }
       Auth.setAuthToken(token, oidc);
       dispatch(setAuthenticated(true, oidc, Auth.defaultNamespaceFromToken(token)));
@@ -74,7 +75,7 @@ export function expireSession(): ThunkAction<Promise<void>, IStoreState, null, A
   };
 }
 
-export function checkCookieAuthentication(): ThunkAction<
+export function checkCookieAuthentication(cluster: string): ThunkAction<
   Promise<void>,
   IStoreState,
   null,
@@ -85,9 +86,9 @@ export function checkCookieAuthentication(): ThunkAction<
     // but we dispatch it early so that the login screen is shown as
     // loading while we query isAuthenticatedWithCookie().
     dispatch(authenticating());
-    const isAuthed = await Auth.isAuthenticatedWithCookie();
+    const isAuthed = await Auth.isAuthenticatedWithCookie(cluster);
     if (isAuthed) {
-      dispatch(authenticate("", true));
+      dispatch(authenticate(cluster, "", true));
     } else {
       dispatch(setAuthenticated(false, false, ""));
     }

--- a/dashboard/src/components/LoginForm/LoginForm.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.test.tsx
@@ -14,7 +14,10 @@ const emptyLocation: Location = {
   state: "",
 };
 
+const defaultCluster = "default";
+
 const defaultProps = {
+  cluster: defaultCluster,
   authenticate: jest.fn(),
   authenticated: false,
   authenticating: false,
@@ -95,7 +98,7 @@ describe("token login form", () => {
     const wrapper = shallow(<LoginForm {...defaultProps} />);
     wrapper.find("input#token").simulate("change", { currentTarget: { value: "f00b4r" } });
     wrapper.find("form").simulate("submit", { preventDefault: jest.fn() });
-    expect(defaultProps.authenticate).toBeCalledWith("f00b4r");
+    expect(defaultProps.authenticate).toBeCalledWith(defaultCluster, "f00b4r");
   });
 
   it("displays an error if the authentication error is passed", () => {

--- a/dashboard/src/components/LoginForm/LoginForm.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.tsx
@@ -7,12 +7,13 @@ import LoadingWrapper from "../../components/LoadingWrapper";
 import "./LoginForm.css";
 
 export interface ILoginFormProps {
+  cluster: string;
   authenticated: boolean;
   authenticating: boolean;
   authenticationError: string | undefined;
   oauthLoginURI: string;
-  authenticate: (token: string) => any;
-  checkCookieAuthentication: () => void;
+  authenticate: (cluster: string, token: string) => any;
+  checkCookieAuthentication: (cluster: string) => void;
   location: Location;
 }
 
@@ -25,7 +26,7 @@ class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
 
   public componentDidMount() {
     if (this.props.oauthLoginURI) {
-      this.props.checkCookieAuthentication();
+      this.props.checkCookieAuthentication(this.props.cluster);
     }
   }
 
@@ -65,7 +66,7 @@ class LoginForm extends React.Component<ILoginFormProps, ILoginFormState> {
   private handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const { token } = this.state;
-    return token && (await this.props.authenticate(token));
+    return token && (await this.props.authenticate(this.props.cluster, token));
   };
 
   private handleTokenChange = (e: React.FormEvent<HTMLInputElement>) => {

--- a/dashboard/src/components/LoginForm/LoginForm.v2.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.v2.test.tsx
@@ -16,7 +16,10 @@ const emptyLocation: Location = {
   state: "",
 };
 
+const defaultCluster = "default";
+
 const defaultProps = {
+  cluster: defaultCluster,
   authenticate: jest.fn(),
   authenticated: false,
   authenticating: false,
@@ -111,7 +114,7 @@ describe("token login form", () => {
     act(() => {
       wrapper.find("form").simulate("submit", { preventDefault: jest.fn() });
     });
-    expect(authenticate).toBeCalledWith("f00b4r");
+    expect(authenticate).toBeCalledWith(defaultCluster, "f00b4r");
   });
 
   it("displays an error if the authentication error is passed", () => {

--- a/dashboard/src/components/LoginForm/LoginForm.v2.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.v2.tsx
@@ -13,12 +13,13 @@ import TokenLogin from "./TokenLogin";
 ClarityIcons.addIcons(infoCircleIcon);
 
 export interface ILoginFormProps {
+  cluster: string;
   authenticated: boolean;
   authenticating: boolean;
   authenticationError: string | undefined;
   oauthLoginURI: string;
-  authenticate: (token: string) => any;
-  checkCookieAuthentication: () => void;
+  authenticate: (cluster: string, token: string) => any;
+  checkCookieAuthentication: (cluster: string) => void;
   appVersion: string;
   location: Location;
 }
@@ -28,7 +29,7 @@ function LoginForm(props: ILoginFormProps) {
   const { oauthLoginURI, checkCookieAuthentication } = props;
   useEffect(() => {
     if (oauthLoginURI) {
-      checkCookieAuthentication();
+      checkCookieAuthentication(props.cluster);
     }
   }, [oauthLoginURI, checkCookieAuthentication]);
 
@@ -42,7 +43,7 @@ function LoginForm(props: ILoginFormProps) {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    return token && (await props.authenticate(token));
+    return token && (await props.authenticate(props.cluster, token));
   };
 
   const handleTokenChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/dashboard/src/components/LoginForm/__snapshots__/LoginForm.v2.test.tsx.snap
+++ b/dashboard/src/components/LoginForm/__snapshots__/LoginForm.v2.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`token login form displays an error if the authentication error is passe
   authenticating={false}
   authenticationError="it's a trap"
   checkCookieAuthentication={[MockFunction]}
+  cluster="default"
   location={
     Object {
       "hash": "",

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -2,6 +2,7 @@ import { shallow } from "enzyme";
 import { Location } from "history";
 import * as React from "react";
 import { IAuthState } from "reducers/auth";
+import { IClustersState } from "reducers/cluster";
 import { IConfigState } from "reducers/config";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
@@ -36,7 +37,16 @@ const makeStore = (
     oauthLogoutURI: "",
     featureFlags: { operators: false, additionalClusters: [], ui: "hex" },
   };
-  return mockStore({ auth, config });
+  const clusters: IClustersState = {
+    currentCluster: "default",
+    clusters: {
+      default: {
+        currentNamespace: "default",
+        namespaces: [],
+      },
+    },
+  };
+  return mockStore({ auth, config, clusters });
 };
 
 const emptyLocation: Location = {

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
@@ -9,11 +9,13 @@ import { IStoreState } from "../../shared/types";
 function mapStateToProps({
   auth: { authenticated, authenticating, authenticationError },
   config: { authProxyEnabled, oauthLoginURI, featureFlags, appVersion },
+  clusters,
 }: IStoreState) {
   return {
     authenticated,
     authenticating,
     authenticationError,
+    cluster: clusters.currentCluster,
     oauthLoginURI: authProxyEnabled ? oauthLoginURI : "",
     UI: featureFlags.ui,
     appVersion,
@@ -22,8 +24,10 @@ function mapStateToProps({
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    authenticate: (token: string) => dispatch(actions.auth.authenticate(token, false)),
-    checkCookieAuthentication: () => dispatch(actions.auth.checkCookieAuthentication()),
+    authenticate: (cluster: string, token: string) =>
+      dispatch(actions.auth.authenticate(cluster, token, false)),
+    checkCookieAuthentication: (cluster: string) =>
+      dispatch(actions.auth.checkCookieAuthentication(cluster)),
   };
 }
 

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -1,5 +1,6 @@
 import Axios, { AxiosResponse } from "axios";
 import * as jwt from "jsonwebtoken";
+import * as url from "shared/url";
 import { IConfig } from "./Config";
 import { APIBase } from "./Kube";
 import { definedNamespaces } from "./Namespace";
@@ -57,9 +58,9 @@ export class Auth {
   }
 
   // Throws an error if the token is invalid
-  public static async validateToken(token: string) {
+  public static async validateToken(cluster: string, token: string) {
     try {
-      await Axios.get(APIBase + "/", { headers: { Authorization: `Bearer ${token}` } });
+      await Axios.get(url.api.k8s.base(cluster) + "/", { headers: { Authorization: `Bearer ${token}` } });
     } catch (e) {
       const res = e.response as AxiosResponse;
       if (res.status === 401) {
@@ -96,9 +97,9 @@ export class Auth {
   // isAuthenticatedWithCookie() does an anonymous GET request to determine if
   // the request is authenticated with an http-only cookie (there is, by design,
   // no way to determine via client JS whether an http-only cookie is present).
-  public static async isAuthenticatedWithCookie(): Promise<boolean> {
+  public static async isAuthenticatedWithCookie(cluster: string): Promise<boolean> {
     try {
-      await Axios.get(APIBase + "/");
+      await Axios.get(url.api.k8s.base(cluster) + "/");
     } catch (e) {
       const response = e.response as AxiosResponse;
       // The only error response which can possibly mean we did authenticate is

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -2,7 +2,6 @@ import Axios, { AxiosResponse } from "axios";
 import * as jwt from "jsonwebtoken";
 import * as url from "shared/url";
 import { IConfig } from "./Config";
-import { APIBase } from "./Kube";
 import { definedNamespaces } from "./Namespace";
 
 const AuthTokenKey = "kubeapps_auth_token";
@@ -60,7 +59,9 @@ export class Auth {
   // Throws an error if the token is invalid
   public static async validateToken(cluster: string, token: string) {
     try {
-      await Axios.get(url.api.k8s.base(cluster) + "/", { headers: { Authorization: `Bearer ${token}` } });
+      await Axios.get(url.api.k8s.base(cluster) + "/", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
     } catch (e) {
       const res = e.response as AxiosResponse;
       if (res.status === 401) {


### PR DESCRIPTION
More code pulled out of the demo branch at #1844 . In particular, this PR updates the Auth helper, actions and usage in login forms to all include the cluster from the state.

Follows #1877, Ref: #1762 