### PR TITLE
Add a cluster selector to header when more than one cluster.

### DIFF
--- a/dashboard/src/components/AppView/AppControls/AppControls.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/AppControls.test.tsx
@@ -2,12 +2,8 @@ import { mount, shallow } from "enzyme";
 import context from "jest-plugin-context";
 import * as React from "react";
 import Modal from "react-modal";
-import { Provider } from "react-redux";
-import configureMockStore, { MockStore } from "redux-mock-store";
-import thunk from "redux-thunk";
 
 import { IRelease } from "shared/types";
-import { IStoreState } from "shared/types";
 import RollbackButtonContainer from "../../../containers/RollbackButtonContainer";
 import { hapi } from "../../../shared/hapi/release";
 import itBehavesLike from "../../../shared/specs";
@@ -15,32 +11,7 @@ import * as url from "../../../shared/url";
 import ConfirmDialog from "../../ConfirmDialog";
 import AppControls, { IAppControlsProps } from "./AppControls";
 import UpgradeButton from "./UpgradeButton";
-
-const mockStore = configureMockStore([thunk]);
-
-// TODO(absoludity): As we move to function components with (redux) hooks we'll need to
-// be including state in tests, so we may want to put things like initialState
-// and a generalized getWrapper in a test helpers or similar package?
-const initialState = {
-  apps: {},
-  auth: {},
-  catalog: {},
-  charts: {},
-  config: {},
-  kube: {},
-  clusters: {
-    currentCluster: "default-cluster",
-  },
-  repos: {},
-  operators: {},
-} as IStoreState;
-
-const getWrapper = (store: MockStore, props: IAppControlsProps) =>
-  mount(
-    <Provider store={store}>
-      <AppControls {...props} />
-    </Provider>,
-  );
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 
 const namespace = "bar";
 const defaultProps = {
@@ -51,7 +22,7 @@ const defaultProps = {
 } as IAppControlsProps;
 
 it("calls delete function without purge when clicking the button", done => {
-  const store = mockStore(initialState);
+  const store = getStore({});
   const push = jest.fn();
   const deleteApp = jest.fn().mockReturnValue(true);
   const props = {
@@ -59,7 +30,7 @@ it("calls delete function without purge when clicking the button", done => {
     deleteApp,
     push,
   };
-  const wrapper = getWrapper(store, props);
+  const wrapper = mountWrapper(store, <AppControls {...props} />);
   const appControls = wrapper.find(AppControls);
   const button = appControls.children().find(".button-danger");
   expect(button.exists()).toBe(true);
@@ -86,8 +57,8 @@ it("calls delete function with additional purge", () => {
   // Return "false" to avoid redirect when mounting
   const deleteApp = jest.fn().mockReturnValue(false);
   const props = { ...defaultProps, deleteApp };
-  const store = mockStore(initialState);
-  const wrapper = getWrapper(store, props);
+  const store = getStore({});
+  const wrapper = mountWrapper(store, <AppControls {...props} />);
   Modal.setAppElement(document.createElement("div"));
   const appControls = wrapper.find(AppControls);
   const button = appControls.children().find(".button-danger");

--- a/dashboard/src/components/AppView/AppControls/AppControls.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/AppControls.test.tsx
@@ -3,6 +3,7 @@ import context from "jest-plugin-context";
 import * as React from "react";
 import Modal from "react-modal";
 
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 import { IRelease } from "shared/types";
 import RollbackButtonContainer from "../../../containers/RollbackButtonContainer";
 import { hapi } from "../../../shared/hapi/release";
@@ -11,7 +12,6 @@ import * as url from "../../../shared/url";
 import ConfirmDialog from "../../ConfirmDialog";
 import AppControls, { IAppControlsProps } from "./AppControls";
 import UpgradeButton from "./UpgradeButton";
-import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 
 const namespace = "bar";
 const defaultProps = {

--- a/dashboard/src/components/AppView/AppControls/UpgradeButton.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/UpgradeButton.test.tsx
@@ -1,40 +1,10 @@
-import { mount } from "enzyme";
 import context from "jest-plugin-context";
 import * as React from "react";
 import { ArrowUpCircle } from "react-feather";
-import { Provider } from "react-redux";
 import { Redirect } from "react-router";
-import configureMockStore, { MockStore } from "redux-mock-store";
-import thunk from "redux-thunk";
-import { IStoreState } from "shared/types";
 import * as url from "shared/url";
 import UpgradeButton, { IUpgradeButtonProps } from "./UpgradeButton";
-
-const mockStore = configureMockStore([thunk]);
-
-// TODO(absoludity): As we move to function components with (redux) hooks we'll need to
-// be including state in tests, so we may want to put things like initialState
-// and a generalized getWrapper in a test helpers or similar package?
-const initialState = {
-  apps: {},
-  auth: {},
-  catalog: {},
-  charts: {},
-  config: {},
-  kube: {},
-  clusters: {
-    currentCluster: "default-cluster",
-  },
-  repos: {},
-  operators: {},
-} as IStoreState;
-
-const getWrapper = (store: MockStore, props: IUpgradeButtonProps) =>
-  mount(
-    <Provider store={store}>
-      <UpgradeButton {...props} />
-    </Provider>,
-  );
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 
 const defaultProps = {
   releaseName: "foo",
@@ -44,8 +14,9 @@ const defaultProps = {
 
 it("renders a redirect when clicking upgrade", () => {
   const push = jest.fn();
-  const store = mockStore(initialState);
-  const wrapper = getWrapper(store, { ...defaultProps, push });
+  const store = getStore({});
+  const props = { ...defaultProps, push };
+  const wrapper = mountWrapper(store, <UpgradeButton {...props} />);
   const button = wrapper.find(".button").filterWhere(i => i.text() === "Upgrade");
   expect(button.exists()).toBe(true);
   expect(wrapper.find(Redirect).exists()).toBe(false);
@@ -57,8 +28,9 @@ it("renders a redirect when clicking upgrade", () => {
 
 context("when a new version is available", () => {
   it("should show a modify the style", () => {
-    const store = mockStore(initialState);
-    const wrapper = getWrapper(store, { ...defaultProps, newVersion: true });
+    const store = getStore({});
+    const props = { ...defaultProps, newVersion: true };
+    const wrapper = mountWrapper(store, <UpgradeButton {...props} />);
     const icon = wrapper.find(ArrowUpCircle);
     expect(icon).toExist();
   });

--- a/dashboard/src/components/AppView/AppControls/UpgradeButton.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/UpgradeButton.test.tsx
@@ -2,9 +2,9 @@ import context from "jest-plugin-context";
 import * as React from "react";
 import { ArrowUpCircle } from "react-feather";
 import { Redirect } from "react-router";
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 import * as url from "shared/url";
 import UpgradeButton, { IUpgradeButtonProps } from "./UpgradeButton";
-import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 
 const defaultProps = {
   releaseName: "foo",

--- a/dashboard/src/components/Catalog/CatalogItem.test.tsx
+++ b/dashboard/src/components/Catalog/CatalogItem.test.tsx
@@ -1,12 +1,9 @@
-import { mount, shallow } from "enzyme";
+import { shallow } from "enzyme";
 import context from "jest-plugin-context";
 import * as React from "react";
-import { Provider } from "react-redux";
-import { BrowserRouter as Router } from "react-router-dom";
-import configureMockStore, { MockStore } from "redux-mock-store";
-import thunk from "redux-thunk";
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 
-import { IRepo, IStoreState } from "../../shared/types";
+import { IRepo } from "../../shared/types";
 import { CardIcon } from "../Card";
 import InfoCard from "../InfoCard";
 import CatalogItem, {
@@ -16,33 +13,6 @@ import CatalogItem, {
 } from "./CatalogItem";
 
 jest.mock("../../placeholder.png", () => "placeholder.png");
-const mockStore = configureMockStore([thunk]);
-
-// TODO(absoludity): As we move to function components with (redux) hooks we'll need to
-// be including state in tests, so we may want to put things like initialState
-// and a generalized getWrapper in a test helpers or similar package?
-const initialState = {
-  apps: {},
-  auth: {},
-  catalog: {},
-  charts: {},
-  config: {},
-  kube: {},
-  clusters: {
-    currentCluster: "default-cluster",
-  },
-  repos: {},
-  operators: {},
-} as IStoreState;
-
-const getWrapper = (store: MockStore, props: ICatalogItemProps) =>
-  mount(
-    <Provider store={store}>
-      <Router>
-        <CatalogItem {...props} />
-      </Router>
-    </Provider>,
-  );
 
 const defaultItem = {
   id: "foo1",
@@ -63,10 +33,10 @@ const defaultProps: ICatalogItemProps = {
   type: "chart",
 };
 
-const defaultStore = mockStore(initialState);
+const defaultStore = getStore({});
 
 it("should render a chart item in a namespace", () => {
-  const wrapper = getWrapper(defaultStore, defaultProps);
+  const wrapper = mountWrapper(defaultStore, <CatalogItem {...defaultProps} />);
   // Can't shallow render connected components for easy snapshotting :/
   // https://github.com/enzymejs/enzyme/issues/2202
   expect(wrapper.find(InfoCard)).toMatchSnapshot();
@@ -83,7 +53,7 @@ it("should render a global chart item in a namespace", () => {
       } as IRepo,
     },
   };
-  const wrapper = getWrapper(defaultStore, props);
+  const wrapper = mountWrapper(defaultStore, <CatalogItem {...props} />);
   expect(wrapper.find(InfoCard)).toMatchSnapshot();
 });
 
@@ -95,7 +65,7 @@ it("should use the default placeholder for the icon if it doesn't exist", () => 
       icon: undefined,
     },
   };
-  const wrapper = getWrapper(defaultStore, props);
+  const wrapper = mountWrapper(defaultStore, <CatalogItem {...props} />);
   // Importing an image returns "undefined"
   expect(wrapper.find(CardIcon).prop("src")).toBe(undefined);
 });
@@ -108,7 +78,7 @@ it("should place a dash if the version is not avaliable", () => {
       version: "",
     },
   };
-  const wrapper = getWrapper(defaultStore, props);
+  const wrapper = mountWrapper(defaultStore, <CatalogItem {...props} />);
   expect(wrapper.find(".type-color-light-blue").text()).toBe("-");
 });
 
@@ -120,7 +90,7 @@ it("show the chart description", () => {
       description: "This is a description",
     },
   };
-  const wrapper = getWrapper(defaultStore, props);
+  const wrapper = mountWrapper(defaultStore, <CatalogItem {...props} />);
   expect(wrapper.find(".ListItem__content__description").text()).toBe(props.item.description);
 });
 
@@ -134,7 +104,7 @@ context("when the description is too long", () => {
           "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ultrices velit leo, quis pharetra mi vestibulum quis.",
       },
     };
-    const wrapper = getWrapper(defaultStore, props);
+    const wrapper = mountWrapper(defaultStore, <CatalogItem {...props} />);
     expect(wrapper.find(".ListItem__content__description").text()).toMatch(/\.\.\.$/);
   });
 });

--- a/dashboard/src/components/ChartView/ChartDeployButton.test.tsx
+++ b/dashboard/src/components/ChartView/ChartDeployButton.test.tsx
@@ -1,35 +1,8 @@
-import { mount } from "enzyme";
 import * as React from "react";
-import { Provider } from "react-redux";
-import configureMockStore, { MockStore } from "redux-mock-store";
-import thunk from "redux-thunk";
-import { IChartVersion, IStoreState } from "../../shared/types";
+import { IChartVersion } from "../../shared/types";
 import * as url from "../../shared/url";
 import ChartDeployButton, { IChartDeployButtonProps } from "./ChartDeployButton";
-
-const mockStore = configureMockStore([thunk]);
-
-// TODO(absoludity): As we move to function components with (redux) hooks we'll need to
-// be including state in tests, so we may want to put things like initialState
-// and a generalized getWrapper in a test helpers or similar package?
-const initialState = {
-  apps: {},
-  auth: {},
-  catalog: {},
-  charts: {},
-  config: {},
-  kube: {},
-  clusters: {},
-  repos: {},
-  operators: {},
-} as IStoreState;
-
-const getWrapper = (store: MockStore, props: IChartDeployButtonProps) =>
-  mount(
-    <Provider store={store}>
-      <ChartDeployButton {...props} />
-    </Provider>,
-  );
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 
 const testChartVersion: IChartVersion = {
   attributes: {
@@ -49,10 +22,11 @@ const testChartVersion: IChartVersion = {
 } as IChartVersion;
 
 it("renders a button to deploy the chart version", () => {
-  const wrapper = getWrapper(mockStore(initialState), {
+  const props = {
     version: testChartVersion,
     namespace: "kubeapps",
-  });
+  } as IChartDeployButtonProps;
+  const wrapper = mountWrapper(getStore({}), <ChartDeployButton {...props} />);
   const button = wrapper.find("button");
   expect(button.exists()).toBe(true);
   expect(button.text()).toBe("Deploy");
@@ -61,13 +35,13 @@ it("renders a button to deploy the chart version", () => {
 it("dispatches a URL change with the correct URL when the button is clicked", () => {
   const testCases = [
     {
-      clustersState: { currentCluster: "default" },
+      clustersState: { currentCluster: "default", clusters: {} },
       namespace: "kubeapps",
       version: "1.2.3",
       url: url.app.apps.new("default", "kubeapps", testChartVersion, "1.2.3"),
     },
     {
-      clustersState: { currentCluster: "other-cluster" },
+      clustersState: { currentCluster: "other-cluster", clusters: {} },
       namespace: "foo",
       version: "alpha-0",
       url: url.app.apps.new("other-cluster", "foo", testChartVersion, "alpha-0"),
@@ -75,11 +49,19 @@ it("dispatches a URL change with the correct URL when the button is clicked", ()
   ];
 
   testCases.forEach(t => {
-    const store = mockStore({ ...initialState, clusters: t.clustersState });
-    const version = Object.assign({}, testChartVersion);
-    version.attributes.version = t.version;
+    const props = {
+      version: {
+        ...testChartVersion,
+        attributes: {
+          ...testChartVersion.attributes,
+          version: t.version,
+        },
+      },
+      namespace: t.namespace,
+    } as IChartDeployButtonProps;
+    const store = getStore({ clusters: t.clustersState });
 
-    const wrapper = getWrapper(store, { version, namespace: t.namespace });
+    const wrapper = mountWrapper(store, <ChartDeployButton {...props} />);
 
     const button = wrapper.find("button");
     expect(button.exists()).toBe(true);

--- a/dashboard/src/components/ChartView/ChartDeployButton.test.tsx
+++ b/dashboard/src/components/ChartView/ChartDeployButton.test.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 import { IChartVersion } from "../../shared/types";
 import * as url from "../../shared/url";
 import ChartDeployButton, { IChartDeployButtonProps } from "./ChartDeployButton";
-import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 
 const testChartVersion: IChartVersion = {
   attributes: {

--- a/dashboard/src/components/Header/ClusterSelector.test.tsx
+++ b/dashboard/src/components/Header/ClusterSelector.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as ReactRedux from "react-redux";
 
 import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 import ClusterSelector, { IClusterSelectorProps } from "./ClusterSelector";
@@ -39,6 +40,8 @@ it("dispatches fetchNamespaces and calls onChange prop when changed", () => {
     ...defaultProps,
     onChange,
   };
+  const mockDispatch = jest.fn();
+  const spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
 
   const wrapper = mountWrapper(store, <ClusterSelector {...props} />);
   const select = wrapper.find("Select");
@@ -48,7 +51,10 @@ it("dispatches fetchNamespaces and calls onChange prop when changed", () => {
   expect(selectOnChange).toBeDefined();
   selectOnChange!({ value: "other" } as any);
 
-  // TODO: how can we see the action for fetchNamespace?
-  expect(store.getActions()).toEqual([]);
+  // fetchNamespaces returns an async thunk action - hand to test more than dispatch
+  // was called once.
+  expect(mockDispatch).toBeCalledTimes(1);
   expect(onChange).toBeCalledWith("other");
+
+  spyOnUseDispatch.mockRestore();
 });

--- a/dashboard/src/components/Header/ClusterSelector.test.tsx
+++ b/dashboard/src/components/Header/ClusterSelector.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
-import ClusterSelector, { IClusterSelectorProps } from "./ClusterSelector";
 import { getStore, mountWrapper } from "shared/specs/mountWrapper";
+import ClusterSelector, { IClusterSelectorProps } from "./ClusterSelector";
 
 const defaultProps = {
   onChange: jest.fn(),

--- a/dashboard/src/components/Header/ClusterSelector.test.tsx
+++ b/dashboard/src/components/Header/ClusterSelector.test.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+
+import ClusterSelector, { IClusterSelectorProps } from "./ClusterSelector";
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
+
+const defaultProps = {
+  onChange: jest.fn(),
+  clusters: {
+    currentCluster: "default",
+    clusters: {
+      default: {
+        currentNamespace: "default",
+        namespaces: ["default", "other"],
+      },
+      other: {
+        currentNamespace: "default",
+        namespaces: ["default", "other"],
+      },
+    },
+  },
+} as IClusterSelectorProps;
+
+it("renders the cluster selector with the correct options", () => {
+  const store = getStore({});
+
+  const wrapper = mountWrapper(store, <ClusterSelector {...defaultProps} />);
+  const options = wrapper.find("Select").prop("options");
+
+  expect(options).toEqual([
+    { label: "default", value: "default" },
+    { label: "other", value: "other" },
+  ]);
+});
+
+it("dispatches fetchNamespaces and calls onChange prop when changed", () => {
+  const store = getStore({});
+  const onChange = jest.fn();
+  const props = {
+    ...defaultProps,
+    onChange,
+  };
+
+  const wrapper = mountWrapper(store, <ClusterSelector {...props} />);
+  const select = wrapper.find("Select");
+  expect(select).toExist();
+
+  const selectOnChange = select.prop("onChange");
+  expect(selectOnChange).toBeDefined();
+  selectOnChange!({ value: "other" } as any);
+
+  // TODO: how can we see the action for fetchNamespace?
+  expect(store.getActions()).toEqual([]);
+  expect(onChange).toBeCalledWith("other");
+});

--- a/dashboard/src/components/Header/ClusterSelector.tsx
+++ b/dashboard/src/components/Header/ClusterSelector.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { useDispatch } from "react-redux";
+import Select from "react-select";
+
+import actions from "actions";
+import { IClustersState } from "reducers/cluster";
+
+export interface IClusterSelectorProps {
+  clusters: IClustersState;
+  onChange: (cluster: string) => void;
+}
+
+const ClusterSelector: React.FC<IClusterSelectorProps> = props => {
+  const clusters = Object.keys(props.clusters.clusters);
+  const options = clusters.length > 0 ? clusters.map(c => ({ value: c, label: c })) : [];
+  const dispatch = useDispatch();
+  const handleClusterChange = (option: any) => {
+    dispatch(actions.namespace.fetchNamespaces(option.value));
+    props.onChange(option.value);
+  };
+
+  return (
+    <div className="NamespaceSelector margin-r-normal">
+      <label className="NamespaceSelector__label type-tiny">CLUSTER</label>
+      <Select
+        className="NamespaceSelector__select type-small"
+        value={props.clusters.currentCluster}
+        options={options}
+        multi={false}
+        onChange={handleClusterChange}
+        clearable={false}
+      />
+    </div>
+  );
+};
+
+export default ClusterSelector;

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -163,3 +163,39 @@ it("doesn't call getNamespace when selecting all namespaces", () => {
   expect(setNamespace).toHaveBeenCalledWith("_all");
   expect(getNamespace).not.toHaveBeenCalled();
 });
+
+describe("ClusterSelector", () => {
+  it("does not render the cluster switcher when there is only one cluster", () => {
+    const wrapper = shallow(<Header {...defaultProps} />);
+
+    const clusterSelector = wrapper.find("ClusterSelector");
+
+    expect(clusterSelector).not.toExist();
+  });
+
+  it("renders the cluster switcher when there are multiple clusters", () => {
+    const props = {
+      ...defaultProps,
+      clusters: {
+        ...defaultProps.clusters,
+        clusters: {
+          ...defaultProps.clusters.clusters,
+          other: {
+            currentNamespace: "default",
+            namespaces: ["default", "other"],
+          },
+        },
+      } as IClustersState,
+    };
+    const wrapper = shallow(<Header {...props} />);
+
+    const clusterSelector = wrapper.find("ClusterSelector");
+
+    expect(clusterSelector).toExist();
+    expect(clusterSelector.props()).toEqual(
+      expect.objectContaining({
+        clusters: props.clusters,
+      }),
+    );
+  });
+});

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -7,6 +7,7 @@ import logo from "../../logo.svg";
 import { IClustersState } from "../../reducers/cluster";
 import { definedNamespaces } from "../../shared/Namespace";
 import { app } from "../../shared/url";
+import ClusterSelector from "./ClusterSelector";
 import "./Header.css";
 import HeaderLink from "./HeaderLink";
 import NamespaceSelector from "./NamespaceSelector";
@@ -59,6 +60,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
       createNamespace,
       getNamespace,
     } = this.props;
+    const showClusterSelector = Object.keys(clusters.clusters).length > 1;
     const cluster = clusters.clusters[clusters.currentCluster];
     const header = `header ${this.state.mobileOpen ? "header-open" : ""}`;
     const submenu = `header__nav__submenu ${
@@ -112,6 +114,9 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
             )}
             {showNav && (
               <div className="header__nav header__nav-config">
+                {showClusterSelector && (
+                  <ClusterSelector clusters={clusters} onChange={this.handleClusterChange} />
+                )}
                 <NamespaceSelector
                   clusters={clusters}
                   defaultNamespace={defaultNamespace}
@@ -201,6 +206,14 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
     if (ns !== definedNamespaces.all) {
       getNamespace(currentCluster, ns);
     }
+    if (to !== pathname) {
+      push(to);
+    }
+  };
+
+  private handleClusterChange = (cluster: string) => {
+    const { pathname, push } = this.props;
+    const to = pathname.replace(/\/c\/[^/]*/, `/c/${cluster}`);
     if (to !== pathname) {
       push(to);
     }

--- a/dashboard/src/shared/specs/mountWrapper.tsx
+++ b/dashboard/src/shared/specs/mountWrapper.tsx
@@ -4,6 +4,7 @@ import { Provider } from "react-redux";
 import { BrowserRouter as Router } from "react-router-dom";
 import configureMockStore, { MockStore } from "redux-mock-store";
 import thunk from "redux-thunk";
+import { merge } from "lodash";
 
 import { IStoreState } from "../../shared/types";
 
@@ -25,7 +26,14 @@ const initialState = {
 
 export const defaultStore = mockStore(initialState);
 
-export const mountWrapper = (store: MockStore, children: any) =>
+// getStore returns a store initialised with a merge of
+// the initial state with any passed extra state.
+export const getStore = (extraState: Object) => {
+  const state = { ...initialState };
+  return mockStore(merge(state, extraState));
+};
+
+export const mountWrapper = (store: MockStore, children: React.ReactElement) =>
   mount(
     <Provider store={store}>
       <Router>{children}</Router>

--- a/dashboard/src/shared/specs/mountWrapper.tsx
+++ b/dashboard/src/shared/specs/mountWrapper.tsx
@@ -1,10 +1,10 @@
 import { mount } from "enzyme";
+import { merge } from "lodash";
 import * as React from "react";
 import { Provider } from "react-redux";
 import { BrowserRouter as Router } from "react-router-dom";
 import configureMockStore, { MockStore } from "redux-mock-store";
 import thunk from "redux-thunk";
-import { merge } from "lodash";
 
 import { IStoreState } from "../../shared/types";
 
@@ -28,7 +28,7 @@ export const defaultStore = mockStore(initialState);
 
 // getStore returns a store initialised with a merge of
 // the initial state with any passed extra state.
-export const getStore = (extraState: Object) => {
+export const getStore = (extraState: object) => {
   const state = { ...initialState };
   return mockStore(merge(state, extraState));
 };


### PR DESCRIPTION
# Description of the change

Adds a cluster selector to the header iff more than one cluster is configured.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Applicable issues

#1762 

### Additional information
I've also updated previous code I'd landed to use the new `mountWrapper` helper (and updated the helper lib to be able to create a store with some merged attributes).