### PR TITLE
Fix/#1855

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -172,5 +172,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://127.0.0.1:8080"
 }

--- a/dashboard/src/shared/ServiceBinding.ts
+++ b/dashboard/src/shared/ServiceBinding.ts
@@ -57,6 +57,8 @@ export class ServiceBinding {
   ) {
     const u = ServiceBinding.getLink(namespace);
     const { data } = await axiosWithAuth.post<IServiceBinding>(u, {
+      apiVersion: "servicecatalog.k8s.io/v1beta1",
+      kind: "ServiceBinding",
       metadata: {
         name: bindingName,
       },

--- a/docs/developer/dashboard.md
+++ b/docs/developer/dashboard.md
@@ -53,7 +53,7 @@ Next, create a `telepresence` shell to swap the `kubeapps-internal-dashboard` de
 telepresence --namespace kubeapps --method inject-tcp --swap-deployment kubeapps-internal-dashboard --expose 3000:8080 --run-shell
 ```
 
-> **NOTE**: If you encounter issues getting this setup working correctly, please try switching the telepresence proxying method in the above command to `vpn-tcp`. Refer to [the telepresence docs](https://www.telepresence.io/reference/methods) to learn more about the available proxying methods and their limitations.
+> **NOTE**: If you encounter issues getting this setup working correctly, please try switching the telepresence proxying method in the above command to `vpn-tcp`. Refer to [the telepresence docs](https://www.telepresence.io/reference/methods) to learn more about the available proxying methods and their limitations. If this doesn't work you can use the [Telepresence alternative](#telepresence-alternative).
 
 Finally, launch the dashboard within the telepresence shell:
 
@@ -63,6 +63,20 @@ yarn run start
 ```
 
 > **NOTE**: The commands above assume you install Kubeapps in the `kubeapps` namespace. Please update the environment variable `TELEPRESENCE_CONTAINER_NAMESPACE` if you are using a different namespace.
+
+#### Telepresence alternative
+
+As an alternative to using [Telepresence](https://www.telepresence.io/) you can use the default [Create React App API proxy](https://create-react-app.dev/docs/proxying-api-requests-in-development/) functionality.
+
+To use this a run Kubeapps per the [getting-started documentation](../../docs/user/getting-started.md#step-3-start-the-kubeapps-dashboard). This will start Kubeapps running on port `8080`.
+
+Next you can launch the dashboard.
+
+```bash
+yarn run start
+```
+
+> **NOTE**: The [proxy](../../dashboard/package.json#L176) `key:value` has already added to the `package.json` for convenience but you can change the `host:port` values to meet your needs.
 
 You can now access the local development server simply by accessing the dashboard as you usually would (e.g. doing a port-forward or accesing the Ingress URL).
 


### PR DESCRIPTION
This fix adds missing post body parameter to `ServiceBinding:create`. These parameters are required.

I didn't use a close commit for this because while this does solve the problem of creating a binding I'm still seeing a 404 error fetching the secret after the binding is created. I will look at that further but I would like to keep the commits focused and small.

The second commit in this PR is an update to the developer documentation that provide an alternative to Telepresence for running the dashboard locally. I needed to do that myself since I could not get past the Mac SIP issue with Telepresence without disabling it entirely which I did not want to do.

As noted above I don't want to but `fixes` because it solves some of the issues with Binding but I'm not sure yet if it solves all the problems. 
