### PR TITLE
Update namespace actions/reducer to be cluster aware.

### DIFF
--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -3,7 +3,7 @@ import { ActionType, createAction } from "typesafe-actions";
 
 import { Auth } from "../shared/Auth";
 import { IStoreState } from "../shared/types";
-import { clearNamespaces, NamespaceAction } from "./namespace";
+import { clearClusters, NamespaceAction } from "./namespace";
 
 export const setAuthenticated = createAction("SET_AUTHENTICATED", resolve => {
   return (authenticated: boolean, oidc: boolean, defaultNamespace: string) =>
@@ -61,7 +61,7 @@ export function logout(): ThunkAction<
     } else {
       Auth.unsetAuthToken();
       dispatch(setAuthenticated(false, false, ""));
-      dispatch(clearNamespaces());
+      dispatch(clearClusters());
     }
   };
 }

--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -77,7 +77,7 @@ describe("fetchNamespaces", () => {
     const expectedActions = [
       {
         type: getType(errorNamespaces),
-        payload: { err, op: "list" },
+        payload: { cluster: "default-c", err, op: "list" },
       },
     ];
 
@@ -117,7 +117,7 @@ describe("createNamespace", () => {
     const expectedActions = [
       {
         type: getType(errorNamespaces),
-        payload: { err, op: "create" },
+        payload: { cluster: "default-c", err, op: "create" },
       },
     ];
 
@@ -156,7 +156,7 @@ describe("getNamespace", () => {
       },
       {
         type: getType(errorNamespaces),
-        payload: { err, op: "get" },
+        payload: { cluster: "default-c", err, op: "get" },
       },
     ];
     const r = await store.dispatch(getNamespace("default-c", "default-ns"));

--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -32,19 +32,19 @@ interface ITestCase {
 }
 
 const actionTestCases: ITestCase[] = [
-  { name: "setNamespace", action: setNamespace, args: "jack", payload: "jack" },
+  { name: "setNamespace", action: setNamespace, args: ["jack"], payload: "jack" },
   {
     name: "receiveNamespces",
     action: receiveNamespaces,
-    args: ["jack", "danny"],
-    payload: ["jack", "danny"],
+    args: ["default", ["jack", "danny"]],
+    payload: { cluster: "default", namespaces: ["jack", "danny"] },
   },
 ];
 
 actionTestCases.forEach(tc => {
   describe(tc.name, () => {
     it("has expected structure", () => {
-      expect(tc.action.call(null, tc.args)).toEqual({
+      expect(tc.action.call(null, ...tc.args)).toEqual({
         type: getType(tc.action),
         payload: tc.payload,
       });
@@ -63,7 +63,7 @@ describe("fetchNamespaces", () => {
     const expectedActions = [
       {
         type: getType(receiveNamespaces),
-        payload: ["overlook-hotel", "room-217"],
+        payload: { cluster: "default-c", namespaces: ["overlook-hotel", "room-217"] },
       },
     ];
 
@@ -98,11 +98,11 @@ describe("createNamespace", () => {
     const expectedActions = [
       {
         type: getType(postNamespace),
-        payload: "overlook-hotel",
+        payload: { cluster: "default-c", namespace: "overlook-hotel" },
       },
       {
         type: getType(receiveNamespaces),
-        payload: ["overlook-hotel", "room-217"],
+        payload: { cluster: "default-c", namespaces: ["overlook-hotel", "room-217"] },
       },
     ];
 
@@ -134,11 +134,11 @@ describe("getNamespace", () => {
     const expectedActions = [
       {
         type: getType(requestNamespace),
-        payload: "default-ns",
+        payload: { cluster: "default-c", namespace: "default-ns" },
       },
       {
         type: getType(receiveNamespace),
-        payload: ns,
+        payload: { cluster: "default-c", namespace: ns },
       },
     ];
     const r = await store.dispatch(getNamespace("default-c", "default-ns"));
@@ -152,7 +152,7 @@ describe("getNamespace", () => {
     const expectedActions = [
       {
         type: getType(requestNamespace),
-        payload: "default-ns",
+        payload: { cluster: "default-c", namespace: "default-ns" },
       },
       {
         type: getType(errorNamespaces),

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -6,10 +6,10 @@ import Namespace from "../shared/Namespace";
 import { IResource, IStoreState } from "../shared/types";
 
 export const requestNamespace = createAction("REQUEST_NAMESPACE", resolve => {
-  return (namespace: string) => resolve(namespace);
+  return (cluster: string, namespace: string) => resolve({ cluster, namespace });
 });
 export const receiveNamespace = createAction("RECEIVE_NAMESPACE", resolve => {
-  return (namespace: IResource) => resolve(namespace);
+  return (cluster: string, namespace: IResource) => resolve({ cluster, namespace });
 });
 
 export const setNamespace = createAction("SET_NAMESPACE", resolve => {
@@ -17,11 +17,11 @@ export const setNamespace = createAction("SET_NAMESPACE", resolve => {
 });
 
 export const postNamespace = createAction("CREATE_NAMESPACE", resolve => {
-  return (namespace: string) => resolve(namespace);
+  return (cluster: string, namespace: string) => resolve({ cluster, namespace });
 });
 
 export const receiveNamespaces = createAction("RECEIVE_NAMESPACES", resolve => {
-  return (namespaces: string[]) => resolve(namespaces);
+  return (cluster: string, namespaces: string[]) => resolve({ cluster, namespaces });
 });
 
 export const errorNamespaces = createAction("ERROR_NAMESPACES", resolve => {
@@ -48,7 +48,7 @@ export function fetchNamespaces(
     try {
       const namespaceList = await Namespace.list(cluster);
       const namespaceStrings = namespaceList.namespaces.map((n: IResource) => n.metadata.name);
-      dispatch(receiveNamespaces(namespaceStrings));
+      dispatch(receiveNamespaces(cluster, namespaceStrings));
     } catch (e) {
       dispatch(errorNamespaces(e, "list"));
       return;
@@ -63,7 +63,7 @@ export function createNamespace(
   return async dispatch => {
     try {
       await Namespace.create(cluster, ns);
-      dispatch(postNamespace(ns));
+      dispatch(postNamespace(cluster, ns));
       dispatch(fetchNamespaces(cluster));
       return true;
     } catch (e) {
@@ -79,9 +79,9 @@ export function getNamespace(
 ): ThunkAction<Promise<boolean>, IStoreState, null, NamespaceAction> {
   return async dispatch => {
     try {
-      dispatch(requestNamespace(ns));
+      dispatch(requestNamespace(cluster, ns));
       const namespace = await Namespace.get(cluster, ns);
-      dispatch(receiveNamespace(namespace));
+      dispatch(receiveNamespace(cluster, namespace));
       return true;
     } catch (e) {
       dispatch(errorNamespaces(e, "get"));

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -25,10 +25,10 @@ export const receiveNamespaces = createAction("RECEIVE_NAMESPACES", resolve => {
 });
 
 export const errorNamespaces = createAction("ERROR_NAMESPACES", resolve => {
-  return (err: Error, op: string) => resolve({ err, op });
+  return (cluster: string, err: Error, op: string) => resolve({ cluster, err, op });
 });
 
-export const clearNamespaces = createAction("CLEAR_NAMESPACES");
+export const clearClusters = createAction("CLEAR_CLUSTERS");
 
 const allActions = [
   requestNamespace,
@@ -36,7 +36,7 @@ const allActions = [
   setNamespace,
   receiveNamespaces,
   errorNamespaces,
-  clearNamespaces,
+  clearClusters,
   postNamespace,
 ];
 export type NamespaceAction = ActionType<typeof allActions[number]>;
@@ -50,7 +50,7 @@ export function fetchNamespaces(
       const namespaceStrings = namespaceList.namespaces.map((n: IResource) => n.metadata.name);
       dispatch(receiveNamespaces(cluster, namespaceStrings));
     } catch (e) {
-      dispatch(errorNamespaces(e, "list"));
+      dispatch(errorNamespaces(cluster, e, "list"));
       return;
     }
   };
@@ -67,7 +67,7 @@ export function createNamespace(
       dispatch(fetchNamespaces(cluster));
       return true;
     } catch (e) {
-      dispatch(errorNamespaces(e, "create"));
+      dispatch(errorNamespaces(cluster, e, "create"));
       return false;
     }
   };
@@ -84,7 +84,7 @@ export function getNamespace(
       dispatch(receiveNamespace(cluster, namespace));
       return true;
     } catch (e) {
-      dispatch(errorNamespaces(e, "get"));
+      dispatch(errorNamespaces(cluster, e, "get"));
       return false;
     }
   };

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -102,7 +102,7 @@ actionTestCases.forEach(tc => {
 
 // Async action creators
 describe("deleteRepo", () => {
-  context("dispatches requestRepos and receivedRepos after deletion if no error", async () => {
+  context("dispatches requestRepos and receivedRepos after deletion if no error", () => {
     const currentNamespace = "current-namespace";
     it("dispatches requestRepos with current namespace", async () => {
       const storeWithFlag: any = mockStore({

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -59,7 +59,11 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
       namespace,
     } = this.props;
     // refetch if new namespace or error removed due to location change
-    if (prevProps.namespace !== namespace || (!error && prevProps.apps.error)) {
+    if (
+      prevProps.namespace !== namespace ||
+      prevProps.cluster !== cluster ||
+      (!error && prevProps.apps.error)
+    ) {
       fetchAppsWithUpdateInfo(cluster, namespace, listingAll);
       if (this.props.featureFlags.operators) {
         getCustomResources(namespace);

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -90,7 +90,7 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
 
   public componentDidUpdate(prevProps: IAppViewProps) {
     const { releaseName, getAppWithUpdateInfo, cluster, namespace, error, app } = this.props;
-    if (prevProps.namespace !== namespace) {
+    if (prevProps.namespace !== namespace || prevProps.cluster !== cluster) {
       getAppWithUpdateInfo(cluster, namespace, releaseName);
       return;
     }

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -91,13 +91,18 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
 
   public componentDidUpdate(prevProps: IAppRepoListProps) {
     const {
+      cluster,
       errors: { fetch },
       fetchRepos,
       fetchImagePullSecrets,
       namespace,
     } = this.props;
     // refetch if namespace changes or if error removed due to location change
-    if (prevProps.namespace !== namespace || (prevProps.errors.fetch && !fetch)) {
+    if (
+      prevProps.namespace !== namespace ||
+      prevProps.cluster !== cluster ||
+      (prevProps.errors.fetch && !fetch)
+    ) {
       fetchRepos(namespace);
       fetchImagePullSecrets(namespace);
     }

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -267,7 +267,9 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
     const deleted = await this.props.deleteResource(namespace, crd!.name.split(".")[0], resource!);
     this.closeModal();
     if (deleted) {
-      this.props.push(app.apps.list(cluster, namespace));
+      // TODO: The operator routes do not currently include the cluster so ensure
+      // it has a default.
+      this.props.push(app.apps.list(cluster || "default", namespace));
     }
   };
 }

--- a/dashboard/src/reducers/cluster.ts
+++ b/dashboard/src/reducers/cluster.ts
@@ -35,7 +35,7 @@ const getInitialState: () => IClustersState = (): IClustersState => {
     },
   } as IClustersState;
 };
-const initialState: IClustersState = getInitialState();
+export const initialState: IClustersState = getInitialState();
 
 const clusterReducer = (
   state: IClustersState = initialState,
@@ -92,24 +92,17 @@ const clusterReducer = (
         ...state,
         clusters: {
           ...state.clusters,
-          // TODO(absoludity): Update errorNamespaces to include cluster?
-          default: {
-            ...state.clusters.default,
+          [action.payload.cluster]: {
+            ...state.clusters[action.payload.cluster],
             error: { action: action.payload.op, error: action.payload.err },
           },
         },
       };
-    case getType(actions.namespace.clearNamespaces):
-      // TODO(absoludity): Update to include cluster in the payload to clear namespaces for cluster.
+    case getType(actions.namespace.clearClusters):
       return {
         ...state,
         clusters: {
-          ...state.clusters,
-          default: {
-            ...state.clusters.default,
-            currentNamespace: initialState.clusters.default.currentNamespace,
-            namespaces: [],
-          },
+          ...initialState.clusters,
         },
       };
     case LOCATION_CHANGE:


### PR DESCRIPTION
### Description of the change

Updates the namespace actions and the reducer to be cluster-aware, updating state per-cluster.

### Benefits

Required for multicluster.

### Possible drawbacks

None

### Applicable issues

Ref: #1762 
