### PR TITLE
Update all call-sites to ensure ResourceRefs use cluster.

### DIFF
--- a/dashboard/src/components/AppView/AppSecrets/AppSecrets.test.tsx
+++ b/dashboard/src/components/AppView/AppSecrets/AppSecrets.test.tsx
@@ -10,6 +10,7 @@ const defaultProps = {
 };
 
 const sampleResourceRef = {
+  cluster: "cluster-name",
   apiVersion: "v1",
   kind: "Secret",
   name: "foo",

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -18,6 +18,8 @@ import AppViewComponent from "./AppView";
 import ChartInfo from "./ChartInfo";
 import ResourceTable from "./ResourceTable";
 
+const clusterName = "cluster-name";
+
 describe("AppViewComponent", () => {
   // Generates a Yaml file separated by --- containing every object passed.
   const generateYamlManifest = (items: any[]): string => {
@@ -40,7 +42,7 @@ describe("AppViewComponent", () => {
     error: undefined,
     getAppWithUpdateInfo: jest.fn(),
     namespace: "my-happy-place",
-    cluster: "default",
+    cluster: clusterName,
     releaseName: "mr-sunshine",
     push: jest.fn(),
   };
@@ -105,16 +107,16 @@ describe("AppViewComponent", () => {
       wrapper.setProps(validProps);
 
       expect(wrapper.state("deployRefs")).toEqual([
-        new ResourceRef(resources.deployment, appRelease.namespace),
+        new ResourceRef(resources.deployment, clusterName, appRelease.namespace),
       ]);
       expect(wrapper.state("serviceRefs")).toEqual([
-        new ResourceRef(resources.service, appRelease.namespace),
+        new ResourceRef(resources.service, clusterName, appRelease.namespace),
       ]);
       expect(wrapper.state("ingressRefs")).toEqual([
-        new ResourceRef(resources.ingress, appRelease.namespace),
+        new ResourceRef(resources.ingress, clusterName, appRelease.namespace),
       ]);
       expect(wrapper.state("secretRefs")).toEqual([
-        new ResourceRef(resources.secret, appRelease.namespace),
+        new ResourceRef(resources.secret, clusterName, appRelease.namespace),
       ]);
     });
 
@@ -270,7 +272,7 @@ describe("AppViewComponent", () => {
         },
       },
     };
-    const ingressRefs = [new ResourceRef(ingress.item as IResource, "default")];
+    const ingressRefs = [new ResourceRef(ingress.item as IResource, clusterName, "default")];
     const service = {
       isFetching: false,
       item: {
@@ -282,7 +284,7 @@ describe("AppViewComponent", () => {
         spec: {},
       },
     };
-    const serviceRefs = [new ResourceRef(service.item as IResource, "default")];
+    const serviceRefs = [new ResourceRef(service.item as IResource, clusterName, "default")];
 
     wrapper.setState({ ingressRefs, serviceRefs });
 
@@ -303,7 +305,7 @@ describe("AppViewComponent", () => {
       },
       spec: {},
     };
-    const deployRefs = [new ResourceRef(deployment as IResource, "default")];
+    const deployRefs = [new ResourceRef(deployment as IResource, clusterName, "default")];
 
     wrapper.setState({ deployRefs });
 
@@ -322,7 +324,7 @@ describe("AppViewComponent", () => {
       },
       spec: {},
     };
-    const ref = [new ResourceRef(r as IResource, "default")];
+    const ref = [new ResourceRef(r as IResource, clusterName, "default")];
 
     wrapper.setState({ statefulSetRefs: ref });
 
@@ -341,7 +343,7 @@ describe("AppViewComponent", () => {
       },
       spec: {},
     };
-    const ref = [new ResourceRef(r as IResource, "default")];
+    const ref = [new ResourceRef(r as IResource, clusterName, "default")];
 
     wrapper.setState({ daemonSetRefs: ref });
 
@@ -383,9 +385,9 @@ describe("AppViewComponent", () => {
     wrapper.setProps(validProps);
 
     expect(wrapper.state()).toMatchObject({
-      deployRefs: [new ResourceRef(resources.deployment, appRelease.namespace)],
-      serviceRefs: [new ResourceRef(resources.service, appRelease.namespace)],
-      otherResources: [new ResourceRef(obj, appRelease.namespace)],
+      deployRefs: [new ResourceRef(resources.deployment, clusterName, appRelease.namespace)],
+      serviceRefs: [new ResourceRef(resources.service, clusterName, appRelease.namespace)],
+      otherResources: [new ResourceRef(obj, clusterName, appRelease.namespace)],
     });
   });
 
@@ -403,9 +405,9 @@ describe("AppViewComponent", () => {
     wrapper.setProps(validProps);
 
     expect(wrapper.state()).toMatchObject({
-      deployRefs: [new ResourceRef(resources.deployment, appRelease.namespace)],
-      serviceRefs: [new ResourceRef(resources.service, appRelease.namespace)],
-      otherResources: [new ResourceRef(obj, appRelease.namespace)],
+      deployRefs: [new ResourceRef(resources.deployment, clusterName, appRelease.namespace)],
+      serviceRefs: [new ResourceRef(resources.service, clusterName, appRelease.namespace)],
+      otherResources: [new ResourceRef(obj, clusterName, appRelease.namespace)],
     });
   });
 
@@ -421,10 +423,10 @@ describe("AppViewComponent", () => {
     expect(applicationStatus).toExist();
 
     expect(applicationStatus.prop("statefulsetRefs")).toEqual([
-      new ResourceRef(resources.statefulset, appRelease.namespace),
+      new ResourceRef(resources.statefulset, clusterName, appRelease.namespace),
     ]);
     expect(applicationStatus.prop("daemonsetRefs")).toEqual([
-      new ResourceRef(resources.daemonset, appRelease.namespace),
+      new ResourceRef(resources.daemonset, clusterName, appRelease.namespace),
     ]);
   });
 });

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -230,25 +230,39 @@ class AppView extends React.Component<IAppViewProps, IAppViewState> {
         const resource = { isFetching: true, item };
         switch (i.kind) {
           case "Deployment":
-            result.deployRefs.push(new ResourceRef(resource.item, releaseNamespace));
+            result.deployRefs.push(
+              new ResourceRef(resource.item, this.props.cluster, releaseNamespace),
+            );
             break;
           case "StatefulSet":
-            result.statefulSetRefs.push(new ResourceRef(resource.item, releaseNamespace));
+            result.statefulSetRefs.push(
+              new ResourceRef(resource.item, this.props.cluster, releaseNamespace),
+            );
             break;
           case "DaemonSet":
-            result.daemonSetRefs.push(new ResourceRef(resource.item, releaseNamespace));
+            result.daemonSetRefs.push(
+              new ResourceRef(resource.item, this.props.cluster, releaseNamespace),
+            );
             break;
           case "Service":
-            result.serviceRefs.push(new ResourceRef(resource.item, releaseNamespace));
+            result.serviceRefs.push(
+              new ResourceRef(resource.item, this.props.cluster, releaseNamespace),
+            );
             break;
           case "Ingress":
-            result.ingressRefs.push(new ResourceRef(resource.item, releaseNamespace));
+            result.ingressRefs.push(
+              new ResourceRef(resource.item, this.props.cluster, releaseNamespace),
+            );
             break;
           case "Secret":
-            result.secretRefs.push(new ResourceRef(resource.item, releaseNamespace));
+            result.secretRefs.push(
+              new ResourceRef(resource.item, this.props.cluster, releaseNamespace),
+            );
             break;
           default:
-            result.otherResources.push(new ResourceRef(resource.item, releaseNamespace));
+            result.otherResources.push(
+              new ResourceRef(resource.item, this.props.cluster, releaseNamespace),
+            );
         }
       }
     });

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
@@ -15,7 +15,11 @@ it("skips the element if there are no resources", () => {
 
 it("renders a ResourceItem", () => {
   const resourceRefs = [
-    new ResourceRef({ kind: "Deployment", metadata: { name: "foo" } } as IResource, "default"),
+    new ResourceRef(
+      { kind: "Deployment", metadata: { name: "foo" } } as IResource,
+      "cluster-name",
+      "default",
+    ),
   ];
   const wrapper = shallow(<ResourceTable resourceRefs={resourceRefs} title={""} />);
   expect(wrapper).toMatchSnapshot();

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
@@ -7,6 +7,8 @@ import { IResource } from "../../../shared/types";
 import OtherResourceItem from "./ResourceItem/OtherResourceItem";
 import ResourceTable from "./ResourceTable";
 
+const clusterName = "cluster-name";
+
 it("skips the element if there are no resources", () => {
   const wrapper = shallow(<ResourceTable resourceRefs={[]} title={""} />);
   expect(wrapper.find(ResourceItemContainer)).not.toExist();
@@ -17,7 +19,7 @@ it("renders a ResourceItem", () => {
   const resourceRefs = [
     new ResourceRef(
       { kind: "Deployment", metadata: { name: "foo" } } as IResource,
-      "cluster-name",
+      clusterName,
       "default",
     ),
   ];
@@ -28,8 +30,16 @@ it("renders a ResourceItem", () => {
 
 it("renders two resources", () => {
   const deployRefs = [
-    new ResourceRef({ kind: "Deployment", metadata: { name: "foo" } } as IResource, "default"),
-    new ResourceRef({ kind: "Deployment", metadata: { name: "bar" } } as IResource, "default"),
+    new ResourceRef(
+      { kind: "Deployment", metadata: { name: "foo" } } as IResource,
+      clusterName,
+      "default",
+    ),
+    new ResourceRef(
+      { kind: "Deployment", metadata: { name: "bar" } } as IResource,
+      clusterName,
+      "default",
+    ),
   ];
   const wrapper = shallow(<ResourceTable resourceRefs={deployRefs} title={""} />);
   expect(wrapper.find(ResourceItemContainer).length).toBe(2);
@@ -49,7 +59,11 @@ it("renders two resources", () => {
 
 it("renders OtherResourceItem", () => {
   const resourceRefs = [
-    new ResourceRef({ kind: "ConfigMap", metadata: { name: "foo" } } as IResource, "default"),
+    new ResourceRef(
+      { kind: "ConfigMap", metadata: { name: "foo" } } as IResource,
+      clusterName,
+      "default",
+    ),
   ];
   const wrapper = shallow(<ResourceTable resourceRefs={resourceRefs} title={""} />);
   expect(wrapper.find(OtherResourceItem)).toExist();
@@ -58,7 +72,11 @@ it("renders OtherResourceItem", () => {
 
 it("renders OtherResource as ItemContainer", () => {
   const resourceRefs = [
-    new ResourceRef({ kind: "ConfigMap", metadata: { name: "foo" } } as IResource, "default"),
+    new ResourceRef(
+      { kind: "ConfigMap", metadata: { name: "foo" } } as IResource,
+      clusterName,
+      "default",
+    ),
   ];
   const wrapper = shallow(
     <ResourceTable resourceRefs={resourceRefs} title={""} requestOtherResources={true} />,

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.v2.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.v2.test.tsx
@@ -16,6 +16,7 @@ const defaultProps = {
 };
 
 const sampleResourceRef = {
+  cluster: "cluster-name",
   apiVersion: "v1",
   kind: "Deployment",
   name: "foo",

--- a/dashboard/src/components/AppView/ResourceTable/__snapshots__/ResourceTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/ResourceTable/__snapshots__/ResourceTable.test.tsx.snap
@@ -13,10 +13,11 @@ exports[`renders a ResourceItem 1`] = `
     </thead>
     <tbody>
       <Connect(WorkloadItem)
-        key="api/clusters/default/apis/undefined/namespaces/default/deployments/foo"
+        key="api/clusters/cluster-name/api/v1/namespaces/default/deployments/foo"
         resourceRef={
           ResourceRef {
             "apiVersion": undefined,
+            "cluster": "cluster-name",
             "filter": undefined,
             "kind": "Deployment",
             "name": "foo",

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -84,25 +84,25 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
           crd.resources?.forEach(r => {
             switch (r.kind) {
               case "Deployment":
-                result.deployRefs.push(fromCRD(r, this.props.namespace, ownerRef));
+                result.deployRefs.push(fromCRD(r, "default", this.props.namespace, ownerRef));
                 break;
               case "StatefulSet":
-                result.statefulSetRefs.push(fromCRD(r, this.props.namespace, ownerRef));
+                result.statefulSetRefs.push(fromCRD(r, "default", this.props.namespace, ownerRef));
                 break;
               case "DaemonSet":
-                result.daemonSetRefs.push(fromCRD(r, this.props.namespace, ownerRef));
+                result.daemonSetRefs.push(fromCRD(r, "default", this.props.namespace, ownerRef));
                 break;
               case "Service":
-                result.serviceRefs.push(fromCRD(r, this.props.namespace, ownerRef));
+                result.serviceRefs.push(fromCRD(r, "default", this.props.namespace, ownerRef));
                 break;
               case "Ingress":
-                result.ingressRefs.push(fromCRD(r, this.props.namespace, ownerRef));
+                result.ingressRefs.push(fromCRD(r, "default", this.props.namespace, ownerRef));
                 break;
               case "Secret":
-                result.secretRefs.push(fromCRD(r, this.props.namespace, ownerRef));
+                result.secretRefs.push(fromCRD(r, "default", this.props.namespace, ownerRef));
                 break;
               default:
-                result.otherResources.push(fromCRD(r, this.props.namespace, ownerRef));
+                result.otherResources.push(fromCRD(r, "default", this.props.namespace, ownerRef));
             }
           });
         } else {
@@ -110,21 +110,38 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
           // The CRD definition doesn't define any service so pull everything
           result = {
             deployRefs: [
-              fromCRD({ ...emptyCRD, kind: "Deployment" }, this.props.namespace, ownerRef),
+              fromCRD(
+                { ...emptyCRD, kind: "Deployment" },
+                "default",
+                this.props.namespace,
+                ownerRef,
+              ),
             ],
             ingressRefs: [
-              fromCRD({ ...emptyCRD, kind: "Ingress" }, this.props.namespace, ownerRef),
+              fromCRD({ ...emptyCRD, kind: "Ingress" }, "default", this.props.namespace, ownerRef),
             ],
             statefulSetRefs: [
-              fromCRD({ ...emptyCRD, kind: "StatefulSet" }, this.props.namespace, ownerRef),
+              fromCRD(
+                { ...emptyCRD, kind: "StatefulSet" },
+                "default",
+                this.props.namespace,
+                ownerRef,
+              ),
             ],
             daemonSetRefs: [
-              fromCRD({ ...emptyCRD, kind: "DaemonSet" }, this.props.namespace, ownerRef),
+              fromCRD(
+                { ...emptyCRD, kind: "DaemonSet" },
+                "default",
+                this.props.namespace,
+                ownerRef,
+              ),
             ],
             serviceRefs: [
-              fromCRD({ ...emptyCRD, kind: "Service" }, this.props.namespace, ownerRef),
+              fromCRD({ ...emptyCRD, kind: "Service" }, "default", this.props.namespace, ownerRef),
             ],
-            secretRefs: [fromCRD({ ...emptyCRD, kind: "Secret" }, this.props.namespace, ownerRef)],
+            secretRefs: [
+              fromCRD({ ...emptyCRD, kind: "Secret" }, "default", this.props.namespace, ownerRef),
+            ],
             otherResources: [],
           };
         }

--- a/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
+++ b/dashboard/src/components/OperatorInstance/__snapshots__/OperatorInstance.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
                   Array [
                     ResourceRef {
                       "apiVersion": "apps/v1",
+                      "cluster": "default",
                       "filter": Object {
                         "metadata": Object {
                           "ownerReferences": Array [
@@ -132,6 +133,7 @@ exports[`renders a resource renders the resource and CSV info 1`] = `
               Array [
                 ResourceRef {
                   "apiVersion": "apps/v1",
+                  "cluster": "default",
                   "filter": Object {
                     "metadata": Object {
                       "ownerReferences": Array [

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
@@ -9,6 +9,7 @@ import AccessURLTable from "../../components/AppView/AccessURLTable";
 import ResourceRef from "../../shared/ResourceRef";
 
 const mockStore = configureMockStore([thunk]);
+const clusterName = "cluster-name";
 
 const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
   const state: IKubeState = {
@@ -31,25 +32,31 @@ describe("AccessURLTableContainer", () => {
       item: { metadata: { name: `${name}-ingress` } } as IResource,
     };
     const store = makeStore({
-      "api/clusters/default/api/v1/namespaces/wee/services/foo-service": service,
-      "api/clusters/default/api/v1/namespaces/wee/ingresses/foo-ingress": ingress,
+      [`api/clusters/${clusterName}/api/v1/namespaces/wee/services/foo-service`]: service,
+      [`api/clusters/${clusterName}/api/v1/namespaces/wee/ingresses/foo-ingress`]: ingress,
     });
-    const serviceRef = new ResourceRef({
-      apiVersion: "v1",
-      kind: "Service",
-      metadata: {
-        namespace: ns,
-        name: `${name}-service`,
-      },
-    } as IResource);
-    const ingressRef = new ResourceRef({
-      apiVersion: "v1",
-      kind: "Ingress",
-      metadata: {
-        namespace: ns,
-        name: `${name}-ingress`,
-      },
-    } as IResource);
+    const serviceRef = new ResourceRef(
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          namespace: ns,
+          name: `${name}-service`,
+        },
+      } as IResource,
+      clusterName,
+    );
+    const ingressRef = new ResourceRef(
+      {
+        apiVersion: "v1",
+        kind: "Ingress",
+        metadata: {
+          namespace: ns,
+          name: `${name}-ingress`,
+        },
+      } as IResource,
+      clusterName,
+    );
     const wrapper = shallow(
       <AccessURLTableContainer
         store={store}

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
@@ -9,6 +9,7 @@ import ResourceRef from "../../shared/ResourceRef";
 import { IKubeItem, IKubeState, IResource } from "../../shared/types";
 
 const mockStore = configureMockStore([thunk]);
+const clusterName = "cluster-Name";
 
 const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
   const state: IKubeState = {
@@ -24,16 +25,19 @@ describe("ApplicationStatusContainer", () => {
     const name = "foo";
     const item = { isFetching: false, item: { metadata: { name } } as IResource };
     const store = makeStore({
-      "api/clusters/default/apis/apps/v1/namespaces/wee/deployments/foo": item,
+      [`api/clusters/${clusterName}/apis/apps/v1/namespaces/wee/deployments/foo`]: item,
     });
-    const ref = new ResourceRef({
-      apiVersion: "apps/v1",
-      kind: "Deployment",
-      metadata: {
-        namespace: ns,
-        name,
-      },
-    } as IResource);
+    const ref = new ResourceRef(
+      {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: {
+          namespace: ns,
+          name,
+        },
+      } as IResource,
+      clusterName,
+    );
     const wrapper = shallow(
       <ApplicationStatusContainer
         store={store}

--- a/dashboard/src/containers/ResourceItemContainer/ResourceItemContainer.test.tsx
+++ b/dashboard/src/containers/ResourceItemContainer/ResourceItemContainer.test.tsx
@@ -9,6 +9,7 @@ import ResourceItem from "../../components/AppView/ResourceTable/ResourceItem/Re
 import ResourceRef from "../../shared/ResourceRef";
 
 const mockStore = configureMockStore([thunk]);
+const clusterName = "cluster-name";
 
 const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
   const state: IKubeState = {
@@ -23,17 +24,23 @@ describe("ResourceItemContainer", () => {
     const ns = "wee";
     const name = "foo";
     const item = { isFetching: false, item: { metadata: { name } } as IResource };
+    const expectedURL = `api/clusters/${clusterName}/apis/apps/v1/namespaces/wee/statefulsets/foo`;
     const store = makeStore({
-      "api/clusters/default/apis/apps/v1/namespaces/wee/statefulsets/foo": item,
+      [expectedURL]: item,
     });
-    const ref = new ResourceRef({
-      apiVersion: "apps/v1",
-      kind: "StatefulSet",
-      metadata: {
-        namespace: ns,
-        name,
-      },
-    } as IResource);
+
+    const ref = new ResourceRef(
+      {
+        apiVersion: "apps/v1",
+        kind: "StatefulSet",
+        metadata: {
+          namespace: ns,
+          name,
+        },
+      } as IResource,
+      clusterName,
+    );
+    expect(ref.getResourceURL()).toEqual(expectedURL);
     const wrapper = shallow(<ResourceItemContainer store={store} resourceRef={ref} />);
     const form = wrapper.find(ResourceItem);
     expect(form).toHaveProp({

--- a/dashboard/src/containers/helpers/index.test.ts
+++ b/dashboard/src/containers/helpers/index.test.ts
@@ -2,6 +2,8 @@ import { filterByResourceRefs } from ".";
 import ResourceRef from "../../shared/ResourceRef";
 import { IKubeItem, IKubeState, IResource } from "../../shared/types";
 
+const clusterName = "cluster-name";
+
 describe("filterByResourceRefs", () => {
   const svc1 = {
     apiVersion: "v1",
@@ -20,18 +22,21 @@ describe("filterByResourceRefs", () => {
   } as IResource;
 
   const items: IKubeState["items"] = {
-    "api/clusters/default/api/v1/namespaces/foo/services/bar": { item: svc1 } as IKubeItem<
+    [`api/clusters/${clusterName}/api/v1/namespaces/foo/services/bar`]: { item: svc1 } as IKubeItem<
       IResource
     >,
-    "api/clusters/default/api/v1/namespaces/foo1/services/bar": { item: svc2 } as IKubeItem<
-      IResource
-    >,
-    "api/clusters/default/apis/apps/v1/namespaces/foo1/deployments/bar": {
+    [`api/clusters/${clusterName}/api/v1/namespaces/foo1/services/bar`]: {
+      item: svc2,
+    } as IKubeItem<IResource>,
+    [`api/clusters/${clusterName}/apis/apps/v1/namespaces/foo1/deployments/bar`]: {
       item: deploy,
     } as IKubeItem<IResource>,
   };
   it("returns the IKubeItems in the state referenced by each ResourceRef", () => {
-    const resourceRefs: ResourceRef[] = [new ResourceRef(svc1), new ResourceRef(svc2)];
+    const resourceRefs: ResourceRef[] = [
+      new ResourceRef(svc1, clusterName),
+      new ResourceRef(svc2, clusterName),
+    ];
 
     expect(filterByResourceRefs(resourceRefs, items)).toEqual([{ item: svc1 }, { item: svc2 }]);
   });
@@ -45,7 +50,10 @@ describe("filterByResourceRefs", () => {
         namespace: "foo1",
       },
     } as IResource;
-    const resourceRefs: ResourceRef[] = [new ResourceRef(svc2), new ResourceRef(missingSvc)];
+    const resourceRefs: ResourceRef[] = [
+      new ResourceRef(svc2, clusterName),
+      new ResourceRef(missingSvc, clusterName),
+    ];
 
     expect(filterByResourceRefs(resourceRefs, items)).toEqual([{ item: svc2 }]);
   });

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -4,6 +4,8 @@ import ResourceRef from "../shared/ResourceRef";
 import { IKubeState, IResource } from "../shared/types";
 import kubeReducer from "./kube";
 
+const clusterName = "cluster-name";
+
 describe("authReducer", () => {
   let initialState: IKubeState;
 
@@ -16,14 +18,17 @@ describe("authReducer", () => {
     receiveResourceFromList: getType(actions.kube.receiveResourceFromList),
   };
 
-  const ref = new ResourceRef({
-    apiVersion: "v1",
-    kind: "Service",
-    metadata: {
-      name: "foo",
-      namespace: "default",
-    },
-  } as IResource);
+  const ref = new ResourceRef(
+    {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        name: "foo",
+        namespace: "default",
+      },
+    } as IResource,
+    clusterName,
+  );
 
   beforeEach(() => {
     initialState = {

--- a/dashboard/src/shared/ResourceRef.test.ts
+++ b/dashboard/src/shared/ResourceRef.test.ts
@@ -2,6 +2,8 @@ import { Kube } from "./Kube";
 import ResourceRef, { fromCRD } from "./ResourceRef";
 import { IClusterServiceVersionCRDResource, IResource } from "./types";
 
+const clusterName = "cluster-name";
+
 describe("ResourceRef", () => {
   describe("constructor", () => {
     it("it returns a ResourceRef with the correct details", () => {
@@ -14,9 +16,10 @@ describe("ResourceRef", () => {
         },
       } as IResource;
 
-      const ref = new ResourceRef(r);
+      const ref = new ResourceRef(r, clusterName);
       expect(ref).toBeInstanceOf(ResourceRef);
       expect(ref).toEqual({
+        cluster: clusterName,
         apiVersion: r.apiVersion,
         kind: r.kind,
         name: r.metadata.name,
@@ -33,7 +36,7 @@ describe("ResourceRef", () => {
         },
       } as IResource;
 
-      const ref = new ResourceRef(r, "default");
+      const ref = new ResourceRef(r, clusterName, "default");
       expect(ref.namespace).toBe("default");
     });
 
@@ -46,7 +49,7 @@ describe("ResourceRef", () => {
         },
       } as IResource;
 
-      const ref = new ResourceRef(r, "bar");
+      const ref = new ResourceRef(r, clusterName, "bar");
       expect(ref.namespace).toBe("bar");
     });
 
@@ -62,7 +65,7 @@ describe("ResourceRef", () => {
             name: "test",
           },
         };
-        const res = fromCRD(r, "default", ownerRef);
+        const res = fromCRD(r, clusterName, "default", ownerRef);
         expect(res).toMatchObject({
           apiVersion: "apps/v1",
           kind: "Deployment",
@@ -83,7 +86,7 @@ describe("ResourceRef", () => {
             name: "test",
           },
         };
-        const res = fromCRD(r, "default", ownerRef);
+        const res = fromCRD(r, clusterName, "default", ownerRef);
         expect(res).toMatchObject({
           apiVersion: "rbac.authorization.k8s.io/v1",
           kind: "ClusterRole",
@@ -114,10 +117,10 @@ describe("ResourceRef", () => {
         },
       } as IResource;
 
-      const ref = new ResourceRef(r);
+      const ref = new ResourceRef(r, clusterName);
 
       ref.getResourceURL();
-      expect(kubeGetResourceURLMock).toBeCalledWith("v1", "services", "bar", "foo");
+      expect(kubeGetResourceURLMock).toBeCalledWith(clusterName, "v1", "services", "bar", "foo");
     });
   });
 
@@ -140,10 +143,10 @@ describe("ResourceRef", () => {
         },
       } as IResource;
 
-      const ref = new ResourceRef(r);
+      const ref = new ResourceRef(r, clusterName);
 
       ref.watchResourceURL();
-      expect(kubeWatchResourceURLMock).toBeCalledWith("v1", "services", "bar", "foo");
+      expect(kubeWatchResourceURLMock).toBeCalledWith(clusterName, "v1", "services", "bar", "foo");
     });
   });
 
@@ -168,10 +171,10 @@ describe("ResourceRef", () => {
         },
       } as IResource;
 
-      const ref = new ResourceRef(r);
+      const ref = new ResourceRef(r, clusterName);
 
       ref.getResource();
-      expect(kubeGetResourceMock).toBeCalledWith("v1", "services", "bar", "foo");
+      expect(kubeGetResourceMock).toBeCalledWith(clusterName, "v1", "services", "bar", "foo");
     });
 
     it("filters out the result when receiving a list", async () => {
@@ -184,7 +187,7 @@ describe("ResourceRef", () => {
         },
       } as IResource;
 
-      const ref = new ResourceRef(r);
+      const ref = new ResourceRef(r, clusterName);
       ref.filter = { metadata: { name: "bar" } };
       Kube.getResource = jest.fn().mockReturnValue({
         items: [r],
@@ -213,10 +216,10 @@ describe("ResourceRef", () => {
         },
       } as IResource;
 
-      const ref = new ResourceRef(r);
+      const ref = new ResourceRef(r, clusterName);
 
       ref.watchResource();
-      expect(kubeWatchResourceMock).toBeCalledWith("v1", "services", "bar", "foo");
+      expect(kubeWatchResourceMock).toBeCalledWith(clusterName, "v1", "services", "bar", "foo");
     });
   });
 });

--- a/dashboard/src/shared/ResourceRef.ts
+++ b/dashboard/src/shared/ResourceRef.ts
@@ -5,6 +5,7 @@ import { IClusterServiceVersionCRDResource, IK8sList, IResource } from "./types"
 
 export function fromCRD(
   r: IClusterServiceVersionCRDResource,
+  cluster: string,
   namespace: string,
   ownerReference: any,
 ) {
@@ -17,7 +18,7 @@ export function fromCRD(
   // TODO(andresmgot): This won't work for new resource types, we would need to dinamically
   // resolve those
   const resourceNamespace = r.kind.startsWith("Cluster") ? "" : namespace;
-  return new ResourceRef(resource, resourceNamespace, {
+  return new ResourceRef(resource, cluster, resourceNamespace, {
     metadata: { ownerReferences: [ownerReference] },
   });
 }
@@ -25,6 +26,7 @@ export function fromCRD(
 // ResourceRef defines a reference to a namespaced Kubernetes API Object and
 // provides helpers to retrieve the resource URL
 class ResourceRef {
+  public cluster: string;
   public apiVersion: string;
   public kind: ResourceKind;
   public name: string;
@@ -33,9 +35,8 @@ class ResourceRef {
 
   // Creates a new ResourceRef instance from an existing IResource. Provide
   // defaultNamespace to set if the IResource doesn't specify a namespace.
-  // TODO: add support for cluster-scoped resources, or add a ClusterResourceRef
-  // class.
-  constructor(r: IResource, defaultNamespace?: string, defaultFilter?: any) {
+  constructor(r: IResource, cluster: string, defaultNamespace?: string, defaultFilter?: any) {
+    this.cluster = cluster;
     this.apiVersion = r.apiVersion;
     this.kind = r.kind;
     this.name = r.metadata.name;
@@ -47,6 +48,7 @@ class ResourceRef {
   // Gets a full resource URL for the referenced resource
   public getResourceURL() {
     return Kube.getResourceURL(
+      this.cluster,
       this.apiVersion,
       Kube.resourcePlural(this.kind),
       this.namespace,
@@ -56,6 +58,7 @@ class ResourceRef {
 
   public watchResourceURL() {
     return Kube.watchResourceURL(
+      this.cluster,
       this.apiVersion,
       Kube.resourcePlural(this.kind),
       this.namespace,
@@ -65,6 +68,7 @@ class ResourceRef {
 
   public async getResource() {
     const resource = await Kube.getResource(
+      this.cluster,
       this.apiVersion,
       Kube.resourcePlural(this.kind),
       this.namespace,
@@ -84,6 +88,7 @@ class ResourceRef {
   // the socket.
   public watchResource() {
     return Kube.watchResource(
+      this.cluster,
       this.apiVersion,
       Kube.resourcePlural(this.kind),
       this.namespace,

--- a/dashboard/src/shared/ResourceRef.ts
+++ b/dashboard/src/shared/ResourceRef.ts
@@ -18,9 +18,11 @@ export function fromCRD(
   // TODO(andresmgot): This won't work for new resource types, we would need to dinamically
   // resolve those
   const resourceNamespace = r.kind.startsWith("Cluster") ? "" : namespace;
-  return new ResourceRef(resource, cluster, resourceNamespace, {
+  const ref = new ResourceRef(resource, cluster, resourceNamespace);
+  ref.filter = {
     metadata: { ownerReferences: [ownerReference] },
-  });
+  };
+  return ref;
 }
 
 // ResourceRef defines a reference to a namespaced Kubernetes API Object and
@@ -35,13 +37,12 @@ class ResourceRef {
 
   // Creates a new ResourceRef instance from an existing IResource. Provide
   // defaultNamespace to set if the IResource doesn't specify a namespace.
-  constructor(r: IResource, cluster: string, defaultNamespace?: string, defaultFilter?: any) {
+  constructor(r: IResource, cluster: string, defaultNamespace?: string) {
     this.cluster = cluster;
     this.apiVersion = r.apiVersion;
     this.kind = r.kind;
     this.name = r.metadata.name;
     this.namespace = r.metadata.namespace || defaultNamespace || "";
-    this.filter = defaultFilter;
     return this;
   }
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Follows on from #1886, updating ResourceRefs to include the cluster (in the constructor as a required arg) then updating all the call-sites to use it (mainly in tests, other than AppView and OperatorInstance (which uses fromCRD)).

It was a pain to audit because the typechecker can't find everything, as the 3rd arg is an optional string. Anyway, I think I've audited all call-sites now.

This is slightly different to how I did the change in the demo branch, and has the benefit that the resource refs just calculate multicluster URLs once created, so users of the objects don't need to care.

### Benefits

Required for multicluster support.

### Possible drawbacks

Danger of missing a call-site.

### Applicable issues

Ref: #1762 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
