### PR TITLE
Update dev setup to document oidc RBAC with ldap groups.

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -71,6 +71,7 @@ spec:
             - -skip-auth-regex=^\/favicon.*\.png$
             - -skip-auth-regex=^\/static\/
             - -skip-auth-regex=^\/$
+            - -scope=openid email groups
             {{- range .Values.authProxy.additionalFlags }}
             - {{ . }}
             {{- end }}

--- a/docs/user/manifests/kubeapps-local-dev-apiserver-config.json
+++ b/docs/user/manifests/kubeapps-local-dev-apiserver-config.json
@@ -6,7 +6,7 @@
       "group": "kubeadm.k8s.io",
       "version": "v1beta2",
       "kind": "ClusterConfiguration",
-      "patch": "[{ \"op\": \"add\", \"path\": \"/apiServer/extraArgs\", \"value\": {}}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-issuer-url\", \"value\": \"https://172.18.0.2:32000\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-client-id\", \"value\": \"kubeapps\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-ca-file\", \"value\": \"/etc/kubernetes/pki/apiserver.crt\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-username-claim\", \"value\": \"email\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-username-prefix\",\"value\": \"oidc:\"}]"
+      "patch": "[{ \"op\": \"add\", \"path\": \"/apiServer/extraArgs\", \"value\": {}}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-issuer-url\", \"value\": \"https://172.18.0.2:32000\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-client-id\", \"value\": \"kubeapps\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-ca-file\", \"value\": \"/etc/kubernetes/pki/apiserver.crt\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-username-claim\", \"value\": \"email\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-username-prefix\",\"value\": \"oidc:\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-groups-claim\", \"value\": \"groups\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-groups-prefix\",\"value\": \"oidc:\"}]"
     }
   ]
 }

--- a/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml
@@ -8,3 +8,5 @@ authProxy:
     - -cookie-secure=false
     - -oidc-issuer-url=https://172.18.0.2:32000
     - -ssl-insecure-skip-verify=true
+    # If you need to access the actual token in the frontend for testing, uncomment the following.
+    # - -set-authorization-header=true

--- a/docs/user/manifests/kubeapps-local-dev-openldap-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-openldap-values.yaml
@@ -36,3 +36,13 @@ customLdifFiles:
     objectClass: groupOfNames
     cn: developers
     member: cn=jane,ou=People,dc=example,dc=org
+
+    dn: cn=kubeapps-operators,ou=Groups,dc=example,dc=org
+    objectClass: groupOfNames
+    cn: kubeapps-operators
+    member: cn=jane,ou=People,dc=example,dc=org
+
+    dn: cn=kubeapps-users,ou=Groups,dc=example,dc=org
+    objectClass: groupOfNames
+    cn: kubeapps-users
+    member: cn=john,ou=People,dc=example,dc=org

--- a/docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
@@ -8,12 +8,15 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
+# dex does not allow group claims when using the static connector
+# https://github.com/dexidp/dex/issues/1080
+# So instead use the testing of groups with the ldap access only.
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: oidc:kubeapps-operator@example.com
 - apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: oidc:kubeapps-operator-ldap@example.org
+  kind: Group
+  name: oidc:kubeapps-operators
 # kubeapps-user has access only to the kubeapps-user-namespace namespace
 ---
 kind: Namespace
@@ -35,8 +38,8 @@ subjects:
   kind: User
   name: oidc:kubeapps-user@example.com
 - apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: oidc:kubeapps-user-ldap@example.org
+  kind: Group
+  name: oidc:kubeapps-users
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -52,9 +55,12 @@ subjects:
   kind: User
   name: oidc:kubeapps-user@example.com
 - apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: oidc:kubeapps-user-ldap@example.org
+  kind: Group
+  name: oidc:kubeapps-users
 ---
+# Currently unnecessary (when kubeapps operators are already cluster-admin) but
+# included to be explicit and plan to replace cluster-admin for kubeapps
+# operators with something less privileged.
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -69,6 +75,6 @@ subjects:
   kind: User
   name: oidc:kubeapps-operator@example.com
 - apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: oidc:kubeapps-operator-ldap@example.org
+  kind: Group
+  name: oidc:kubeapps-operators
 


### PR DESCRIPTION
### Description of the change

Updates the oauth2-proxy settings to explicitly include the `groups` scope. Updates the (my) developer local setup to demonstrate using groups rather than users for RBAC when logging in with LDAP.

The only actual (non-dev) change here is to set the scope explicitly. It hadn't been set and had worked fine as most providers (including dex) assuming `oidc email` if not set, it seems. Explicitly including `groups` in the scope of the request from the auth proxy to dex causes dex to query the ldap service for groups also:

```
kubectl -n dex logs deployment/dex --tail 4
time="2020-07-24T04:10:10Z" level=info msg="performing ldap search ou=People,dc=example,dc=org sub (&(objectClass=person)(mail=kubeapps-user-ldap@example.org))"
time="2020-07-24T04:10:10Z" level=info msg="username \"kubeapps-user-ldap@example.org\" mapped to entry cn=john,ou=People,dc=example,dc=org"
time="2020-07-24T04:10:10Z" level=info msg="performing ldap search ou=Groups,dc=example,dc=org sub (&(objectClass=groupOfNames)(member=cn=john,ou=People,dc=example,dc=org))"
time="2020-07-24T04:10:10Z" level=info msg="login successful: connector \"ldap\", username=\"john\", email=\"kubeapps-user-ldap@example.org\", groups=[\"admins\" \"kubeapps-users\"]"
```

which, in turn, enables the oauth2 proxy to include the groups in the signed json web token which the k8s api server uses to verify the authentication:

```
{
  "iss": "https://172.18.0.2:32000",
  "sub": "CiNjbj1qb2huLG91PVBlb3BsZSxkYz1leGFtcGxlLGRjPW9yZxIEbGRhcA",
  "aud": "kubeapps",
  "exp": 1595650210,
  "iat": 1595563810,
  "at_hash": "2RhcexrYXP1GOoAXAoIxcQ",
  "email": "kubeapps-user-ldap@example.org",
  "email_verified": true,
  "groups": [
    "admins",
    "kubeapps-users"
  ]
}
```

The remaining changes are updates to the local development setup, which already used dex and ldap, but wasn't using groups to authenticate. Dex's static provider doesn't support setting up groups, so only I've only updated the RBAC to remove the ldap users and replace them with the equivalent groups (which I used to test the scenario locally and verify the fix). I'll include in-line comments below.
 
### Benefits

Fixes and partially documents an OIDC setup using groups (we should document this in the docs explicitly).

### Possible drawbacks

None

### Applicable issues

The issue was brought up in a [slack discussion (thanks Dan and Scott)](https://kubernetes.slack.com/archives/C9D3TSUG4/p1595447676124500).

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
