### PR TITLE
Disable host check for dev setup

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -79,7 +79,7 @@
   "scripts": {
     "build-css": "node-sass-chokidar src/ -o src/",
     "watch-css": "yarn run build-css && node-sass-chokidar src/ -o src/ --watch --recursive",
-    "start-js": "BROWSER=none DANGEROUSLY_DISABLE_HOST_CHECK=true REACT_APP_KUBEAPPS_NS=${TELEPRESENCE_CONTAINER_NAMESPACE} react-scripts start",
+    "start-js": "BROWSER=none REACT_APP_KUBEAPPS_NS=${TELEPRESENCE_CONTAINER_NAMESPACE} react-scripts start",
     "build-js": "react-scripts build",
     "start": "npm-run-all -p watch-css start-js",
     "build": "npm-run-all build-css build-js",
@@ -175,6 +175,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "proxy": "http://127.0.0.1:8080"
+  }
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -79,7 +79,7 @@
   "scripts": {
     "build-css": "node-sass-chokidar src/ -o src/",
     "watch-css": "yarn run build-css && node-sass-chokidar src/ -o src/ --watch --recursive",
-    "start-js": "BROWSER=none REACT_APP_KUBEAPPS_NS=${TELEPRESENCE_CONTAINER_NAMESPACE} react-scripts start",
+    "start-js": "BROWSER=none DANGEROUSLY_DISABLE_HOST_CHECK=true REACT_APP_KUBEAPPS_NS=${TELEPRESENCE_CONTAINER_NAMESPACE} react-scripts start",
     "build-js": "react-scripts build",
     "start": "npm-run-all -p watch-css start-js",
     "build": "npm-run-all build-css build-js",

--- a/docs/developer/dashboard.md
+++ b/docs/developer/dashboard.md
@@ -68,6 +68,16 @@ yarn run start
 
 As an alternative to using [Telepresence](https://www.telepresence.io/) you can use the default [Create React App API proxy](https://create-react-app.dev/docs/proxying-api-requests-in-development/) functionality.
 
+First add the desired host:port to the package.json:
+
+```patch
+-  }
++  },
++  "proxy": "http://127.0.0.1:8080"
+```
+
+> **NOTE**: The [proxy](../../dashboard/package.json#L176) `key:value` has already added to the `package.json` for convenience but you can change the `host:port` values to meet your needs.
+
 To use this a run Kubeapps per the [getting-started documentation](../../docs/user/getting-started.md#step-3-start-the-kubeapps-dashboard). This will start Kubeapps running on port `8080`.
 
 Next you can launch the dashboard.
@@ -75,8 +85,6 @@ Next you can launch the dashboard.
 ```bash
 yarn run start
 ```
-
-> **NOTE**: The [proxy](../../dashboard/package.json#L176) `key:value` has already added to the `package.json` for convenience but you can change the `host:port` values to meet your needs.
 
 You can now access the local development server simply by accessing the dashboard as you usually would (e.g. doing a port-forward or accesing the Ingress URL).
 

--- a/docs/developer/dashboard.md
+++ b/docs/developer/dashboard.md
@@ -76,7 +76,7 @@ First add the desired host:port to the package.json:
 +  "proxy": "http://127.0.0.1:8080"
 ```
 
-> **NOTE**: The [proxy](../../dashboard/package.json#L176) `key:value` has already added to the `package.json` for convenience but you can change the `host:port` values to meet your needs.
+> **NOTE**: Add the [proxy](../../dashboard/package.json#L176) `key:value` to the end of the `package.json`. For convenience, you can change the `host:port` values to meet your needs.
 
 To use this a run Kubeapps per the [getting-started documentation](../../docs/user/getting-started.md#step-3-start-the-kubeapps-dashboard). This will start Kubeapps running on port `8080`.
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

After https://github.com/kubeapps/kubeapps/pull/1884, the expected host is `127.0.0.1` when running the server locally, this breaks my local dev environment because I am using `kubeapps.local`. Disabling the host check since we don't need it for the dev setup.