### PR TITLE
Update the app repo config route to be clustered.

### DIFF
--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -133,6 +133,7 @@ class AppUpgrade extends React.Component<IAppUpgradeProps> {
         isFetching={this.props.reposIsFetching}
         error={this.props.chartsError}
         kubeappsNamespace={this.props.kubeappsNamespace}
+        cluster={this.props.cluster}
         namespace={this.props.namespace}
         repoError={this.props.repoError}
         repo={this.props.repo}

--- a/dashboard/src/components/AppUpgrade/__snapshots__/AppUpgrade.test.tsx.snap
+++ b/dashboard/src/components/AppUpgrade/__snapshots__/AppUpgrade.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`renders the repo selection form if not introduced 1`] = `
 <SelectRepoForm
   chartName="bar"
   checkChart={[MockFunction]}
+  cluster="default"
   fetchRepositories={[MockFunction]}
   isFetching={false}
   kubeappsNamespace="kubeapps"

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -24,6 +24,7 @@ const defaultProps = {
   filter: "",
   fetchCharts: jest.fn(),
   pushSearchFilter: jest.fn(),
+  cluster: "default",
   namespace: "kubeapps",
   kubeappsNamespace: "kubeapps",
   csvs: [],

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 
 import { IFeatureFlags } from "shared/Config";
+import { app } from "shared/url";
 import { ForbiddenError, IChart, IChartState, IClusterServiceVersion } from "../../shared/types";
 import { escapeRegExp } from "../../shared/utils";
 import { CardGrid } from "../Card";
@@ -22,6 +23,7 @@ export interface ICatalogProps {
   filter: string;
   fetchCharts: (namespace: string, repo: string) => void;
   pushSearchFilter: (filter: string) => RouterAction;
+  cluster: string;
   namespace: string;
   kubeappsNamespace: string;
   getCSVs: (namespace: string) => void;
@@ -70,6 +72,7 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
         selected: { error },
         items: allItems,
       },
+      cluster,
       namespace,
       pushSearchFilter,
       csvs,
@@ -98,7 +101,10 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
             <div>
               <h5>Charts not found.</h5>
               Manage your Helm chart repositories in Kubeapps by visiting the{" "}
-              <Link to={`/config/ns/${namespace}/repos`}>App repositories configuration</Link> page.
+              <Link to={app.config.apprepositories(cluster, namespace)}>
+                App repositories configuration
+              </Link>{" "}
+              page.
             </div>
           }
         />

--- a/dashboard/src/components/Catalog/Catalog.v2.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.v2.test.tsx
@@ -24,6 +24,7 @@ const defaultProps = {
   filter: "",
   fetchCharts: jest.fn(),
   pushSearchFilter: jest.fn(),
+  cluster: "default",
   namespace: "kubeapps",
   kubeappsNamespace: "kubeapps",
   csvs: [],

--- a/dashboard/src/components/Catalog/Catalog.v2.tsx
+++ b/dashboard/src/components/Catalog/Catalog.v2.tsx
@@ -30,6 +30,7 @@ interface ICatalogProps {
   filter: string;
   fetchCharts: (namespace: string, repo: string) => void;
   pushSearchFilter: (filter: string) => RouterAction;
+  cluster: string;
   namespace: string;
   kubeappsNamespace: string;
   getCSVs: (namespace: string) => void;
@@ -45,6 +46,7 @@ function Catalog(props: ICatalogProps) {
       items: charts,
     },
     fetchCharts,
+    cluster,
     namespace,
     pushSearchFilter,
     getCSVs,
@@ -110,7 +112,7 @@ function Catalog(props: ICatalogProps) {
               Manage your Helm chart repositories in Kubeapps by visiting the App repositories
               configuration page.
             </p>
-            <Link to={app.config.apprepositories(namespace)}>
+            <Link to={app.config.apprepositories(cluster, namespace)}>
               <CdsButton>Manage App Repositories</CdsButton>
             </Link>
           </div>

--- a/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
@@ -114,7 +114,7 @@ exports[`renderization when no charts should render an error 1`] = `
     Manage your Helm chart repositories in Kubeapps by visiting the
      
     <Link
-      to="/config/ns/kubeapps/repos"
+      to="/c/default/ns/kubeapps/config/repos"
     >
       App repositories configuration
     </Link>

--- a/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/Catalog.test.tsx.snap
@@ -118,7 +118,8 @@ exports[`renderization when no charts should render an error 1`] = `
     >
       App repositories configuration
     </Link>
-     page.
+     
+    page.
   </div>
 </MessageAlertPage>
 `;

--- a/dashboard/src/components/Catalog/__snapshots__/Catalog.v2.test.tsx.snap
+++ b/dashboard/src/components/Catalog/__snapshots__/Catalog.v2.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`when fetching apps loading spinner matches the snapshot 1`] = `
         Manage your Helm chart repositories in Kubeapps by visiting the App repositories configuration page.
       </p>
       <Link
-        to="/config/ns/kubeapps/repos"
+        to="/c/default/ns/kubeapps/config/repos"
       >
         <ReactWrapperComponent>
           Manage App Repositories

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -53,7 +53,7 @@ describe("settings", () => {
     const settingsbar = wrapper.find(".header__nav__submenu").first();
     const items = settingsbar.find("NavLink").map(p => p.props());
     const expectedItems = [
-      { children: "App Repositories", to: "/config/ns/default/repos" },
+      { children: "App Repositories", to: "/c/default/ns/default/config/repos" },
       { children: "Service Brokers", to: "/config/brokers" },
     ];
     items.forEach((item, index) => {
@@ -69,7 +69,7 @@ describe("settings", () => {
     const settingsbar = wrapper.find(".header__nav__submenu").first();
     const items = settingsbar.find("NavLink").map(p => p.props());
     const expectedItems = [
-      { children: "App Repositories", to: "/config/ns/default/repos" },
+      { children: "App Repositories", to: "/c/default/ns/default/config/repos" },
       { children: "Service Brokers", to: "/config/brokers" },
       { children: "Operators", to: "/ns/default/operators" },
     ];

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -67,7 +67,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
       this.state.configOpen ? "header__nav__submenu-open" : ""
     }`;
 
-    const reposPath = `/config/ns/${cluster.currentNamespace}/repos`;
+    const reposPath = app.config.apprepositories(clusters.currentCluster, cluster.currentNamespace);
     return (
       <section className="gradient-135-brand type-color-reverse type-color-reverse-anchor-reset">
         <div className="container">

--- a/dashboard/src/components/Header/Menu.tsx
+++ b/dashboard/src/components/Header/Menu.tsx
@@ -59,7 +59,7 @@ function Menu({ clusters, defaultNamespace, appVersion, logout }: IContextSelect
             <div>
               <label className="dropdown-menu-padding dropdown-menu-label">Administration</label>
               <Link
-                to={app.config.apprepositories(namespaceSelected)}
+                to={app.config.apprepositories(clusters.currentCluster, namespaceSelected)}
                 className="dropdown-menu-link"
                 onClick={toggleOpen}
               >

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 
+import * as url from "shared/url";
 import { IAppRepository, IRBACRole } from "../../shared/types";
 import LoadingWrapper from "../LoadingWrapper";
 
@@ -8,6 +9,7 @@ import { ErrorSelector, MessageAlert } from "../ErrorAlert";
 
 interface ISelectRepoFormProps {
   isFetching: boolean;
+  cluster: string;
   namespace: string;
   kubeappsNamespace: string;
   repoError?: Error;
@@ -58,7 +60,7 @@ class SelectRepoForm extends React.Component<ISelectRepoFormProps, ISelectRepoFo
             <div>
               <h5>Chart repositories not found.</h5>
               Manage your Helm chart repositories in Kubeapps by visiting the{" "}
-              <Link to={`/config/ns/${this.props.namespace}/repos`}>
+              <Link to={url.app.config.apprepositories(this.props.cluster, this.props.namespace)}>
                 App repositories configuration
               </Link>{" "}
               page.
@@ -101,7 +103,10 @@ class SelectRepoForm extends React.Component<ISelectRepoFormProps, ISelectRepoFo
             <p>
               {" "}
               * If the repository containing {this.props.chartName} is not in the list add it{" "}
-              <a href="/config/repos"> here </a>.{" "}
+              <a href={url.app.config.apprepositories(this.props.cluster, this.props.namespace)}>
+                here
+              </a>
+              .{" "}
             </p>
           </div>
         </div>

--- a/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
+++ b/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
@@ -9,13 +9,17 @@ import { IStoreState } from "../../shared/types";
 
 function mapStateToProps(
   { charts, operators, config }: IStoreState,
-  { match: { params }, location }: RouteComponentProps<{ namespace: string; repo: string }>,
+  {
+    match: { params },
+    location,
+  }: RouteComponentProps<{ cluster: string; namespace: string; repo: string }>,
 ) {
   return {
     charts,
     filter: qs.parse(location.search, { ignoreQueryPrefix: true }).q || "",
     repo: params.repo,
     csvs: operators.csvs,
+    cluster: params.cluster,
     namespace: params.namespace,
     kubeappsNamespace: config.namespace,
     featureFlags: config.featureFlags,

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -62,7 +62,7 @@ class Routes extends React.Component<IRoutesProps> {
     featureFlags: { operators: false, additionalClusters: [], ui: "hex" },
   };
   public render() {
-    const reposPath = "/config/ns/:namespace/repos";
+    const reposPath = "/c/:cluster/ns/:namespace/config/repos";
     if (this.props.featureFlags.operators) {
       // Add routes related to operators
       Object.assign(privateRoutes, {

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -48,7 +48,7 @@ describe("clusterReducer", () => {
         },
         {
           // It still updates the current namespace for a non-multicluster route.
-          path: "/config/ns/default/repos",
+          path: "/ns/default/operators",
           currentNamespace: "default",
           currentCluster: "initial-cluster",
         },

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -45,7 +45,8 @@ export const app = {
       `/ns/${namespace}/operators-instances/new/${csvName}/${crdName}`,
   },
   config: {
-    apprepositories: (namespace: string) => `/config/ns/${namespace}/repos`,
+    apprepositories: (cluster: string, namespace: string) =>
+      `/c/${cluster}/ns/${namespace}/config/repos`,
     operators: (namespace: string) => `/ns/${namespace}/operators`,
   },
 };

--- a/integration/use-cases/create-private-registry.js
+++ b/integration/use-cases/create-private-registry.js
@@ -2,7 +2,7 @@ const axios = require("axios");
 const utils = require("./lib/utils");
 
 test("Creates a private registry", async () => {
-  await page.goto(getUrl("/#/config/ns/default/repos"));
+  await page.goto(getUrl("/#/c/default/ns/default/config/repos"));
 
   await expect(page).toFillForm("form", {
     token: process.env.ADMIN_TOKEN,

--- a/integration/use-cases/create-registry.js
+++ b/integration/use-cases/create-registry.js
@@ -1,7 +1,7 @@
 const utils = require("./lib/utils");
 
 test("Creates a registry", async () => {
-  await page.goto(getUrl("/#/config/ns/kubeapps/repos"));
+  await page.goto(getUrl("/#/c/default/ns/kubeapps/config/repos"));
 
   await expect(page).toFillForm("form", {
     token: process.env.ADMIN_TOKEN,


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Updates the app repo config route and all call-sites to be clustered (last point on #1762).

A follow-up will ensure that if you select another cluster while browsing the app repos you will be unable to view them and see an appropriate info.

### Benefits

Since the cluster selector will be visible for all pages, we need to ensure appropriate behaviour or info is displayed when switching clusters.. Created #1894 to ensure other ones are done.

### Applicable issues
Ref: #1762 