### PR TITLE
Do not allow app repo listing for other clusterss.

### DIFF
--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -1,6 +1,7 @@
 import { shallow } from "enzyme";
 import * as React from "react";
 
+import { MessageAlert } from "components/ErrorAlert";
 import AppRepoList from "./AppRepoList";
 
 const defaultNamespace = "default-namespace";
@@ -117,6 +118,21 @@ describe("AppRepoList", () => {
     };
     const wrapper = shallow(<AppRepoList {...props} />);
 
+    const addButton = wrapper.find("AppRepoAddButton");
+    expect(addButton.length).toBe(0);
+  });
+
+  it("displays not-supported alert when an additional cluster is selected", () => {
+    const props = {
+      ...defaultProps,
+      cluster: "other-cluster",
+    };
+
+    const wrapper = shallow(<AppRepoList {...props} />);
+
+    const msgAlert = wrapper.find(MessageAlert);
+    expect(msgAlert.length).toBe(1);
+    expect(msgAlert.prop("header")).toEqual("AppRepositories are available on the default cluster only");
     const addButton = wrapper.find("AppRepoAddButton");
     expect(addButton.length).toBe(0);
   });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -132,7 +132,9 @@ describe("AppRepoList", () => {
 
     const msgAlert = wrapper.find(MessageAlert);
     expect(msgAlert.length).toBe(1);
-    expect(msgAlert.prop("header")).toEqual("AppRepositories are available on the default cluster only");
+    expect(msgAlert.prop("header")).toEqual(
+      "AppRepositories are available on the default cluster only",
+    );
     const addButton = wrapper.find("AppRepoAddButton");
     expect(addButton.length).toBe(0);
   });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -130,6 +130,28 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
       createDockerRegistrySecret,
     } = this.props;
     const renderNamespace = namespace === definedNamespaces.all;
+
+    // We do not currently support app repositories on additional clusters.
+    if (cluster !== "default") {
+      return (
+        <MessageAlert header="AppRepositories are available on the default cluster only">
+          <div>
+            <p className="margin-v-normal">
+              Currently the multi-cluster support in Kubeapps supports AppRepositories on the
+              default cluster only.
+            </p>
+            <p className="margin-v-normal">
+              The catalog of charts from AppRepositories on the default cluster which are available
+              for all namespaces will be avaialble on additional clusters also, but you can not
+              currently create a private AppRepository for a particular namespace of an additional
+              cluster. We may in the future support AppRepositories on additional clusters but for
+              now you will need to switch back to your default cluster.
+            </p>
+          </div>
+        </MessageAlert>
+      );
+    }
+
     return (
       <div className="app-repo-list">
         <h1>App Repositories</h1>

--- a/docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
@@ -1,0 +1,4 @@
+featureFlags:
+  additionalClusters:
+   - name: second-cluster
+     apiServiceURL: https://172.18.0.3:6443

--- a/docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
@@ -2,3 +2,4 @@ featureFlags:
   additionalClusters:
    - name: second-cluster
      apiServiceURL: https://172.18.0.3:6443
+     insecure: true

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -174,7 +174,10 @@ func NewActionConfig(storageForDriver StorageForDriver, config *rest.Config, cli
 // NewConfigFlagsFromCluster returns ConfigFlags with default values set from within cluster.
 func NewConfigFlagsFromCluster(namespace string, clusterConfig *rest.Config) *genericclioptions.ConfigFlags {
 	impersonateGroup := []string{}
-	insecure := false
+
+	// If no CAFile was included in the config, assume an insecure connection.
+	// This should be an intentional decision at the CLI.
+	insecure := clusterConfig.CAFile == ""
 
 	// CertFile and KeyFile must be nil for the BearerToken to be used for authentication and authorization instead of the pod's service account.
 	return &genericclioptions.ConfigFlags{

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -175,13 +175,9 @@ func NewActionConfig(storageForDriver StorageForDriver, config *rest.Config, cli
 func NewConfigFlagsFromCluster(namespace string, clusterConfig *rest.Config) *genericclioptions.ConfigFlags {
 	impersonateGroup := []string{}
 
-	// If no CAFile was included in the config, assume an insecure connection.
-	// This should be an intentional decision at the CLI.
-	insecure := clusterConfig.CAFile == ""
-
 	// CertFile and KeyFile must be nil for the BearerToken to be used for authentication and authorization instead of the pod's service account.
 	return &genericclioptions.ConfigFlags{
-		Insecure:         &insecure,
+		Insecure:         &clusterConfig.TLSClientConfig.Insecure,
 		Timeout:          stringptr("0"),
 		Namespace:        stringptr(namespace),
 		APIServer:        stringptr(clusterConfig.Host),

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -73,6 +73,9 @@ func NewClusterConfig(inClusterConfig *rest.Config, token string, cluster string
 
 	config.Host = additionalCluster.APIServiceURL
 	config.TLSClientConfig = rest.TLSClientConfig{}
+	// If no CAFile was included in the config, assume an insecure connection.
+	// This should be an intentional decision at the CLI.
+	config.TLSClientConfig.Insecure = additionalCluster.CertificateAuthorityData == ""
 	if additionalCluster.CertificateAuthorityData != "" {
 		config.TLSClientConfig.CAData = []byte(additionalCluster.CertificateAuthorityData)
 	}

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -51,6 +51,7 @@ type AdditionalClusterConfig struct {
 	Name                     string `json:"name"`
 	APIServiceURL            string `json:"apiServiceURL"`
 	CertificateAuthorityData string `json:"certificateAuthorityData,omitempty"`
+	Insecure                 bool   `json:"insecure"`
 }
 
 // AdditionalClustersConfig is an alias for a map of additional cluster configs.
@@ -73,9 +74,7 @@ func NewClusterConfig(inClusterConfig *rest.Config, token string, cluster string
 
 	config.Host = additionalCluster.APIServiceURL
 	config.TLSClientConfig = rest.TLSClientConfig{}
-	// If no CAFile was included in the config, assume an insecure connection.
-	// This should be an intentional decision at the CLI.
-	config.TLSClientConfig.Insecure = additionalCluster.CertificateAuthorityData == ""
+	config.TLSClientConfig.Insecure = additionalCluster.Insecure
 	if additionalCluster.CertificateAuthorityData != "" {
 		config.TLSClientConfig.CAData = []byte(additionalCluster.CertificateAuthorityData)
 	}

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -22,6 +22,7 @@ deploy-dev: deploy-dex deploy-openldap
 	helm install kubeapps ./chart/kubeapps --namespace kubeapps \
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
+		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml \
 		--set useHelm3=true
 	@echo "\nYou can now simply open your browser at http://172.18.0.2:30000 to access Kubeapps!"
 	@echo "When logging in, you will be redirected to dex (with a self-signed cert) and can login with email as either of"


### PR DESCRIPTION
### Description of the change

Ensures that if a user navigates to an additional cluster while viewing the config for app repos, or visits the config with the additional cluster already selected, that an informative message is displayed regarding their options:

![apprepos-default-only](https://user-images.githubusercontent.com/497518/88618377-58d5a380-d0dc-11ea-94c3-26ddb9d40775.png)

### Benefits

We don't leave people not knowing why app repos aren't working for additional clusters.

### Applicable issues

Follows #1893 Ref: #1762

### Additional information

The next PR will ensure that an `--insecure` flag is passed before accepting additional clusters without CAData, as well as fixing the issue when CAData is provided and calls fail.