### PR TITLE
Update pinned bitnami charts in values.yaml

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -105,7 +105,7 @@ frontend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.18.0-debian-10-r38
+    tag: 1.19.1-debian-10-r16
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -279,7 +279,7 @@ hooks:
   image:
     registry: docker.io
     repository: bitnami/kubectl
-    tag: 1.16.3-debian-10-r85
+    tag: 1.16.3-debian-10-r176
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -633,7 +633,7 @@ securityContext:
 testImage:
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.18.0-debian-10-r38
+  tag: 1.19.1-debian-10-r16
 
 # Auth Proxy for OIDC support
 # ref: https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md
@@ -646,7 +646,7 @@ authProxy:
   image:
     registry: docker.io
     repository: bitnami/oauth2-proxy
-    tag: 5.1.0-debian-10-r24
+    tag: 5.1.1-debian-10-r58
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/node:12.18.1 AS build
+FROM bitnami/node:12.18.3 AS build
 WORKDIR /app
 
 COPY package.json yarn.lock /app/
@@ -11,5 +11,5 @@ COPY . /app
 RUN yarn run prettier-check && yarn run ts-compile-check
 RUN yarn run build
 
-FROM bitnami/nginx:1.18.0-debian-10-r38
+FROM bitnami/nginx:1.19.1-debian-10-r16
 COPY --from=build /app/build /app


### PR DESCRIPTION
### Description of the change

Updates the bitnami charts in the values.yaml to their latest versions.

### Benefits

Some providers delete older tags (odd?) breaking chart deployments without manual configuration.

### Possible drawbacks

See if CI passes without issue.

### Additional information

Longer term, we should not pin these in our Kubeapps main branch, but pin them to the current latest when releasing the Kubeapps chart.