### PR TITLE
Enable secure config multicluster

### DIFF
--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -54,8 +54,8 @@ spec:
           volumeMounts:
             - name: kubeops-config
               mountPath: /config
-            - name: tmp-dir
-              mountPath: /tmp
+            - name: ca-certs
+              mountPath: /etc/additional-clusters-cafiles
           {{- end }}
           env:
             - name: POD_NAMESPACE
@@ -79,7 +79,7 @@ spec:
         - name: kubeops-config
           configMap:
             name: {{ template "kubeapps.kubeops-config.fullname" . }}
-        - name: tmp-dir
+        - name: ca-certs
           emptyDir: {}
       {{- end }}
 

--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -54,6 +54,8 @@ spec:
           volumeMounts:
             - name: kubeops-config
               mountPath: /config
+            - name: tmp-dir
+              mountPath: /tmp
           {{- end }}
           env:
             - name: POD_NAMESPACE
@@ -77,6 +79,8 @@ spec:
         - name: kubeops-config
           configMap:
             name: {{ template "kubeapps.kubeops-config.fullname" . }}
+        - name: tmp-dir
+          emptyDir: {}
       {{- end }}
 
 {{- end }}{{/* matches useHelm3 */}}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -696,8 +696,9 @@ featureFlags:
   invalidateCache: true
   operators: false
   # additionalClusters is a WIP feature for multi-cluster support.
-  # The certificateAuthorityData can be obtained from the additional cluster's control plane with
-  #  kubectl -n kube-system exec -ti kube-apiserver-<...>-control-plane -- cat /etc/kubernetes/pki/ca.crt | base64 -w0
+  # The base64-encoded certificateAuthorityData can be obtained from the additional cluster's kube config
+  # file, for example:
+  # kubectl --kubeconfig ~/.kube/kind-config-kubeapps-additional config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}'
   additionalClusters: []
   # additionalClusters:
   # - name: second-cluster

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -696,6 +696,8 @@ featureFlags:
   invalidateCache: true
   operators: false
   # additionalClusters is a WIP feature for multi-cluster support.
+  # The certificateAuthorityData can be obtained from the additional cluster's control plane with
+  #  kubectl -n kube-system exec -ti kube-apiserver-<...>-control-plane -- cat /etc/kubernetes/pki/ca.crt | base64 -w0
   additionalClusters: []
   # additionalClusters:
   # - name: second-cluster

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -185,6 +186,15 @@ func parseAdditionalClusterConfig(path string) (kube.AdditionalClustersConfig, e
 
 	configs := kube.AdditionalClustersConfig{}
 	for _, c := range clusterConfigs {
+		// We need to decode the base64-encoded cadata from the input.
+		if c.CertificateAuthorityData != "" {
+			decodedCAData, err := base64.StdEncoding.DecodeString(c.CertificateAuthorityData)
+			if err != nil {
+				return nil, err
+			}
+			c.CertificateAuthorityData = string(decodedCAData)
+			// time="2020-07-28T06:59:23Z" level=error msg="unable to create app repo: Get https://172.18.0.3:6443/api/v1/namespaces: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"kubernetes\")"
+		}
 		configs[c.Name] = c
 	}
 	return configs, nil

--- a/cmd/kubeops/main_test.go
+++ b/cmd/kubeops/main_test.go
@@ -10,28 +10,6 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/kube"
 )
 
-// configComparer is a custom comparer to include CAFile contents
-var configComparer = cmp.Comparer(func(want, got kube.AdditionalClusterConfig) bool {
-	if !(want.Name == got.Name &&
-		want.APIServiceURL == got.APIServiceURL &&
-		want.CertificateAuthorityData == got.CertificateAuthorityData &&
-		want.Insecure == got.Insecure) {
-		return false
-	}
-
-	if want.CertificateAuthorityData != "" {
-		caBytes, err := ioutil.ReadFile(got.CAFile)
-		if err != nil {
-			return false
-		}
-
-		if string(caBytes) != want.CertificateAuthorityData {
-			return false
-		}
-	}
-	return true
-})
-
 func TestParseAdditionalClusterConfig(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/cmd/kubeops/main_test.go
+++ b/cmd/kubeops/main_test.go
@@ -18,37 +18,42 @@ func TestParseAdditionalClusterConfig(t *testing.T) {
 	}{
 		{
 			name:       "parses a single additional cluster",
-			configJSON: `[{"name": "cluster-2", "apiServiceURL": "https://example.com", "certificateAuthorityData": "abcd"}]`,
+			configJSON: `[{"name": "cluster-2", "apiServiceURL": "https://example.com", "certificateAuthorityData": "Y2EtY2VydC1kYXRhCg=="}]`,
 			expectedConfig: kube.AdditionalClustersConfig{
 				"cluster-2": {
 					Name:                     "cluster-2",
 					APIServiceURL:            "https://example.com",
-					CertificateAuthorityData: "abcd",
+					CertificateAuthorityData: "ca-cert-data\n",
 				},
 			},
 		},
 		{
 			name: "parses multiple additional clusters",
 			configJSON: `[
-	{"name": "cluster-2", "apiServiceURL": "https://example.com/cluster-2", "certificateAuthorityData": "abcd"},
-	{"name": "cluster-3", "apiServiceURL": "https://example.com/cluster-3", "certificateAuthorityData": "efgh"}
+	{"name": "cluster-2", "apiServiceURL": "https://example.com/cluster-2", "certificateAuthorityData": "Y2EtY2VydC1kYXRhCg=="},
+	{"name": "cluster-3", "apiServiceURL": "https://example.com/cluster-3", "certificateAuthorityData": "Y2EtY2VydC1kYXRhLWFkZGl0aW9uYWwK"}
 ]`,
 			expectedConfig: kube.AdditionalClustersConfig{
 				"cluster-2": {
 					Name:                     "cluster-2",
 					APIServiceURL:            "https://example.com/cluster-2",
-					CertificateAuthorityData: "abcd",
+					CertificateAuthorityData: "ca-cert-data\n",
 				},
 				"cluster-3": {
 					Name:                     "cluster-3",
 					APIServiceURL:            "https://example.com/cluster-3",
-					CertificateAuthorityData: "efgh",
+					CertificateAuthorityData: "ca-cert-data-additional\n",
 				},
 			},
 		},
 		{
 			name:        "errors if the cluster configs cannot be parsed",
 			configJSON:  `[{"name": "cluster-2", "apiServiceURL": "https://example.com", "certificateAuthorityData": "extracomma",}]`,
+			expectedErr: true,
+		},
+		{
+			name:        "errors if any CAData cannot be decoded",
+			configJSON:  `[{"name": "cluster-2", "apiServiceURL": "https://example.com", "certificateAuthorityData": "not-base64-encoded"}]`,
 			expectedErr: true,
 		},
 	}

--- a/cmd/kubeops/main_test.go
+++ b/cmd/kubeops/main_test.go
@@ -66,7 +66,7 @@ func TestParseAdditionalClusterConfig(t *testing.T) {
 			path := createConfigFile(t, tc.configJSON)
 			defer os.Remove(path)
 
-			config, deferFn, err := parseAdditionalClusterConfig(path)
+			config, deferFn, err := parseAdditionalClusterConfig(path, "/tmp")
 			if got, want := err != nil, tc.expectedErr; got != want {
 				t.Errorf("got: %t, want: %t", got, want)
 			}

--- a/docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
@@ -2,4 +2,6 @@ featureFlags:
   additionalClusters:
    - name: second-cluster
      apiServiceURL: https://172.18.0.3:6443
+     # insecure is set to true only for local dev cluster testing. Always specify the
+     # certificateAuthorityData as documented in teh values.yaml.
      insecure: true

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -171,22 +171,6 @@ func NewActionConfig(storageForDriver StorageForDriver, config *rest.Config, cli
 	return actionConfig, nil
 }
 
-// ConfigFlags implements the RESTConfigGetter interface.
-// The genericclioptions.ConfigFlags struct includes only a CAFile field, not
-// a CAData field.
-// https://github.com/kubernetes/cli-runtime/issues/8
-// Rather than writing the CA data to a file unnecessarily, we embed the ConfigFlags implementation
-// and update the ToRestConfig method only.
-type ConfigFlags struct {
-	genericclioptions.ConfigFlags
-	clusterConfig *rest.Config
-}
-
-// ToRESTConfig overrides the embedded genericclioptions.ConfigFlags.ToToRESTConfig
-func (cf *ConfigFlags) ToRESTConfig() (*rest.Config, error) {
-	return cf.clusterConfig, nil
-}
-
 // NewConfigFlagsFromCluster returns ConfigFlags with default values set from within cluster.
 func NewConfigFlagsFromCluster(namespace string, clusterConfig *rest.Config) genericclioptions.RESTClientGetter {
 	impersonateGroup := []string{}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -192,17 +192,14 @@ func NewConfigFlagsFromCluster(namespace string, clusterConfig *rest.Config) gen
 	impersonateGroup := []string{}
 
 	// CertFile and KeyFile must be nil for the BearerToken to be used for authentication and authorization instead of the pod's service account.
-	return &ConfigFlags{
-		ConfigFlags: genericclioptions.ConfigFlags{
-			Insecure:         &clusterConfig.TLSClientConfig.Insecure,
-			Timeout:          stringptr("0"),
-			Namespace:        stringptr(namespace),
-			APIServer:        stringptr(clusterConfig.Host),
-			CAFile:           stringptr(clusterConfig.CAFile),
-			BearerToken:      stringptr(clusterConfig.BearerToken),
-			ImpersonateGroup: &impersonateGroup,
-		},
-		clusterConfig: clusterConfig,
+	return &genericclioptions.ConfigFlags{
+		Insecure:         &clusterConfig.TLSClientConfig.Insecure,
+		Timeout:          stringptr("0"),
+		Namespace:        stringptr(namespace),
+		APIServer:        stringptr(clusterConfig.Host),
+		CAFile:           stringptr(clusterConfig.CAFile),
+		BearerToken:      stringptr(clusterConfig.BearerToken),
+		ImpersonateGroup: &impersonateGroup,
 	}
 }
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -15,7 +15,6 @@ import (
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	chartv1 "k8s.io/helm/pkg/proto/hapi/chart"
 
 	"github.com/google/go-cmp/cmp"
@@ -707,22 +706,5 @@ func TestUpgradeRelease(t *testing.T) {
 				t.Errorf("got: %q, want: %q", got, want)
 			}
 		})
-	}
-}
-
-func TestNewConfigFlagsFromCluster(t *testing.T) {
-	caData := []byte("ca-data-not-from-file")
-	tlsClientConfig := rest.TLSClientConfig{CAData: caData}
-	clientConfig := &rest.Config{TLSClientConfig: tlsClientConfig}
-
-	flags := NewConfigFlagsFromCluster("mynamespace", clientConfig)
-
-	returnedClientConfig, err := flags.ToRESTConfig()
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
-
-	if got, want := returnedClientConfig, clientConfig; !cmp.Equal(want, got) {
-		t.Errorf(cmp.Diff(want, got))
 	}
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -15,6 +15,7 @@ import (
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	chartv1 "k8s.io/helm/pkg/proto/hapi/chart"
 
 	"github.com/google/go-cmp/cmp"
@@ -706,5 +707,22 @@ func TestUpgradeRelease(t *testing.T) {
 				t.Errorf("got: %q, want: %q", got, want)
 			}
 		})
+	}
+}
+
+func TestNewConfigFlagsFromCluster(t *testing.T) {
+	caData := []byte("ca-data-not-from-file")
+	tlsClientConfig := rest.TLSClientConfig{CAData: caData}
+	clientConfig := &rest.Config{TLSClientConfig: tlsClientConfig}
+
+	flags := NewConfigFlagsFromCluster("mynamespace", clientConfig)
+
+	returnedClientConfig, err := flags.ToRESTConfig()
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if got, want := returnedClientConfig, clientConfig; !cmp.Equal(want, got) {
+		t.Errorf(cmp.Diff(want, got))
 	}
 }

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -51,7 +51,14 @@ type AdditionalClusterConfig struct {
 	Name                     string `json:"name"`
 	APIServiceURL            string `json:"apiServiceURL"`
 	CertificateAuthorityData string `json:"certificateAuthorityData,omitempty"`
-	Insecure                 bool   `json:"insecure"`
+	// The genericclioptions.ConfigFlags struct includes only a CAFile field, not
+	// a CAData field.
+	// https://github.com/kubernetes/cli-runtime/issues/8
+	// Embedding genericclioptions.ConfigFlags in a struct which includes the actual rest.Config
+	// and returning that for ToRESTConfig() isn't enough, so we each configured cert out and
+	// include a CAFile field in the config.
+	CAFile   string
+	Insecure bool `json:"insecure"`
 }
 
 // AdditionalClustersConfig is an alias for a map of additional cluster configs.
@@ -77,6 +84,7 @@ func NewClusterConfig(inClusterConfig *rest.Config, token string, cluster string
 	config.TLSClientConfig.Insecure = additionalCluster.Insecure
 	if additionalCluster.CertificateAuthorityData != "" {
 		config.TLSClientConfig.CAData = []byte(additionalCluster.CertificateAuthorityData)
+		config.CAFile = additionalCluster.CAFile
 	}
 	return config, nil
 }

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -924,6 +924,7 @@ func TestNewClusterConfig(t *testing.T) {
 				"cluster-1": {
 					APIServiceURL:            "https://cluster-1.example.com:7890",
 					CertificateAuthorityData: "ca-file-data",
+					CAFile:                   "/tmp/ca-file-data",
 				},
 			},
 			inClusterConfig: &rest.Config{
@@ -940,6 +941,7 @@ func TestNewClusterConfig(t *testing.T) {
 				BearerTokenFile: "",
 				TLSClientConfig: rest.TLSClientConfig{
 					CAData: []byte("ca-file-data"),
+					CAFile: "/tmp/ca-file-data",
 				},
 			},
 		},

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -37,10 +37,6 @@ reset-dev:
 	helm -n kubeapps delete kubeapps || true
 	helm -n dex delete dex || true
 	helm -n ldap delete ldap || true
-	# In case helm installations fail, still delete non-namespaced resources.
-	kubectl delete clusterrole dex kubeapps:controller:apprepository-reader-kubeapps || true
-	kubectl delete clusterrolebinding dex kubeapps:controller:apprepository-reader-kubeapps || true
 	kubectl delete namespace --wait dex ldap kubeapps || true
-	kubectl delete --wait -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml || true
 
 .PHONY: deploy-dex deploy-dev deploy-openldap reset-dev update-apiserver-etc-hosts


### PR DESCRIPTION
### Description of the change

There were two issues stopping secure connections to additional clusters:
 * The base64-encoded ca data was not being decode before being used, and
 * the `genericclioptions.ConfigFlags` struct used by Helm does not support CAData, but only a CAFile field

The latter required adding an emptydir /tmp mount so we can write the cafile for each additional cluster and Helm can use that.

It turns the only reason this wasn't working yesterday was that I had misconfigured the additional clusters cadata with that of the main cluster :/

### Benefits

With this change, I can create and delete releases on the additional cluster, as per the earlier video, but using a secure connection.

### Possible drawbacks

### Applicable issues

#1762 

### Additional information

Also noticed that the RBAC on the additional cluster works fine when using a user with explicit rolebindings, but not when using a user with access through groups only (though this works fine on the default cluster). Updated #1896 .
