### PR TITLE
Update oauth2-proxy from 5.x to 6.x

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -57,21 +57,21 @@ spec:
         {{- if .Values.authProxy.enabled }}
         - name: auth-proxy
           args:
-            - -provider={{ required "You must fill \".Values.authProxy.provider\" with the provider. Valid values at https://pusher.github.io/oauth2_proxy/auth-configuration" .Values.authProxy.provider }}
-            - -client-id={{ required "You must fill \".Values.authProxy.clientID\" with the Client ID of the provider" .Values.authProxy.clientID }}
-            - -client-secret={{ required "You must fill \".Values.authProxy.clientSecret\" with the Client Secret of the provider" .Values.authProxy.clientSecret }}
-            - -cookie-secret={{ required "You must fill \".Values.authProxy.cookieSecret\" with a 16, 24 or 32 byte base64 encoded seed string for secure cookies" .Values.authProxy.cookieSecret }}
-            - -upstream=http://localhost:8080/
-            - -http-address=0.0.0.0:3000
-            - -email-domain={{ .Values.authProxy.emailDomain }}
-            - -pass-basic-auth=false
-            - -pass-access-token=true
-            - -pass-authorization-header=true
-            - -skip-auth-regex=^\/config\.json$
-            - -skip-auth-regex=^\/favicon.*\.png$
-            - -skip-auth-regex=^\/static\/
-            - -skip-auth-regex=^\/$
-            - -scope=openid email groups
+            - --provider={{ required "You must fill \".Values.authProxy.provider\" with the provider. Valid values at https://pusher.github.io/oauth2_proxy/auth-configuration" .Values.authProxy.provider }}
+            - --client-id={{ required "You must fill \".Values.authProxy.clientID\" with the Client ID of the provider" .Values.authProxy.clientID }}
+            - --client-secret={{ required "You must fill \".Values.authProxy.clientSecret\" with the Client Secret of the provider" .Values.authProxy.clientSecret }}
+            - --cookie-secret={{ required "You must fill \".Values.authProxy.cookieSecret\" with a 16, 24 or 32 byte base64 encoded seed string for secure cookies" .Values.authProxy.cookieSecret }}
+            - --upstream=http://localhost:8080/
+            - --http-address=0.0.0.0:3000
+            - --email-domain={{ .Values.authProxy.emailDomain }}
+            - --pass-basic-auth=false
+            - --pass-access-token=true
+            - --pass-authorization-header=true
+            - --skip-auth-regex=^\/config\.json$
+            - --skip-auth-regex=^\/favicon.*\.png$
+            - --skip-auth-regex=^\/static\/
+            - --skip-auth-regex=^\/$
+            - --scope=openid email groups
             {{- range .Values.authProxy.additionalFlags }}
             - {{ . }}
             {{- end }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -668,10 +668,10 @@ authProxy:
   ## Additional flags for oauth2-proxy
   ##
   additionalFlags: []
-  # - -ssl-insecure-skip-verify
-  # - -cookie-secure=false
-  # - -scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-platform
-  # - -oidc-issuer-url=https://accounts.google.com # Only needed if provider is oidc
+  # - --ssl-insecure-skip-verify
+  # - --cookie-secure=false
+  # - --scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-platform
+  # - --oidc-issuer-url=https://accounts.google.com # Only needed if provider is oidc
   ## OAuth2 Proxy containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -646,7 +646,7 @@ authProxy:
   image:
     registry: docker.io
     repository: bitnami/oauth2-proxy
-    tag: 5.1.1-debian-10-r58
+    tag: 6.0.0-debian-10-r23
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##

--- a/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml
@@ -5,8 +5,10 @@ authProxy:
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
   cookieSecret: bm90LWdvb2Qtc2VjcmV0Cg==
   additionalFlags:
-    - -cookie-secure=false
-    - -oidc-issuer-url=https://172.18.0.2:32000
-    - -ssl-insecure-skip-verify=true
+    # Can't use secure cookies locally without running frontend with ssl
+    - --cookie-secure=false
+    - --oidc-issuer-url=https://172.18.0.2:32000
+    # Can't verify ssl of dex locally without setting --provider-ca-file and mounting etc.
+    - --ssl-insecure-skip-verify=true
     # If you need to access the actual token in the frontend for testing, uncomment the following.
-    # - -set-authorization-header=true
+    # - --set-authorization-header=true


### PR DESCRIPTION
### Description of the change

The only breaking change is that flags now require -- .
For details of breaking changes in 6.x:
https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md#breaking-changes-1

### Benefits

Using more secure latest oauth2-proxy (project migrated earlier this year).

### Possible drawbacks

Users who have set `.Values.authProxy.additionalFlags` will need to update those (auth-proxy container will refuse to start).