### PR TITLE
Update MongoDB chart from 7.X to 8.X

### DIFF
--- a/chart/kubeapps/requirements.lock
+++ b/chart/kubeapps/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 7.14.8
+  version: 8.2.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 8.10.11
-digest: sha256:ab1c99273fd342dce2879dece3c38eb0d525a1df870758e873ca293cdd857a25
-generated: "2020-07-01T14:11:29.916518817+10:00"
+  version: 8.10.14
+digest: sha256:0ee57ab834a01756bd7861923711a4b2052726349fc47788ca033ddf4c44025d
+generated: "2020-07-29T10:57:26.484335228+02:00"

--- a/chart/kubeapps/requirements.yaml
+++ b/chart/kubeapps/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: mongodb
-    version: "~ 7.14.2"
+    version: ">= 8.2.1"
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
   - name: postgresql

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - --repo-sync-cmd=/asset-syncer
             - --namespace={{ .Release.Namespace }}
             {{- if .Values.mongodb.enabled }}
-            - --database-secret-name={{ .Values.mongodb.existingSecret }}
+            - --database-secret-name={{ .Values.mongodb.auth.existingSecret }}
             - --database-secret-key=mongodb-root-password
             - --database-type=mongodb
             - --database-url={{ template "kubeapps.mongodb.fullname" . }}

--- a/chart/kubeapps/templates/apprepository-jobs-postupgrade.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-postupgrade.yaml
@@ -62,7 +62,7 @@ spec:
                 secretKeyRef:
             {{- if .Values.mongodb.enabled }}
                   key: mongodb-root-password
-                  name: {{ .Values.mongodb.existingSecret }}
+                  name: {{ .Values.mongodb.auth.existingSecret }}
             {{- end }}
             {{- if .Values.postgresql.enabled }}
                   key: postgresql-password

--- a/chart/kubeapps/templates/assetsvc-deployment.yaml
+++ b/chart/kubeapps/templates/assetsvc-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.mongodb.existingSecret }}
+                  name: {{ .Values.mongodb.auth.existingSecret }}
                   key: mongodb-root-password
             - name: POD_NAMESPACE
               valueFrom:

--- a/chart/kubeapps/templates/db-secret-bootstrap.yaml
+++ b/chart/kubeapps/templates/db-secret-bootstrap.yaml
@@ -1,9 +1,9 @@
-{{- if or .Values.mongodb.existingSecret .Values.postgresql.existingSecret -}}
+{{- if or .Values.mongodb.auth.existingSecret .Values.postgresql.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
   {{- if .Values.mongodb.enabled }}
-  name: {{ .Values.mongodb.existingSecret }}
+  name: {{ .Values.mongodb.auth.existingSecret }}
   {{- end }}
   {{- if .Values.postgresql.enabled }}
   name: {{ .Values.postgresql.existingSecret }}

--- a/chart/kubeapps/templates/db-secret-jobs-cleanup.yaml
+++ b/chart/kubeapps/templates/db-secret-jobs-cleanup.yaml
@@ -41,4 +41,4 @@ spec:
             - /bin/sh
           args:
             - -c
-            - "kubectl delete secret -n {{ .Release.Namespace }} {{ .Values.mongodb.existingSecret }} {{ .Values.postgresql.existingSecret }}|| true"
+            - "kubectl delete secret -n {{ .Release.Namespace }} {{ .Values.mongodb.auth.existingSecret }} {{ .Values.postgresql.existingSecret }}|| true"

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -561,7 +561,8 @@ mongodb:
     size: 8Gi
   ## MongoDB credentials are handled by kubeapps to facilitate upgrades
   ##
-  existingSecret: kubeapps-mongodb
+  auth:
+    existingSecret: kubeapps-mongodb
   ## Pod Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Upgrade the MongoDB chart. As far as I can tell, the only breaking change for us is that `existingSecret` is now under an "auth" subsection. We still need to manually check if upgrading using MongoDB fails (our CI only checks PostgreSQL).

