### PR TITLE
Allow to disable ipv6

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -198,6 +198,16 @@ kubectl delete namespace kubeapps
 
 ## Troubleshooting
 
+### Nginx Ipv6 error
+
+When starting the application, the Nginx server present in the services `kubeapps` and `kubeapps-internal-dashboard` may fail with the following:
+
+```
+nginx: [emerg] socket() [::]:8080 failed (97: Address family not supported by protocol)
+```
+
+This usually means that your cluster is not compatible with IPv6. To disable it, install kubeapps with the flag: `--set enableIPv6=false`.
+
 ### Forbidden error while installing the Chart
 
 If during installation you run into an error similar to:

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -8,7 +8,9 @@ data:
   vhost.conf: |-
     server {
       listen 8080;
+  {{- if .Values.enableIPv6 }}
       listen [::]:8080;
+  {{- end}}
       server_name _;
 
       gzip on;

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -40,7 +40,9 @@ data:
 
     server {
       listen 8080;
+  {{- if .Values.enableIPv6 }}
       listen [::]:8080;
+  {{- end}}
       server_name _;
 
       location /healthz {

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -16,6 +16,9 @@ useHelm3: false
 ## When set to true, Kubeapps creates a ClusterRole to be able to list namespaces.
 allowNamespaceDiscovery: true
 
+## Enable IPv6 Configuration for Nginx
+enableIPv6: true
+
 ## The frontend service is the main reverse proxy used to access the Kubeapps UI
 ## To expose Kubeapps externally either configure the ingress object below or
 ## set frontend.service.type=LoadBalancer in the frontend configuration.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

After https://github.com/kubeapps/kubeapps/pull/1856/ the installation of Kubeapps will fail if the cluster doesn't support IPv6.
