### PR TITLE
Fix TL;DR typo

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -12,7 +12,7 @@
 - Secure authentication to Kubeapps using an [OAuth2/OIDC provider](https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md)
 - Secure authorization based on Kubernetes [Role-Based Access Control](https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md)
 
-## TL;DR;
+## TL;DR
 
 For Helm 2:
 


### PR DESCRIPTION
A user noticed the typo in https://github.com/bitnami/bitnami-docker-dreamfactory/pull/20. We are fixing it in our READMEs. Anchors shouldn't be affected: `README.md#tldr` it omits the semicolons.