### PR TITLE
Bump chart 3.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,16 +70,13 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      # TODO(andresmgot): Latest release was made on a fork so the current
-      # tests are not fully compatible. Reenable these tests after the next
-      # release.
-      # - GKE_1_15_LATEST_RELEASE:
-      #     <<: *build_on_master
-      #     requires:
-      #       - test_go
-      #       - test_dashboard
-      #       - build_go_images
-      #       - build_dashboard
+      - GKE_1_15_LATEST_RELEASE:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
       - GKE_1_14_MASTER:
           <<: *build_on_master
           requires:
@@ -87,13 +84,13 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      # - GKE_1_14_LATEST_RELEASE:
-      #     <<: *build_on_master
-      #     requires:
-      #       - test_go
-      #       - test_dashboard
-      #       - build_go_images
-      #       - build_dashboard
+      - GKE_1_14_LATEST_RELEASE:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
       - sync_chart:
           <<: *build_on_master
           requires:
@@ -102,9 +99,9 @@ workflows:
             - local_e2e_tests_mongodb_helm2
             - local_e2e_tests_mongodb_helm3
             - GKE_1_15_MASTER
-            # - GKE_1_15_LATEST_RELEASE
+            - GKE_1_15_LATEST_RELEASE
             - GKE_1_14_MASTER
-            # - GKE_1_14_LATEST_RELEASE
+            - GKE_1_14_LATEST_RELEASE
       - push_images:
           <<: *build_on_master
           requires:
@@ -113,9 +110,9 @@ workflows:
             - local_e2e_tests_mongodb_helm2
             - local_e2e_tests_mongodb_helm3
             - GKE_1_15_MASTER
-            # - GKE_1_15_LATEST_RELEASE
+            - GKE_1_15_LATEST_RELEASE
             - GKE_1_14_MASTER
-            # - GKE_1_14_LATEST_RELEASE
+            - GKE_1_14_LATEST_RELEASE
       - release:
           <<: *build_on_tag
           requires:
@@ -124,9 +121,9 @@ workflows:
             - local_e2e_tests_mongodb_helm2
             - local_e2e_tests_mongodb_helm3
             - GKE_1_15_MASTER
-            # - GKE_1_15_LATEST_RELEASE
+            - GKE_1_15_LATEST_RELEASE
             - GKE_1_14_MASTER
-            # - GKE_1_14_LATEST_RELEASE
+            - GKE_1_14_LATEST_RELEASE
 
 ## Definitions
 install_gcloud_sdk: &install_gcloud_sdk
@@ -352,26 +349,26 @@ jobs:
       HELM_VERSION: "v3.0.2"
       GKE_BRANCH: "1.15"
       KUBEAPPS_DB: "postgresql"
-  # GKE_1_15_LATEST_RELEASE:
-  #   <<: *gke_test
-  #   environment:
-  #     HELM_VERSION: "v3.0.2"
-  #     GKE_BRANCH: "1.15"
-  #     KUBEAPPS_DB: "postgresql"
-  #     TEST_LATEST_RELEASE: 1
+  GKE_1_15_LATEST_RELEASE:
+    <<: *gke_test
+    environment:
+      HELM_VERSION: "v3.0.2"
+      GKE_BRANCH: "1.15"
+      KUBEAPPS_DB: "postgresql"
+      TEST_LATEST_RELEASE: 1
   GKE_1_14_MASTER:
     <<: *gke_test
     environment:
       HELM_VERSION: "v3.0.2"
       GKE_BRANCH: "1.14"
       KUBEAPPS_DB: "postgresql"
-  # GKE_1_14_LATEST_RELEASE:
-  #   <<: *gke_test
-  #   environment:
-  #     HELM_VERSION: "v3.0.2"
-  #     GKE_BRANCH: "1.14"
-  #     KUBEAPPS_DB: "postgresql"
-  #     TEST_LATEST_RELEASE: 1
+  GKE_1_14_LATEST_RELEASE:
+    <<: *gke_test
+    environment:
+      HELM_VERSION: "v3.0.2"
+      GKE_BRANCH: "1.14"
+      KUBEAPPS_DB: "postgresql"
+      TEST_LATEST_RELEASE: 1
   sync_chart:
     docker:
       - image: circleci/golang:1.13

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 3.7.4
+version: 3.8.0
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png


### PR DESCRIPTION
### Description of the change

Bumps the chart minor version to trigger a chart release. Also re-enables the latest release test (disabled in #1863).