### PR TITLE
Fix dev additional cluster groups

### DIFF
--- a/docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.json
+++ b/docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.json
@@ -18,7 +18,7 @@
       "group": "kubeadm.k8s.io",
       "version": "v1beta2",
       "kind": "ClusterConfiguration",
-      "patch": "[{ \"op\": \"add\", \"path\": \"/apiServer/extraArgs\", \"value\": {}}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-issuer-url\", \"value\": \"https://172.18.0.2:32000\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-client-id\", \"value\": \"kubeapps\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-ca-file\", \"value\": \"/etc/ssl/certs/dex.crt\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-username-claim\", \"value\": \"email\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-username-prefix\",\"value\": \"oidc:\"}]"
+      "patch": "[{ \"op\": \"add\", \"path\": \"/apiServer/extraArgs\", \"value\": {}}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-issuer-url\", \"value\": \"https://172.18.0.2:32000\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-client-id\", \"value\": \"kubeapps\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-ca-file\", \"value\": \"/etc/ssl/certs/dex.crt\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-username-claim\", \"value\": \"email\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-username-prefix\",\"value\": \"oidc:\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-groups-claim\", \"value\": \"groups\"}, {\"op\": \"add\", \"path\": \"/apiServer/extraArgs/oidc-groups-prefix\",\"value\": \"oidc:\"}]"
     }
   ]
 }

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -9,7 +9,7 @@ deploy-dex: devel/dex.crt devel/dex.key
 	kubectl -n dex create secret tls dex-web-server-tls \
 		--key ./devel/dex.key \
 		--cert ./devel/dex.crt
-	helm install dex stable/dex --namespace dex --version 2.4.0 \
+	helm install dex stable/dex --namespace dex --version 2.13.0 \
 		--values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
 
 deploy-openldap:


### PR DESCRIPTION
### Description of the change

While testing last week I'd noticed I was unable to use group RBAC (via an LDAP login) to authenticate with the additional cluster in my dev env, though it worked fine for the main cluster.

Checked now to find it was just missing oidc config for the additional cluster.

Also upgraded the dex chart to the latest stable.

### Applicable issues
  - fixes #1896 