### PR TITLE
Remove stable, svc-cat and incubator from default app repositories.

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -224,12 +224,6 @@ apprepository:
   ## Initial chart repositories to configure
   ##
   initialRepos:
-    - name: stable
-      url: https://kubernetes-charts.storage.googleapis.com
-    - name: incubator
-      url: https://kubernetes-charts-incubator.storage.googleapis.com
-    - name: svc-cat
-      url: https://svc-catalog-charts.storage.googleapis.com
     - name: bitnami
       url: https://charts.bitnami.com/bitnami
   # Additional repositories


### PR DESCRIPTION
### Description of the change

Removes stable and incubator from the default app repositories since they will cease to be included in helm-hub and helm2 charts no longer being updated / maintained. 

I've also removed the `svc-cat` repo from the default values, as it is applicable for service catalog functionality only and can be enabled as required.

### Benefits

We don't advertise stale charts in the Kubeapps UI by default.

### Possible drawbacks

We don't advertise charts people are used to seeing - but they can be configured and bitnami will begin to publish some that were only available in stable (I hope?)
