### PR TITLE
Ensure chart will not render if additional clusters configured without oidc

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -41,7 +41,7 @@ data:
     {
       "namespace": "{{ .Release.Namespace }}",
       "appVersion": "{{ .Chart.AppVersion }}",
-      "authProxyEnabled": {{ .Values.authProxy.enabled }},
+      "authProxyEnabled": {{ or .Values.authProxy.enabled .Values.authProxy.externallyEnabled }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},
       "featureFlags": {{ .Values.featureFlags | toJson }}

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -83,6 +83,8 @@ spec:
           {{- if .Values.authProxy.resources }}
           resources: {{- toYaml .Values.authProxy.resources | nindent 12 }}
           {{- end }}
+        {{- else }}
+          {{- if .Values.featureFlags.additionalClusters }}{{ fail "additionalClusters can be configured only when using the authProxy for oidc authentication."}}{{ end -}}
         {{- end }}
       volumes:
         - name: vhost

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -84,7 +84,9 @@ spec:
           resources: {{- toYaml .Values.authProxy.resources | nindent 12 }}
           {{- end }}
         {{- else }}
-          {{- if .Values.featureFlags.additionalClusters }}{{ fail "additionalClusters can be configured only when using the authProxy for oidc authentication."}}{{ end -}}
+          {{- if and .Values.featureFlags.additionalClusters (not .Values.authProxy.externallyEnabled) }}
+            {{ fail "additionalClusters can be configured only when using an authenticate proxy for cluster oidc authentication."}}
+          {{ end -}}
         {{- end }}
       volumes:
         - name: vhost

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -644,6 +644,9 @@ testImage:
 authProxy:
   # Set to true to enable the OIDC proxy
   enabled: false
+  # Set to true if an external auth proxy is setup to provide cookie authentication
+  # at the oauthLoginURI and oauthLogoutURI values below.
+  externallyEnabled: false
   ## Bitnami OAuth2 Proxy image
   ## ref: https://hub.docker.com/r/bitnami/oauth2-proxy/tags/
   ##


### PR DESCRIPTION
### Description of the change

Ensures that the chart won't render if additional clusters are configured but the oidc auth proxy is not configured.

If people use an externally configured auth proxy, we also want to enable configuring additional clusters.

Note that since we switched to oauth2-proxy (well, in particular, started supporting http-only cookies for auth), people have experienced issues with using an external auth proxy, as the frontend assumed cookie authn iff `.Values.authProxy.enabled` (see #1579). The new `.Values.authProxy.externallyEnabled` means we can trivially fix that in the frontend also, as done below.

So, configuring additional clusters but not using oidc fails:
```
$ helm install kubeapps ./chart/kubeapps --namespace kubeapps --values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml --set useHelm3=true

Error: template: kubeapps/templates/kubeapps-frontend-deployment.yaml:88:15: executing "kubeapps/templates/kubeapps-frontend-deployment.yaml" at <fail "additionalClusters can be configured only when using an authenticate proxy for cluster oidc authentication.">: error calling fail: additionalClusters can be configured only when using an authenticate proxy for cluster oidc authentication.
```

Install works fine with the `make deploy-dev` target that configures the internal oauth2-proxy running on the frontend. Additionally, the new `authProxy.externallyEnabled` value will also enable additional clusters:

```
$ helm install kubeapps ./chart/kubeapps --namespace kubeapps --values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml --set useHelm3=true --set authProxy.externallyEnabled=true
...
(install works fine and login page assumes the oauth redirect urls as expe8cted)

```

### Benefits

We can now ensure people don't install Kubeapps with multi-cluster configured without an auth proxy.

Also, people can now use an external auth proxy without manual updating of config maps.

### Possible drawbacks


### Applicable issues

  - fixes #1917 
  - fixes #1579 

### Additional information

