### PR TITLE
Ensure service brokers are default cluster only

### DIFF
--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -131,7 +131,7 @@ describe("AppRepoList", () => {
     const wrapper = shallow(<AppRepoList {...props} />);
 
     const msgAlert = wrapper.find(MessageAlert);
-    expect(msgAlert.length).toBe(1);
+    expect(msgAlert).toExist();
     expect(msgAlert.prop("header")).toEqual(
       "AppRepositories can be created on the default cluster only",
     );

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -133,7 +133,7 @@ describe("AppRepoList", () => {
     const msgAlert = wrapper.find(MessageAlert);
     expect(msgAlert.length).toBe(1);
     expect(msgAlert.prop("header")).toEqual(
-      "AppRepositories are available on the default cluster only",
+      "AppRepositories can be created on the default cluster only",
     );
     const addButton = wrapper.find("AppRepoAddButton");
     expect(addButton.length).toBe(0);

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -145,7 +145,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
             <p className="margin-v-normal">
               You cannot currently create an app repository on an additional cluster, but you can
               create an app repository with charts available for installation across clusters and
-              namespaces in the
+              namespaces in the{" "}
               <Link to={url.app.config.apprepositories("default", definedNamespaces.all)}>
                 default cluster's app repository listing for all namespaces
               </Link>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
+import { Link } from "react-router-dom";
 
+import * as url from "shared/url";
 import { definedNamespaces } from "../../../shared/Namespace";
 import { IAppRepository, IAppRepositoryKey, IRBACRole, ISecret } from "../../../shared/types";
 import { ErrorSelector, MessageAlert } from "../../ErrorAlert";
@@ -134,18 +136,20 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
     // We do not currently support app repositories on additional clusters.
     if (cluster !== "default") {
       return (
-        <MessageAlert header="AppRepositories are available on the default cluster only">
+        <MessageAlert header="AppRepositories can be created on the default cluster only">
           <div>
             <p className="margin-v-normal">
-              Currently the multi-cluster support in Kubeapps supports AppRepositories on the
-              default cluster only.
+              Kubeapps' multi-cluster support currently enables creation of custom app repositories
+              on the default cluster only.
             </p>
             <p className="margin-v-normal">
-              The catalog of charts from AppRepositories on the default cluster which are available
-              for all namespaces will be avaialble on additional clusters also, but you can not
-              currently create a private AppRepository for a particular namespace of an additional
-              cluster. We may in the future support AppRepositories on additional clusters but for
-              now you will need to switch back to your default cluster.
+              You cannot currently create an app repository on an additional cluster, but you can
+              create an app repository with charts available for installation across clusters and
+              namespaces in the
+              <Link to={url.app.config.apprepositories("default", definedNamespaces.all)}>
+                default cluster's app repository listing for all namespaces
+              </Link>
+              .
             </p>
           </div>
         </MessageAlert>

--- a/dashboard/src/components/Config/ServiceBrokerList/ServiceBrokerList.test.tsx
+++ b/dashboard/src/components/Config/ServiceBrokerList/ServiceBrokerList.test.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import ServiceBrokerList from ".";
 import {
   ErrorSelector,
+  MessageAlert,
   ServiceBrokersNotFoundAlert,
   ServiceCatalogNotInstalledAlert,
 } from "../../../components/ErrorAlert";
@@ -19,6 +20,7 @@ let defaultProps = {
   errors: {},
   checkCatalogInstalled: jest.fn(),
   isInstalled: true,
+  cluster: "default",
 };
 
 beforeEach(() => {
@@ -30,6 +32,7 @@ beforeEach(() => {
     errors: {},
     checkCatalogInstalled: jest.fn(),
     isInstalled: true,
+    cluster: "default",
   };
 });
 
@@ -49,6 +52,18 @@ context("if the service broker is not installed", () => {
     const wrapper = shallow(<ServiceBrokerList {...props} />);
     expect(wrapper.find(ServiceCatalogNotInstalledAlert)).toExist();
     expect(wrapper).toMatchSnapshot();
+  });
+});
+
+context("if the service brokers are accessed on an additional cluster", () => {
+  it("shows an alert with info", () => {
+    const props = { ...defaultProps, cluster: "other-cluster" };
+    const wrapper = shallow(<ServiceBrokerList {...props} />);
+    const msgAlert = wrapper.find(MessageAlert);
+    expect(msgAlert).toExist();
+    expect(msgAlert.prop("header")).toEqual(
+      "Service brokers can be created on the default cluster only",
+    );
   });
 });
 

--- a/dashboard/src/components/Config/ServiceBrokerList/ServiceBrokerList.test.tsx
+++ b/dashboard/src/components/Config/ServiceBrokerList/ServiceBrokerList.test.tsx
@@ -65,6 +65,12 @@ context("if the service brokers are accessed on an additional cluster", () => {
       "Service brokers can be created on the default cluster only",
     );
   });
+
+  it("does not show an alert with info on the default cluster", () => {
+    const wrapper = shallow(<ServiceBrokerList {...defaultProps} />);
+    const msgAlert = wrapper.find(MessageAlert);
+    expect(msgAlert).not.toExist();
+  });
 });
 
 context("while fetching brokers", () => {

--- a/dashboard/src/components/Config/ServiceBrokerList/__snapshots__/ServiceBrokerList.test.tsx.snap
+++ b/dashboard/src/components/Config/ServiceBrokerList/__snapshots__/ServiceBrokerList.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`when all the brokers are loaded shows a forbiden (resync) error if it e
       ],
     }
   }
+  cluster="default"
   errors={
     Object {
       "update": [Error],
@@ -344,6 +345,7 @@ exports[`when all the brokers are loaded shows a warning to install no service b
       ],
     }
   }
+  cluster="default"
   errors={Object {}}
   getBrokers={
     [MockFunction] {

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -54,7 +54,7 @@ describe("settings", () => {
     const items = settingsbar.find("NavLink").map(p => p.props());
     const expectedItems = [
       { children: "App Repositories", to: "/c/default/ns/default/config/repos" },
-      { children: "Service Brokers", to: "/config/brokers" },
+      { children: "Service Brokers", to: "/c/default/config/brokers" },
     ];
     items.forEach((item, index) => {
       expect(item.children).toBe(expectedItems[index].children);
@@ -70,7 +70,7 @@ describe("settings", () => {
     const items = settingsbar.find("NavLink").map(p => p.props());
     const expectedItems = [
       { children: "App Repositories", to: "/c/default/ns/default/config/repos" },
-      { children: "Service Brokers", to: "/config/brokers" },
+      { children: "Service Brokers", to: "/c/default/config/brokers" },
       { children: "Operators", to: "/ns/default/operators" },
     ];
     items.forEach((item, index) => {

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -139,7 +139,9 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                         <NavLink to={reposPath}>App Repositories</NavLink>
                       </li>
                       <li role="none">
-                        <NavLink to="/config/brokers">Service Brokers</NavLink>
+                        <NavLink to={app.config.brokers(clusters.currentCluster)}>
+                          Service Brokers
+                        </NavLink>
                       </li>
                       {this.props.featureFlags.operators && (
                         <li role="none">

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -38,7 +38,7 @@ const privateRoutes = {
   "/c/:cluster/ns/:namespace/:global(global)-charts/:repo/:id": ChartViewContainer,
   "/c/:cluster/ns/:namespace/charts/:repo/:id/versions/:version": ChartViewContainer,
   "/c/:cluster/ns/:namespace/:global(global)-charts/:repo/:id/versions/:version": ChartViewContainer,
-  "/config/brokers": ServiceBrokerListContainer,
+  "/c/:cluster/config/brokers": ServiceBrokerListContainer,
   "/services/brokers/:brokerName/classes/:className": ServiceClassViewContainer,
   "/services/brokers/:brokerName/instances/ns/:namespace/:instanceName": ServiceInstanceViewContainer,
   "/services/classes": ServiceClassListContainer,

--- a/dashboard/src/containers/ServiceBrokerListContainer/ServiceBrokerListContainer.ts
+++ b/dashboard/src/containers/ServiceBrokerListContainer/ServiceBrokerListContainer.ts
@@ -7,11 +7,12 @@ import ServiceBrokerList from "../../components/Config/ServiceBrokerList";
 import { IServiceBroker } from "../../shared/ServiceCatalog";
 import { IStoreState } from "../../shared/types";
 
-function mapStateToProps({ catalog }: IStoreState) {
+function mapStateToProps({ catalog, clusters }: IStoreState) {
   return {
     brokers: catalog.brokers,
     errors: catalog.errors,
     isInstalled: catalog.isServiceCatalogInstalled,
+    cluster: clusters.currentCluster,
   };
 }
 

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -13,8 +13,8 @@ describe("clusterReducer", () => {
     currentCluster: "initial-cluster",
     clusters: {
       default: {
-        currentNamespace: "default",
-        namespaces: ["default"],
+        currentNamespace: "initial-namespace",
+        namespaces: ["default", "initial-namespace"],
       },
       "initial-cluster": {
         currentNamespace: "initial-namespace",
@@ -32,29 +32,32 @@ describe("clusterReducer", () => {
     describe("changes the current stored namespace if it is in the URL", () => {
       const testCases = [
         {
+          name: "updates both the cluster and namespace",
           path: "/c/default/ns/cyberdyne/apps",
           currentNamespace: "cyberdyne",
           currentCluster: "default",
         },
         {
+          name: "does not change cluster or namespace when neither is in url",
           path: "/cyberdyne/apps",
           currentNamespace: "initial-namespace",
           currentCluster: "initial-cluster",
         },
         {
-          path: "/c/barcluster/ns/T-600/charts",
-          currentNamespace: "T-600",
-          currentCluster: "barcluster",
-        },
-        {
-          // It still updates the current namespace for a non-multicluster route.
+          name: "updates namespace for a non-multicluster URI",
           path: "/ns/default/operators",
           currentNamespace: "default",
           currentCluster: "initial-cluster",
         },
+        {
+          name: "updates cluster for a non-namespaced URI",
+          path: "/c/default/config/brokers",
+          currentNamespace: "initial-namespace",
+          currentCluster: "default",
+        },
       ];
       testCases.forEach(tc => {
-        it(tc.path, () =>
+        it(tc.name, () =>
           expect(
             clusterReducer(initialTestState, {
               type: LOCATION_CHANGE,

--- a/dashboard/src/reducers/cluster.ts
+++ b/dashboard/src/reducers/cluster.ts
@@ -108,10 +108,12 @@ const clusterReducer = (
       };
     case LOCATION_CHANGE:
       const pathname = action.payload.location.pathname;
-      // looks for /c/:cluster/ns/:namespace/ in URL
-      const matches = pathname.match(/\/c\/([^/]*)\/ns\/([^/]*)/);
-      if (matches) {
-        const [currentCluster, currentNamespace] = [matches[1], matches[2]];
+      // looks for either or both of /c/:cluster and /ns/:namespace in URL
+      const matches = pathname.match(/(?:\/c\/(?<cluster>[^/]*))?(?:\/ns\/(?<namespace>[^/]*))?/);
+      if (matches && matches.groups) {
+        let [currentCluster, currentNamespace] = [matches.groups.cluster, matches.groups.namespace];
+        currentCluster = currentCluster || state.currentCluster;
+        currentNamespace = currentNamespace || state.clusters[currentCluster].currentNamespace;
         return {
           ...state,
           currentCluster,
@@ -123,23 +125,6 @@ const clusterReducer = (
             },
           },
         };
-      } else {
-        // Default to previous behaviour for non-clustered routes.
-        // Looks for /ns/:namespace/ in URL
-        const matchesNSOnly = pathname.match(/\/ns\/([^/]*)/);
-        if (matchesNSOnly) {
-          const currentNamespace = matchesNSOnly[1];
-          return {
-            ...state,
-            clusters: {
-              ...state.clusters,
-              [state.currentCluster]: {
-                ...state.clusters[state.currentCluster],
-                currentNamespace,
-              },
-            },
-          };
-        }
       }
       break;
     case getType(actions.auth.setAuthenticated):

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -47,6 +47,7 @@ export const app = {
   config: {
     apprepositories: (cluster: string, namespace: string) =>
       `/c/${cluster}/ns/${namespace}/config/repos`,
+    brokers: (cluster: string) => `/c/${cluster}/config/brokers`,
     operators: (namespace: string) => `/ns/${namespace}/operators`,
   },
 };


### PR DESCRIPTION
### Description of the change

Updates the service broker configuration to be clear its only supported on the default cluster:

![1894-service-brokers](https://user-images.githubusercontent.com/497518/89600692-fb90dd80-d8a5-11ea-9691-823588f49c53.png)

While there, also included a commit addressing the [feedback from Andres](https://github.com/kubeapps/kubeapps/pull/1897#issuecomment-666983924) from the similar app repository info

![1894-app-repositories](https://user-images.githubusercontent.com/497518/89600713-09def980-d8a6-11ea-8ea8-da039d651bda.png)


### Benefits

Users who switch clusters when viewing the service broker config won't mistakenly think it's supported there.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref #1894 