### PR TITLE
Only show the Service Instances menu if the broker is configured.

### DIFF
--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -25,9 +25,29 @@ const defaultProps = {
   getNamespace: jest.fn(),
   featureFlags: { operators: false, additionalClusters: [], ui: "hex" },
   appVersion: "",
+  isServiceCatalogInstalled: false,
 };
 it("renders the header links and titles", () => {
   const wrapper = shallow(<Header {...defaultProps} />);
+  const menubar = wrapper.find(".header__nav__menu").first();
+  const items = menubar.children().map(p => p.props().children.props);
+  const expectedItems = [
+    { children: "Applications", to: app.apps.list("default", "default") },
+    { children: "Catalog", to: app.catalog("default", "default") },
+  ];
+  expect(items.length).toEqual(expectedItems.length);
+  expectedItems.forEach((expectedItem, index) => {
+    expect(expectedItem.children).toBe(items[index].children);
+    expect(expectedItem.to).toBe(items[index].to);
+  });
+});
+
+it("includes the service instances when the broker is installed", () => {
+  const props = {
+    ...defaultProps,
+    isServiceCatalogInstalled: true,
+  };
+  const wrapper = shallow(<Header {...props} />);
   const menubar = wrapper.find(".header__nav__menu").first();
   const items = menubar.children().map(p => p.props().children.props);
   const expectedItems = [

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -25,6 +25,7 @@ export interface IHeaderProps {
   createNamespace: (cluster: string, ns: string) => Promise<boolean>;
   getNamespace: (cluster: string, ns: string) => void;
   featureFlags: IFeatureFlags;
+  isServiceCatalogInstalled: boolean;
 }
 
 interface IHeaderState {
@@ -59,6 +60,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
       authenticated: showNav,
       createNamespace,
       getNamespace,
+      isServiceCatalogInstalled,
     } = this.props;
     const showClusterSelector = Object.keys(clusters.clusters).length > 1;
     const cluster = clusters.clusters[clusters.currentCluster];
@@ -104,11 +106,13 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
                       Catalog
                     </HeaderLink>
                   </li>
-                  <li>
-                    <HeaderLink to={app.servicesInstances(cluster.currentNamespace)}>
-                      Service Instances (alpha)
-                    </HeaderLink>
-                  </li>
+                  {isServiceCatalogInstalled && (
+                    <li>
+                      <HeaderLink to={app.servicesInstances(cluster.currentNamespace)}>
+                        Service Instances (alpha)
+                      </HeaderLink>
+                    </li>
+                  )}
                 </ul>
               </nav>
             )}

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.test.tsx
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.test.tsx
@@ -27,6 +27,7 @@ const defaultState = {
   config: {
     featureFlags: { operators: true, additionalClusters: [], ui: "hex" },
   },
+  catalog: { isServiceCatalogInstalled: false },
   clusters: {
     currentCluster: "default",
     clusters: {

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -14,6 +14,7 @@ function mapStateToProps({
     location: { pathname },
   },
   config: { featureFlags, appVersion },
+  catalog: { isServiceCatalogInstalled },
 }: IStoreState) {
   return {
     authenticated,
@@ -23,6 +24,7 @@ function mapStateToProps({
     featureFlags,
     UI: featureFlags.ui,
     appVersion,
+    isServiceCatalogInstalled,
   };
 }
 


### PR DESCRIPTION

### Description of the change

Updates the main menu to display the Service Instances (alpha?!) menu item only if a broker has been configured.

I think this option won't even be visible in the new UI. I'm only doing this here so that I don't need to make all the routes for service instances cluster aware, plus we had a recent request along these lines on the related issue (and it'll be a few weeks yet before the new UI is complete).

### Benefits

Users don't see a useless menu entry when service brokers have not even been configured.

### Applicable issues

  - fixes #605 

