### PR TITLE
Update the login URL to be cluster aware.

### DIFF
--- a/dashboard/src/components/PrivateRoute/PrivateRoute.test.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.test.tsx
@@ -28,6 +28,7 @@ it("redirects to the /login route if not authenticated", () => {
     <PrivateRoute
       sessionExpired={false}
       authenticated={false}
+      cluster="my-cluster"
       path="/test"
       component={MockComponent}
       {...emptyRouteComponentProps}
@@ -37,7 +38,7 @@ it("redirects to the /login route if not authenticated", () => {
   const wrapper2 = shallow(<RenderMethod {...emptyRouteComponentProps} />);
   expect(wrapper2.find(Redirect).exists()).toBe(true);
   expect(wrapper2.find(Redirect).props()).toMatchObject({
-    to: { pathname: "/login" },
+    to: { pathname: "/c/my-cluster/login" },
   } as any);
 });
 
@@ -46,6 +47,7 @@ it("renders the given component when authenticated", () => {
     <PrivateRoute
       sessionExpired={false}
       authenticated={true}
+      cluster="default"
       path="/test"
       component={MockComponent}
       {...emptyRouteComponentProps}
@@ -58,7 +60,12 @@ it("renders the given component when authenticated", () => {
 
 it("renders modal to reload the page if the session is expired", () => {
   const wrapper = shallow(
-    <PrivateRoute sessionExpired={true} authenticated={false} {...emptyRouteComponentProps} />,
+    <PrivateRoute
+      sessionExpired={true}
+      authenticated={false}
+      cluster="default"
+      {...emptyRouteComponentProps}
+    />,
   );
   const renderization: JSX.Element = wrapper.prop("render")();
   expect(renderization.type.toString()).toContain("Modal");

--- a/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/dashboard/src/components/PrivateRoute/PrivateRoute.tsx
@@ -2,11 +2,14 @@ import * as React from "react";
 import Modal from "react-modal";
 import { Redirect, Route, RouteComponentProps, RouteProps } from "react-router";
 
+import * as url from "shared/url";
+
 type IRouteComponentPropsAndRouteProps = RouteProps & RouteComponentProps<any>;
 
 interface IPrivateRouteProps extends IRouteComponentPropsAndRouteProps {
   authenticated: boolean;
   sessionExpired: boolean;
+  cluster: string;
 }
 
 class PrivateRoute extends React.Component<IPrivateRouteProps> {
@@ -36,7 +39,11 @@ class PrivateRoute extends React.Component<IPrivateRouteProps> {
         </Modal>
       );
     }
-    return <Redirect to={{ pathname: "/login", state: { from: props.location } }} />;
+    return (
+      <Redirect
+        to={{ pathname: url.app.login(this.props.cluster), state: { from: props.location } }}
+      />
+    );
   };
 
   private reload() {

--- a/dashboard/src/containers/PrivateRouteContainer/PrivateRouteContainer.ts
+++ b/dashboard/src/containers/PrivateRouteContainer/PrivateRouteContainer.ts
@@ -6,11 +6,13 @@ import { IStoreState } from "../../shared/types";
 
 function mapStateToProps({
   auth: { authenticated, oidcAuthenticated, sessionExpired },
+  clusters: { currentCluster },
 }: IStoreState) {
   return {
     sessionExpired,
     authenticated,
     oidcAuthenticated,
+    cluster: currentCluster,
   };
 }
 

--- a/dashboard/src/containers/RoutesContainer/Routes.test.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.test.tsx
@@ -65,7 +65,7 @@ it("should render a redirect to the login page", () => {
     </StaticRouter>,
   );
   expect(wrapper.find(NotFound)).not.toExist();
-  expect(wrapper.find(Redirect).prop("to")).toEqual("/login");
+  expect(wrapper.find(Redirect).prop("to")).toEqual("/c/default/login");
 });
 
 it("should render a redirect to the login page (when not authenticated)", () => {
@@ -80,5 +80,5 @@ it("should render a redirect to the login page (when not authenticated)", () => 
     </StaticRouter>,
   );
   expect(wrapper.find(NotFound)).not.toExist();
-  expect(wrapper.find(Redirect).prop("to")).toEqual("/login");
+  expect(wrapper.find(Redirect).prop("to")).toEqual("/c/default/login");
 });

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -47,7 +47,7 @@ const privateRoutes = {
 
 // Public routes that don't require authentication
 const routes = {
-  "/login": LoginFormContainer,
+  "/c/:cluster/login": LoginFormContainer,
 } as const;
 
 interface IRoutesProps extends IRouteComponentPropsAndRouteProps {
@@ -99,7 +99,7 @@ class Routes extends React.Component<IRoutesProps> {
       return <Redirect to={app.apps.list(this.props.cluster, this.props.namespace)} />;
     }
     // There is not a default namespace, redirect to login page
-    return <Redirect to={"/login"} />;
+    return <Redirect to={app.login(this.props.cluster)} />;
   };
 }
 

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -52,6 +52,7 @@ export const app = {
     brokers: (cluster: string) => `/c/${cluster}/config/brokers`,
     operators: (cluster: string, namespace: string) => `/c/${cluster}/ns/${namespace}/operators`,
   },
+  login: (cluster: string) => `/c/${cluster}/login`,
 };
 
 function withNS(namespace: string) {

--- a/integration/use-cases/default-deployment.js
+++ b/integration/use-cases/default-deployment.js
@@ -1,5 +1,5 @@
 test("Deploys an application with the values by default", async () => {
-  await page.goto(getUrl("/#/login"));
+  await page.goto(getUrl("/#/c/default/login"));
 
   await expect(page).toFillForm("form", {
     token: process.env.ADMIN_TOKEN,

--- a/integration/use-cases/missing-permissions.js
+++ b/integration/use-cases/missing-permissions.js
@@ -1,5 +1,5 @@
 test("Fails to deploy an application due to missing permissions", async () => {
-  await page.goto(getUrl("/#/login"));
+  await page.goto(getUrl("/#/c/default/login"));
 
   await expect(page).toFillForm("form", {
     token: process.env.VIEW_TOKEN,

--- a/integration/use-cases/upgrade.js
+++ b/integration/use-cases/upgrade.js
@@ -1,5 +1,5 @@
 test("Upgrades an application", async () => {
-  await page.goto(getUrl("/#/login"));
+  await page.goto(getUrl("/#/c/default/login"));
 
   await expect(page).toFillForm("form", {
     token: process.env.EDIT_TOKEN


### PR DESCRIPTION
### Description of the change

Updates the login URL to be cluster aware.

### Benefits

Some multicluster setups configure different `--oidc-client-id`'s per cluster, so the URL for login needs to include the cluster to know which configuration to use when authenticating. 

This should not affect the generic multi-cluster setup where a single client id is used for the cluster api servers.

### Applicable issues

  - Ref #1933 