### PR TITLE
Switch the default for IPv6 support to false.

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -200,7 +200,7 @@ kubectl delete namespace kubeapps
 
 ### Nginx Ipv6 error
 
-When starting the application, the Nginx server present in the services `kubeapps` and `kubeapps-internal-dashboard` may fail with the following:
+When starting the application with the `--set enableIPv6=true` option, the Nginx server present in the services `kubeapps` and `kubeapps-internal-dashboard` may fail with the following:
 
 ```
 nginx: [emerg] socket() [::]:8080 failed (97: Address family not supported by protocol)

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -17,7 +17,7 @@ useHelm3: false
 allowNamespaceDiscovery: true
 
 ## Enable IPv6 Configuration for Nginx
-enableIPv6: true
+enableIPv6: false
 
 ## The frontend service is the main reverse proxy used to access the Kubeapps UI
 ## To expose Kubeapps externally either configure the ingress object below or


### PR DESCRIPTION
In  #1910 this flag was added but defaulting to true. This has caught out a number of people as [dual stack IPv4/IPv6 is still alpha in kubernetes](https://kubernetes.io/docs/concepts/services-networking/dual-stack/), and not supported on some standard cluster setups (eg. Tanzu Kubernetes Grid).