### PR TITLE
Improve wording and semantics for external oauth proxy support.

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -41,7 +41,7 @@ data:
     {
       "namespace": "{{ .Release.Namespace }}",
       "appVersion": "{{ .Chart.AppVersion }}",
-      "authProxyEnabled": {{ or .Values.authProxy.enabled .Values.externalAuthProxy }},
+      "authProxyEnabled": {{ .Values.authProxy.enabled }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},
       "featureFlags": {{ .Values.featureFlags | toJson }},

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -41,7 +41,7 @@ data:
     {
       "namespace": "{{ .Release.Namespace }}",
       "appVersion": "{{ .Chart.AppVersion }}",
-      "authProxyEnabled": {{ or .Values.authProxy.enabled .Values.authProxy.externallyEnabled }},
+      "authProxyEnabled": {{ or .Values.authProxy.enabled .Values.externalAuthProxy }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},
       "featureFlags": {{ .Values.featureFlags | toJson }},

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -54,7 +54,7 @@ spec:
           {{- if .Values.frontend.resources }}
           resources: {{- toYaml .Values.frontend.resources | nindent 12 }}
           {{- end }}
-        {{- if .Values.authProxy.enabled }}
+        {{- if and .Values.authProxy.enabled (not .Values.authProxy.external) }}
         - name: auth-proxy
           args:
             - --provider={{ required "You must fill \".Values.authProxy.provider\" with the provider. Valid values at https://pusher.github.io/oauth2_proxy/auth-configuration" .Values.authProxy.provider }}
@@ -83,10 +83,9 @@ spec:
           {{- if .Values.authProxy.resources }}
           resources: {{- toYaml .Values.authProxy.resources | nindent 12 }}
           {{- end }}
-        {{- else }}
-          {{- if and .Values.clusters (not .Values.authProxy.externallyEnabled) }}
-            {{ fail "clusters can be configured only when using an auth proxy for cluster oidc authentication."}}
-          {{ end -}}
+        {{- end }}
+        {{- if and (gt (len .Values.clusters) 0) (not .Values.authProxy.enabled) }}
+          {{ fail "clusters can be configured only when using an auth proxy for cluster oidc authentication."}}
         {{- end }}
       volumes:
         - name: vhost

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -654,14 +654,17 @@ testImage:
   repository: bitnami/nginx
   tag: 1.19.1-debian-10-r16
 
-# Auth Proxy for OIDC support
+# An internal Auth Proxy for OIDC support
 # ref: https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md
 authProxy:
-  # Set to true to enable the OIDC proxy
+  ## Set to true to enable Kubeapps to include an OIDC proxy as part of the Kubeapps frontend deployment.
+  #
   enabled: false
-  # Set to true if an external auth proxy is setup to provide cookie authentication
-  # at the oauthLoginURI and oauthLogoutURI values below.
-  externallyEnabled: false
+  ## Overridable flags for OAuth URIs to which the Kubeapps frontend redirects for authn.
+  ## Useful when serving Kubeapps under a sub path or using an external auth proxy.
+  ##
+  oauthLoginURI: /oauth2/start
+  oauthLogoutURI: /oauth2/sign_out
   ## Bitnami OAuth2 Proxy image
   ## ref: https://hub.docker.com/r/bitnami/oauth2-proxy/tags/
   ##
@@ -674,7 +677,7 @@ authProxy:
     ##
     pullPolicy: IfNotPresent
 
-  ## Mandatory parameters
+  ## Mandatory parameters for the internal auth-proxy.
   ##
   provider: ""
   clientID: ""
@@ -697,11 +700,6 @@ authProxy:
   ## OAuth2 Proxy containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  ## Overridable flags for OAuth URIs that Kubeapps uses, useful when serving
-  ## Kubeapps under a sub path
-  oauthLoginURI: /oauth2/start
-  oauthLogoutURI: /oauth2/sign_out
-  ##
   resources:
     ## Default values set based on usage data from running Kubeapps instances
     ## ref: https://github.com/kubeapps/kubeapps/issues/478#issuecomment-422979262
@@ -712,6 +710,12 @@ authProxy:
     requests:
       cpu: 25m
       memory: 32Mi
+## Set to true if an external auth proxy has been manually configured to
+## provide OIDC authentication. The chart will then ensure the dashboard
+## uses the configured OAuth login/logout URIs.
+#
+externalAuthProxy: false
+
 ## Feature flags
 ## These are used to switch on in development features or new features which are ready to be released.
 featureFlags:

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -654,17 +654,25 @@ testImage:
   repository: bitnami/nginx
   tag: 1.19.1-debian-10-r16
 
-# An internal Auth Proxy for OIDC support
+# Auth Proxy configuration for OIDC support
 # ref: https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md
 authProxy:
-  ## Set to true to enable Kubeapps to include an OIDC proxy as part of the Kubeapps frontend deployment.
+  ## Set to true if Kubeapps should configure the OAuth login/logout URIs defined below.
   #
   enabled: false
+  ## When authProxy.enabled is true, by default Kubeapps will deploy its own
+  ## auth-proxy service as part of the Kubeapps frontend. Set external to true
+  ## if you are configuring your own auth proxy service external to Kubeapps
+  ## and therefore don't want Kubeapps to deploy its own auth-proxy.
+  #
+  external: false
   ## Overridable flags for OAuth URIs to which the Kubeapps frontend redirects for authn.
   ## Useful when serving Kubeapps under a sub path or using an external auth proxy.
   ##
   oauthLoginURI: /oauth2/start
   oauthLogoutURI: /oauth2/sign_out
+  ## The remaining auth proxy values are relevant only if an internal auth-proxy is
+  ## being configured by Kubeapps.
   ## Bitnami OAuth2 Proxy image
   ## ref: https://hub.docker.com/r/bitnami/oauth2-proxy/tags/
   ##
@@ -710,11 +718,6 @@ authProxy:
     requests:
       cpu: 25m
       memory: 32Mi
-## Set to true if an external auth proxy has been manually configured to
-## provide OIDC authentication. The chart will then ensure the dashboard
-## uses the configured OAuth login/logout URIs.
-#
-externalAuthProxy: false
 
 ## Feature flags
 ## These are used to switch on in development features or new features which are ready to be released.


### PR DESCRIPTION
### Description of the change

On #1926 Andres mentioned:

> the comment's are not that clear, people may enable both `authProxy.enabled` and `authProxy.externallyEnabled` (mostly because we don't say anything about not setting `enabled` to true). I think the UX would be better if the params are:
> 
> ```
> enabled: false
> deployOauth2Proxy: true
> ```
> 
> so if people want to use their own auth proxy they disable that. WDYT?

I think in both my original PR and your suggestion above, the confusion is that it becomes ambiguous exactly what the `authProxy` section of the values is controlling (an init container resource? enabling an externally defined auth proxy? configuring oauth login/logout URIs for the dashboard?). And it's hard to find a way which doesn't have some ambiguity without breaking the existing options. If we were starting from scratch, I'd decouple the dashboard configuration from any auth proxy deployment config, but we don't have that option, so what I've suggested here is to at least decouple the internal authProxy configuration from the option for an external auth proxy, and updated the comments to be clearer. 

See what you think. As above, if we were breaking existing options, I'd also move the `authProxy,oauth{Login|Logout}URI`s into the `dashboard: ` config. Hopefully this should be clearer that you either use the internal authProxy or indicate you're using an external one. I can add a condition so it fails if you set both to true, but I'm not sure that's necessary or a good idea (imagining a scenario where Kubeapps is exposed via two networks, one internal, one external with ingress - using different clients of the same auth provider or some bizarre setup).