### PR TITLE
Remove broken link.

### DIFF
--- a/dashboard/src/components/ErrorAlert/ServiceCatalogNotInstalledAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/ServiceCatalogNotInstalledAlert.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { Link } from "react-router-dom";
 
 import NotFoundErrorAlert from "./NotFoundErrorAlert";
 
@@ -19,9 +18,6 @@ class ServiceCatalogNotInstalledAlert extends React.Component {
             </a>{" "}
             to browse, provision and manage external services within Kubeapps.
           </p>
-          <Link className="button button-primary button-small" to={"/charts/svc-cat/catalog"}>
-            Install Catalog
-          </Link>
         </div>
       </NotFoundErrorAlert>
     );


### PR DESCRIPTION
### Description of the change

As per the [comment on #1922](https://github.com/kubeapps/kubeapps/pull/1922#issuecomment-674796484), this link has been broken for some time, but is doubly broken now that the svc-cat app repository is not installed by default. 