### PR TITLE
Sanitize the multicluster config when sending to frontend.

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -50,5 +50,4 @@ data:
         {{- $sanitizedClusters = append $sanitizedClusters (pick . "name" "apiServiceURL") }}
       {{- end }}
       "clusters": {{ $sanitizedClusters | toJson }}
-      ]
     }

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -45,5 +45,10 @@ data:
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},
       "featureFlags": {{ .Values.featureFlags | toJson }},
-      "clusters": {{ .Values.clusters | toJson }}
+      {{- $sanitizedClusters := list }}
+      {{- range .Values.clusters }}
+        {{- $sanitizedClusters = append $sanitizedClusters (pick . "name" "apiServiceURL") }}
+      {{- end }}
+      "clusters": {{ $sanitizedClusters | toJson }}
+      ]
     }


### PR DESCRIPTION
### Description of the change

Just sanitizes the templated output so it looks like:

```
  config.json: |-
    {
      "namespace": "kubeapps",
      "appVersion": "DEVEL",
      "authProxyEnabled": true,
      "oauthLoginURI": "/oauth2/start",
      "oauthLogoutURI": "/oauth2/sign_out",
      "featureFlags": {"invalidateCache":true,"operators":false,"ui":"hex"},
      "clusters": [{"apiServiceURL":"https://172.18.0.3:6443","name":"second-cluster"},{"apiServiceURL":"https://example.com:6443","name":"third-cluster"}]
    }
```

Not sure if there's a better way to filter a list of dicts?