### PR TITLE
Added minimum required minimum nodeSelector to sidecar container (kubeapps-asset-syncer) executed from apprepository-controller.

### DIFF
--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -489,6 +489,11 @@ func syncJobSpec(apprepo *apprepov1alpha1.AppRepository, kubeappsNamespace strin
 	podTemplateSpec.Spec.Containers[0].VolumeMounts = append(podTemplateSpec.Spec.Containers[0].VolumeMounts, volumeMounts...)
 	// Add volumes
 	podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, volumes...)
+	// Add nodeSelector
+	podTemplateSpec.Spec.NodeSelector = map[string]string{
+		"beta.kubernetes.io/arch": "amd64",
+		"beta.kubernetes.io/os":   "linux",
+	}
 
 	return batchv1.JobSpec{
 		Template: podTemplateSpec,
@@ -514,6 +519,10 @@ func cleanupJobSpec(repoName, repoNamespace string) batchv1.JobSpec {
 			Spec: corev1.PodSpec{
 				// If there's an issue, delay till the next cron
 				RestartPolicy: "Never",
+				NodeSelector: map[string]string{
+					"beta.kubernetes.io/arch": "amd64",
+					"beta.kubernetes.io/os":   "linux",
+				},
 				Containers: []corev1.Container{
 					{
 						Name:            "delete",

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -76,6 +76,10 @@ func Test_newCronJob(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: "OnFailure",
+									NodeSelector: map[string]string{
+										"beta.kubernetes.io/arch": "amd64",
+										"beta.kubernetes.io/os":   "linux",
+									},
 									Containers: []corev1.Container{
 										{
 											Name:            "sync",
@@ -167,6 +171,10 @@ func Test_newCronJob(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: "OnFailure",
+									NodeSelector: map[string]string{
+										"beta.kubernetes.io/arch": "amd64",
+										"beta.kubernetes.io/os":   "linux",
+									},
 									Containers: []corev1.Container{
 										{
 											Name:            "sync",
@@ -255,6 +263,10 @@ func Test_newCronJob(t *testing.T) {
 								},
 								Spec: corev1.PodSpec{
 									RestartPolicy: "OnFailure",
+									NodeSelector: map[string]string{
+										"beta.kubernetes.io/arch": "amd64",
+										"beta.kubernetes.io/os":   "linux",
+									},
 									Containers: []corev1.Container{
 										{
 											Name:            "sync",
@@ -373,6 +385,10 @@ func Test_newSyncJob(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: "OnFailure",
+							NodeSelector: map[string]string{
+								"beta.kubernetes.io/arch": "amd64",
+								"beta.kubernetes.io/os":   "linux",
+							},
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -440,6 +456,10 @@ func Test_newSyncJob(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: "OnFailure",
+							NodeSelector: map[string]string{
+								"beta.kubernetes.io/arch": "amd64",
+								"beta.kubernetes.io/os":   "linux",
+							},
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -521,6 +541,10 @@ func Test_newSyncJob(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: "OnFailure",
+							NodeSelector: map[string]string{
+								"beta.kubernetes.io/arch": "amd64",
+								"beta.kubernetes.io/os":   "linux",
+							},
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -609,6 +633,10 @@ func Test_newSyncJob(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: "OnFailure",
+							NodeSelector: map[string]string{
+								"beta.kubernetes.io/arch": "amd64",
+								"beta.kubernetes.io/os":   "linux",
+							},
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -708,6 +736,10 @@ func Test_newSyncJob(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							RestartPolicy: "OnFailure",
+							NodeSelector: map[string]string{
+								"beta.kubernetes.io/arch": "amd64",
+								"beta.kubernetes.io/os":   "linux",
+							},
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -825,6 +857,10 @@ func Test_newSyncJob(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Affinity:      &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{}}},
 							RestartPolicy: "OnFailure",
+							NodeSelector: map[string]string{
+								"beta.kubernetes.io/arch": "amd64",
+								"beta.kubernetes.io/os":   "linux",
+							},
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -902,6 +938,10 @@ func Test_newCleanupJob(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							RestartPolicy: "Never",
+							NodeSelector: map[string]string{
+								"beta.kubernetes.io/arch": "amd64",
+								"beta.kubernetes.io/os":   "linux",
+							},
 							Containers: []corev1.Container{
 								{
 									Name:            "delete",


### PR DESCRIPTION
### Description of the change

Added minimum required minimum nodeSelector to sidecar container (kubeapps-asset-syncer) executed from apprepository-controller.

### Benefits

NodeSelector is not specified for the sidecar container (kubeapps-asset-syncer) executed from apprepository-controller.
On the other hand, kubeapps-asset-syncer is provided only with images of "Linux" and "amd64" as https://hub.docker.com/r/bitnami/kubeapps-asset-syncer. I am getting an error because my Kubernetes cluster has a mixture of nodes from different architects.

### Possible drawbacks

### Applicable issues

### Additional information

