### PR TITLE
Allow to list repositories using the backend

### DIFF
--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -45,6 +45,15 @@ func (c *FakeHandler) AsSVC() handler {
 	return c
 }
 
+// ListAppRepositories fake
+func (c *FakeHandler) ListAppRepositories(requestNamespace string) (*v1alpha1.AppRepositoryList, error) {
+	appRepos := &v1alpha1.AppRepositoryList{}
+	for _, repo := range c.AppRepos {
+		appRepos.Items = append(appRepos.Items, *repo)
+	}
+	return appRepos, c.Err
+}
+
 // CreateAppRepository fake
 func (c *FakeHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error) {
 	c.AppRepos = append(c.AppRepos, c.CreatedRepo)

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -331,6 +331,58 @@ func TestAppRepositoryCreate(t *testing.T) {
 	}
 }
 
+func TestAppRepositoryList(t *testing.T) {
+	testCases := []struct {
+		name             string
+		requestNamespace string
+		existingRepos    map[string][]repoStub
+	}{
+		{
+			name:             "it gets repos from the global namespace",
+			requestNamespace: kubeappsNamespace,
+			existingRepos: map[string][]repoStub{
+				"kubeapps": {repoStub{name: "test-repo"}},
+			},
+		},
+		{
+			name:             "it gets repos from a namespace",
+			requestNamespace: "foo",
+			existingRepos: map[string][]repoStub{
+				"foo": {repoStub{name: "test-repo"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := fakeCombinedClientset{
+				fakeapprepoclientset.NewSimpleClientset(makeAppRepoObjects(tc.existingRepos)...),
+				fakecoreclientset.NewSimpleClientset(),
+				&fakeRest.RESTClient{},
+			}
+			handler := userHandler{
+				kubeappsNamespace: kubeappsNamespace,
+				svcClientset:      cs,
+			}
+			if tc.requestNamespace != kubeappsNamespace {
+				handler = userHandler{
+					kubeappsNamespace: kubeappsNamespace,
+					clientset:         cs,
+				}
+			}
+
+			apprepos, err := handler.ListAppRepositories(tc.requestNamespace)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if got, want := len(apprepos.Items), len(tc.existingRepos[tc.requestNamespace]); got != want {
+				t.Errorf("expected %d repos, got %d", want, got)
+			}
+		})
+	}
+}
+
 func TestAppRepositoryUpdate(t *testing.T) {
 	const kubeappsNamespace = "kubeapps"
 	testCases := []struct {

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -360,6 +360,8 @@ func TestAppRepositoryList(t *testing.T) {
 				fakecoreclientset.NewSimpleClientset(),
 				&fakeRest.RESTClient{},
 			}
+			// Depending on the namespace, we instantiate the svcClientset or the user clientset
+			// to ensure that we are using the expected clientset.
 			handler := userHandler{
 				kubeappsNamespace: kubeappsNamespace,
 				svcClientset:      cs,


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This is needed to show the list of both the app repositories in the global namespace and other namespaces. Note that in the case that the request is for the `kubeapps` namespace, the request is made using the backend serviceaccount. This is to allow unprivileged users to list global apprepositories.
