### PR TITLE
Use AppRepo http_proxy env when fetching chart.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/xenolf/lego v0.3.2-0.20160613233155-a9d8cec0e656 // indirect
 	github.com/yvasiyarov/go-metrics v0.0.0-20150112132944-c25f46c4b940 // indirect
 	github.com/yvasiyarov/gorelic v0.0.6 // indirect
-	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 // indirect
+	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271
 	golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e // indirect

--- a/pkg/kube/http_utils.go
+++ b/pkg/kube/http_utils.go
@@ -21,10 +21,12 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
 	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	"golang.org/x/net/http/httpproxy"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -100,12 +102,14 @@ func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *co
 		defaultHeaders.Set("Authorization", string(auth))
 	}
 
-	// Return Transport for testing purposes
+	proxyConfig := getProxyConfig(appRepo)
+	proxyFunc := func(r *http.Request) (*url.URL, error) { return proxyConfig.ProxyFunc()(r.URL) }
+
 	return &clientWithDefaultHeaders{
 		client: &http.Client{
 			Timeout: time.Second * defaultTimeoutSeconds,
 			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
+				Proxy: proxyFunc,
 				TLSClientConfig: &tls.Config{
 					RootCAs: caCertPool,
 				},
@@ -113,4 +117,22 @@ func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *co
 		},
 		defaultHeaders: defaultHeaders,
 	}, nil
+}
+
+func getProxyConfig(appRepo *v1alpha1.AppRepository) *httpproxy.Config {
+	template := appRepo.Spec.SyncJobPodTemplate
+	proxyConfig := httpproxy.Config{}
+	if len(template.Spec.Containers) > 0 {
+		for _, e := range template.Spec.Containers[0].Env {
+			switch e.Name {
+			case "http_proxy":
+				proxyConfig.HTTPProxy = e.Value
+			case "https_proxy":
+				proxyConfig.HTTPSProxy = e.Value
+			case "no_proxy":
+				proxyConfig.NoProxy = e.Value
+			}
+		}
+	}
+	return &proxyConfig
 }


### PR DESCRIPTION
### Description of the change

Configures the http client used to fetch the chart with the same `http_proxy` vars specifiied in the AppRepository's sync job pod template, if any.

### Benefits

You can now actually install a chart from an app repository that requires a proxy.

### Applicable issues

  - fixes #1962 

### Additional information

Verified the fix in my local env setup as per 1962 as well.