### PR TITLE
Bump chart to release app v1.11.2 with chart 3.9.1

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 3.9.0
+version: 3.9.1
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png


### PR DESCRIPTION
### Description of the change

Bump chart to release app v1.11.2 with more UI behind FF and fix for #1962
### Benefits
