### PR TITLE
Update dashboard components to use config.kubeappsCluster pt1

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -107,9 +107,9 @@ describe("deleteRepo", () => {
     it("dispatches requestRepos with current namespace", async () => {
       const storeWithFlag: any = mockStore({
         clusters: {
-          currentCluster: "default",
+          currentCluster: "defaultCluster",
           clusters: {
-            default: {
+            defaultCluster: {
               currentNamespace,
             },
           },

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -18,6 +18,7 @@ const defaultProps = {
   validate: jest.fn(),
   namespace: defaultNamespace,
   cluster: "default",
+  kubeappsCluster: "default",
   kubeappsNamespace: "kubeapps",
   displayReposPerNamespaceMsg: false,
   validating: false,

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -46,6 +46,7 @@ export interface IAppRepoListProps {
   validate: (url: string, authHeader: string, customCA: string) => Promise<any>;
   cluster: string;
   namespace: string;
+  kubeappsCluster: string;
   kubeappsNamespace: string;
   displayReposPerNamespaceMsg: boolean;
   isFetching: boolean;
@@ -118,6 +119,7 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
       update,
       cluster,
       namespace,
+      kubeappsCluster,
       kubeappsNamespace,
       displayReposPerNamespaceMsg,
       isFetching,
@@ -134,22 +136,26 @@ class AppRepoList extends React.Component<IAppRepoListProps> {
     const renderNamespace = namespace === definedNamespaces.all;
 
     // We do not currently support app repositories on additional clusters.
-    if (cluster !== "default") {
+    if (cluster !== kubeappsCluster) {
       return (
         <MessageAlert header="AppRepositories can be created on the default cluster only">
           <div>
             <p className="margin-v-normal">
               Kubeapps' multi-cluster support currently enables creation of custom app repositories
-              on the default cluster only.
+              on the cluster on which Kubeapps is installed.
             </p>
             <p className="margin-v-normal">
-              You cannot currently create an app repository on an additional cluster, but you can
-              create an app repository with charts available for installation across clusters and
-              namespaces in the{" "}
-              <Link to={url.app.config.apprepositories("default", definedNamespaces.all)}>
-                default cluster's app repository listing for all namespaces
-              </Link>
-              .
+              You cannot currently create an app repository on an additional cluster.
+              {kubeappsCluster && (
+                <>
+                  You can create an app repository with charts available for installation across
+                  clusters and namespaces on the{" "}
+                  <Link to={url.app.config.apprepositories(kubeappsCluster, definedNamespaces.all)}>
+                    cluster on which Kubeapps is installed
+                  </Link>
+                  , if you have the appropriate authorization.
+                </>
+              )}
             </p>
           </div>
         </MessageAlert>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.v2.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.v2.test.tsx
@@ -18,6 +18,7 @@ const defaultNamespace = "default-namespace";
 const defaultProps = {
   namespace: defaultNamespace,
   cluster: "default",
+  kubeappsCluster: "default",
   kubeappsNamespace: "kubeapps",
 };
 

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.v2.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.v2.tsx
@@ -18,13 +18,19 @@ import { AppRepoRefreshAllButton } from "./AppRepoRefreshAllButton.v2";
 export interface IAppRepoListProps {
   cluster: string;
   namespace: string;
+  kubeappsCluster: string;
   kubeappsNamespace: string;
 }
 
-function AppRepoList({ cluster, namespace, kubeappsNamespace }: IAppRepoListProps) {
+function AppRepoList({
+  cluster,
+  namespace,
+  kubeappsCluster,
+  kubeappsNamespace,
+}: IAppRepoListProps) {
   const dispatch = useDispatch();
   // We do not currently support app repositories on additional clusters.
-  const supportedCluster = cluster === "default";
+  const supportedCluster = cluster === kubeappsCluster;
 
   useEffect(() => {
     if (!supportedCluster || namespace === kubeappsNamespace) {
@@ -133,15 +139,16 @@ function AppRepoList({ cluster, namespace, kubeappsNamespace }: IAppRepoListProp
                 <h3>Global Repositories</h3>
                 <p>
                   Global repositories are available for all Kubeapps users.{" "}
-                  {namespace !== kubeappsNamespace && (
-                    <>
-                      Administrators can go to the{" "}
-                      <Link to={app.config.apprepositories("default", kubeappsNamespace)}>
-                        {kubeappsNamespace}
-                      </Link>{" "}
-                      namespace to manage them.
-                    </>
-                  )}
+                  {kubeappsCluster &&
+                    (kubeappsCluster !== cluster || namespace !== kubeappsNamespace) && (
+                      <>
+                        Administrators can go to the{" "}
+                        <Link to={app.config.apprepositories(kubeappsCluster, kubeappsNamespace)}>
+                          {kubeappsNamespace}
+                        </Link>{" "}
+                        namespace to manage them.
+                      </>
+                    )}
                 </p>
                 {globalRepos.length ? (
                   <Table

--- a/dashboard/src/components/Config/ServiceBrokerList/ServiceBrokerList.test.tsx
+++ b/dashboard/src/components/Config/ServiceBrokerList/ServiceBrokerList.test.tsx
@@ -21,6 +21,7 @@ let defaultProps = {
   checkCatalogInstalled: jest.fn(),
   isInstalled: true,
   cluster: "default",
+  kubeappsCluster: "default",
 };
 
 beforeEach(() => {
@@ -33,6 +34,7 @@ beforeEach(() => {
     checkCatalogInstalled: jest.fn(),
     isInstalled: true,
     cluster: "default",
+    kubeappsCluster: "default",
   };
 });
 
@@ -62,7 +64,7 @@ context("if the service brokers are accessed on an additional cluster", () => {
     const msgAlert = wrapper.find(MessageAlert);
     expect(msgAlert).toExist();
     expect(msgAlert.prop("header")).toEqual(
-      "Service brokers can be created on the default cluster only",
+      "Service brokers can be created on the cluster on which Kubeapps is installed only",
     );
   });
 

--- a/dashboard/src/components/Config/ServiceBrokerList/ServiceBrokerList.tsx
+++ b/dashboard/src/components/Config/ServiceBrokerList/ServiceBrokerList.tsx
@@ -27,6 +27,7 @@ interface IServiceBrokerListProps {
   checkCatalogInstalled: () => Promise<any>;
   isInstalled: boolean;
   cluster: string;
+  kubeappsCluster: string;
 }
 
 export const RequiredRBACRoles: { [s: string]: IRBACRole[] } = {
@@ -101,21 +102,35 @@ class ServiceBrokerList extends React.Component<IServiceBrokerListProps> {
   }
 
   private renderBody(body: React.ReactFragment) {
-    const { cluster, isInstalled } = this.props;
-    if (cluster !== "default") {
-      return (
-        <MessageAlert header="Service brokers can be created on the default cluster only">
-          <div>
-            <p className="margin-v-normal">
-              Kubeapps' Service Broker support enables the addition of{" "}
-              <Link to={url.app.config.brokers("default")}>
-                service brokers on the default cluster only
-              </Link>
-              .
-            </p>
-          </div>
-        </MessageAlert>
-      );
+    const { cluster, isInstalled, kubeappsCluster } = this.props;
+    if (cluster !== kubeappsCluster) {
+      if (kubeappsCluster) {
+        return (
+          <MessageAlert header="Service brokers can be created on the cluster on which Kubeapps is installed only">
+            <div>
+              <p className="margin-v-normal">
+                Kubeapps' Service Broker support enables the addition of{" "}
+                <Link to={url.app.config.brokers(kubeappsCluster)}>
+                  service brokers on the cluster on which Kubeapps is installed only
+                </Link>
+                .
+              </p>
+            </div>
+          </MessageAlert>
+        );
+      } else {
+        return (
+          <MessageAlert header="Service brokers are not supported on this installation">
+            <div>
+              <p className="margin-v-normal">
+                Kubeapps' Service Broker support enables the addition of service brokers on the
+                cluster on which Kubeapps is installed only. This installation of Kubeapps is
+                configured without access to that cluster.
+              </p>
+            </div>
+          </MessageAlert>
+        );
+      }
     }
 
     if (!isInstalled) {

--- a/dashboard/src/components/Config/ServiceBrokerList/__snapshots__/ServiceBrokerList.test.tsx.snap
+++ b/dashboard/src/components/Config/ServiceBrokerList/__snapshots__/ServiceBrokerList.test.tsx.snap
@@ -120,6 +120,7 @@ exports[`when all the brokers are loaded shows a forbiden (resync) error if it e
     }
   }
   isInstalled={true}
+  kubeappsCluster="default"
   sync={[MockFunction]}
 >
   <section
@@ -361,6 +362,7 @@ exports[`when all the brokers are loaded shows a warning to install no service b
     }
   }
   isInstalled={true}
+  kubeappsCluster="default"
   sync={[MockFunction]}
 >
   <section

--- a/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
+++ b/dashboard/src/containers/RepoListContainer/RepoListContainer.ts
@@ -22,6 +22,7 @@ function mapStateToProps({ config, clusters: { currentCluster, clusters }, repos
     repoSecrets: repos.repoSecrets,
     validating: repos.validating,
     imagePullSecrets: repos.imagePullSecrets,
+    kubeappsCluster: config.kubeappsCluster,
     kubeappsNamespace: config.kubeappsNamespace,
     UI: config.featureFlags.ui,
   };

--- a/dashboard/src/containers/ServiceBrokerListContainer/ServiceBrokerListContainer.ts
+++ b/dashboard/src/containers/ServiceBrokerListContainer/ServiceBrokerListContainer.ts
@@ -7,12 +7,13 @@ import ServiceBrokerList from "../../components/Config/ServiceBrokerList";
 import { IServiceBroker } from "../../shared/ServiceCatalog";
 import { IStoreState } from "../../shared/types";
 
-function mapStateToProps({ catalog, clusters }: IStoreState) {
+function mapStateToProps({ catalog, config, clusters }: IStoreState) {
   return {
     brokers: catalog.brokers,
     errors: catalog.errors,
     isInstalled: catalog.isServiceCatalogInstalled,
     cluster: clusters.currentCluster,
+    kubeappsCluster: config.kubeappsCluster,
   };
 }
 


### PR DESCRIPTION
### Description of the change

Part 1 of updating the dashboard components to use the `kubeappsCluster` config and remove "default" assumptions.

### Benefits

Work towards #1942
