### PR TITLE
Remove assumption of "default" cluster for operator URLs pt1

### DIFF
--- a/dashboard/src/actions/catalog.test.tsx
+++ b/dashboard/src/actions/catalog.test.tsx
@@ -18,6 +18,7 @@ const clusterClass = { metadata: { name: "cluster-class" } } as any;
 let store: any;
 const testArgs = {
   releaseName: "my-release",
+  kubeappsCluster: "kubeappsCluster",
   namespace: "my-namespace",
   className: "my-class",
   planName: "myPlan",
@@ -29,7 +30,11 @@ let boomFn: any;
 const errorPayload = (op: string) => ({ err: new Error("Boom!"), op });
 
 beforeEach(() => {
-  store = mockStore();
+  store = mockStore({
+    config: {
+      kubeappsCluster: testArgs.kubeappsCluster,
+    },
+  });
 
   ServiceInstance.create = jest.fn().mockImplementationOnce(() => {
     return { metadata: { name: testArgs.instanceName } };
@@ -330,7 +335,7 @@ describe("sync", () => {
   it("calls ServiceCatalog.syncBroker if no error", async () => {
     await store.dispatch(provisionCMD);
     expect(store.getActions().length).toBe(0);
-    expect(ServiceCatalog.syncBroker).toHaveBeenCalledWith(broker);
+    expect(ServiceCatalog.syncBroker).toHaveBeenCalledWith(testArgs.kubeappsCluster, broker);
   });
 
   it("dispatches errorCatalog if error", async () => {
@@ -364,7 +369,7 @@ describe("getBindings", () => {
 
     await store.dispatch(provisionCMD);
     expect(store.getActions()).toEqual(expectedActions);
-    expect(ServiceBinding.list).toHaveBeenCalledWith(testArgs.namespace);
+    expect(ServiceBinding.list).toHaveBeenCalledWith(testArgs.kubeappsCluster, testArgs.namespace);
   });
 
   it("dispatches requestBindingsWithSecrets and errorCatalog if error", async () => {

--- a/dashboard/src/actions/catalog.ts
+++ b/dashboard/src/actions/catalog.ts
@@ -130,9 +130,12 @@ export function deprovision(
 export function sync(
   broker: IServiceBroker,
 ): ThunkAction<Promise<void>, IStoreState, null, ServiceCatalogAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      config: { kubeappsCluster },
+    } = getState();
     try {
-      await ServiceCatalog.syncBroker(broker);
+      await ServiceCatalog.syncBroker(kubeappsCluster, broker);
     } catch (e) {
       dispatch(errorCatalog(e, "update"));
     }
@@ -142,13 +145,16 @@ export function sync(
 export function getBindings(
   ns?: string,
 ): ThunkAction<Promise<void>, IStoreState, null, ServiceCatalogAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      config: { kubeappsCluster },
+    } = getState();
     if (ns && ns === definedNamespaces.all) {
       ns = undefined;
     }
     dispatch(requestBindingsWithSecrets());
     try {
-      const bindingsWithSecrets = await ServiceBinding.list(ns);
+      const bindingsWithSecrets = await ServiceBinding.list(kubeappsCluster, ns);
       dispatch(receiveBindingsWithSecrets(bindingsWithSecrets));
     } catch (e) {
       dispatch(errorCatalog(e, "fetch"));

--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -136,7 +136,7 @@ describe("getCSVs", () => {
         payload: sortedCSVs,
       },
     ];
-    await store.dispatch(operatorActions.getCSVs("default"));
+    await store.dispatch(operatorActions.getCSVs("default", "default"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -153,7 +153,7 @@ describe("getCSVs", () => {
         payload: new Error("Boom!"),
       },
     ];
-    await store.dispatch(operatorActions.getCSVs("default"));
+    await store.dispatch(operatorActions.getCSVs("default", "default"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -292,7 +292,7 @@ describe("getResources", () => {
         payload: [resource],
       },
     ];
-    await store.dispatch(operatorActions.getResources("default"));
+    await store.dispatch(operatorActions.getResources("default", "default"));
     expect(store.getActions()).toEqual(expectedActions);
     expect(Operators.listResources).toHaveBeenCalledWith("default", "kubeapps.com/v1alpha1", "foo");
   });
@@ -328,7 +328,7 @@ describe("getResources", () => {
         payload: [],
       },
     ];
-    await store.dispatch(operatorActions.getResources("default"));
+    await store.dispatch(operatorActions.getResources("default", "default"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -27,7 +27,7 @@ describe("checkOLMInstalled", () => {
         type: getType(operatorActions.OLMInstalled),
       },
     ];
-    await store.dispatch(operatorActions.checkOLMInstalled("ns"));
+    await store.dispatch(operatorActions.checkOLMInstalled("default", "ns"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -44,7 +44,7 @@ describe("checkOLMInstalled", () => {
         payload: new Error("nope"),
       },
     ];
-    await store.dispatch(operatorActions.checkOLMInstalled("ns"));
+    await store.dispatch(operatorActions.checkOLMInstalled("default", "ns"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -64,7 +64,7 @@ describe("getOperators", () => {
         payload: sortedOperators,
       },
     ];
-    await store.dispatch(operatorActions.getOperators("default"));
+    await store.dispatch(operatorActions.getOperators("default", "default"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -81,7 +81,7 @@ describe("getOperators", () => {
         payload: new Error("Boom!"),
       },
     ];
-    await store.dispatch(operatorActions.getOperators("default"));
+    await store.dispatch(operatorActions.getOperators("default", "default"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -99,7 +99,7 @@ describe("getOperator", () => {
         payload: op,
       },
     ];
-    await store.dispatch(operatorActions.getOperator("default", "foo"));
+    await store.dispatch(operatorActions.getOperator("default", "default", "foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -116,7 +116,7 @@ describe("getOperator", () => {
         payload: new Error("Boom!"),
       },
     ];
-    await store.dispatch(operatorActions.getOperator("default", "foo"));
+    await store.dispatch(operatorActions.getOperator("default", "default", "foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -206,7 +206,7 @@ describe("createResource", () => {
         payload: resource,
       },
     ];
-    await store.dispatch(operatorActions.createResource("default", "v1", "pods", {}));
+    await store.dispatch(operatorActions.createResource("default", "default", "v1", "pods", {}));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -223,7 +223,7 @@ describe("createResource", () => {
         payload: new Error("Boom!"),
       },
     ];
-    await store.dispatch(operatorActions.createResource("default", "v1", "pods", {}));
+    await store.dispatch(operatorActions.createResource("default", "default", "v1", "pods", {}));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -241,7 +241,9 @@ describe("updateResource", () => {
         payload: resource,
       },
     ];
-    await store.dispatch(operatorActions.updateResource("default", "v1", "pods", "foo", {}));
+    await store.dispatch(
+      operatorActions.updateResource("default", "default", "v1", "pods", "foo", {}),
+    );
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -258,7 +260,9 @@ describe("updateResource", () => {
         payload: new Error("Boom!"),
       },
     ];
-    await store.dispatch(operatorActions.updateResource("default", "v1", "pods", "foo", {}));
+    await store.dispatch(
+      operatorActions.updateResource("default", "default", "v1", "pods", "foo", {}),
+    );
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -294,7 +298,12 @@ describe("getResources", () => {
     ];
     await store.dispatch(operatorActions.getResources("default", "default"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(Operators.listResources).toHaveBeenCalledWith("default", "kubeapps.com/v1alpha1", "foo");
+    expect(Operators.listResources).toHaveBeenCalledWith(
+      "default",
+      "default",
+      "kubeapps.com/v1alpha1",
+      "foo",
+    );
   });
 
   it("dispatches an error if listing resources fail", async () => {
@@ -365,6 +374,7 @@ describe("getResources", () => {
     );
     expect(store.getActions()).toEqual(expectedActions);
     expect(Operators.getResource).toHaveBeenCalledWith(
+      "default",
       "default",
       "kubeapps.com/v1alpha1",
       "foo",
@@ -471,7 +481,7 @@ describe("deleteResource", () => {
         type: getType(operatorActions.resourceDeleted),
       },
     ];
-    await store.dispatch(operatorActions.deleteResource("default", "foos", resource));
+    await store.dispatch(operatorActions.deleteResource("default", "default", "foos", resource));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -489,7 +499,7 @@ describe("deleteResource", () => {
         payload: new Error("Boom!"),
       },
     ];
-    await store.dispatch(operatorActions.deleteResource("default", "foos", resource));
+    await store.dispatch(operatorActions.deleteResource("default", "default", "foos", resource));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -508,7 +518,7 @@ describe("createOperator", () => {
       },
     ];
     await store.dispatch(
-      operatorActions.createOperator("default", "etcd", "alpha", "Manual", "etcd.1.0.0"),
+      operatorActions.createOperator("default", "default", "etcd", "alpha", "Manual", "etcd.1.0.0"),
     );
     expect(store.getActions()).toEqual(expectedActions);
   });
@@ -527,7 +537,7 @@ describe("createOperator", () => {
       },
     ];
     await store.dispatch(
-      operatorActions.createOperator("default", "etcd", "alpha", "Manual", "etcd.1.0.0"),
+      operatorActions.createOperator("default", "default", "etcd", "alpha", "Manual", "etcd.1.0.0"),
     );
     expect(store.getActions()).toEqual(expectedActions);
   });

--- a/dashboard/src/actions/operators.test.tsx
+++ b/dashboard/src/actions/operators.test.tsx
@@ -171,7 +171,7 @@ describe("getCSV", () => {
         payload: csv,
       },
     ];
-    await store.dispatch(operatorActions.getCSV("default", "foo"));
+    await store.dispatch(operatorActions.getCSV("default", "default", "foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -188,7 +188,7 @@ describe("getCSV", () => {
         payload: new Error("Boom!"),
       },
     ];
-    await store.dispatch(operatorActions.getCSV("default", "foo"));
+    await store.dispatch(operatorActions.getCSV("default", "default", "foo"));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -360,7 +360,9 @@ describe("getResources", () => {
         payload: resource,
       },
     ];
-    await store.dispatch(operatorActions.getResource("default", "foo", "foo.kubeapps.com", "bar"));
+    await store.dispatch(
+      operatorActions.getResource("default", "default", "foo", "foo.kubeapps.com", "bar"),
+    );
     expect(store.getActions()).toEqual(expectedActions);
     expect(Operators.getResource).toHaveBeenCalledWith(
       "default",
@@ -397,7 +399,9 @@ describe("getResources", () => {
         payload: new Error("Boom!"),
       },
     ];
-    await store.dispatch(operatorActions.getResource("default", "foo", "foo.kubeapps.com", "bar"));
+    await store.dispatch(
+      operatorActions.getResource("default", "default", "foo", "foo.kubeapps.com", "bar"),
+    );
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -418,7 +422,9 @@ describe("getResources", () => {
         payload: new Error("CSV foo not found in default"),
       },
     ];
-    await store.dispatch(operatorActions.getResource("default", "foo", "foo.kubeapps.com", "bar"));
+    await store.dispatch(
+      operatorActions.getResource("default", "default", "foo", "foo.kubeapps.com", "bar"),
+    );
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -447,7 +453,7 @@ describe("getResources", () => {
       },
     ];
     await store.dispatch(
-      operatorActions.getResource("default", "foo", "not-foo.kubeapps.com", "bar"),
+      operatorActions.getResource("default", "default", "foo", "not-foo.kubeapps.com", "bar"),
     );
     expect(store.getActions()).toEqual(expectedActions);
   });

--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -171,12 +171,13 @@ export function getOperator(
 }
 
 export function getCSVs(
+  cluster: string,
   namespace: string,
 ): ThunkAction<Promise<IClusterServiceVersion[]>, IStoreState, null, OperatorAction> {
   return async dispatch => {
     dispatch(requestCSVs());
     try {
-      const csvs = await Operators.getCSVs(namespace);
+      const csvs = await Operators.getCSVs(cluster, namespace);
       const sortedCSVs = csvs.sort((o1, o2) => (o1.metadata.name > o2.metadata.name ? 1 : -1));
       dispatch(receiveCSVs(sortedCSVs));
       return sortedCSVs;
@@ -275,11 +276,12 @@ function parseCRD(crdName: string) {
 }
 
 export function getResources(
+  cluster: string,
   namespace: string,
 ): ThunkAction<Promise<IResource[]>, IStoreState, null, OperatorAction> {
   return async dispatch => {
     dispatch(requestCustomResources());
-    const csvs = await dispatch(getCSVs(namespace));
+    const csvs = await dispatch(getCSVs(cluster, namespace));
     let resources: IResource[] = [];
     const csvPromises = csvs.map(async csv => {
       const crdPromises = csv.spec.customresourcedefinitions.owned.map(async crd => {

--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -207,6 +207,7 @@ export function getCSV(
 }
 
 export function createResource(
+  cluster: string,
   namespace: string,
   apiVersion: string,
   resource: string,
@@ -215,7 +216,7 @@ export function createResource(
   return async dispatch => {
     dispatch(creatingResource());
     try {
-      const r = await Operators.createResource(namespace, apiVersion, resource, body);
+      const r = await Operators.createResource(cluster, namespace, apiVersion, resource, body);
       dispatch(resourceCreated(r));
       return true;
     } catch (e) {
@@ -226,6 +227,7 @@ export function createResource(
 }
 
 export function deleteResource(
+  cluster: string,
   namespace: string,
   plural: string,
   resource: IResource,
@@ -234,6 +236,7 @@ export function deleteResource(
     dispatch(deletingResource());
     try {
       await Operators.deleteResource(
+        cluster,
         namespace,
         resource.apiVersion,
         plural,
@@ -249,6 +252,7 @@ export function deleteResource(
 }
 
 export function updateResource(
+  cluster: string,
   namespace: string,
   apiVersion: string,
   resource: string,
@@ -258,7 +262,14 @@ export function updateResource(
   return async dispatch => {
     dispatch(updatingResource());
     try {
-      const r = await Operators.updateResource(namespace, apiVersion, resource, name, body);
+      const r = await Operators.updateResource(
+        cluster,
+        namespace,
+        apiVersion,
+        resource,
+        name,
+        body,
+      );
       dispatch(resourceUpdated(r));
       return true;
     } catch (e) {
@@ -288,6 +299,7 @@ export function getResources(
         const { plural, group } = parseCRD(crd.name);
         try {
           const csvResources = await Operators.listResources(
+            cluster,
             namespace,
             `${group}/${crd.version}`,
             plural,
@@ -321,6 +333,7 @@ export function getResource(
         const { plural, group } = parseCRD(crd.name);
         try {
           const resource = await Operators.getResource(
+            cluster,
             namespace,
             `${group}/${crd.version}`,
             plural,
@@ -344,6 +357,7 @@ export function getResource(
 }
 
 export function createOperator(
+  cluster: string,
   namespace: string,
   name: string,
   channel: string,
@@ -353,7 +367,14 @@ export function createOperator(
   return async dispatch => {
     dispatch(creatingOperator());
     try {
-      const r = await Operators.createOperator(namespace, name, channel, installPlanApproval, csv);
+      const r = await Operators.createOperator(
+        cluster,
+        namespace,
+        name,
+        channel,
+        installPlanApproval,
+        csv,
+      );
       dispatch(operatorCreated(r));
       return true;
     } catch (e) {

--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -120,12 +120,13 @@ const actions = [
 export type OperatorAction = ActionType<typeof actions[number]>;
 
 export function checkOLMInstalled(
+  cluster: string,
   namespace: string,
 ): ThunkAction<Promise<boolean>, IStoreState, null, OperatorAction> {
   return async dispatch => {
     dispatch(checkingOLM());
     try {
-      const installed = await Operators.isOLMInstalled(namespace);
+      const installed = await Operators.isOLMInstalled(cluster, namespace);
       if (installed) {
         dispatch(OLMInstalled());
       }
@@ -138,12 +139,13 @@ export function checkOLMInstalled(
 }
 
 export function getOperators(
+  cluster: string,
   namespace: string,
 ): ThunkAction<Promise<void>, IStoreState, null, OperatorAction> {
   return async dispatch => {
     dispatch(requestOperators());
     try {
-      const operators = await Operators.getOperators(namespace);
+      const operators = await Operators.getOperators(cluster, namespace);
       const sortedOp = operators.sort((o1, o2) => (o1.metadata.name > o2.metadata.name ? 1 : -1));
       dispatch(receiveOperators(sortedOp));
     } catch (e) {
@@ -153,13 +155,14 @@ export function getOperators(
 }
 
 export function getOperator(
+  cluster: string,
   namespace: string,
   operatorName: string,
 ): ThunkAction<Promise<void>, IStoreState, null, OperatorAction> {
   return async dispatch => {
     dispatch(requestOperator());
     try {
-      const operator = await Operators.getOperator(namespace, operatorName);
+      const operator = await Operators.getOperator(cluster, namespace, operatorName);
       dispatch(receiveOperator(operator));
     } catch (e) {
       dispatch(errorOperators(e));

--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -188,13 +188,14 @@ export function getCSVs(
 }
 
 export function getCSV(
+  cluster: string,
   namespace: string,
   name: string,
 ): ThunkAction<Promise<IClusterServiceVersion | undefined>, IStoreState, null, OperatorAction> {
   return async dispatch => {
     dispatch(requestCSV());
     try {
-      const csv = await Operators.getCSV(namespace, name);
+      const csv = await Operators.getCSV(cluster, namespace, name);
       dispatch(receiveCSV(csv));
       return csv;
     } catch (e) {
@@ -303,6 +304,7 @@ export function getResources(
 }
 
 export function getResource(
+  cluster: string,
   namespace: string,
   csvName: string,
   crdName: string,
@@ -310,7 +312,7 @@ export function getResource(
 ): ThunkAction<Promise<void>, IStoreState, null, OperatorAction> {
   return async dispatch => {
     dispatch(requestCustomResource());
-    const csv = await dispatch(getCSV(namespace, csvName));
+    const csv = await dispatch(getCSV(cluster, namespace, csvName));
     if (csv) {
       const crd = csv.spec.customresourcedefinitions.owned.find(c => c.name === crdName);
       if (crd) {

--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -40,7 +40,7 @@ context("when changing props", () => {
     );
     wrapper.setProps({ namespace: "foo" });
     expect(fetchAppsWithUpdateInfo).toHaveBeenCalledWith("defaultc", "foo", undefined);
-    expect(getCustomResources).toHaveBeenCalledWith("foo");
+    expect(getCustomResources).toHaveBeenCalledWith("defaultc", "foo");
   });
 
   it("should update the filter", () => {

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -20,7 +20,7 @@ export interface IAppListProps {
   namespace: string;
   pushSearchFilter: (filter: string) => any;
   filter: string;
-  getCustomResources: (ns: string) => void;
+  getCustomResources: (cluster: string, ns: string) => void;
   customResources: IResource[];
   isFetchingResources: boolean;
   csvs: IClusterServiceVersion[];
@@ -44,7 +44,7 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
     } = this.props;
     fetchAppsWithUpdateInfo(cluster, namespace, apps.listingAll);
     if (this.props.featureFlags.operators) {
-      getCustomResources(namespace);
+      getCustomResources(cluster, namespace);
     }
     this.setState({ filter });
   }
@@ -66,7 +66,7 @@ class AppList extends React.Component<IAppListProps, IAppListState> {
     ) {
       fetchAppsWithUpdateInfo(cluster, namespace, listingAll);
       if (this.props.featureFlags.operators) {
-        getCustomResources(namespace);
+        getCustomResources(cluster, namespace);
       }
     }
     if (prevProps.filter !== filter) {

--- a/dashboard/src/components/AppList/AppList.v2.test.tsx
+++ b/dashboard/src/components/AppList/AppList.v2.test.tsx
@@ -43,7 +43,7 @@ context("when changing props", () => {
       </Router>,
     );
     expect(fetchAppsWithUpdateInfo).toHaveBeenCalledWith("defaultc", "foo", true);
-    expect(getCustomResources).toHaveBeenCalledWith("foo");
+    expect(getCustomResources).toHaveBeenCalledWith("defaultc", "foo");
   });
 
   it("should update the filter", () => {

--- a/dashboard/src/components/AppList/AppList.v2.tsx
+++ b/dashboard/src/components/AppList/AppList.v2.tsx
@@ -23,7 +23,7 @@ export interface IAppListProps {
   namespace: string;
   pushSearchFilter: (filter: string) => any;
   filter: string;
-  getCustomResources: (ns: string) => void;
+  getCustomResources: (cluster: string, ns: string) => void;
   customResources: IResource[];
   isFetchingResources: boolean;
   csvs: IClusterServiceVersion[];
@@ -49,7 +49,7 @@ function AppList(props: IAppListProps) {
 
   useEffect(() => {
     fetchAppsWithUpdateInfo(cluster, namespace, true);
-    getCustomResources(namespace);
+    getCustomResources(cluster, namespace);
   }, [cluster, namespace, fetchAppsWithUpdateInfo, getCustomResources]);
 
   useEffect(() => {

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -70,7 +70,7 @@ describe("componentDidMount", () => {
         featureFlags={{ ...defaultProps.featureFlags, operators: true }}
       />,
     );
-    expect(getCSVs).toHaveBeenCalledWith(namespace);
+    expect(getCSVs).toHaveBeenCalledWith(defaultProps.cluster, namespace);
   });
 });
 
@@ -85,7 +85,7 @@ describe("componentDidUpdate", () => {
       />,
     );
     wrapper.setProps({ namespace: "a-different-one" });
-    expect(getCSVs).toHaveBeenCalledWith("a-different-one");
+    expect(getCSVs).toHaveBeenCalledWith(defaultProps.cluster, "a-different-one");
   });
 });
 

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -26,7 +26,7 @@ export interface ICatalogProps {
   cluster: string;
   namespace: string;
   kubeappsNamespace: string;
-  getCSVs: (namespace: string) => void;
+  getCSVs: (cluster: string, namespace: string) => void;
   csvs: IClusterServiceVersion[];
   featureFlags: IFeatureFlags;
 }
@@ -45,11 +45,11 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
   };
 
   public componentDidMount() {
-    const { repo, fetchCharts, filter, namespace, getCSVs, featureFlags } = this.props;
+    const { repo, fetchCharts, filter, cluster, namespace, getCSVs, featureFlags } = this.props;
     this.setState({ filter });
     fetchCharts(namespace, repo);
     if (featureFlags.operators) {
-      getCSVs(namespace);
+      getCSVs(cluster, namespace);
     }
   }
 
@@ -61,7 +61,7 @@ class Catalog extends React.Component<ICatalogProps, ICatalogState> {
       this.props.fetchCharts(this.props.namespace, this.props.repo);
     }
     if (this.props.namespace !== prevProps.namespace && this.props.featureFlags.operators) {
-      this.props.getCSVs(this.props.namespace);
+      this.props.getCSVs(this.props.cluster, this.props.namespace);
     }
   }
 

--- a/dashboard/src/components/Catalog/Catalog.v2.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.v2.test.tsx
@@ -81,7 +81,7 @@ const populatedProps = {
 it("retrieves csvs in the namespace", () => {
   const getCSVs = jest.fn();
   mountWrapper(defaultStore, <Catalog {...populatedProps} getCSVs={getCSVs} />);
-  expect(getCSVs).toHaveBeenCalledWith(defaultProps.namespace);
+  expect(getCSVs).toHaveBeenCalledWith(defaultProps.cluster, defaultProps.namespace);
 });
 
 it("shows all the elements", () => {

--- a/dashboard/src/components/Catalog/Catalog.v2.tsx
+++ b/dashboard/src/components/Catalog/Catalog.v2.tsx
@@ -40,7 +40,7 @@ interface ICatalogProps {
   cluster: string;
   namespace: string;
   kubeappsNamespace: string;
-  getCSVs: (namespace: string) => void;
+  getCSVs: (cluster: string, namespace: string) => void;
   csvs: IClusterServiceVersion[];
   featureFlags: IFeatureFlags;
 }
@@ -77,8 +77,8 @@ function Catalog(props: ICatalogProps) {
 
   useEffect(() => {
     fetchCharts(namespace, repo);
-    getCSVs(namespace);
-  }, [namespace, repo, fetchCharts, getCSVs]);
+    getCSVs(cluster, namespace);
+  }, [cluster, namespace, repo, fetchCharts, getCSVs]);
 
   useEffect(() => {
     setSearchFilter(propsFilter);

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
@@ -43,6 +43,7 @@ it("gets a resource when loading the component", () => {
   const getResource = jest.fn();
   shallow(<OperatorInstance {...defaultProps} getResource={getResource} />);
   expect(getResource).toHaveBeenCalledWith(
+    defaultProps.cluster,
     defaultProps.namespace,
     defaultProps.csvName,
     defaultProps.crdName,

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.test.tsx
@@ -115,7 +115,12 @@ describe("renders a resource", () => {
     const dialog = wrapper.find(ConfirmDialog);
     expect(dialog.prop("modalIsOpen")).toEqual(true);
     (dialog.prop("onConfirm") as any)();
-    expect(deleteResource).toHaveBeenCalledWith(defaultProps.namespace, "foo", resource);
+    expect(deleteResource).toHaveBeenCalledWith(
+      defaultProps.cluster,
+      defaultProps.namespace,
+      "foo",
+      resource,
+    );
     // wait async calls
     await new Promise(r => r());
     expect(push).toHaveBeenCalledWith(app.apps.list(defaultProps.cluster, defaultProps.namespace));

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -27,6 +27,7 @@ export interface IOperatorInstanceProps {
   crdName: string;
   instanceName: string;
   getResource: (
+    cluster: string,
     namespace: string,
     csvName: string,
     crdName: string,
@@ -55,8 +56,8 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
   };
 
   public componentDidMount() {
-    const { csvName, crdName, instanceName, namespace, getResource } = this.props;
-    getResource(namespace, csvName, crdName, instanceName);
+    const { cluster, csvName, crdName, instanceName, namespace, getResource } = this.props;
+    getResource(cluster, namespace, csvName, crdName, instanceName);
   }
 
   public componentDidUpdate(prevProps: IOperatorInstanceProps) {
@@ -71,7 +72,7 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
       csv,
     } = this.props;
     if (prevProps.namespace !== namespace) {
-      getResource(namespace, csvName, crdName, instanceName);
+      getResource(cluster, namespace, csvName, crdName, instanceName);
       return;
     }
     let crd = this.state.crd;

--- a/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
+++ b/dashboard/src/components/OperatorInstance/OperatorInstance.tsx
@@ -33,7 +33,12 @@ export interface IOperatorInstanceProps {
     crdName: string,
     resourceName: string,
   ) => Promise<void>;
-  deleteResource: (namespace: string, crdName: string, resource: IResource) => Promise<boolean>;
+  deleteResource: (
+    cluster: string,
+    namespace: string,
+    crdName: string,
+    resource: IResource,
+  ) => Promise<boolean>;
   push: (location: string) => RouterAction;
   errors: {
     fetch?: Error;
@@ -286,9 +291,14 @@ class OperatorInstance extends React.Component<IOperatorInstanceProps, IOperator
   };
 
   private handleDeleteClick = async () => {
-    const { kubeappsCluster, namespace, resource } = this.props;
+    const { kubeappsCluster, cluster, namespace, resource } = this.props;
     const { crd } = this.state;
-    const deleted = await this.props.deleteResource(namespace, crd!.name.split(".")[0], resource!);
+    const deleted = await this.props.deleteResource(
+      cluster,
+      namespace,
+      crd!.name.split(".")[0],
+      resource!,
+    );
     this.closeModal();
     if (deleted) {
       this.props.push(app.apps.list(kubeappsCluster, namespace));

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.test.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.test.tsx
@@ -47,7 +47,11 @@ it("displays an alert if rendered for an additional cluster", () => {
 it("retrieves CSV when mounted", () => {
   const getCSV = jest.fn();
   shallow(<OperatorInstanceForm {...defaultProps} getCSV={getCSV} />);
-  expect(getCSV).toHaveBeenCalledWith(defaultProps.namespace, defaultProps.csvName);
+  expect(getCSV).toHaveBeenCalledWith(
+    defaultProps.cluster,
+    defaultProps.namespace,
+    defaultProps.csvName,
+  );
 });
 
 it("retrieves the example values and the target CRD from the given CSV", () => {

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.test.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.test.tsx
@@ -103,6 +103,7 @@ it("should submit the form", () => {
     },
   };
   expect(createResource).toHaveBeenCalledWith(
+    defaultProps.cluster,
     defaultProps.namespace,
     resource.apiVersion,
     defaultCRD.name,

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
@@ -19,6 +19,7 @@ export interface IOperatorInstanceFormProps {
   kubeappsCluster: string;
   getCSV: (cluster: string, namespace: string, csvName: string) => void;
   createResource: (
+    cluster: string,
     namespace: string,
     apiVersion: string,
     resource: string,
@@ -129,7 +130,13 @@ class DeploymentFormBody extends React.Component<
       throw new Error(`Missing CRD (${JSON.stringify(crd)}) or CSV (${JSON.stringify(csv)})`);
     }
     const resourceType = crd.name.split(".")[0];
-    const created = await createResource(namespace, resource.apiVersion, resourceType, resource);
+    const created = await createResource(
+      cluster,
+      namespace,
+      resource.apiVersion,
+      resourceType,
+      resource,
+    );
     if (created) {
       push(
         url.app.operatorInstances.view(

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
@@ -17,7 +17,7 @@ export interface IOperatorInstanceFormProps {
   cluster: string;
   namespace: string;
   kubeappsCluster: string;
-  getCSV: (namespace: string, csvName: string) => void;
+  getCSV: (cluster: string, namespace: string, csvName: string) => void;
   createResource: (
     namespace: string,
     apiVersion: string,
@@ -46,8 +46,8 @@ class DeploymentFormBody extends React.Component<
   };
 
   public componentDidMount() {
-    const { getCSV, csvName, namespace } = this.props;
-    getCSV(namespace, csvName);
+    const { cluster, getCSV, csvName, namespace } = this.props;
+    getCSV(cluster, namespace, csvName);
   }
 
   public componentDidUpdate(prevProps: IOperatorInstanceFormProps) {

--- a/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.test.tsx
+++ b/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.test.tsx
@@ -69,6 +69,7 @@ it("should submit the form", () => {
   form.simulate("submit", { preventDefault: jest.fn() });
 
   expect(updateResource).toHaveBeenCalledWith(
+    defaultProps.cluster,
     defaultProps.namespace,
     defaultResource.apiVersion,
     defaultProps.crdName,

--- a/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.test.tsx
+++ b/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.test.tsx
@@ -37,6 +37,7 @@ it("gets a resource", () => {
   const getResource = jest.fn();
   shallow(<OperatorInstanceUpdateForm {...defaultProps} getResource={getResource} />);
   expect(getResource).toHaveBeenCalledWith(
+    defaultProps.cluster,
     defaultProps.namespace,
     defaultProps.csvName,
     defaultProps.crdName,

--- a/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.tsx
+++ b/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.tsx
@@ -25,6 +25,7 @@ export interface IOperatorInstanceUpgradeFormProps {
     resourceName: string,
   ) => Promise<void>;
   updateResource: (
+    cluster: string,
     namespace: string,
     apiVersion: string,
     resource: string,
@@ -109,6 +110,7 @@ class DeploymentFormBody extends React.Component<
     const { updateResource, crdName, resourceName, cluster, namespace, push, csvName } = this.props;
 
     const created = await updateResource(
+      cluster,
       namespace,
       resource.apiVersion,
       crdName.split(".")[0],

--- a/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.tsx
+++ b/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.tsx
@@ -18,6 +18,7 @@ export interface IOperatorInstanceUpgradeFormProps {
   kubeappsCluster: string;
   resourceName: string;
   getResource: (
+    cluster: string,
     namespace: string,
     csvName: string,
     crdName: string,
@@ -52,8 +53,8 @@ class DeploymentFormBody extends React.Component<
   };
 
   public componentDidMount() {
-    const { csvName, crdName, resourceName, namespace, getResource } = this.props;
-    getResource(namespace, csvName, crdName, resourceName);
+    const { cluster, csvName, crdName, resourceName, namespace, getResource } = this.props;
+    getResource(cluster, namespace, csvName, crdName, resourceName);
   }
 
   public componentDidUpdate(prevProps: IOperatorInstanceUpgradeFormProps) {

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -29,12 +29,12 @@ import "./OperatorList.css";
 
 export interface IOperatorListProps {
   isFetching: boolean;
-  checkOLMInstalled: (namespace: string) => Promise<boolean>;
+  checkOLMInstalled: (cluster: string, namespace: string) => Promise<boolean>;
   isOLMInstalled: boolean;
   cluster: string;
   namespace: string;
   kubeappsCluster: string;
-  getOperators: (namespace: string) => Promise<void>;
+  getOperators: (cluster: string, namespace: string) => Promise<void>;
   operators: IPackageManifest[];
   error?: Error;
   getCSVs: (namespace: string) => Promise<IClusterServiceVersion[]>;
@@ -81,19 +81,19 @@ class OperatorList extends React.Component<IOperatorListProps, IOperatorListStat
   };
 
   public componentDidMount() {
-    this.props.checkOLMInstalled(this.props.namespace);
-    this.props.getOperators(this.props.namespace);
+    this.props.checkOLMInstalled(this.props.cluster, this.props.namespace);
+    this.props.getOperators(this.props.cluster, this.props.namespace);
     this.props.getCSVs(this.props.namespace);
     this.setState({ filter: this.props.filter });
   }
 
   public componentDidUpdate(prevProps: IOperatorListProps) {
     if (prevProps.namespace !== this.props.namespace) {
-      this.props.getOperators(this.props.namespace);
+      this.props.getOperators(this.props.cluster, this.props.namespace);
       this.props.getCSVs(this.props.namespace);
     }
     if (this.props.filter !== prevProps.filter) {
-      this.props.getOperators(this.props.namespace);
+      this.props.getOperators(this.props.cluster, this.props.namespace);
       this.props.getCSVs(this.props.namespace);
       this.setState({ filter: this.props.filter });
     }

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -37,7 +37,7 @@ export interface IOperatorListProps {
   getOperators: (cluster: string, namespace: string) => Promise<void>;
   operators: IPackageManifest[];
   error?: Error;
-  getCSVs: (namespace: string) => Promise<IClusterServiceVersion[]>;
+  getCSVs: (cluster: string, namespace: string) => Promise<IClusterServiceVersion[]>;
   csvs: IClusterServiceVersion[];
   filter: string;
   pushSearchFilter: (filter: string) => RouterAction;
@@ -83,18 +83,18 @@ class OperatorList extends React.Component<IOperatorListProps, IOperatorListStat
   public componentDidMount() {
     this.props.checkOLMInstalled(this.props.cluster, this.props.namespace);
     this.props.getOperators(this.props.cluster, this.props.namespace);
-    this.props.getCSVs(this.props.namespace);
+    this.props.getCSVs(this.props.cluster, this.props.namespace);
     this.setState({ filter: this.props.filter });
   }
 
   public componentDidUpdate(prevProps: IOperatorListProps) {
     if (prevProps.namespace !== this.props.namespace) {
       this.props.getOperators(this.props.cluster, this.props.namespace);
-      this.props.getCSVs(this.props.namespace);
+      this.props.getCSVs(this.props.cluster, this.props.namespace);
     }
     if (this.props.filter !== prevProps.filter) {
       this.props.getOperators(this.props.cluster, this.props.namespace);
-      this.props.getCSVs(this.props.namespace);
+      this.props.getCSVs(this.props.cluster, this.props.namespace);
       this.setState({ filter: this.props.filter });
     }
 

--- a/dashboard/src/components/OperatorList/OperatorList.v2.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.v2.tsx
@@ -71,7 +71,7 @@ export default function OperatorList({
   }, [filter]);
 
   useEffect(() => {
-    dispatch(actions.operators.checkOLMInstalled(namespace));
+    dispatch(actions.operators.checkOLMInstalled(cluster, namespace));
   }, [dispatch, namespace]);
 
   const {
@@ -85,7 +85,7 @@ export default function OperatorList({
 
   useEffect(() => {
     if (isOLMInstalled) {
-      dispatch(actions.operators.getOperators(namespace));
+      dispatch(actions.operators.getOperators(cluster, namespace));
     }
   }, [dispatch, namespace, isOLMInstalled]);
 

--- a/dashboard/src/components/OperatorList/OperatorList.v2.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.v2.tsx
@@ -72,7 +72,7 @@ export default function OperatorList({
 
   useEffect(() => {
     dispatch(actions.operators.checkOLMInstalled(cluster, namespace));
-  }, [dispatch, namespace]);
+  }, [dispatch, cluster, namespace]);
 
   const {
     operators,
@@ -87,7 +87,7 @@ export default function OperatorList({
     if (isOLMInstalled) {
       dispatch(actions.operators.getOperators(cluster, namespace));
     }
-  }, [dispatch, namespace, isOLMInstalled]);
+  }, [dispatch, cluster, namespace, isOLMInstalled]);
 
   if (cluster !== "default") {
     return <OperatorNotSupported namespace={namespace} />;

--- a/dashboard/src/components/OperatorNew/OperatorNew.test.tsx
+++ b/dashboard/src/components/OperatorNew/OperatorNew.test.tsx
@@ -57,15 +57,27 @@ it("displays an alert if rendered for an additional cluster", () => {
 it("calls getOperator when mounting the component", () => {
   const getOperator = jest.fn();
   shallow(<OperatorNew {...defaultProps} getOperator={getOperator} />);
-  expect(getOperator).toHaveBeenCalledWith(defaultProps.namespace, defaultProps.operatorName);
+  expect(getOperator).toHaveBeenCalledWith(
+    defaultProps.cluster,
+    defaultProps.namespace,
+    defaultProps.operatorName,
+  );
 });
 
 it("calls getOperator when changing the namespace the component", () => {
   const getOperator = jest.fn();
   const wrapper = shallow(<OperatorNew {...defaultProps} getOperator={getOperator} />);
-  expect(getOperator).toHaveBeenCalledWith(defaultProps.namespace, defaultProps.operatorName);
+  expect(getOperator).toHaveBeenCalledWith(
+    defaultProps.cluster,
+    defaultProps.namespace,
+    defaultProps.operatorName,
+  );
   wrapper.setProps({ namespace: "foo" });
-  expect(getOperator).toHaveBeenCalledWith("foo", defaultProps.operatorName);
+  expect(getOperator).toHaveBeenCalledWith(
+    defaultProps.cluster,
+    defaultProps.namespace,
+    defaultProps.operatorName,
+  );
 });
 
 it("parses the default channel when receiving the operator", () => {

--- a/dashboard/src/components/OperatorNew/OperatorNew.test.tsx
+++ b/dashboard/src/components/OperatorNew/OperatorNew.test.tsx
@@ -142,6 +142,13 @@ it("deploys an operator", async () => {
   const onSubmit = wrapper.find("form").prop("onSubmit") as () => Promise<void>;
   await onSubmit();
 
-  expect(createOperator).toHaveBeenCalledWith("operators", "foo", "beta", "Automatic", "foo.1.0.0");
+  expect(createOperator).toHaveBeenCalledWith(
+    "default",
+    "operators",
+    "foo",
+    "beta",
+    "Automatic",
+    "foo.1.0.0",
+  );
   expect(push).toHaveBeenCalledWith("/c/default/ns/operators/operators");
 });

--- a/dashboard/src/components/OperatorNew/OperatorNew.tsx
+++ b/dashboard/src/components/OperatorNew/OperatorNew.tsx
@@ -16,7 +16,7 @@ import "./OperatorNew.css";
 export interface IOperatorNewProps {
   operatorName: string;
   operator?: IPackageManifest;
-  getOperator: (namespace: string, name: string) => Promise<void>;
+  getOperator: (cluster: string, namespace: string, name: string) => Promise<void>;
   isFetching: boolean;
   cluster: string;
   namespace: string;
@@ -49,8 +49,8 @@ class OperatorNew extends React.Component<IOperatorNewProps, IOperatorNewState> 
   };
 
   public componentDidMount() {
-    const { operatorName, namespace, getOperator } = this.props;
-    getOperator(namespace, operatorName);
+    const { cluster, operatorName, namespace, getOperator } = this.props;
+    getOperator(cluster, namespace, operatorName);
   }
 
   public componentDidUpdate(prevProps: IOperatorNewProps) {
@@ -64,7 +64,7 @@ class OperatorNew extends React.Component<IOperatorNewProps, IOperatorNewState> 
       });
     }
     if (prevProps.namespace !== this.props.namespace) {
-      this.props.getOperator(this.props.namespace, this.props.operatorName);
+      this.props.getOperator(this.props.cluster, this.props.namespace, this.props.operatorName);
     }
   }
 

--- a/dashboard/src/components/OperatorNew/OperatorNew.tsx
+++ b/dashboard/src/components/OperatorNew/OperatorNew.tsx
@@ -23,6 +23,7 @@ export interface IOperatorNewProps {
   kubeappsCluster: string;
   errors: IOperatorsStateError;
   createOperator: (
+    cluster: string,
     namespace: string,
     name: string,
     channel: string,
@@ -265,6 +266,7 @@ class OperatorNew extends React.Component<IOperatorNewProps, IOperatorNewState> 
     const targetNS = installationModeGlobal ? "operators" : namespace;
     const approvalStrategy = approvalStrategyAutomatic ? "Automatic" : "Manual";
     const deployed = await createOperator(
+      cluster,
       targetNS,
       operator!.metadata.name,
       updateChannel!.name,

--- a/dashboard/src/components/OperatorView/OperatorView.test.tsx
+++ b/dashboard/src/components/OperatorView/OperatorView.test.tsx
@@ -71,6 +71,7 @@ it("tries to get the CSV for the current operator", () => {
   wrapper.setProps({ operator: defaultOperator });
 
   expect(getCSV).toHaveBeenCalledWith(
+    defaultProps.cluster,
     defaultOperator.metadata.namespace,
     defaultOperator.status.channels[0].currentCSV,
   );

--- a/dashboard/src/components/OperatorView/OperatorView.test.tsx
+++ b/dashboard/src/components/OperatorView/OperatorView.test.tsx
@@ -58,7 +58,11 @@ it("displays an alert if rendered for an additional cluster", () => {
 it("calls getOperator when mounting the component", () => {
   const getOperator = jest.fn();
   shallow(<OperatorView {...defaultProps} getOperator={getOperator} />);
-  expect(getOperator).toHaveBeenCalledWith(defaultProps.namespace, defaultProps.operatorName);
+  expect(getOperator).toHaveBeenCalledWith(
+    defaultProps.cluster,
+    defaultProps.namespace,
+    defaultProps.operatorName,
+  );
 });
 
 it("tries to get the CSV for the current operator", () => {

--- a/dashboard/src/components/OperatorView/OperatorView.tsx
+++ b/dashboard/src/components/OperatorView/OperatorView.tsx
@@ -22,7 +22,11 @@ export interface IOperatorViewProps {
   kubeappsCluster: string;
   error?: Error;
   push: (location: string) => RouterAction;
-  getCSV: (namespace: string, name: string) => Promise<IClusterServiceVersion | undefined>;
+  getCSV: (
+    cluster: string,
+    namespace: string,
+    name: string,
+  ) => Promise<IClusterServiceVersion | undefined>;
   csv?: IClusterServiceVersion;
 }
 
@@ -37,7 +41,7 @@ class OperatorView extends React.Component<IOperatorViewProps> {
     if (prevProps.operator !== this.props.operator && this.props.operator) {
       const defaultChannel = Operators.getDefaultChannel(this.props.operator);
       if (defaultChannel) {
-        getCSV(namespace, defaultChannel.currentCSV);
+        getCSV(cluster, namespace, defaultChannel.currentCSV);
       }
     }
     if (prevProps.namespace !== this.props.namespace) {

--- a/dashboard/src/components/OperatorView/OperatorView.tsx
+++ b/dashboard/src/components/OperatorView/OperatorView.tsx
@@ -15,7 +15,7 @@ import OperatorHeader from "./OperatorHeader";
 export interface IOperatorViewProps {
   operatorName: string;
   operator?: IPackageManifest;
-  getOperator: (namespace: string, name: string) => Promise<void>;
+  getOperator: (cluster: string, namespace: string, name: string) => Promise<void>;
   isFetching: boolean;
   cluster: string;
   namespace: string;
@@ -28,12 +28,12 @@ export interface IOperatorViewProps {
 
 class OperatorView extends React.Component<IOperatorViewProps> {
   public componentDidMount() {
-    const { operatorName, namespace, getOperator } = this.props;
-    getOperator(namespace, operatorName);
+    const { cluster, operatorName, namespace, getOperator } = this.props;
+    getOperator(cluster, namespace, operatorName);
   }
 
   public componentDidUpdate(prevProps: IOperatorViewProps) {
-    const { namespace, getOperator, getCSV } = this.props;
+    const { cluster, namespace, getOperator, getCSV } = this.props;
     if (prevProps.operator !== this.props.operator && this.props.operator) {
       const defaultChannel = Operators.getDefaultChannel(this.props.operator);
       if (defaultChannel) {
@@ -41,7 +41,7 @@ class OperatorView extends React.Component<IOperatorViewProps> {
       }
     }
     if (prevProps.namespace !== this.props.namespace) {
-      getOperator(this.props.namespace, this.props.operatorName);
+      getOperator(cluster, this.props.namespace, this.props.operatorName);
     }
   }
 

--- a/dashboard/src/containers/AppListContainer/AppListContainer.tsx
+++ b/dashboard/src/containers/AppListContainer/AppListContainer.tsx
@@ -31,7 +31,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     fetchAppsWithUpdateInfo: (cluster: string, ns: string, all: boolean) =>
       dispatch(actions.apps.fetchAppsWithUpdateInfo(cluster, ns, all)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
-    getCustomResources: (namespace: string) => dispatch(actions.operators.getResources(namespace)),
+    getCustomResources: (cluster: string, namespace: string) =>
+      dispatch(actions.operators.getResources(cluster, namespace)),
   };
 }
 

--- a/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
+++ b/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
@@ -32,7 +32,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     fetchCharts: (namespace: string, repo: string) =>
       dispatch(actions.charts.fetchCharts(namespace, repo)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
-    getCSVs: (namespace: string) => dispatch(actions.operators.getCSVs(namespace)),
+    getCSVs: (cluster: string, namespace: string) =>
+      dispatch(actions.operators.getCSVs(cluster, namespace)),
   };
 }
 

--- a/dashboard/src/containers/OperatorInstanceCreateContainer/OperatorInstanceCreateContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceCreateContainer/OperatorInstanceCreateContainer.tsx
@@ -39,8 +39,13 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
   return {
     getCSV: (cluster: string, namespace: string, name: string) =>
       dispatch(actions.operators.getCSV(cluster, namespace, name)),
-    createResource: (namespace: string, apiVersion: string, resource: string, body: object) =>
-      dispatch(actions.operators.createResource(namespace, apiVersion, resource, body)),
+    createResource: (
+      cluster: string,
+      namespace: string,
+      apiVersion: string,
+      resource: string,
+      body: object,
+    ) => dispatch(actions.operators.createResource(cluster, namespace, apiVersion, resource, body)),
     push: (location: string) => dispatch(push(location)),
   };
 }

--- a/dashboard/src/containers/OperatorInstanceCreateContainer/OperatorInstanceCreateContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceCreateContainer/OperatorInstanceCreateContainer.tsx
@@ -37,8 +37,8 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    getCSV: (namespace: string, name: string) =>
-      dispatch(actions.operators.getCSV(namespace, name)),
+    getCSV: (cluster: string, namespace: string, name: string) =>
+      dispatch(actions.operators.getCSV(cluster, namespace, name)),
     createResource: (namespace: string, apiVersion: string, resource: string, body: object) =>
       dispatch(actions.operators.createResource(namespace, apiVersion, resource, body)),
     push: (location: string) => dispatch(push(location)),

--- a/dashboard/src/containers/OperatorInstanceUpdateContainer/OperatorInstanceUpdateContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceUpdateContainer/OperatorInstanceUpdateContainer.tsx
@@ -46,6 +46,7 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     ) =>
       dispatch(actions.operators.getResource(cluster, namespace, csvName, crdName, resourceName)),
     updateResource: (
+      cluster: string,
       namespace: string,
       apiVersion: string,
       resource: string,
@@ -53,7 +54,14 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
       body: object,
     ) =>
       dispatch(
-        actions.operators.updateResource(namespace, apiVersion, resource, resourceName, body),
+        actions.operators.updateResource(
+          cluster,
+          namespace,
+          apiVersion,
+          resource,
+          resourceName,
+          body,
+        ),
       ),
     push: (location: string) => dispatch(push(location)),
   };

--- a/dashboard/src/containers/OperatorInstanceUpdateContainer/OperatorInstanceUpdateContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceUpdateContainer/OperatorInstanceUpdateContainer.tsx
@@ -37,8 +37,14 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    getResource: (namespace: string, csvName: string, crdName: string, resourceName: string) =>
-      dispatch(actions.operators.getResource(namespace, csvName, crdName, resourceName)),
+    getResource: (
+      cluster: string,
+      namespace: string,
+      csvName: string,
+      crdName: string,
+      resourceName: string,
+    ) =>
+      dispatch(actions.operators.getResource(cluster, namespace, csvName, crdName, resourceName)),
     updateResource: (
       namespace: string,
       apiVersion: string,

--- a/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
@@ -36,8 +36,14 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    getResource: (namespace: string, csvName: string, crdName: string, resourceName: string) =>
-      dispatch(actions.operators.getResource(namespace, csvName, crdName, resourceName)),
+    getResource: (
+      cluster: string,
+      namespace: string,
+      csvName: string,
+      crdName: string,
+      resourceName: string,
+    ) =>
+      dispatch(actions.operators.getResource(cluster, namespace, csvName, crdName, resourceName)),
     deleteResource: (namespace: string, crdName: string, resource: IResource) =>
       dispatch(actions.operators.deleteResource(namespace, crdName, resource)),
     push: (location: string) => dispatch(push(location)),

--- a/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
@@ -44,8 +44,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
       resourceName: string,
     ) =>
       dispatch(actions.operators.getResource(cluster, namespace, csvName, crdName, resourceName)),
-    deleteResource: (namespace: string, crdName: string, resource: IResource) =>
-      dispatch(actions.operators.deleteResource(namespace, crdName, resource)),
+    deleteResource: (cluster: string, namespace: string, crdName: string, resource: IResource) =>
+      dispatch(actions.operators.deleteResource(cluster, namespace, crdName, resource)),
     push: (location: string) => dispatch(push(location)),
   };
 }

--- a/dashboard/src/containers/OperatorNewContainer/OperatorNewContainer.tsx
+++ b/dashboard/src/containers/OperatorNewContainer/OperatorNewContainer.tsx
@@ -35,6 +35,7 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     getOperator: (cluster: string, namespace: string, operatorName: string) =>
       dispatch(actions.operators.getOperator(cluster, namespace, operatorName)),
     createOperator: (
+      cluster: string,
       namespace: string,
       name: string,
       channel: string,
@@ -42,7 +43,14 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
       csv: string,
     ) =>
       dispatch(
-        actions.operators.createOperator(namespace, name, channel, installPlanApproval, csv),
+        actions.operators.createOperator(
+          cluster,
+          namespace,
+          name,
+          channel,
+          installPlanApproval,
+          csv,
+        ),
       ),
     push: (location: string) => dispatch(push(location)),
   };

--- a/dashboard/src/containers/OperatorNewContainer/OperatorNewContainer.tsx
+++ b/dashboard/src/containers/OperatorNewContainer/OperatorNewContainer.tsx
@@ -32,8 +32,8 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    getOperator: (namespace: string, operatorName: string) =>
-      dispatch(actions.operators.getOperator(namespace, operatorName)),
+    getOperator: (cluster: string, namespace: string, operatorName: string) =>
+      dispatch(actions.operators.getOperator(cluster, namespace, operatorName)),
     createOperator: (
       namespace: string,
       name: string,

--- a/dashboard/src/containers/OperatorViewContainer/OperatorViewContainer.tsx
+++ b/dashboard/src/containers/OperatorViewContainer/OperatorViewContainer.tsx
@@ -33,8 +33,8 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    getOperator: (namespace: string, operatorName: string) =>
-      dispatch(actions.operators.getOperator(namespace, operatorName)),
+    getOperator: (cluster: string, namespace: string, operatorName: string) =>
+      dispatch(actions.operators.getOperator(cluster, namespace, operatorName)),
     push: (location: string) => dispatch(push(location)),
     getCSV: (namespace: string, name: string) =>
       dispatch(actions.operators.getCSV(namespace, name)),

--- a/dashboard/src/containers/OperatorViewContainer/OperatorViewContainer.tsx
+++ b/dashboard/src/containers/OperatorViewContainer/OperatorViewContainer.tsx
@@ -36,8 +36,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
     getOperator: (cluster: string, namespace: string, operatorName: string) =>
       dispatch(actions.operators.getOperator(cluster, namespace, operatorName)),
     push: (location: string) => dispatch(push(location)),
-    getCSV: (namespace: string, name: string) =>
-      dispatch(actions.operators.getCSV(namespace, name)),
+    getCSV: (cluster: string, namespace: string, name: string) =>
+      dispatch(actions.operators.getCSV(cluster, namespace, name)),
   };
 }
 

--- a/dashboard/src/containers/OperatorsListContainer/OperatorsListContainer.tsx
+++ b/dashboard/src/containers/OperatorsListContainer/OperatorsListContainer.tsx
@@ -32,7 +32,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
       dispatch(actions.operators.checkOLMInstalled(cluster, namespace)),
     getOperators: (cluster: string, namespace: string) =>
       dispatch(actions.operators.getOperators(cluster, namespace)),
-    getCSVs: (namespace: string) => dispatch(actions.operators.getCSVs(namespace)),
+    getCSVs: (cluster: string, namespace: string) =>
+      dispatch(actions.operators.getCSVs(cluster, namespace)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
   };
 }

--- a/dashboard/src/containers/OperatorsListContainer/OperatorsListContainer.tsx
+++ b/dashboard/src/containers/OperatorsListContainer/OperatorsListContainer.tsx
@@ -28,9 +28,10 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    checkOLMInstalled: (namespace: string) =>
-      dispatch(actions.operators.checkOLMInstalled(namespace)),
-    getOperators: (namespace: string) => dispatch(actions.operators.getOperators(namespace)),
+    checkOLMInstalled: (cluster: string, namespace: string) =>
+      dispatch(actions.operators.checkOLMInstalled(cluster, namespace)),
+    getOperators: (cluster: string, namespace: string) =>
+      dispatch(actions.operators.getOperators(cluster, namespace)),
     getCSVs: (namespace: string) => dispatch(actions.operators.getCSVs(namespace)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
   };

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -309,6 +309,7 @@ describe("clusterReducer", () => {
 
   context("when RECEIVE_CONFIG", () => {
     const config = {
+      kubeappsCluster: "kubeappsCluster",
       kubeappsNamespace: "kubeapps",
       appVersion: "dev",
       authProxyEnabled: false,
@@ -328,6 +329,7 @@ describe("clusterReducer", () => {
         }),
       ).toEqual({
         ...initialTestState,
+        currentCluster: "kubeappsCluster",
         clusters: {
           ...initialTestState.clusters,
           additionalCluster1: {
@@ -354,7 +356,10 @@ describe("clusterReducer", () => {
           type: getType(actions.config.receiveConfig),
           payload: badConfig,
         }),
-      ).toEqual(initialTestState);
+      ).toEqual({
+        ...initialTestState,
+        currentCluster: "kubeappsCluster",
+      });
     });
   });
 });

--- a/dashboard/src/reducers/cluster.ts
+++ b/dashboard/src/reducers/cluster.ts
@@ -159,6 +159,7 @@ const clusterReducer = (
       });
       return {
         ...state,
+        currentCluster: action.payload.kubeappsCluster,
         clusters,
       };
     default:

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -71,7 +71,7 @@ it("get csv", async () => {
   const csv = { metadata: { name: "foo" } } as IClusterServiceVersion;
   const ns = "default";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: csv });
-  expect(await Operators.getCSV(ns, "foo")).toEqual(csv);
+  expect(await Operators.getCSV("default", ns, "foo")).toEqual(csv);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
     `api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions/foo`,

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -48,8 +48,9 @@ it("get operator", async () => {
 it("get csvs", async () => {
   const csv = { metadata: { name: "foo" } } as IClusterServiceVersion;
   const ns = "default";
+  const cluster = "default";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: { items: [csv] } });
-  expect(await Operators.getCSVs(ns)).toEqual([csv]);
+  expect(await Operators.getCSVs(cluster, ns)).toEqual([csv]);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
     `api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions`,
@@ -59,8 +60,9 @@ it("get csvs", async () => {
 it("get global csvs", async () => {
   const csv = { metadata: { name: "foo" } } as IClusterServiceVersion;
   const ns = "_all";
+  const cluster = "default";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: { items: [csv] } });
-  expect(await Operators.getCSVs(ns)).toEqual([csv]);
+  expect(await Operators.getCSVs(cluster, ns)).toEqual([csv]);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
     "api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/operators/clusterserviceversions",

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -34,38 +34,35 @@ it("get operators", async () => {
 
 it("get operator", async () => {
   const operator = { metadata: { name: "foo" } } as IPackageManifest;
-  const cluster = "default";
   const ns = "default";
   const opName = "foo";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: operator });
   expect(await Operators.getOperator(cluster, ns, opName)).toEqual(operator);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
-    `api/clusters/default/apis/packages.operators.coreos.com/v1/namespaces/${ns}/packagemanifests/${opName}`,
+    `api/clusters/defaultc/apis/packages.operators.coreos.com/v1/namespaces/${ns}/packagemanifests/${opName}`,
   );
 });
 
 it("get csvs", async () => {
   const csv = { metadata: { name: "foo" } } as IClusterServiceVersion;
   const ns = "default";
-  const cluster = "default";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: { items: [csv] } });
   expect(await Operators.getCSVs(cluster, ns)).toEqual([csv]);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
-    `api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions`,
+    `api/clusters/defaultc/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions`,
   );
 });
 
 it("get global csvs", async () => {
   const csv = { metadata: { name: "foo" } } as IClusterServiceVersion;
   const ns = "_all";
-  const cluster = "default";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: { items: [csv] } });
   expect(await Operators.getCSVs(cluster, ns)).toEqual([csv]);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
-    "api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/operators/clusterserviceversions",
+    "api/clusters/defaultc/apis/operators.coreos.com/v1alpha1/namespaces/operators/clusterserviceversions",
   );
 });
 
@@ -73,10 +70,10 @@ it("get csv", async () => {
   const csv = { metadata: { name: "foo" } } as IClusterServiceVersion;
   const ns = "default";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: csv });
-  expect(await Operators.getCSV("default", ns, "foo")).toEqual(csv);
+  expect(await Operators.getCSV(cluster, ns, "foo")).toEqual(csv);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
-    `api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions/foo`,
+    `api/clusters/defaultc/apis/operators.coreos.com/v1alpha1/namespaces/${ns}/clusterserviceversions/foo`,
   );
 });
 
@@ -84,10 +81,10 @@ it("creates a resource", async () => {
   const resource = { metadata: { name: "foo" } } as IResource;
   const ns = "default";
   axiosWithAuth.post = jest.fn().mockReturnValue({ data: resource });
-  expect(await Operators.createResource(ns, "v1", "pods", resource)).toEqual(resource);
+  expect(await Operators.createResource(cluster, ns, "v1", "pods", resource)).toEqual(resource);
   expect(axiosWithAuth.post).toHaveBeenCalled();
   expect((axiosWithAuth.post as jest.Mock).mock.calls[0]).toEqual([
-    `api/clusters/default/apis/v1/namespaces/${ns}/pods`,
+    `api/clusters/defaultc/apis/v1/namespaces/${ns}/pods`,
     resource,
   ]);
 });
@@ -96,10 +93,10 @@ it("list resources", async () => {
   const resource = { metadata: { name: "foo" } } as IResource;
   const ns = "default";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: { items: [resource] } });
-  expect(await Operators.listResources(ns, "v1", "pods")).toEqual({ items: [resource] });
+  expect(await Operators.listResources(cluster, ns, "v1", "pods")).toEqual({ items: [resource] });
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0]).toEqual([
-    `api/clusters/default/apis/v1/namespaces/${ns}/pods`,
+    `api/clusters/defaultc/apis/v1/namespaces/${ns}/pods`,
   ]);
 });
 
@@ -107,10 +104,10 @@ it("get a resource", async () => {
   const resource = { metadata: { name: "foo" } } as IResource;
   const ns = "default";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: resource });
-  expect(await Operators.getResource(ns, "v1", "pods", "foo")).toEqual(resource);
+  expect(await Operators.getResource(cluster, ns, "v1", "pods", "foo")).toEqual(resource);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0]).toEqual([
-    `api/clusters/default/apis/v1/namespaces/${ns}/pods/foo`,
+    `api/clusters/defaultc/apis/v1/namespaces/${ns}/pods/foo`,
   ]);
 });
 
@@ -118,10 +115,10 @@ it("deletes a resource", async () => {
   const resource = { metadata: { name: "foo" } } as IResource;
   const ns = "default";
   axiosWithAuth.delete = jest.fn().mockReturnValue({ data: resource });
-  expect(await Operators.deleteResource(ns, "v1", "pods", "foo")).toEqual(resource);
+  expect(await Operators.deleteResource(cluster, ns, "v1", "pods", "foo")).toEqual(resource);
   expect(axiosWithAuth.delete).toHaveBeenCalled();
   expect((axiosWithAuth.delete as jest.Mock).mock.calls[0]).toEqual([
-    `api/clusters/default/apis/v1/namespaces/${ns}/pods/foo`,
+    `api/clusters/defaultc/apis/v1/namespaces/${ns}/pods/foo`,
   ]);
 });
 
@@ -130,15 +127,16 @@ it("updates a resource", async () => {
   const ns = "default";
   axiosWithAuth.put = jest.fn().mockReturnValue({ data: resource });
   expect(
-    await Operators.updateResource(ns, "v1", "pods", resource.metadata.name, resource),
+    await Operators.updateResource(cluster, ns, "v1", "pods", resource.metadata.name, resource),
   ).toEqual(resource);
   expect(axiosWithAuth.post).toHaveBeenCalled();
   expect((axiosWithAuth.post as jest.Mock).mock.calls[0]).toEqual([
-    `api/clusters/default/apis/v1/namespaces/${ns}/pods`,
+    `api/clusters/defaultc/apis/v1/namespaces/${ns}/pods`,
     resource,
   ]);
 });
 
+const cluster = "defaultc";
 const namespace = "default";
 const subscription = {
   apiVersion: "operators.coreos.com/v1alpha1",
@@ -173,20 +171,20 @@ it("creates an operatorgroup and a subscription", async () => {
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: operatorGroups });
   const resource = { metadata: { name: "foo" } } as IResource;
   axiosWithAuth.post = jest.fn().mockReturnValue({ data: resource });
-  expect(await Operators.createOperator(namespace, "foo", "alpha", "Manual", "foo.1.0.0")).toEqual(
-    resource,
-  );
+  expect(
+    await Operators.createOperator(cluster, namespace, "foo", "alpha", "Manual", "foo.1.0.0"),
+  ).toEqual(resource);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0]).toEqual([
-    `api/clusters/default/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
+    `api/clusters/defaultc/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
   ]);
   expect(axiosWithAuth.post).toHaveBeenCalledTimes(2);
   expect((axiosWithAuth.post as jest.Mock).mock.calls[0]).toEqual([
-    `api/clusters/default/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
+    `api/clusters/defaultc/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
     operatorgroup,
   ]);
   expect((axiosWithAuth.post as jest.Mock).mock.calls[1]).toEqual([
-    `api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/foo`,
+    `api/clusters/defaultc/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/foo`,
     subscription,
   ]);
 });
@@ -196,16 +194,16 @@ it("creates only a subscription if the operator group already exists", async () 
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: operatorGroups });
   const resource = { metadata: { name: "foo" } } as IResource;
   axiosWithAuth.post = jest.fn().mockReturnValue({ data: resource });
-  expect(await Operators.createOperator(namespace, "foo", "alpha", "Manual", "foo.1.0.0")).toEqual(
-    resource,
-  );
+  expect(
+    await Operators.createOperator(cluster, namespace, "foo", "alpha", "Manual", "foo.1.0.0"),
+  ).toEqual(resource);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0]).toEqual([
-    `api/clusters/default/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
+    `api/clusters/defaultc/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
   ]);
   expect(axiosWithAuth.post).toHaveBeenCalledTimes(1);
   expect((axiosWithAuth.post as jest.Mock).mock.calls[0]).toEqual([
-    `api/clusters/default/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/foo`,
+    `api/clusters/defaultc/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/foo`,
     subscription,
   ]);
 });
@@ -216,7 +214,7 @@ it("creates only a subscription if the namespace is operators", async () => {
   const resource = { metadata: { name: "foo" } } as IResource;
   axiosWithAuth.post = jest.fn().mockReturnValue({ data: resource });
   expect(
-    await Operators.createOperator("operators", "foo", "alpha", "Manual", "foo.1.0.0"),
+    await Operators.createOperator(cluster, "operators", "foo", "alpha", "Manual", "foo.1.0.0"),
   ).toEqual(resource);
   expect(axiosWithAuth.get).not.toHaveBeenCalled();
   expect(axiosWithAuth.post).toHaveBeenCalledTimes(1);

--- a/dashboard/src/shared/Operators.test.ts
+++ b/dashboard/src/shared/Operators.test.ts
@@ -4,7 +4,7 @@ import { IClusterServiceVersion, IPackageManifest, IResource } from "./types";
 
 it("check if the OLM has been installed", async () => {
   axiosWithAuth.get = jest.fn().mockReturnValue({ status: 200 });
-  expect(await Operators.isOLMInstalled("ns")).toBe(true);
+  expect(await Operators.isOLMInstalled("default", "ns")).toBe(true);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
     "api/clusters/default/apis/packages.operators.coreos.com/v1/namespaces/ns/packagemanifests",
@@ -13,19 +13,19 @@ it("check if the OLM has been installed", async () => {
 
 it("OLM is not installed if the request fails", async () => {
   axiosWithAuth.get = jest.fn().mockReturnValue({ status: 404 });
-  expect(await Operators.isOLMInstalled("ns")).toBe(false);
+  expect(await Operators.isOLMInstalled("default", "ns")).toBe(false);
 });
 
 it("OLM is not installed if the request returns != 200", async () => {
   axiosWithAuth.get = jest.fn().mockReturnValue({ status: 404 });
-  expect(await Operators.isOLMInstalled("ns")).toBe(false);
+  expect(await Operators.isOLMInstalled("default", "ns")).toBe(false);
 });
 
 it("get operators", async () => {
   const operator = { metadata: { name: "foo" } } as IPackageManifest;
   const ns = "default";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: { items: [operator] } });
-  expect(await Operators.getOperators(ns)).toEqual([operator]);
+  expect(await Operators.getOperators("default", ns)).toEqual([operator]);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
     `api/clusters/default/apis/packages.operators.coreos.com/v1/namespaces/${ns}/packagemanifests`,
@@ -34,10 +34,11 @@ it("get operators", async () => {
 
 it("get operator", async () => {
   const operator = { metadata: { name: "foo" } } as IPackageManifest;
+  const cluster = "default";
   const ns = "default";
   const opName = "foo";
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: operator });
-  expect(await Operators.getOperator(ns, opName)).toEqual(operator);
+  expect(await Operators.getOperator(cluster, ns, opName)).toEqual(operator);
   expect(axiosWithAuth.get).toHaveBeenCalled();
   expect((axiosWithAuth.get as jest.Mock).mock.calls[0][0]).toEqual(
     `api/clusters/default/apis/packages.operators.coreos.com/v1/namespaces/${ns}/packagemanifests/${opName}`,

--- a/dashboard/src/shared/Operators.ts
+++ b/dashboard/src/shared/Operators.ts
@@ -31,11 +31,11 @@ export class Operators {
     return data;
   }
 
-  public static async getCSVs(namespace: string) {
+  public static async getCSVs(cluster: string, namespace: string) {
     // Global operators are installed in the "operators" namespace
     const reqNamespace = namespace === "_all" ? "operators" : namespace;
     const { data } = await axiosWithAuth.get<IK8sList<IClusterServiceVersion, {}>>(
-      urls.api.k8s.operators.clusterServiceVersions(reqNamespace),
+      urls.api.k8s.operators.clusterServiceVersions(cluster, reqNamespace),
     );
     return data.items;
   }

--- a/dashboard/src/shared/Operators.ts
+++ b/dashboard/src/shared/Operators.ts
@@ -48,50 +48,59 @@ export class Operators {
   }
 
   public static async createResource(
+    cluster: string,
     namespace: string,
     apiVersion: string,
     resource: string,
     body: object,
   ) {
     const { data } = await axiosWithAuth.post<IResource>(
-      urls.api.k8s.operators.resources(namespace, apiVersion, resource),
+      urls.api.k8s.operators.resources(cluster, namespace, apiVersion, resource),
       body,
     );
     return data;
   }
 
-  public static async listResources(namespace: string, apiVersion: string, resource: string) {
+  public static async listResources(
+    cluster: string,
+    namespace: string,
+    apiVersion: string,
+    resource: string,
+  ) {
     const { data } = await axiosWithAuth.get<IK8sList<IResource, {}>>(
-      urls.api.k8s.operators.resources(namespace, apiVersion, resource),
+      urls.api.k8s.operators.resources(cluster, namespace, apiVersion, resource),
     );
     return data;
   }
 
   public static async getResource(
+    cluster: string,
     namespace: string,
     apiVersion: string,
     crd: string,
     name: string,
   ) {
     const { data } = await axiosWithAuth.get<IResource>(
-      urls.api.k8s.operators.resource(namespace, apiVersion, crd, name),
+      urls.api.k8s.operators.resource(cluster, namespace, apiVersion, crd, name),
     );
     return data;
   }
 
   public static async deleteResource(
+    cluster: string,
     namespace: string,
     apiVersion: string,
     plural: string,
     name: string,
   ) {
     const { data } = await axiosWithAuth.delete<any>(
-      urls.api.k8s.operators.resource(namespace, apiVersion, plural, name),
+      urls.api.k8s.operators.resource(cluster, namespace, apiVersion, plural, name),
     );
     return data;
   }
 
   public static async updateResource(
+    cluster: string,
     namespace: string,
     apiVersion: string,
     resource: string,
@@ -99,13 +108,14 @@ export class Operators {
     body: object,
   ) {
     const { data } = await axiosWithAuth.put<IResource>(
-      urls.api.k8s.operators.resource(namespace, apiVersion, resource, name),
+      urls.api.k8s.operators.resource(cluster, namespace, apiVersion, resource, name),
       body,
     );
     return data;
   }
 
   public static async createOperator(
+    cluster: string,
     namespace: string,
     name: string,
     channel: string,
@@ -113,10 +123,10 @@ export class Operators {
     csv: string,
   ) {
     // First create the OperatorGroup if needed
-    await this.createOperatorGroupIfNotExists(namespace);
+    await this.createOperatorGroupIfNotExists(cluster, namespace);
     // Now create the subscription
     const { data: result } = await axiosWithAuth.post<IResource>(
-      urls.api.k8s.operators.subscription(namespace, name),
+      urls.api.k8s.operators.subscription(cluster, namespace, name),
       {
         apiVersion: "operators.coreos.com/v1alpha1",
         kind: "Subscription",
@@ -145,20 +155,20 @@ export class Operators {
     return !!channel?.currentCSVDesc.installModes.find(m => m.type === "AllNamespaces")?.supported;
   }
 
-  private static async createOperatorGroupIfNotExists(namespace: string) {
+  private static async createOperatorGroupIfNotExists(cluster: string, namespace: string) {
     if (namespace === "operators") {
       // The opertors ns already have an operatorgroup
       return;
     }
     const { data } = await axiosWithAuth.get<IK8sList<IResource, {}>>(
-      urls.api.k8s.operators.operatorGroups(namespace),
+      urls.api.k8s.operators.operatorGroups(cluster, namespace),
     );
     if (data.items.length > 0) {
       // An operatorgroup already exists, do nothing
       return;
     }
     const { data: result } = await axiosWithAuth.post<IK8sList<IResource, {}>>(
-      urls.api.k8s.operators.operatorGroups(namespace),
+      urls.api.k8s.operators.operatorGroups(cluster, namespace),
       {
         apiVersion: "operators.coreos.com/v1",
         kind: "OperatorGroup",

--- a/dashboard/src/shared/Operators.ts
+++ b/dashboard/src/shared/Operators.ts
@@ -10,21 +10,23 @@ import {
 } from "./types";
 
 export class Operators {
-  public static async isOLMInstalled(namespace: string) {
-    const { status } = await axiosWithAuth.get(urls.api.k8s.operators.operators(namespace));
+  public static async isOLMInstalled(cluster: string, namespace: string) {
+    const { status } = await axiosWithAuth.get(
+      urls.api.k8s.operators.operators(cluster, namespace),
+    );
     return status === 200;
   }
 
-  public static async getOperators(namespace: string) {
+  public static async getOperators(cluster: string, namespace: string) {
     const { data } = await axiosWithAuth.get<IK8sList<IPackageManifest, {}>>(
-      urls.api.k8s.operators.operators(namespace),
+      urls.api.k8s.operators.operators(cluster, namespace),
     );
     return data.items;
   }
 
-  public static async getOperator(namespace: string, name: string) {
+  public static async getOperator(cluster: string, namespace: string, name: string) {
     const { data } = await axiosWithAuth.get<IPackageManifest>(
-      urls.api.k8s.operators.operator(namespace, name),
+      urls.api.k8s.operators.operator(cluster, namespace, name),
     );
     return data;
   }

--- a/dashboard/src/shared/Operators.ts
+++ b/dashboard/src/shared/Operators.ts
@@ -40,9 +40,9 @@ export class Operators {
     return data.items;
   }
 
-  public static async getCSV(namespace: string, name: string) {
+  public static async getCSV(cluster: string, namespace: string, name: string) {
     const { data } = await axiosWithAuth.get<IClusterServiceVersion>(
-      urls.api.k8s.operators.clusterServiceVersion(namespace, name),
+      urls.api.k8s.operators.clusterServiceVersion(cluster, namespace, name),
     );
     return data;
   }

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -3,11 +3,6 @@ import { IK8sList, ISecret } from "./types";
 import * as url from "./url";
 
 export default class Secret {
-  public static async delete(name: string, namespace: string) {
-    const u = url.api.k8s.secret("default", namespace, name);
-    return axiosWithAuth.delete(u);
-  }
-
   public static async get(cluster: string, name: string, namespace: string) {
     const u = url.api.k8s.secret(cluster, namespace, name);
     const { data } = await axiosWithAuth.get<ISecret>(u);

--- a/dashboard/src/shared/ServiceBinding.ts
+++ b/dashboard/src/shared/ServiceBinding.ts
@@ -83,7 +83,10 @@ export class ServiceBinding {
     return data;
   }
 
-  public static async list(namespace?: string): Promise<IServiceBindingWithSecret[]> {
+  public static async list(
+    cluster: string,
+    namespace?: string,
+  ): Promise<IServiceBindingWithSecret[]> {
     const bindings = await ServiceCatalog.getItems<IServiceBinding>("servicebindings", namespace);
 
     return Promise.all(
@@ -91,7 +94,7 @@ export class ServiceBinding {
         const { secretName } = binding.spec;
         const ns = binding.metadata.namespace;
         return axiosWithAuth
-          .get<IK8sApiSecretResponse>(url.api.k8s.secret("default", ns, secretName))
+          .get<IK8sApiSecretResponse>(url.api.k8s.secret(cluster, ns, secretName))
           .then(response => {
             return { binding, secret: response.data };
           })

--- a/dashboard/src/shared/ServiceCatalog.ts
+++ b/dashboard/src/shared/ServiceCatalog.ts
@@ -24,9 +24,9 @@ export class ServiceCatalog {
     return data;
   }
 
-  public static async syncBroker(broker: IServiceBroker) {
+  public static async syncBroker(cluster: string, broker: IServiceBroker) {
     const { data } = await axiosWithAuth.patch<IStatus>(
-      urls.api.k8s.clusterservicebrokers.sync(broker),
+      urls.api.k8s.clusterservicebrokers.sync(cluster, broker),
       {
         spec: {
           relistRequests: broker.spec.relistRequests + 1,

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -150,17 +150,23 @@ export const api = {
         `${api.k8s.base(
           cluster,
         )}/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/clusterserviceversions/${name}`,
-      resources: (namespace: string, apiVersion: string, resource: string) =>
-        `${api.k8s.base("default")}/apis/${apiVersion}/${withNS(namespace)}${resource}`,
-      resource: (namespace: string, apiVersion: string, resource: string, name: string) =>
-        `${api.k8s.base("default")}/apis/${apiVersion}/namespaces/${namespace}/${resource}/${name}`,
-      operatorGroups: (namespace: string) =>
+      resources: (cluster: string, namespace: string, apiVersion: string, resource: string) =>
+        `${api.k8s.base(cluster)}/apis/${apiVersion}/${withNS(namespace)}${resource}`,
+      resource: (
+        cluster: string,
+        namespace: string,
+        apiVersion: string,
+        resource: string,
+        name: string,
+      ) =>
+        `${api.k8s.base(cluster)}/apis/${apiVersion}/namespaces/${namespace}/${resource}/${name}`,
+      operatorGroups: (cluster: string, namespace: string) =>
         `${api.k8s.base(
-          "default",
+          cluster,
         )}/apis/operators.coreos.com/v1/namespaces/${namespace}/operatorgroups`,
-      subscription: (namespace: string, name: string) =>
+      subscription: (cluster: string, namespace: string, name: string) =>
         `${api.k8s.base(
-          "default",
+          cluster,
         )}/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/${name}`,
     },
     secrets: (cluster: string, namespace: string) =>

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -134,13 +134,13 @@ export const api = {
         }`,
     },
     operators: {
-      operators: (namespace: string) =>
-        `${api.k8s.base("default")}/apis/packages.operators.coreos.com/v1/${withNS(
+      operators: (cluster: string, namespace: string) =>
+        `${api.k8s.base(cluster)}/apis/packages.operators.coreos.com/v1/${withNS(
           namespace,
         )}packagemanifests`,
-      operator: (namespace: string, name: string) =>
+      operator: (cluster: string, namespace: string, name: string) =>
         `${api.k8s.base(
-          "default",
+          cluster,
         )}/apis/packages.operators.coreos.com/v1/namespaces/${namespace}/packagemanifests/${name}`,
       clusterServiceVersions: (namespace: string) =>
         `${api.k8s.base("default")}/apis/operators.coreos.com/v1alpha1/${withNS(

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -142,8 +142,8 @@ export const api = {
         `${api.k8s.base(
           cluster,
         )}/apis/packages.operators.coreos.com/v1/namespaces/${namespace}/packagemanifests/${name}`,
-      clusterServiceVersions: (namespace: string) =>
-        `${api.k8s.base("default")}/apis/operators.coreos.com/v1alpha1/${withNS(
+      clusterServiceVersions: (cluster: string, namespace: string) =>
+        `${api.k8s.base(cluster)}/apis/operators.coreos.com/v1alpha1/${withNS(
           namespace,
         )}clusterserviceversions`,
       clusterServiceVersion: (cluster: string, namespace: string, name: string) =>

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -128,8 +128,8 @@ export const api = {
       `${api.k8s.namespaces(cluster)}/${namespace}`,
     // clusterservicebrokers and operators operate on the default cluster only, currently.
     clusterservicebrokers: {
-      sync: (broker: IServiceBroker) =>
-        `${api.k8s.base("default")}/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/${
+      sync: (cluster: string, broker: IServiceBroker) =>
+        `${api.k8s.base(cluster)}/apis/servicecatalog.k8s.io/v1beta1/clusterservicebrokers/${
           broker.metadata.name
         }`,
     },

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -146,9 +146,9 @@ export const api = {
         `${api.k8s.base("default")}/apis/operators.coreos.com/v1alpha1/${withNS(
           namespace,
         )}clusterserviceversions`,
-      clusterServiceVersion: (namespace: string, name: string) =>
+      clusterServiceVersion: (cluster: string, namespace: string, name: string) =>
         `${api.k8s.base(
-          "default",
+          cluster,
         )}/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/clusterserviceversions/${name}`,
       resources: (namespace: string, apiVersion: string, resource: string) =>
         `${api.k8s.base("default")}/apis/${apiVersion}/${withNS(namespace)}${resource}`,


### PR DESCRIPTION
Follows #1972 , related to #1942,  updating the following to no longer assume that the cluster on which Kubeapps is installed is the "default":

- Catalog and Service binding URLs
- all operator URLs.

For the service catalog I've just pulled the cluster out of the config (as I don't know that we're going to be furthering the service catalog work and we'd need to route them using cluster as well), whereas for the operator functionality I've done it properly, passing through from the components through the dispatch functions to actions, to the shared helpers and urls.