### PR TITLE
Include global charts when filtering for charts available in a namespace

### DIFF
--- a/cmd/assetsvc/postgres_db_test.go
+++ b/cmd/assetsvc/postgres_db_test.go
@@ -396,3 +396,115 @@ func TestGetPaginatedChartList(t *testing.T) {
 		})
 	}
 }
+
+func TestGetChartsWithFilters(t *testing.T) {
+	pgtest.SkipIfNoDB(t)
+	const (
+		repoName1     = "repo-name"
+		repoName2     = "repo-name-2"
+		namespaceName = "namespace-name"
+	)
+
+	chartVersion := models.ChartVersion{
+		Digest:     "abc-123",
+		Version:    "1.0chart",
+		AppVersion: "2.0app",
+	}
+
+	chartVersions := []models.ChartVersion{chartVersion}
+
+	chartWithVersionRepo1 := models.Chart{ID: repoName1 + "/chart-1", Name: "chart-1", ChartVersions: chartVersions}
+	chartWithVersionRepo2 := models.Chart{ID: repoName2 + "/chart-1", Name: "chart-1", ChartVersions: chartVersions}
+
+	testCases := []struct {
+		name string
+		// existingCharts is a map of charts per namespace and repo
+		existingCharts map[string]map[string][]models.Chart
+		namespace      string
+		chartName      string
+		chartVersion   string
+		appVersion     string
+		expectedCharts []*models.Chart
+		expectedErr    error
+	}{
+		{
+			name: "returns charts in the specific namespace",
+			existingCharts: map[string]map[string][]models.Chart{
+				namespaceName: {
+					repoName1: {chartWithVersionRepo1},
+					"other-repo": []models.Chart{
+						{ID: "other-repo/other-chart", Name: "other-chart"},
+					},
+				},
+				"other-namespace": {
+					repoName1: {chartWithVersionRepo1},
+				},
+			},
+			namespace:    namespaceName,
+			chartName:    chartWithVersionRepo1.Name,
+			chartVersion: chartWithVersionRepo1.ChartVersions[0].Version,
+			appVersion:   chartWithVersionRepo1.ChartVersions[0].AppVersion,
+			expectedCharts: []*models.Chart{
+				&chartWithVersionRepo1,
+			},
+		},
+		{
+			name: "returns charts from different repos in the specific namespace",
+			existingCharts: map[string]map[string][]models.Chart{
+				namespaceName: {
+					repoName1:    {chartWithVersionRepo1},
+					"other-repo": {chartWithVersionRepo2},
+				},
+			},
+			namespace:    namespaceName,
+			chartName:    chartWithVersionRepo1.Name,
+			chartVersion: chartWithVersionRepo1.ChartVersions[0].Version,
+			appVersion:   chartWithVersionRepo1.ChartVersions[0].AppVersion,
+			expectedCharts: []*models.Chart{
+				&chartWithVersionRepo1,
+				&chartWithVersionRepo2,
+			},
+		},
+		{
+			name: "includes charts from global repositories",
+			existingCharts: map[string]map[string][]models.Chart{
+				namespaceName: {
+					repoName1: {chartWithVersionRepo1},
+				},
+				dbutilstest.KubeappsTestNamespace: {
+					"other-repo": {chartWithVersionRepo2},
+				},
+			},
+			namespace:    namespaceName,
+			chartName:    chartWithVersionRepo1.Name,
+			chartVersion: chartWithVersionRepo1.ChartVersions[0].Version,
+			appVersion:   chartWithVersionRepo1.ChartVersions[0].AppVersion,
+			expectedCharts: []*models.Chart{
+				&chartWithVersionRepo1,
+				&chartWithVersionRepo2,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pam, cleanup := getInitializedManager(t)
+			defer cleanup()
+			for namespace, chartsPerRepo := range tc.existingCharts {
+				for repo, charts := range chartsPerRepo {
+					pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repo, Namespace: namespace})
+				}
+			}
+
+			charts, err := pam.getChartsWithFilters(tc.namespace, tc.chartName, tc.chartVersion, tc.appVersion)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+
+			if got, want := charts, tc.expectedCharts; !cmp.Equal(want, got) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+
+	}
+}

--- a/cmd/assetsvc/postgres_db_test.go
+++ b/cmd/assetsvc/postgres_db_test.go
@@ -400,7 +400,7 @@ func TestGetPaginatedChartList(t *testing.T) {
 func TestGetChartsWithFilters(t *testing.T) {
 	pgtest.SkipIfNoDB(t)
 	const (
-		repoName1     = "repo-name"
+		repoName1     = "repo-name-1"
 		repoName2     = "repo-name-2"
 		namespaceName = "namespace-name"
 	)

--- a/cmd/assetsvc/postgresql_utils_test.go
+++ b/cmd/assetsvc/postgresql_utils_test.go
@@ -171,7 +171,7 @@ func Test_getChartWithFilters(t *testing.T) {
 		},
 	}
 	chartsResponse = []*models.Chart{&dbChart}
-	m.On("QueryAllCharts", "SELECT info FROM charts WHERE repo_namespace = $1 AND info ->> 'name' = $2", []interface{}{"namespace", "foo"})
+	m.On("QueryAllCharts", "SELECT info FROM charts WHERE info ->> 'name' = $1 AND (repo_namespace = $2 OR repo_namespace = $3) ORDER BY info ->> 'ID' ASC", []interface{}{"foo", "namespace", "kubeapps"})
 
 	charts, err := pg.getChartsWithFilters("namespace", "foo", "1.0.0", "1.0.1")
 	if err != nil {

--- a/integration/use-cases/upgrade.js
+++ b/integration/use-cases/upgrade.js
@@ -1,13 +1,11 @@
 test("Upgrades an application", async () => {
-  await page.goto(getUrl("/#/login"));
+  await page.goto(getUrl("/#/c/default/ns/default/catalog"));
 
   await expect(page).toFillForm("form", {
     token: process.env.EDIT_TOKEN
   });
 
   await expect(page).toClick("button", { text: "Login" });
-
-  await expect(page).toClick("a", { text: "Catalog" });
 
   await expect(page).toClick("a", { text: "apache" });
 

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -379,6 +379,7 @@ kubectl create clusterrolebinding kubeapps-view --clusterrole=view --serviceacco
 ## Create edit user
 kubectl create serviceaccount kubeapps-edit -n kubeapps
 kubectl create rolebinding kubeapps-edit -n kubeapps --clusterrole=edit --serviceaccount kubeapps:kubeapps-edit
+kubectl create rolebinding kubeapps-edit -n default --clusterrole=edit --serviceaccount kubeapps:kubeapps-edit
 ## Give the cluster some time to avoid issues like
 ## https://circleci.com/gh/kubeapps/kubeapps/16102
 retry_while "kubectl get -n kubeapps serviceaccount kubeapps-operator -o name" "5" "1"


### PR DESCRIPTION
### Description of the change

Fixes #1980 first by ensuring the integration test fails as it should have and then updating the assetsvc function in question to do what was intended - return charts from both the specific namespace as well as the global charts.

Still TODO: update the mongodb driver in the same way.

### Benefits

Can upgrade charts deployed from the global namespace.

### Applicable issues

  - fixes #1980 

### Additional information

More of the problem investigation and description on the issue.