### PR TITLE
Fix incorrect error handling to avoid panic.

### DIFF
--- a/cmd/tiller-proxy/internal/handler/handler.go
+++ b/cmd/tiller-proxy/internal/handler/handler.go
@@ -139,11 +139,11 @@ func (h *TillerProxy) RollbackRelease(w http.ResponseWriter, req *http.Request, 
 func (h *TillerProxy) UpgradeRelease(w http.ResponseWriter, req *http.Request, params handlerutil.Params) {
 	log.Printf("Upgrading Helm Release")
 	chartDetails, chartMulti, err := handlerutil.ParseAndGetChart(req, h.ChartClient, requireV1Support)
-	ch := chartMulti.Helm2Chart
 	if err != nil {
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)
 		return
 	}
+	ch := chartMulti.Helm2Chart
 	manifest, err := h.ProxyClient.ResolveManifest(params["namespace"], chartDetails.Values, ch)
 	if err != nil {
 		response.NewErrorResponse(handlerutil.ErrorCode(err), err.Error()).Write(w)


### PR DESCRIPTION
### Description of the change

Avoid accessing a nil result by moving to after the error check.

Not sure how that slipped through review.

Example of the panic on #1985 
Fixes #1985 