### PR TITLE
Ensure which repo chart is used during upgrade.

### DIFF
--- a/integration/use-cases/upgrade.js
+++ b/integration/use-cases/upgrade.js
@@ -1,5 +1,5 @@
 test("Upgrades an application", async () => {
-  await page.goto(getUrl("/#/c/default/ns/default/catalog"));
+  await page.goto(getUrl("/#/c/default/ns/default/catalog/bitnami"));
 
   await expect(page).toFillForm("form", {
     token: process.env.EDIT_TOKEN


### PR DESCRIPTION
I noticed yesterday while testing CI for other things that one spurious failure is due to the `apache` chart from the *wrong* repository being clicked on. Even before the change landed yesterday, the `upgrade.js` test just goes to the catalog and clicks on `apache` which, depending on luck, may be the bitnami one and so have the old 7.3.2 version, but if not, the `upgrade.js` test fails with:

![ci-fail-option-not-found](https://user-images.githubusercontent.com/497518/91796862-90e47f00-ec64-11ea-9eff-c8036df72f2f.png)

as the `apache` from the private repo created in the earlier test has been clicked on instead, and it only has two very specific versions.

This change just ensures that the upgrade.js test uses the bitnami catalog.