### PR TITLE
Fix opacity and select issue

### DIFF
--- a/dashboard/src/components/Header/ContextSelector.scss
+++ b/dashboard/src/components/Header/ContextSelector.scss
@@ -4,14 +4,14 @@
 }
 
 .kubeapps-dropdown {
-  opacity: 75%;
+  opacity: 0.75;
   padding-left: 0.5rem;
   &:hover {
-    opacity: 100%;
+    opacity: 1;
     background-color: #25333d;
   }
   &.open {
-    opacity: 100%;
+    opacity: 1;
     background-color: #25333d;
   }
   button {

--- a/dashboard/src/components/Header/ContextSelector.test.tsx
+++ b/dashboard/src/components/Header/ContextSelector.test.tsx
@@ -81,6 +81,33 @@ it("selects a different namespace", () => {
   expect(setNamespace).toHaveBeenCalledWith("other");
 });
 
+it("shows the current cluster", () => {
+  const clusters = {
+    currentCluster: "bar",
+    clusters: {
+      foo: {
+        currentNamespace: "default",
+        namespaces: ["default"],
+      },
+      bar: {
+        currentNamespace: "default",
+        namespaces: ["default"],
+      },
+    },
+  } as IClustersState;
+  const wrapper = mount(
+    <Provider store={defaultStore}>
+      <ContextSelector {...defaultProps} clusters={clusters} />
+    </Provider>,
+  );
+  expect(
+    wrapper
+      .find("select")
+      .at(0)
+      .prop("value"),
+  ).toBe("bar");
+});
+
 it("shows the current namespace", () => {
   const props = cloneDeep(defaultProps);
   props.clusters.clusters.default.currentNamespace = "other";

--- a/dashboard/src/components/Header/ContextSelector.test.tsx
+++ b/dashboard/src/components/Header/ContextSelector.test.tsx
@@ -5,6 +5,7 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 
 import { CdsButton } from "components/Clarity/clarity";
+import { cloneDeep } from "lodash";
 import { act } from "react-dom/test-utils";
 import { IClustersState } from "reducers/cluster";
 import ContextSelector from "./ContextSelector";
@@ -78,4 +79,20 @@ it("selects a different namespace", () => {
     (wrapper.find(CdsButton).prop("onClick") as any)();
   });
   expect(setNamespace).toHaveBeenCalledWith("other");
+});
+
+it("shows the current namespace", () => {
+  const props = cloneDeep(defaultProps);
+  props.clusters.clusters.default.currentNamespace = "other";
+  const wrapper = mount(
+    <Provider store={defaultStore}>
+      <ContextSelector {...props} />
+    </Provider>,
+  );
+  expect(
+    wrapper
+      .find("select")
+      .at(1)
+      .prop("value"),
+  ).toBe("other");
 });

--- a/dashboard/src/components/Header/ContextSelector.tsx
+++ b/dashboard/src/components/Header/ContextSelector.tsx
@@ -117,7 +117,12 @@ function ContextSelector({
             <CdsIcon size="sm" shape="file-group" inverse={true} />
             <span className="kubeapps-dropdown-text">Namespace</span>
             <div className="clr-select-wrapper">
-              <select name="namespaces" className="clr-page-size-select" onChange={selectNamespace}>
+              <select
+                name="namespaces"
+                className="clr-page-size-select"
+                onChange={selectNamespace}
+                value={namespace}
+              >
                 {clusters.clusters[cluster].namespaces.map(n => {
                   return (
                     <option key={`kubeapps-dropdown-namespace-${n}`} value={n}>

--- a/dashboard/src/components/Header/ContextSelector.tsx
+++ b/dashboard/src/components/Header/ContextSelector.tsx
@@ -102,7 +102,12 @@ function ContextSelector({
             <CdsIcon size="sm" shape="cluster" inverse={true} />
             <span className="kubeapps-dropdown-text">Cluster</span>
             <div className="clr-select-wrapper">
-              <select name="clusters" className="clr-page-size-select" onChange={selectCluster}>
+              <select
+                name="clusters"
+                className="clr-page-size-select"
+                onChange={selectCluster}
+                value={cluster}
+              >
                 {Object.keys(clusters.clusters).map(c => {
                   return (
                     <option key={`kubeapps-dropdown-cluster-${c}`} value={c}>

--- a/dashboard/src/components/Header/Menu.scss
+++ b/dashboard/src/components/Header/Menu.scss
@@ -8,14 +8,14 @@
 
 .kubeapps-menu {
   display: flex;
-  opacity: 75%;
+  opacity: 0.75;
   align-items: center;
   &:hover {
-    opacity: 100%;
+    opacity: 1;
     background-color: #25333d;
   }
   &.open {
-    opacity: 100%;
+    opacity: 1;
     background-color: #25333d;
   }
   button {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

The script `create-react-app` doesn't play well with percentages in SCSS (apparently): https://stackoverflow.com/questions/58853844/the-opacity-value-was-changed-to-1-after-building-the-reacjs-project which caused the `opacity` of the context selector to be `1%`.

Apart from the fix for the above, this PR includes another small fix for the namespace and cluster selector that was not setting a default `value`.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1354

