### PR TITLE
Fix version selector in update form

### DIFF
--- a/dashboard/src/components/ChartView/ChartHeader.v2.test.tsx
+++ b/dashboard/src/components/ChartView/ChartHeader.v2.test.tsx
@@ -1,0 +1,75 @@
+import { mount, shallow } from "enzyme";
+import * as React from "react";
+import ChartHeader from "./ChartHeader.v2";
+
+const testProps: any = {
+  chartAttrs: {
+    description: "A Test Chart",
+    name: "test",
+    repo: {
+      name: "testrepo",
+    },
+    namespace: "kubeapps",
+    cluster: "default",
+    icon: "test.jpg",
+  },
+  versions: [
+    {
+      attributes: {
+        app_version: "1.2.3",
+      },
+    },
+  ],
+  onSelect: jest.fn(),
+};
+
+it("renders a header for the chart", () => {
+  const wrapper = mount(<ChartHeader {...testProps} />);
+  expect(wrapper.text()).toContain("testrepo/test");
+});
+
+it("displays the appVersion", () => {
+  const wrapper = mount(<ChartHeader {...testProps} />);
+  expect(wrapper.text()).toContain("1.2.3");
+});
+
+it("uses the icon", () => {
+  const wrapper = shallow(<ChartHeader {...testProps} />);
+  const icon = wrapper.find("img").filterWhere(i => i.prop("alt") === "app-icon");
+  expect(icon.exists()).toBe(true);
+  expect(icon.props()).toMatchObject({ src: "api/assetsvc/test.jpg" });
+});
+
+it("uses the first version as default in the select input", () => {
+  const versions = [
+    {
+      attributes: {
+        version: "1.2.3",
+      },
+    },
+    {
+      attributes: {
+        version: "1.2.4",
+      },
+    },
+  ];
+  const wrapper = mount(<ChartHeader {...testProps} versions={versions} />);
+  expect(wrapper.find("select").prop("defaultValue")).toBe("1.2.3");
+});
+
+it("uses the current version as default in the select input", () => {
+  const versions = [
+    {
+      attributes: {
+        version: "1.2.3",
+      },
+    },
+    {
+      attributes: {
+        version: "1.2.4",
+      },
+    },
+  ];
+  const wrapper = mount(<ChartHeader {...testProps} versions={versions} currentVersion="1.2.4" />);
+  expect(wrapper.find("select").prop("defaultValue")).toBe("1.2.4");
+});

--- a/dashboard/src/components/ChartView/ChartHeader.v2.tsx
+++ b/dashboard/src/components/ChartView/ChartHeader.v2.tsx
@@ -76,7 +76,10 @@ export default function ChartHeader({
                     name="chart-versions"
                     className="clr-page-size-select"
                     onChange={onSelect}
-                    value={currentVersion}
+                    defaultValue={
+                      currentVersion ||
+                      (versions.length ? versions[0].attributes.version : undefined)
+                    }
                   >
                     {versions.map(v => {
                       return (


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Small fix for the update form. There, the version in the selector was forced to `currentVersion` so even after changing it, the currentVersion was always displayed in the selector.
