### PR TITLE
Remove dependence on const kube.DefaultClusterName, moving to config.

### DIFF
--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -27,16 +27,16 @@ import (
 	"k8s.io/helm/pkg/helm/environment"
 )
 
-const additionalClustersCAFilesPrefix = "/etc/additional-clusters-cafiles"
+const clustersCAFilesPrefix = "/etc/clusters-cafiles"
 
 var (
-	additionalClustersConfigPath string
-	assetsvcURL                  string
-	helmDriverArg                string
-	listLimit                    int
-	settings                     environment.EnvSettings
-	timeout                      int64
-	userAgentComment             string
+	clustersConfigPath string
+	assetsvcURL        string
+	helmDriverArg      string
+	listLimit          int
+	settings           environment.EnvSettings
+	timeout            int64
+	userAgentComment   string
 )
 
 func init() {
@@ -47,7 +47,7 @@ func init() {
 	pflag.StringVar(&userAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
 	// Default timeout from https://github.com/helm/helm/blob/b0b0accdfc84e154b3d48ec334cd5b4f9b345667/cmd/helm/install.go#L216
 	pflag.Int64Var(&timeout, "timeout", 300, "Timeout to perform release operations (install, upgrade, rollback, delete)")
-	pflag.StringVar(&additionalClustersConfigPath, "additional-clusters-config-path", "", "Configuration for additional clusters")
+	pflag.StringVar(&clustersConfigPath, "clusters-config-path", "", "Configuration for clusters")
 }
 
 func main() {
@@ -59,11 +59,11 @@ func main() {
 		log.Fatal("POD_NAMESPACE should be defined")
 	}
 
-	var additionalClusters map[string]kube.AdditionalClusterConfig
-	if additionalClustersConfigPath != "" {
+	var clustersConfig kube.ClustersConfig
+	if clustersConfigPath != "" {
 		var err error
 		var cleanupCAFiles func()
-		additionalClusters, cleanupCAFiles, err = parseAdditionalClusterConfig(additionalClustersConfigPath, additionalClustersCAFilesPrefix)
+		clustersConfig, cleanupCAFiles, err = parseClusterConfig(clustersConfigPath, clustersCAFilesPrefix)
 		if err != nil {
 			log.Fatalf("unable to parse additional clusters config: %+v", err)
 		}
@@ -71,10 +71,10 @@ func main() {
 	}
 
 	options := handler.Options{
-		ListLimit:          listLimit,
-		Timeout:            timeout,
-		KubeappsNamespace:  kubeappsNamespace,
-		AdditionalClusters: additionalClusters,
+		ListLimit:         listLimit,
+		Timeout:           timeout,
+		KubeappsNamespace: kubeappsNamespace,
+		ClustersConfig:    clustersConfig,
 	}
 
 	storageForDriver := agent.StorageForSecrets
@@ -112,7 +112,7 @@ func main() {
 	addRoute("DELETE", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
 
 	// Backend routes unrelated to kubeops functionality.
-	err := backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), additionalClusters)
+	err := backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), clustersConfig)
 	if err != nil {
 		log.Fatalf("Unable to setup backend routes: %+v", err)
 	}
@@ -178,29 +178,29 @@ func main() {
 	os.Exit(0)
 }
 
-func parseAdditionalClusterConfig(configPath, caFilesPrefix string) (kube.AdditionalClustersConfig, func(), error) {
+func parseClusterConfig(configPath, caFilesPrefix string) (kube.ClustersConfig, func(), error) {
 	caFilesDir, err := ioutil.TempDir(caFilesPrefix, "")
 	if err != nil {
-		return nil, func() {}, err
+		return kube.ClustersConfig{}, func() {}, err
 	}
 	deferFn := func() { os.RemoveAll(caFilesDir) }
 	content, err := ioutil.ReadFile(configPath)
 	if err != nil {
-		return nil, deferFn, err
+		return kube.ClustersConfig{}, deferFn, err
 	}
 
-	var clusterConfigs []kube.AdditionalClusterConfig
+	var clusterConfigs []kube.ClusterConfig
 	if err = json.Unmarshal(content, &clusterConfigs); err != nil {
-		return nil, deferFn, err
+		return kube.ClustersConfig{}, deferFn, err
 	}
 
-	configs := kube.AdditionalClustersConfig{}
+	configs := kube.ClustersConfig{KubeappsClusterName: "default", Clusters: map[string]kube.ClusterConfig{}}
 	for _, c := range clusterConfigs {
 		// We need to decode the base64-encoded cadata from the input.
 		if c.CertificateAuthorityData != "" {
 			decodedCAData, err := base64.StdEncoding.DecodeString(c.CertificateAuthorityData)
 			if err != nil {
-				return nil, deferFn, err
+				return kube.ClustersConfig{}, deferFn, err
 			}
 			c.CertificateAuthorityData = string(decodedCAData)
 
@@ -210,10 +210,10 @@ func parseAdditionalClusterConfig(configPath, caFilesPrefix string) (kube.Additi
 			c.CAFile = filepath.Join(caFilesDir, c.Name)
 			err = ioutil.WriteFile(c.CAFile, decodedCAData, 0644)
 			if err != nil {
-				return nil, deferFn, err
+				return kube.ClustersConfig{}, deferFn, err
 			}
 		}
-		configs[c.Name] = c
+		configs.Clusters[c.Name] = c
 	}
 	return configs, deferFn, nil
 }

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/helm/pkg/helm/environment"
 )
 
-const clustersCAFilesPrefix = "/etc/clusters-cafiles"
+const clustersCAFilesPrefix = "/etc/additional-clusters-cafiles"
 
 var (
 	additionalClustersConfigPath string

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -30,13 +30,14 @@ import (
 const clustersCAFilesPrefix = "/etc/clusters-cafiles"
 
 var (
-	clustersConfigPath string
-	assetsvcURL        string
-	helmDriverArg      string
-	listLimit          int
-	settings           environment.EnvSettings
-	timeout            int64
-	userAgentComment   string
+	additionalClustersConfigPath string
+	clustersConfigPath           string
+	assetsvcURL                  string
+	helmDriverArg                string
+	listLimit                    int
+	settings                     environment.EnvSettings
+	timeout                      int64
+	userAgentComment             string
 )
 
 func init() {
@@ -48,6 +49,7 @@ func init() {
 	// Default timeout from https://github.com/helm/helm/blob/b0b0accdfc84e154b3d48ec334cd5b4f9b345667/cmd/helm/install.go#L216
 	pflag.Int64Var(&timeout, "timeout", 300, "Timeout to perform release operations (install, upgrade, rollback, delete)")
 	pflag.StringVar(&clustersConfigPath, "clusters-config-path", "", "Configuration for clusters")
+	pflag.StringVar(&additionalClustersConfigPath, "additional-clusters-config-path", "", "Configuration for clusters")
 }
 
 func main() {
@@ -60,6 +62,10 @@ func main() {
 	}
 
 	var clustersConfig kube.ClustersConfig
+	// TODO(absoludity): remove support for --additional-clusters-config-path once we're +2 releases away.
+	if clustersConfigPath == "" && additionalClustersConfigPath != "" {
+		clustersConfigPath = additionalClustersConfigPath
+	}
 	if clustersConfigPath != "" {
 		var err error
 		var cleanupCAFiles func()

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -61,7 +61,8 @@ func main() {
 		log.Fatal("POD_NAMESPACE should be defined")
 	}
 
-	var clustersConfig kube.ClustersConfig
+	// If there is no clusters config, we default to the previous behaviour of a "default" cluster.
+	clustersConfig := kube.ClustersConfig{KubeappsClusterName: "default"}
 	// TODO(absoludity): remove support for --additional-clusters-config-path once we're +2 releases away.
 	if clustersConfigPath == "" && additionalClustersConfigPath != "" {
 		clustersConfigPath = additionalClustersConfigPath

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -79,6 +79,8 @@ func init() {
 	// Default timeout from https://github.com/helm/helm/blob/b0b0accdfc84e154b3d48ec334cd5b4f9b345667/cmd/helm/install.go#L216
 	pflag.Int64Var(&timeout, "timeout", 300, "Timeout to perform release operations (install, upgrade, rollback, delete)")
 	pflag.StringVar(&assetsvcURL, "assetsvc-url", "http://kubeapps-internal-assetsvc:8080", "URL to the internal assetsvc")
+	// Probably need to tell tiller-proxy what the kubeappsCluster is named.
+	// If so, set the same on kubeops
 }
 
 func main() {
@@ -133,12 +135,12 @@ func main() {
 		log.Fatalf("POD_NAMESPACE should be defined")
 	}
 
-	kubeHandler, err := kube.NewHandler(kubeappsNamespace, kube.AdditionalClustersConfig{})
+	kubeHandler, err := kube.NewHandler(kubeappsNamespace, kube.ClustersConfig{})
 	if err != nil {
 		log.Fatalf("Failed to create handler: %v", err)
 	}
 
-	chartClient := chartUtils.NewChartClient(kubeHandler, kubeappsNamespace, userAgent())
+	chartClient := chartUtils.NewChartClient(kubeHandler, "default", kubeappsNamespace, userAgent())
 
 	r := mux.NewRouter()
 
@@ -172,7 +174,7 @@ func main() {
 	apiv1.Methods("DELETE").Path("/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}").Handler(handlerutil.WithParams(h.DeleteRelease))
 
 	// Backend routes unrelated to tiller-proxy functionality.
-	err = backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), kube.AdditionalClustersConfig{})
+	err = backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), kube.ClustersConfig{})
 	if err != nil {
 		log.Fatalf("Unable to setup backend routes: %+v", err)
 	}

--- a/cmd/tiller-proxy/main.go
+++ b/cmd/tiller-proxy/main.go
@@ -79,8 +79,6 @@ func init() {
 	// Default timeout from https://github.com/helm/helm/blob/b0b0accdfc84e154b3d48ec334cd5b4f9b345667/cmd/helm/install.go#L216
 	pflag.Int64Var(&timeout, "timeout", 300, "Timeout to perform release operations (install, upgrade, rollback, delete)")
 	pflag.StringVar(&assetsvcURL, "assetsvc-url", "http://kubeapps-internal-assetsvc:8080", "URL to the internal assetsvc")
-	// Probably need to tell tiller-proxy what the kubeappsCluster is named.
-	// If so, set the same on kubeops
 }
 
 func main() {
@@ -135,7 +133,7 @@ func main() {
 		log.Fatalf("POD_NAMESPACE should be defined")
 	}
 
-	kubeHandler, err := kube.NewHandler(kubeappsNamespace, kube.ClustersConfig{})
+	kubeHandler, err := kube.NewHandler(kubeappsNamespace, kube.ClustersConfig{KubeappsClusterName: "default"})
 	if err != nil {
 		log.Fatalf("Failed to create handler: %v", err)
 	}
@@ -174,7 +172,7 @@ func main() {
 	apiv1.Methods("DELETE").Path("/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}").Handler(handlerutil.WithParams(h.DeleteRelease))
 
 	// Backend routes unrelated to tiller-proxy functionality.
-	err = backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), kube.ClustersConfig{})
+	err = backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), kube.ClustersConfig{KubeappsClusterName: "default"})
 	if err != nil {
 		log.Fatalf("Unable to setup backend routes: %+v", err)
 	}

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -171,7 +171,7 @@ func TestParseDetails(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ch := ChartClient{}
+			ch := Client{}
 			details, err := ch.ParseDetails([]byte(tc.data))
 
 			if tc.err {
@@ -333,7 +333,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 			Spec: tc.appRepoSpec,
 		}}
 
-		chUtils := ChartClient{
+		chUtils := Client{
 			appRepoHandler:    &kube.FakeHandler{Secrets: secrets, AppRepos: apprepos},
 			kubeappsNamespace: metav1.NamespaceSystem,
 		}
@@ -488,7 +488,7 @@ func TestGetChart(t *testing.T) {
 		}
 		t.Run(tc.name, func(t *testing.T) {
 			httpClient := newHTTPClient(repoURL, []Details{target}, tc.userAgent)
-			chUtils := ChartClient{
+			chUtils := Client{
 				userAgent: tc.userAgent,
 				appRepo: &appRepov1.AppRepository{
 					ObjectMeta: metav1.ObjectMeta{
@@ -779,7 +779,7 @@ func TestGetRegistrySecretsPerDomain(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &kube.FakeHandler{Secrets: tc.existingSecrets}
 
-			secretsPerDomain, err := getRegistrySecretsPerDomain(tc.secretNames, namespace, "token", client)
+			secretsPerDomain, err := getRegistrySecretsPerDomain(tc.secretNames, "default", namespace, "token", client)
 			if got, want := err != nil, tc.expectError; !cmp.Equal(got, want) {
 				t.Fatalf("got: %t, want: %t, err was: %+v", got, want, err)
 			}

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -67,10 +67,7 @@ func returnK8sError(err error, w http.ResponseWriter) {
 
 func getNamespaceAndCluster(req *http.Request) (string, string) {
 	requestNamespace := mux.Vars(req)["namespace"]
-	requestCluster, ok := mux.Vars(req)["cluster"]
-	if !ok {
-		requestCluster = kube.DefaultClusterName
-	}
+	requestCluster := mux.Vars(req)["cluster"]
 	return requestNamespace, requestCluster
 }
 
@@ -258,8 +255,8 @@ func GetOperatorLogo(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, r
 }
 
 // SetupDefaultRoutes enables call-sites to use the backend api's default routes with minimal setup.
-func SetupDefaultRoutes(r *mux.Router, additionalClusters kube.AdditionalClustersConfig) error {
-	backendHandler, err := kube.NewHandler(os.Getenv("POD_NAMESPACE"), additionalClusters)
+func SetupDefaultRoutes(r *mux.Router, clustersConfig kube.ClustersConfig) error {
+	backendHandler, err := kube.NewHandler(os.Getenv("POD_NAMESPACE"), clustersConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description of the change

Another prep branch for the actual change of 1942: this PR removes the const `kube.DefaultClusterName` to instead be included in the clustersConfig for `kubeops`, still using the value `default`, though this will change in the next PR

I've one concern about the change of the cli arg, which I'll note below.

Ref #1942 