### PR TITLE
1942 app repos use cluster

### DIFF
--- a/dashboard/src/actions/catalog.test.tsx
+++ b/dashboard/src/actions/catalog.test.tsx
@@ -34,6 +34,9 @@ beforeEach(() => {
     config: {
       kubeappsCluster: testArgs.kubeappsCluster,
     },
+    clusters: {
+      currentCluster: testArgs.kubeappsCluster,
+    },
   });
 
   ServiceInstance.create = jest.fn().mockImplementationOnce(() => {
@@ -149,6 +152,7 @@ describe("provision", () => {
 
     expect(store.getActions().length).toBe(0);
     expect(ServiceInstance.create).toHaveBeenCalledWith(
+      testArgs.kubeappsCluster,
       testArgs.releaseName,
       testArgs.namespace,
       testArgs.className,
@@ -197,6 +201,7 @@ describe("provision", () => {
     );
     await store.dispatch(cmd);
     expect(ServiceInstance.create).toHaveBeenCalledWith(
+      testArgs.kubeappsCluster,
       testArgs.releaseName,
       testArgs.namespace,
       testArgs.className,
@@ -214,7 +219,10 @@ describe("deprovision", () => {
     expect(res).toBe(true);
 
     expect(store.getActions().length).toBe(0);
-    expect(ServiceCatalog.deprovisionInstance).toHaveBeenCalledWith(serviceInstance);
+    expect(ServiceCatalog.deprovisionInstance).toHaveBeenCalledWith(
+      testArgs.kubeappsCluster,
+      serviceInstance,
+    );
   });
 
   it("dispatches errorCatalog if error", async () => {
@@ -248,6 +256,7 @@ describe("addBinding", () => {
     expect(ServiceBinding.create).toHaveBeenCalledWith(
       testArgs.bindingName,
       testArgs.instanceName,
+      testArgs.kubeappsCluster,
       testArgs.namespace,
       testArgs.params,
     );
@@ -297,6 +306,7 @@ describe("addBinding", () => {
     expect(ServiceBinding.create).toHaveBeenCalledWith(
       testArgs.bindingName,
       testArgs.instanceName,
+      testArgs.kubeappsCluster,
       testArgs.namespace,
       expectedParams,
     );
@@ -311,7 +321,11 @@ describe("removeBinding", () => {
     expect(res).toBe(true);
 
     expect(store.getActions().length).toBe(0);
-    expect(ServiceBinding.delete).toHaveBeenCalledWith(testArgs.bindingName, testArgs.namespace);
+    expect(ServiceBinding.delete).toHaveBeenCalledWith(
+      testArgs.kubeappsCluster,
+      testArgs.bindingName,
+      testArgs.namespace,
+    );
   });
 
   it("dispatches errorCatalog if error", async () => {
@@ -480,7 +494,7 @@ describe("getInstances", () => {
 
     await store.dispatch(provisionCMD);
     expect(store.getActions()).toEqual(expectedActions);
-    expect(ServiceInstance.list).toHaveBeenCalledWith(testArgs.namespace);
+    expect(ServiceInstance.list).toHaveBeenCalledWith(testArgs.kubeappsCluster, testArgs.namespace);
   });
 
   it("dispatches requestInstances and errorCatalog if error", async () => {

--- a/dashboard/src/actions/catalog.ts
+++ b/dashboard/src/actions/catalog.ts
@@ -68,10 +68,20 @@ export function provision(
   planName: string,
   parameters: {},
 ): ThunkAction<Promise<boolean>, IStoreState, null, ServiceCatalogAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      clusters: { currentCluster },
+    } = getState();
     try {
       const filteredParams = helpers.object.removeEmptyFields(parameters);
-      await ServiceInstance.create(releaseName, namespace, className, planName, filteredParams);
+      await ServiceInstance.create(
+        currentCluster,
+        releaseName,
+        namespace,
+        className,
+        planName,
+        filteredParams,
+      );
       return true;
     } catch (e) {
       dispatch(errorCatalog(e, "create"));
@@ -86,10 +96,19 @@ export function addBinding(
   namespace: string,
   parameters: {},
 ): ThunkAction<Promise<boolean>, IStoreState, null, ServiceCatalogAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      clusters: { currentCluster },
+    } = getState();
     try {
       const filteredParams = helpers.object.removeEmptyFields(parameters);
-      await ServiceBinding.create(bindingName, instanceName, namespace, filteredParams);
+      await ServiceBinding.create(
+        bindingName,
+        instanceName,
+        currentCluster,
+        namespace,
+        filteredParams,
+      );
       return true;
     } catch (e) {
       dispatch(errorCatalog(e, "create"));
@@ -102,9 +121,12 @@ export function removeBinding(
   name: string,
   namespace: string,
 ): ThunkAction<Promise<boolean>, IStoreState, null, ServiceCatalogAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      clusters: { currentCluster },
+    } = getState();
     try {
-      await ServiceBinding.delete(name, namespace);
+      await ServiceBinding.delete(currentCluster, name, namespace);
       return true;
     } catch (e) {
       dispatch(errorCatalog(e, "delete"));
@@ -116,9 +138,12 @@ export function removeBinding(
 export function deprovision(
   instance: IServiceInstance,
 ): ThunkAction<Promise<boolean>, IStoreState, null, ServiceCatalogAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      clusters: { currentCluster },
+    } = getState();
     try {
-      await ServiceCatalog.deprovisionInstance(instance);
+      await ServiceCatalog.deprovisionInstance(currentCluster, instance);
       return true;
     } catch (e) {
       dispatch(errorCatalog(e, "deprovision"));
@@ -163,10 +188,13 @@ export function getBindings(
 }
 
 export function getBrokers(): ThunkAction<Promise<void>, IStoreState, null, ServiceCatalogAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      clusters: { currentCluster },
+    } = getState();
     dispatch(requestBrokers());
     try {
-      const brokers = await ServiceCatalog.getServiceBrokers();
+      const brokers = await ServiceCatalog.getServiceBrokers(currentCluster);
       dispatch(receiveBrokers(brokers));
     } catch (e) {
       dispatch(errorCatalog(e, "fetch"));
@@ -175,10 +203,13 @@ export function getBrokers(): ThunkAction<Promise<void>, IStoreState, null, Serv
 }
 
 export function getClasses(): ThunkAction<Promise<void>, IStoreState, null, ServiceCatalogAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      clusters: { currentCluster },
+    } = getState();
     dispatch(requestClasses());
     try {
-      const classes = await ServiceCatalog.getServiceClasses();
+      const classes = await ServiceCatalog.getServiceClasses(currentCluster);
       dispatch(receiveClasses(classes));
     } catch (e) {
       dispatch(errorCatalog(e, "fetch"));
@@ -189,13 +220,16 @@ export function getClasses(): ThunkAction<Promise<void>, IStoreState, null, Serv
 export function getInstances(
   ns?: string,
 ): ThunkAction<Promise<void>, IStoreState, null, ServiceCatalogAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      clusters: { currentCluster },
+    } = getState();
     if (ns && ns === definedNamespaces.all) {
       ns = undefined;
     }
     dispatch(requestInstances());
     try {
-      const instances = await ServiceInstance.list(ns);
+      const instances = await ServiceInstance.list(currentCluster, ns);
       dispatch(receiveInstances(instances));
     } catch (e) {
       dispatch(errorCatalog(e, "fetch"));
@@ -204,10 +238,13 @@ export function getInstances(
 }
 
 export function getPlans(): ThunkAction<Promise<void>, IStoreState, null, ServiceCatalogAction> {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const {
+      clusters: { currentCluster },
+    } = getState();
     dispatch(requestPlans());
     try {
-      const plans = await ServiceCatalog.getServicePlans();
+      const plans = await ServiceCatalog.getServicePlans(currentCluster);
       dispatch(receivePlans(plans));
     } catch (e) {
       dispatch(errorCatalog(e, "fetch"));
@@ -221,8 +258,11 @@ export function checkCatalogInstalled(): ThunkAction<
   null,
   ServiceCatalogAction
 > {
-  return async dispatch => {
-    const isServiceCatalogInstalled = await ServiceCatalog.isCatalogInstalled();
+  return async (dispatch, getState) => {
+    const {
+      clusters: { currentCluster },
+    } = getState();
+    const isServiceCatalogInstalled = await ServiceCatalog.isCatalogInstalled(currentCluster);
     isServiceCatalogInstalled ? dispatch(installed()) : dispatch(notInstalled());
     return isServiceCatalogInstalled;
   };

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -200,8 +200,8 @@ describe("resyncAllRepos", () => {
     );
 
     expect(appRepoGetMock).toHaveBeenCalledTimes(2);
-    expect(appRepoGetMock.mock.calls[0]).toEqual(["foo", "namespace-1"]);
-    expect(appRepoGetMock.mock.calls[1]).toEqual(["bar", "namespace-2"]);
+    expect(appRepoGetMock.mock.calls[0]).toEqual(["default", "foo", "namespace-1"]);
+    expect(appRepoGetMock.mock.calls[1]).toEqual(["default", "bar", "namespace-2"]);
   });
 });
 
@@ -349,6 +349,7 @@ describe("installRepo", () => {
     it("calls AppRepository create including a auth struct", async () => {
       await store.dispatch(installRepoCMDAuth);
       expect(AppRepository.create).toHaveBeenCalledWith(
+        "default",
         "my-repo",
         "my-namespace",
         "http://foo.bar",
@@ -379,6 +380,7 @@ describe("installRepo", () => {
     it("calls AppRepository create including a auth struct", async () => {
       await store.dispatch(installRepoCMDAuth);
       expect(AppRepository.create).toHaveBeenCalledWith(
+        "default",
         "my-repo",
         "my-namespace",
         "http://foo.bar",
@@ -409,6 +411,7 @@ describe("installRepo", () => {
         );
 
         expect(AppRepository.create).toHaveBeenCalledWith(
+          "default",
           "my-repo",
           "my-namespace",
           "http://foo.bar",
@@ -446,6 +449,7 @@ describe("installRepo", () => {
     it("calls AppRepository create without a auth struct", async () => {
       await store.dispatch(installRepoCMD);
       expect(AppRepository.create).toHaveBeenCalledWith(
+        "default",
         "my-repo",
         "my-namespace",
         "http://foo.bar",
@@ -511,6 +515,7 @@ describe("installRepo", () => {
     );
 
     expect(AppRepository.create).toHaveBeenCalledWith(
+      "default",
       "my-repo",
       "kubeapps-namespace",
       "http://foo.bar",
@@ -527,6 +532,7 @@ describe("installRepo", () => {
     );
 
     expect(AppRepository.create).toHaveBeenCalledWith(
+      "default",
       "my-repo",
       "kubeapps-namespace",
       "http://foo.bar",
@@ -576,6 +582,7 @@ describe("updateRepo", () => {
     );
     expect(store.getActions()).toEqual(expectedActions);
     expect(AppRepository.update).toHaveBeenCalledWith(
+      "default",
       "my-repo",
       "my-namespace",
       "http://foo.bar",
@@ -623,6 +630,7 @@ describe("updateRepo", () => {
     );
     expect(store.getActions()).toEqual(expectedActions);
     expect(AppRepository.update).toHaveBeenCalledWith(
+      "default",
       "my-repo",
       "my-namespace",
       "http://foo.bar",

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -141,9 +141,7 @@ export const resyncRepo = (
 ): ThunkAction<Promise<void>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     const {
-      clusters: {
-        currentCluster,
-      },
+      clusters: { currentCluster },
     } = getState();
     try {
       await AppRepository.resync(currentCluster, name, namespace);
@@ -201,9 +199,7 @@ export const fetchRepos = (
 ): ThunkAction<Promise<void>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     const {
-      clusters: {
-        currentCluster,
-      },
+      clusters: { currentCluster },
     } = getState();
     try {
       dispatch(requestRepos(namespace));
@@ -258,9 +254,7 @@ export const installRepo = (
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     const {
-      clusters: {
-        currentCluster,
-      },
+      clusters: { currentCluster },
     } = getState();
     try {
       const syncJobPodTemplateObj = parsePodTemplate(syncJobPodTemplate);
@@ -297,9 +291,7 @@ export const updateRepo = (
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     const {
-      clusters: {
-        currentCluster,
-      },
+      clusters: { currentCluster },
     } = getState();
     try {
       const syncJobPodTemplateObj = parsePodTemplate(syncJobPodTemplate);
@@ -347,9 +339,7 @@ export const validateRepo = (
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     const {
-      clusters: {
-        currentCluster,
-      },
+      clusters: { currentCluster },
     } = getState();
     try {
       dispatch(repoValidating());
@@ -375,9 +365,7 @@ export function checkChart(
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> {
   return async (dispatch, getState) => {
     const {
-      clusters: {
-        currentCluster,
-      },
+      clusters: { currentCluster },
     } = getState();
     dispatch(requestRepo());
     const appRepository = await AppRepository.get(currentCluster, repo, repoNamespace);

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -18,7 +18,10 @@ export class AppRepository {
     const repo = await AppRepository.get(cluster, name, namespace);
     repo.spec.resyncRequests = repo.spec.resyncRequests || 0;
     repo.spec.resyncRequests++;
-    const { data } = await axiosWithAuth.put(AppRepository.getSelfLink(cluster, namespace, name), repo);
+    const { data } = await axiosWithAuth.put(
+      AppRepository.getSelfLink(cluster, namespace, name),
+      repo,
+    );
     return data;
   }
 
@@ -70,7 +73,12 @@ export class AppRepository {
     return data;
   }
 
-  public static async validate(cluster: string, repoURL: string, authHeader: string, customCA: string) {
+  public static async validate(
+    cluster: string,
+    repoURL: string,
+    authHeader: string,
+    customCA: string,
+  ) {
     const { data } = await axiosWithAuth.post<any>(url.backend.apprepositories.validate(cluster), {
       appRepository: { repoURL, authHeader, customCA },
     });
@@ -78,8 +86,8 @@ export class AppRepository {
   }
 
   private static APIEndpoint(cluster: string): string {
-    return `${APIBase(cluster)}/apis/kubeapps.com/v1alpha1`
-  };
+    return `${APIBase(cluster)}/apis/kubeapps.com/v1alpha1`;
+  }
   private static getSelfLink(cluster: string, namespace: string, name?: string): string {
     return `${AppRepository.APIEndpoint(cluster)}/namespaces/${namespace}/apprepositories${
       name ? `/${name}` : ""

--- a/dashboard/src/shared/ClusterServiceClass.ts
+++ b/dashboard/src/shared/ClusterServiceClass.ts
@@ -33,19 +33,26 @@ export interface IClusterServiceClass {
 }
 
 export class ClusterServiceClass {
-  public static async get(namespace?: string, name?: string): Promise<IClusterServiceClass> {
-    const url = this.getLink(namespace, name);
+  public static async get(
+    cluster: string,
+    namespace?: string,
+    name?: string,
+  ): Promise<IClusterServiceClass> {
+    const url = this.getLink(cluster, namespace, name);
     const { data } = await axiosWithAuth.get<IClusterServiceClass>(url);
     return data;
   }
 
-  public static async list(namespace?: string): Promise<IClusterServiceClass[]> {
-    const instances = await ServiceCatalog.getItems<IClusterServiceClass>("serviceinstances");
+  public static async list(cluster: string, namespace?: string): Promise<IClusterServiceClass[]> {
+    const instances = await ServiceCatalog.getItems<IClusterServiceClass>(
+      cluster,
+      "serviceinstances",
+    );
     return instances;
   }
 
-  private static getLink(namespace?: string, name?: string): string {
-    return `${APIBase}/apis/servicecatalog.k8s.io/v1beta1${
+  private static getLink(cluster: string, namespace?: string, name?: string): string {
+    return `${APIBase(cluster)}/apis/servicecatalog.k8s.io/v1beta1${
       namespace ? `/namespaces/${namespace}` : ""
     }/clusterserviceclasses${name ? `/${name}` : ""}`;
   }

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -5,7 +5,7 @@ import { ResourceKindsWithAPIVersions } from "./ResourceAPIVersion";
 import { isNamespaced, ResourceKind, ResourceKindsWithPlurals } from "./ResourceKinds";
 import { IK8sList, IResource } from "./types";
 
-export const APIBase = "api/clusters/default";
+export const APIBase = (cluster: string) => `api/clusters/${cluster}`;
 export let WebSocketAPIBase: string;
 if (window.location.protocol === "https:") {
   WebSocketAPIBase = `wss://${window.location.host}${window.location.pathname}`;

--- a/dashboard/src/shared/ServiceBinding.ts
+++ b/dashboard/src/shared/ServiceBinding.ts
@@ -52,10 +52,11 @@ export class ServiceBinding {
   public static async create(
     bindingName: string,
     instanceRefName: string,
+    cluster: string,
     namespace: string,
     parameters: {},
   ) {
-    const u = ServiceBinding.getLink(namespace);
+    const u = ServiceBinding.getLink(cluster, namespace);
     const { data } = await axiosWithAuth.post<IServiceBinding>(u, {
       apiVersion: "servicecatalog.k8s.io/v1beta1",
       kind: "ServiceBinding",
@@ -72,13 +73,13 @@ export class ServiceBinding {
     return data;
   }
 
-  public static async delete(name: string, namespace: string) {
-    const u = this.getLink(namespace, name);
+  public static async delete(cluster: string, name: string, namespace: string) {
+    const u = this.getLink(cluster, namespace, name);
     return axiosWithAuth.delete(u);
   }
 
-  public static async get(namespace: string, name: string) {
-    const u = this.getLink(namespace, name);
+  public static async get(cluster: string, namespace: string, name: string) {
+    const u = this.getLink(cluster, namespace, name);
     const { data } = await axiosWithAuth.get<IServiceBinding>(u);
     return data;
   }
@@ -87,7 +88,11 @@ export class ServiceBinding {
     cluster: string,
     namespace?: string,
   ): Promise<IServiceBindingWithSecret[]> {
-    const bindings = await ServiceCatalog.getItems<IServiceBinding>("servicebindings", namespace);
+    const bindings = await ServiceCatalog.getItems<IServiceBinding>(
+      cluster,
+      "servicebindings",
+      namespace,
+    );
 
     return Promise.all(
       bindings.map(binding => {
@@ -106,8 +111,8 @@ export class ServiceBinding {
     );
   }
 
-  private static getLink(namespace?: string, name?: string): string {
-    return `${APIBase}/apis/servicecatalog.k8s.io/v1beta1${
+  private static getLink(cluster: string, namespace?: string, name?: string): string {
+    return `${APIBase(cluster)}/apis/servicecatalog.k8s.io/v1beta1${
       namespace ? `/namespaces/${namespace}` : ""
     }/servicebindings${name ? `/${name}` : ""}`;
   }

--- a/dashboard/src/shared/ServiceInstance.ts
+++ b/dashboard/src/shared/ServiceInstance.ts
@@ -30,13 +30,14 @@ export interface IServiceInstance {
 
 export class ServiceInstance {
   public static async create(
+    cluster: string,
     releaseName: string,
     namespace: string,
     className: string,
     planName: string,
     parameters: {},
   ) {
-    const { data } = await axiosWithAuth.post<IStatus>(this.getLink(namespace), {
+    const { data } = await axiosWithAuth.post<IStatus>(this.getLink(cluster, namespace), {
       apiVersion: "servicecatalog.k8s.io/v1beta1",
       kind: "ServiceInstance",
       metadata: {
@@ -51,22 +52,27 @@ export class ServiceInstance {
     return data;
   }
 
-  public static async get(namespace?: string, name?: string): Promise<IServiceInstance> {
-    const url = this.getLink(namespace, name);
+  public static async get(
+    cluster: string,
+    namespace?: string,
+    name?: string,
+  ): Promise<IServiceInstance> {
+    const url = this.getLink(cluster, namespace, name);
     const { data } = await axiosWithAuth.get<IServiceInstance>(url);
     return data;
   }
 
-  public static async list(namespace?: string): Promise<IServiceInstance[]> {
+  public static async list(cluster: string, namespace?: string): Promise<IServiceInstance[]> {
     const instances = await ServiceCatalog.getItems<IServiceInstance>(
+      cluster,
       "serviceinstances",
       namespace,
     );
     return instances;
   }
 
-  private static getLink(namespace?: string, name?: string): string {
-    return `${APIBase}/apis/servicecatalog.k8s.io/v1beta1${
+  private static getLink(cluster: string, namespace?: string, name?: string): string {
+    return `${APIBase(cluster)}/apis/servicecatalog.k8s.io/v1beta1${
       namespace ? `/namespaces/${namespace}` : ""
     }/serviceinstances${name ? `/${name}` : ""}`;
   }

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -74,13 +74,13 @@ export const backend = {
     list: (cluster: string) => `api/v1/clusters/${cluster}/namespaces`,
   },
   apprepositories: {
-    base: (namespace: string) => `api/v1/namespaces/${namespace}/apprepositories`,
-    create: (namespace: string) => backend.apprepositories.base(namespace),
-    validate: () => `${backend.apprepositories.base("kubeapps")}/validate`,
-    delete: (name: string, namespace: string) =>
-      `${backend.apprepositories.base(namespace)}/${name}`,
-    update: (namespace: string, name: string) =>
-      `${backend.apprepositories.base(namespace)}/${name}`,
+    base: (cluster: string, namespace: string) => `api/v1/clusters/${cluster}/namespaces/${namespace}/apprepositories`,
+    create: (cluster: string, namespace: string) => backend.apprepositories.base(cluster, namespace),
+    validate: (cluster: string) => `${backend.apprepositories.base(cluster, "kubeapps")}/validate`,
+    delete: (cluster: string, name: string, namespace: string) =>
+      `${backend.apprepositories.base(cluster, namespace)}/${name}`,
+    update: (cluster: string, namespace: string, name: string) =>
+      `${backend.apprepositories.base(cluster, namespace)}/${name}`,
   },
 };
 

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -74,8 +74,10 @@ export const backend = {
     list: (cluster: string) => `api/v1/clusters/${cluster}/namespaces`,
   },
   apprepositories: {
-    base: (cluster: string, namespace: string) => `api/v1/clusters/${cluster}/namespaces/${namespace}/apprepositories`,
-    create: (cluster: string, namespace: string) => backend.apprepositories.base(cluster, namespace),
+    base: (cluster: string, namespace: string) =>
+      `api/v1/clusters/${cluster}/namespaces/${namespace}/apprepositories`,
+    create: (cluster: string, namespace: string) =>
+      backend.apprepositories.base(cluster, namespace),
     validate: (cluster: string) => `${backend.apprepositories.base(cluster, "kubeapps")}/validate`,
     delete: (cluster: string, name: string, namespace: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,


### PR DESCRIPTION
### Description of the change

Updates shared helpers for AppRepositories, ServiceBrokers and ServiceInstances to no longer rely on the non-cluster-aware backend URIs.

### Benefits

Required for #1995 to be able to pass CI.


### Applicable issues

Ref: #1942 
