### PR TITLE
Update chart's clusters list to be definitive.

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -247,3 +247,29 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Sets the value of kubeappsCluster based on the configured clusters by finding the cluster without
+a defined apiServiceURL.
+*/}}
+{{- define "kubeapps.kubeappsCluster" -}}
+    {{- $clusterName := "" }}
+    {{- range .Values.clusters }}
+        {{- if eq .apiServiceURL "" }}
+            {{- if eq $clusterName "" }}
+                {{- $clusterName = .name }}
+            {{- else }}
+                {{- fail "Only one cluster can be specified without an apiServiceURL to refer to the cluster on which Kubeapps is installed." }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- $clusterName }}
+{{- end -}}
+
+{{- define "kubeapps.clusterNames" -}}
+    {{- $sanitizedClusters := list }}
+    {{- range .Values.clusters }}
+    {{- $sanitizedClusters = append $sanitizedClusters .name }}
+    {{- end }}
+    {{- $sanitizedClusters | toJson }}
+{{- end -}}

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -249,23 +249,29 @@ Usage:
 {{- end -}}
 
 {{/*
-Sets the value of kubeappsCluster based on the configured clusters by finding the cluster without
+Returns the kubeappsCluster based on the configured clusters by finding the cluster without
 a defined apiServiceURL.
 */}}
 {{- define "kubeapps.kubeappsCluster" -}}
-    {{- $clusterName := "" }}
+    {{- $kubeappsCluster := "" }}
+    {{- if eq (len .Values.clusters) 0 }}
+        {{- fail "At least one cluster must be defined." }}
+    {{- end }}
     {{- range .Values.clusters }}
-        {{- if eq .apiServiceURL "" }}
-            {{- if eq $clusterName "" }}
-                {{- $clusterName = .name }}
+        {{- if eq (.apiServiceURL | toString) "<nil>" }}
+            {{- if eq $kubeappsCluster "" }}
+                {{- $kubeappsCluster = .name }}
             {{- else }}
                 {{- fail "Only one cluster can be specified without an apiServiceURL to refer to the cluster on which Kubeapps is installed." }}
             {{- end }}
         {{- end }}
     {{- end }}
-    {{- $clusterName }}
+    {{- $kubeappsCluster }}
 {{- end -}}
 
+{{/*
+Returns a JSON list of cluster names only (without sensitive tokens etc.)
+*/}}
 {{- define "kubeapps.clusterNames" -}}
     {{- $sanitizedClusters := list }}
     {{- range .Values.clusters }}

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -39,7 +39,17 @@ data:
     }
   config.json: |-
     {
-      "kubeappsCluster": "default",
+      {{- $kubeappsCluster := "" }}
+      {{- range .Values.clusters }}
+          {{- if eq (.apiServiceURL | toString) "<nil>" }}
+              {{- if eq $kubeappsCluster "" }}
+                  {{- $kubeappsCluster = .name }}
+              {{- else }}
+                  {{- fail "Only one cluster can be specified without an apiServiceURL to refer to the cluster on which Kubeapps is installed." }}
+              {{- end }}
+          {{- end }}
+      {{- end }}
+      "kubeappsCluster": "{{ $kubeappsCluster -}}",
       "kubeappsNamespace": "{{ .Release.Namespace }}",
       "appVersion": "{{ .Chart.AppVersion }}",
       "authProxyEnabled": {{ .Values.authProxy.enabled }},

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -39,26 +39,12 @@ data:
     }
   config.json: |-
     {
-      {{- $kubeappsCluster := "" }}
-      {{- range .Values.clusters }}
-          {{- if eq (.apiServiceURL | toString) "<nil>" }}
-              {{- if eq $kubeappsCluster "" }}
-                  {{- $kubeappsCluster = .name }}
-              {{- else }}
-                  {{- fail "Only one cluster can be specified without an apiServiceURL to refer to the cluster on which Kubeapps is installed." }}
-              {{- end }}
-          {{- end }}
-      {{- end }}
-      "kubeappsCluster": "{{ $kubeappsCluster -}}",
+      "kubeappsCluster": "{{ template "kubeapps.kubeappsCluster" . -}}",
       "kubeappsNamespace": "{{ .Release.Namespace }}",
       "appVersion": "{{ .Chart.AppVersion }}",
       "authProxyEnabled": {{ .Values.authProxy.enabled }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},
       "featureFlags": {{ .Values.featureFlags | toJson }},
-      {{- $sanitizedClusters := list }}
-      {{- range .Values.clusters }}
-        {{- $sanitizedClusters = append $sanitizedClusters .name }}
-      {{- end }}
-      "clusters": {{ $sanitizedClusters | toJson }}
+      "clusters": {{ template "kubeapps.clusterNames" . }}
     }

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -51,22 +51,14 @@ data:
         return 200 "healthy\n";
       }
 
-      # The default cluster running on the same cluster as Kubeapps.
-      location ~* /api/clusters/default {
-        rewrite /api/clusters/default/(.*) /$1 break;
-        rewrite /api/clusters/default / break;
-        proxy_pass https://kubernetes.default;
-        include "./server_blocks/k8s-api-proxy.conf";
-      }
-
-      # Ensure each additional cluster can be reached (should only be
+      # Ensure each cluster can be reached (should only be
       # used with an auth-proxy where k8s credentials never leave
       # the cluster). See clusters option.
       {{- range .Values.clusters }}
       location ~* /api/clusters/{{ .name }} {
         rewrite /api/clusters/{{ .name }}/(.*) /$1 break;
         rewrite /api/clusters/{{ .name }} / break;
-        proxy_pass {{ .apiServiceURL }};
+        proxy_pass {{ default "https://kubernetes.default" .apiServiceURL }};
         {{- if .certificateAuthorityData }}
         proxy_ssl_trusted_certificate "./server_blocks/{{ .name }}-ca.pem";
         {{- end }}

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -84,7 +84,7 @@ spec:
           resources: {{- toYaml .Values.authProxy.resources | nindent 12 }}
           {{- end }}
         {{- end }}
-        {{- if and (gt (len .Values.clusters) 0) (not .Values.authProxy.enabled) }}
+        {{- if and (gt (len .Values.clusters) 1) (not .Values.authProxy.enabled) }}
           {{ fail "clusters can be configured only when using an auth proxy for cluster oidc authentication."}}
         {{- end }}
       volumes:

--- a/chart/kubeapps/templates/kubeops-config.yaml
+++ b/chart/kubeapps/templates/kubeops-config.yaml
@@ -9,6 +9,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  additional-clusters.conf: |-
+  clusters.conf: |-
 {{ .Values.clusters | toPrettyJson | indent 4 }}
 {{- end -}}

--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
             - --assetsvc-url=http://{{ template "kubeapps.assetsvc.fullname" . }}:{{ .Values.assetsvc.service.port }}
             {{- if .Values.clusters }}
-            - --additional-clusters-config-path=/config/additional-clusters.conf
+            - --clusters-config-path=/config/clusters.conf
             {{- end }}
           {{- if .Values.clusters }}
           volumeMounts:

--- a/chart/kubeapps/templates/tiller-proxy-deployment.yaml
+++ b/chart/kubeapps/templates/tiller-proxy-deployment.yaml
@@ -47,6 +47,7 @@ spec:
             - --host={{ .Values.tillerProxy.host }}
             - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
             - --assetsvc-url=http://{{ template "kubeapps.assetsvc.fullname" . }}:{{ .Values.assetsvc.service.port }}
+            - --kubeapps-cluster-name={{ template "kubeapps.kubeappsCluster" . }}
             {{- if .Values.tillerProxy.tls }}
             - --tls
             {{- if .Values.tillerProxy.tls.verify }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -20,7 +20,6 @@ allowNamespaceDiscovery: true
 enableIPv6: false
 
 ## clusters can be configured with a list of clusters that Kubeapps can target for deployments.
-## If empty, Kubeapps will only target the cluster on which Kubeapps is itself installed.
 ## When populated with a single cluster (as it is by default), Kubeapps will not allow users to
 ## change the target cluster. When populated with multiple clusters, Kubeapps will present the clusters to
 ## the user as potential targets for install or browsing.
@@ -32,6 +31,7 @@ enableIPv6: false
 ## kubectl --kubeconfig ~/.kube/kind-config-kubeapps-additional config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}'
 #
 # clusters:
+# - name: default
 # - name: second-cluster
 #   apiServiceURL: https://second-cluster:6443
 #   # certificateAuthorityData is required for secure communication with the additional API server.

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -20,12 +20,13 @@ allowNamespaceDiscovery: true
 enableIPv6: false
 
 ## clusters can be configured with a list of clusters that Kubeapps can target for deployments.
-## This is an alpha feature and the semantics are expected to change slightly in future releases.
-## If empty, Kubeapps will target the cluster on which it is installed only.
-## When populated, Kubeapps will currently present the listed clusters in addition to the default
-## cluster on which Kubeapps is installed. In the future a populated list here will be definitive, so that
-## it is possible to configure Kubeapps to target other clusters only (ie. not target the cluster on which
-## Kubeapps is installed), as per https://github.com/kubeapps/kubeapps/issues/1942 .
+## If empty, Kubeapps will only target the cluster on which Kubeapps is itself installed.
+## When populated with a single cluster (as it is by default), Kubeapps will not allow users to
+## change the target cluster. When populated with multiple clusters, Kubeapps will present the clusters to
+## the user as potential targets for install or browsing.
+## Note that you can define a single cluster without an apiServiceURL and the chart will assume this is
+## the name you are assigning to the cluster on which Kubeapps is itself installed. Specifying more than
+## one cluster without an apiServiceURL will cause the chart display an error.
 ## The base64-encoded certificateAuthorityData can be obtained from the additional cluster's kube config
 ## file, for example:
 ## kubectl --kubeconfig ~/.kube/kind-config-kubeapps-additional config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}'
@@ -38,7 +39,8 @@ enableIPv6: false
 #   # serviceToken is an optional token configured to allow LIST namespaces only on the additional cluster
 #   # so that the UI can present a list of (only) those namespaces to which the user has access.
 #   serviceToken: ...
-clusters: []
+clusters:
+  - name: default
 
 ## The frontend service is the main reverse proxy used to access the Kubeapps UI
 ## To expose Kubeapps externally either configure the ingress object below or

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -309,7 +309,7 @@ describe("clusterReducer", () => {
 
   context("when RECEIVE_CONFIG", () => {
     const config = {
-      kubeappsCluster: "kubeappsCluster",
+      kubeappsCluster: "",
       kubeappsNamespace: "kubeapps",
       appVersion: "dev",
       authProxyEnabled: false,
@@ -329,7 +329,7 @@ describe("clusterReducer", () => {
         }),
       ).toEqual({
         ...initialTestState,
-        currentCluster: "kubeappsCluster",
+        currentCluster: "additionalCluster1",
         clusters: {
           additionalCluster1: {
             currentNamespace: "default",
@@ -343,21 +343,29 @@ describe("clusterReducer", () => {
       } as IClustersState);
     });
 
-    it("creates a default cluster if no clusters defined", () => {
-      const configNoClusters = {
+    it("sets the current cluster to the first cluster in the list", () => {
+      const configClusters = {
         ...config,
-        clusters: [],
+        clusters: ["one", "two", "three"],
       };
       expect(
         clusterReducer(initialTestState, {
           type: getType(actions.config.receiveConfig),
-          payload: configNoClusters,
+          payload: configClusters,
         }),
       ).toEqual({
         ...initialTestState,
-        currentCluster: "kubeappsCluster",
+        currentCluster: "one",
         clusters: {
-          default: {
+          one: {
+            currentNamespace: "default",
+            namespaces: [],
+          },
+          two: {
+            currentNamespace: "default",
+            namespaces: [],
+          },
+          three: {
             currentNamespace: "default",
             namespaces: [],
           },

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -321,7 +321,7 @@ describe("clusterReducer", () => {
       },
       clusters: ["additionalCluster1", "additionalCluster2"],
     } as IConfig;
-    it("adds the additional clusters to the clusters state", () => {
+    it("re-writes the clusters to match the config.clusters state", () => {
       expect(
         clusterReducer(initialTestState, {
           type: getType(actions.config.receiveConfig),
@@ -331,7 +331,6 @@ describe("clusterReducer", () => {
         ...initialTestState,
         currentCluster: "kubeappsCluster",
         clusters: {
-          ...initialTestState.clusters,
           additionalCluster1: {
             currentNamespace: "default",
             namespaces: [],
@@ -344,22 +343,26 @@ describe("clusterReducer", () => {
       } as IClustersState);
     });
 
-    it("does not error if there is not feature flag", () => {
-      const badConfig = {
+    it("creates a default cluster if no clusters defined", () => {
+      const configNoClusters = {
         ...config,
+        clusters: [],
       };
-      // Manually delete clusters so typescript doesn't complain
-      // while still allowing us to test the case where it is not present.
-      delete badConfig.clusters;
       expect(
         clusterReducer(initialTestState, {
           type: getType(actions.config.receiveConfig),
-          payload: badConfig,
+          payload: configNoClusters,
         }),
       ).toEqual({
         ...initialTestState,
         currentCluster: "kubeappsCluster",
-      });
+        clusters: {
+          default: {
+            currentNamespace: "default",
+            namespaces: [],
+          },
+        },
+      } as IClustersState);
     });
   });
 });

--- a/dashboard/src/reducers/cluster.ts
+++ b/dashboard/src/reducers/cluster.ts
@@ -155,15 +155,10 @@ const clusterReducer = (
           namespaces: [],
         };
       });
-      if (Object.keys(clusters).length === 0) {
-        clusters.default = {
-          currentNamespace: "default",
-          namespaces: [],
-        };
-      }
+
       return {
         ...state,
-        currentCluster: action.payload.kubeappsCluster,
+        currentCluster: config.clusters[0],
         clusters,
       };
     default:

--- a/dashboard/src/reducers/cluster.ts
+++ b/dashboard/src/reducers/cluster.ts
@@ -146,17 +146,21 @@ const clusterReducer = (
       }
       break;
     case getType(actions.config.receiveConfig):
-      // Initialize the additional clusters when receiving the config.
-      const clusters = {
-        ...state.clusters,
-      };
+      // Initialize the clusters when receiving the config.
       const config = action.payload as IConfig;
+      const clusters: IClustersMap = {};
       config.clusters?.forEach(cluster => {
         clusters[cluster] = {
           currentNamespace: "default",
           namespaces: [],
         };
       });
+      if (Object.keys(clusters).length === 0) {
+        clusters.default = {
+          currentNamespace: "default",
+          namespaces: [],
+        };
+      }
       return {
         ...state,
         currentCluster: action.payload.kubeappsCluster,

--- a/dashboard/src/reducers/cluster.ts
+++ b/dashboard/src/reducers/cluster.ts
@@ -149,9 +149,13 @@ const clusterReducer = (
       // Initialize the clusters when receiving the config.
       const config = action.payload as IConfig;
       const clusters: IClustersMap = {};
-      config.clusters?.forEach(cluster => {
+      config.clusters.forEach(cluster => {
+        const currentNamespace =
+          cluster === config.kubeappsCluster
+            ? Auth.defaultNamespaceFromToken(Auth.getAuthToken() || "")
+            : "default";
         clusters[cluster] = {
-          currentNamespace: "default",
+          currentNamespace,
           namespaces: [],
         };
       });

--- a/docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
@@ -1,4 +1,5 @@
 clusters:
+ - name: mydefaultcluster
  - name: second-cluster
    apiServiceURL: https://172.18.0.3:6443
    # insecure is set to true only for local dev cluster testing. Always specify the

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -26,12 +26,26 @@ deploy-dependencies: deploy-dex deploy-openldap devel/localhost-cert.pem
 		--key ./devel/localhost-key.pem \
 		--cert ./devel/localhost-cert.pem
 
+template-test:
+	helm template kubeapps ./chart/kubeapps --namespace kubeapps \
+		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
+		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
+		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml \
+		--set useHelm3=true --show-only templates/kubeapps-frontend-config.yaml
+
+upgrade:
+	helm upgrade kubeapps ./chart/kubeapps --namespace kubeapps \
+		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
+		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
+		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml \
+		--set useHelm3=true --set featureFlags.ui=clarity
+
 deploy-dev: deploy-dependencies
 	helm install kubeapps ./chart/kubeapps --namespace kubeapps \
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml \
-		--set useHelm3=true
+		--set useHelm3=true --set featureFlags.ui=clarity
 	@echo "\nYou can now simply open your browser at https://localhost/ to access Kubeapps!"
 	@echo "When logging in, you will be redirected to dex (with a self-signed cert) and can login with email as either of"
 	@echo "  kubeapps-operator@example.com:password"

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -26,20 +26,6 @@ deploy-dependencies: deploy-dex deploy-openldap devel/localhost-cert.pem
 		--key ./devel/localhost-key.pem \
 		--cert ./devel/localhost-cert.pem
 
-template-test:
-	helm template kubeapps ./chart/kubeapps --namespace kubeapps \
-		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
-		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
-		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml \
-		--set useHelm3=true --show-only templates/kubeapps-frontend-config.yaml
-
-upgrade:
-	helm upgrade kubeapps ./chart/kubeapps --namespace kubeapps \
-		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
-		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
-		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml \
-		--set useHelm3=true --set featureFlags.ui=clarity
-
 deploy-dev: deploy-dependencies
 	helm install kubeapps ./chart/kubeapps --namespace kubeapps \
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \


### PR DESCRIPTION
### Description of the change

Updates the `.Values.clusters` list of clusters to be definitive, enabling the cluster on which kubeapps is installed to have a name other than `default` or to not be a target cluster at all for users.

### Benefits

See #1942 and #1943 

TL;DR is that with this change, the cluster on which Kubeapps is running can be called whatever the user likes, but still defaults to `default`, and this is included in the definitive list of `.Values.clusters`.

### Applicable issues

  - fixes #1942 
  - fixes #1943 
