### PR TITLE
Refactor cards

### DIFF
--- a/dashboard/src/components/AppList/AppListItem.v2.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.v2.test.tsx
@@ -1,5 +1,7 @@
+import Tooltip from "components/js/Tooltip";
 import { shallow } from "enzyme";
 import * as React from "react";
+import { defaultStore, mountWrapper } from "shared/specs/mountWrapper";
 import { app } from "shared/url";
 import InfoCard from "../InfoCard/InfoCard.v2";
 import AppListItem, { IAppListItemProps } from "./AppListItem.v2";
@@ -31,13 +33,12 @@ it("renders an app item", () => {
       defaultProps.app.releaseName,
     ),
     tag1Class: "label-success",
-    tag1Content: "Status: deployed",
-    tag2Content: undefined,
+    tag1Content: "deployed",
     title: defaultProps.app.releaseName,
   });
 });
 
-it("should add a second label with the chart update available", () => {
+it("should add a tooltip with the chart update available", () => {
   const props = {
     ...defaultProps,
     app: {
@@ -53,9 +54,9 @@ it("should add a second label with the chart update available", () => {
       },
     },
   } as IAppListItemProps;
-  const wrapper = shallow(<AppListItem {...props} />);
-  const card = wrapper.find(InfoCard);
-  expect(card.prop("tag2Content")).toBe("New Chart: 1.1.0");
+  const wrapper = mountWrapper(defaultStore, <AppListItem {...props} />);
+  const tooltip = wrapper.find(Tooltip);
+  expect(tooltip.text()).toBe("New Chart Version: 1.1.0");
 });
 
 it("should add a second label with the app update available", () => {
@@ -74,7 +75,7 @@ it("should add a second label with the app update available", () => {
       },
     },
   } as IAppListItemProps;
-  const wrapper = shallow(<AppListItem {...props} />);
-  const card = wrapper.find(InfoCard);
-  expect(card.prop("tag2Content")).toBe("New App: 1.1.0");
+  const wrapper = mountWrapper(defaultStore, <AppListItem {...props} />);
+  const tooltip = wrapper.find(Tooltip);
+  expect(tooltip.text()).toBe("New App Version: 1.1.0");
 });

--- a/dashboard/src/components/AppList/AppListItem.v2.tsx
+++ b/dashboard/src/components/AppList/AppListItem.v2.tsx
@@ -5,6 +5,7 @@ import { IAppOverview } from "../../shared/types";
 import * as url from "../../shared/url";
 import InfoCard from "../InfoCard/InfoCard.v2";
 
+import Tooltip from "components/js/Tooltip";
 import "./AppListItem.v2.css";
 
 export interface IAppListItemProps {
@@ -16,13 +17,38 @@ function AppListItem(props: IAppListItemProps) {
   const { app, cluster } = props;
   const icon = app.icon ? app.icon : placeholder;
   const appStatus = app.status.toLocaleLowerCase();
+  let tooltip = <></>;
   const updateAvailable = app.updateInfo && !app.updateInfo.error && !app.updateInfo.upToDate;
-  let tag2Content;
+  // let tag2Content;
   if (app.updateInfo && updateAvailable) {
     if (app.updateInfo.appLatestVersion !== app.chartMetadata.appVersion) {
-      tag2Content = `New App: ${app.updateInfo.appLatestVersion}`;
+      tooltip = (
+        <div className="color-icon-info">
+          <Tooltip
+            label="update-tooltip"
+            id={`${app.releaseName}-update-tooltip`}
+            icon="circle-arrow"
+            position="top-left"
+            iconProps={{ solid: true, size: "md", color: "blue" }}
+          >
+            New App Version: {app.updateInfo.appLatestVersion}
+          </Tooltip>
+        </div>
+      );
     } else {
-      tag2Content = `New Chart: ${app.updateInfo.chartLatestVersion}`;
+      tooltip = (
+        <div className="color-icon-info">
+          <Tooltip
+            label="update-tooltip"
+            id={`${app.releaseName}-update-tooltip`}
+            icon="circle-arrow"
+            position="top-left"
+            iconProps={{ solid: true, size: "md" }}
+          >
+            New Chart Version: {app.updateInfo.chartLatestVersion}
+          </Tooltip>
+        </div>
+      );
     }
   }
   return (
@@ -33,16 +59,16 @@ function AppListItem(props: IAppListItemProps) {
       icon={icon}
       info={
         <div>
-          <span>App: {app.chartMetadata.appVersion}</span>
+          <span>App: {app.chartMetadata.name}</span>
           <br />
-          <span>Chart: {app.chartMetadata.version}</span>
+          <span>Chart: {app.chartMetadata.appVersion}</span>
         </div>
       }
       description={app.chartMetadata.description}
-      tag1Content={`Status: ${appStatus}`}
+      tag1Content={appStatus}
       tag1Class={appStatus === "deployed" ? "label-success" : "label-warning"}
-      tag2Content={tag2Content}
-      subIcon={helmIcon}
+      tooltip={tooltip}
+      bgIcon={helmIcon}
     />
   );
 }

--- a/dashboard/src/components/AppList/AppListItem.v2.tsx
+++ b/dashboard/src/components/AppList/AppListItem.v2.tsx
@@ -19,7 +19,6 @@ function AppListItem(props: IAppListItemProps) {
   const appStatus = app.status.toLocaleLowerCase();
   let tooltip = <></>;
   const updateAvailable = app.updateInfo && !app.updateInfo.error && !app.updateInfo.upToDate;
-  // let tag2Content;
   if (app.updateInfo && updateAvailable) {
     if (app.updateInfo.appLatestVersion !== app.chartMetadata.appVersion) {
       tooltip = (
@@ -59,9 +58,12 @@ function AppListItem(props: IAppListItemProps) {
       icon={icon}
       info={
         <div>
-          <span>App: {app.chartMetadata.name}</span>
+          <span>
+            App: {app.chartMetadata.name}{" "}
+            {app.chartMetadata.appVersion ? `v${app.chartMetadata.appVersion}` : ""}
+          </span>
           <br />
-          <span>Chart: {app.chartMetadata.appVersion}</span>
+          <span>Chart: {app.chartMetadata.version}</span>
         </div>
       }
       description={app.chartMetadata.description}

--- a/dashboard/src/components/AppList/CustomResourceListItem.v2.test.tsx
+++ b/dashboard/src/components/AppList/CustomResourceListItem.v2.test.tsx
@@ -49,7 +49,6 @@ it("renders an cr item", () => {
       crd.name,
       resource.metadata.name,
     ),
-    tag1Content: "bar",
     title: resource.metadata.name,
   });
 });

--- a/dashboard/src/components/AppList/CustomResourceListItem.v2.tsx
+++ b/dashboard/src/components/AppList/CustomResourceListItem.v2.tsx
@@ -41,11 +41,10 @@ function CustomResourceListItem(props: ICustomResourceListItemProps) {
       info={
         <>
           <div>App: {resource.kind}</div>
-          <div>Operator: v{csv.spec.version || "-"}</div>
+          <div>Operator: {csv.spec.version || "-"}</div>
         </>
       }
-      tag1Content={csv.metadata.name.split(".")[0]}
-      subIcon={operatorIcon}
+      bgIcon={operatorIcon}
     />
   );
 }

--- a/dashboard/src/components/Catalog/ChartCatalogItem.tsx
+++ b/dashboard/src/components/Catalog/ChartCatalogItem.tsx
@@ -13,7 +13,7 @@ export default function ChartCatalogItem(props: IChartCatalogItem) {
   const iconSrc = icon || placeholder;
   const cluster = useSelector((state: IStoreState) => state.clusters.currentCluster);
   const link = url.app.charts.get(cluster, namespace, name, repo || ({} as IRepo));
-  const subIcon = helmIcon;
+  const bgIcon = helmIcon;
 
   return (
     <InfoCard
@@ -24,7 +24,7 @@ export default function ChartCatalogItem(props: IChartCatalogItem) {
       icon={iconSrc}
       description={trimDescription(description)}
       tag1Content={<span>{repo.name}</span>}
-      subIcon={subIcon}
+      bgIcon={bgIcon}
     />
   );
 }

--- a/dashboard/src/components/Catalog/OperatorCatalogItem.tsx
+++ b/dashboard/src/components/Catalog/OperatorCatalogItem.tsx
@@ -13,7 +13,7 @@ export default function OperatorCatalogItem(props: IOperatorCatalogItem) {
   const csvName = props.csv.split(".")[0];
   const tag1 = <span>{csvName}</span>;
   const link = app.operatorInstances.new(cluster, namespace, csv, id);
-  const subIcon = operatorIcon;
+  const bgIcon = operatorIcon;
   return (
     <InfoCard
       key={id}
@@ -23,7 +23,7 @@ export default function OperatorCatalogItem(props: IOperatorCatalogItem) {
       icon={iconSrc}
       description={trimDescription(description)}
       tag1Content={tag1}
-      subIcon={subIcon}
+      bgIcon={bgIcon}
     />
   );
 }

--- a/dashboard/src/components/InfoCard/InfoCard.v2.scss
+++ b/dashboard/src/components/InfoCard/InfoCard.v2.scss
@@ -1,27 +1,55 @@
 .card-header {
-  .card-title {
-    max-width: calc(100% - 24px);
-    overflow-x: hidden;
-    text-overflow: ellipsis;
+  .info-card-header {
+    display: flex;
+    justify-content: space-between;
+    .card-title {
+      max-width: calc(100% - 24px);
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      margin-bottom: 0px;
+    }
+    .card-tooltip {
+      align-self: flex-end;
+    }
   }
+}
+
+.bg-img {
+  width: 0px;
+  opacity: 0.05;
+  position: relative;
+  right: 80px;
+  bottom: 10px;
   img {
-    position: absolute;
-    max-width: 24px;
-    top: 14px;
-    right: 1rem;
+    height: 100px;
   }
 }
 
 .card-block {
   height: 4.5rem;
-  overflow-y: hidden;
-  .card-icon {
+  overflow: hidden;
+  .info-card-block {
     display: flex;
-    align-items: center;
-    text-align: center;
-    height: 3.5rem;
-    img {
-      max-width: 100%;
+    .card-icon {
+      display: flex;
+      align-items: center;
+      text-align: center;
+      width: 64px;
+      height: 64px;
+      img {
+        width: 64px;
+        max-height: 64px;
+      }
+    }
+    .card-description-wrapper {
+      display: grid;
+      height: 64px;
+      width: 100%;
+      align-items: center;
+      .card-description {
+        max-height: 64px;
+        padding-left: 0.6rem;
+      }
     }
   }
 }

--- a/dashboard/src/components/InfoCard/InfoCard.v2.test.tsx
+++ b/dashboard/src/components/InfoCard/InfoCard.v2.test.tsx
@@ -77,3 +77,18 @@ it("should parse a description as JSX.Element", () => {
   const wrapper = shallow(<InfoCard title="foo" info="foobar" description={desc} />);
   expect(wrapper.find(".description").text()).toBe("This is a description");
 });
+
+it("should parse an icon", () => {
+  const wrapper = shallow(<InfoCard title="foo" info="foobar" />);
+  expect(wrapper.find("img")).toExist();
+});
+
+it("should parse a background img", () => {
+  const wrapper = shallow(<InfoCard title="foo" info="foobar" bgIcon="img.png" />);
+  expect(wrapper.find(".bg-img").find("img")).toExist();
+});
+
+it("should parse a tooltip component", () => {
+  const wrapper = shallow(<InfoCard title="foo" info="foobar" tooltip={<div id="foo" />} />);
+  expect(wrapper.find(".info-card-header").find("#foo")).toExist();
+});

--- a/dashboard/src/components/InfoCard/InfoCard.v2.tsx
+++ b/dashboard/src/components/InfoCard/InfoCard.v2.tsx
@@ -12,8 +12,9 @@ export interface IInfoCardProps {
   info: string | JSX.Element;
   link?: string;
   icon?: string;
-  subIcon?: string;
+  bgIcon?: string;
   description?: string | JSX.Element;
+  tooltip?: JSX.Element;
   tag1Class?: string;
   tag1Content?: string | JSX.Element;
   tag2Class?: string;
@@ -26,11 +27,12 @@ function InfoCard(props: IInfoCardProps) {
     link,
     info,
     description,
+    tooltip,
     tag1Content,
     tag1Class,
     tag2Content,
     tag2Class,
-    subIcon,
+    bgIcon,
   } = props;
   const icon = props.icon ? props.icon : placeholder;
   return (
@@ -38,22 +40,29 @@ function InfoCard(props: IInfoCardProps) {
       <Card clickable={true}>
         <Link to={link || "#"}>
           <CardHeader>
-            <>
+            <div className="info-card-header">
               <div className="card-title">{title}</div>
-              {subIcon && <img src={subIcon} alt="icon" />}
-            </>
+              {tooltip ? <div className="card-tooltip">{tooltip}</div> : <></>}
+            </div>
           </CardHeader>
           <CardBlock>
-            <Row>
-              <Column span={3}>
-                <div className="card-icon">
-                  <img src={icon} alt="icon" sizes="64px" />
+            <div className="info-card-block">
+              <div className="card-icon">
+                <img src={icon} alt="icon" />
+              </div>
+              <div className="card-description-wrapper">
+                <div className="card-description">
+                  <span>{description}</span>
                 </div>
-              </Column>
-              <Column span={9}>
-                <span>{description}</span>
-              </Column>
-            </Row>
+              </div>
+              {bgIcon ? (
+                <div className="bg-img">
+                  <img src={bgIcon} alt="bg-img" />
+                </div>
+              ) : (
+                <></>
+              )}
+            </div>
           </CardBlock>
           <CardFooter>
             <Row>

--- a/dashboard/src/components/InfoCard/__snapshots__/InfoCard.v2.test.tsx.snap
+++ b/dashboard/src/components/InfoCard/__snapshots__/InfoCard.v2.test.tsx.snap
@@ -23,36 +23,37 @@ exports[`should render a Card 1`] = `
         noBorder={false}
       >
         <div
-          className="card-title"
+          className="info-card-header"
         >
-          foo
+          <div
+            className="card-title"
+          >
+            foo
+          </div>
         </div>
       </CardHeader>
       <CardBlock>
-        <Row
-          list={false}
+        <div
+          className="info-card-block"
         >
-          <Column
-            listItem={false}
-            span={3}
+          <div
+            className="card-icon"
+          >
+            <img
+              alt="icon"
+              src="an-icon.png"
+            />
+          </div>
+          <div
+            className="card-description-wrapper"
           >
             <div
-              className="card-icon"
+              className="card-description"
             >
-              <img
-                alt="icon"
-                sizes="64px"
-                src="an-icon.png"
-              />
+              <span />
             </div>
-          </Column>
-          <Column
-            listItem={false}
-            span={9}
-          >
-            <span />
-          </Column>
-        </Row>
+          </div>
+        </div>
       </CardBlock>
       <CardFooter>
         <Row


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

 - [X] Remove the `Status: ` prefix of the status label.
 - [X] Standardize footer: App <app>, Version: <version>. Since operators don't include the app version but it's important for charts, the format is now `App: name vVersion / Chart: version` for charts and `App: name / Operator: version` for operators. 
 - [X] Move update info to a more prominent place (title?). Since the title already had an icon (helm or OLM icon) I moved the type icon as a subtle background image in the description so I can add a tooltip with the update info in the title.
 - [X] Vertically center the description of cards
 ~~- [ ] Add status for operator instances~~ This cannot be done since there is no a generic way to obtain a short status from arbitrary instances
 - [X] Fix icon issues in bigger screens

Screenshots:

![Screenshot from 2020-09-03 11-57-33](https://user-images.githubusercontent.com/4025665/92101708-cd87b600-eddd-11ea-97eb-2bfa1af4194b.png)

![Screenshot from 2020-09-03 11-44-43](https://user-images.githubusercontent.com/4025665/92101722-d37d9700-eddd-11ea-9bbc-2f3cee172c5e.png)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1907
