### PR TITLE
Add option for all namespaces in the namespace selector

### DIFF
--- a/dashboard/src/components/Header/ContextSelector.scss
+++ b/dashboard/src/components/Header/ContextSelector.scss
@@ -56,3 +56,12 @@
     }
   }
 }
+
+.kubeapps-create-new-ns {
+  display: flex;
+  justify-content: flex-end;
+  cds-button {
+    --color: var(--clr-header-font-color, #fafafa);
+    outline: 0px;
+  }
+}

--- a/dashboard/src/components/Header/ContextSelector.test.tsx
+++ b/dashboard/src/components/Header/ContextSelector.test.tsx
@@ -8,6 +8,7 @@ import { CdsButton } from "@clr/react/button";
 import { cloneDeep } from "lodash";
 import { act } from "react-dom/test-utils";
 import { IClustersState } from "reducers/cluster";
+import { definedNamespaces } from "shared/Namespace";
 import ContextSelector from "./ContextSelector";
 
 const mockStore = configureMockStore([thunk]);
@@ -122,4 +123,23 @@ it("shows the current namespace", () => {
       .at(1)
       .prop("value"),
   ).toBe("other");
+});
+
+it("includes all namespaces", () => {
+  const props = cloneDeep(defaultProps);
+  props.clusters.clusters.default.currentNamespace = definedNamespaces.all;
+  const wrapper = mount(
+    <Provider store={defaultStore}>
+      <ContextSelector {...props} />
+    </Provider>,
+  );
+  expect(wrapper.find("label").findWhere(l => l.prop("htmlFor") === "namespaces")).toIncludeText(
+    "All Namespaces",
+  );
+  expect(
+    wrapper
+      .find("select")
+      .find("option")
+      .filterWhere(op => op.prop("value") === definedNamespaces.all),
+  ).toExist();
 });

--- a/dashboard/src/components/Header/ContextSelector.tsx
+++ b/dashboard/src/components/Header/ContextSelector.tsx
@@ -47,6 +47,10 @@ function ContextSelector({
     }
   }, [fetchNamespaces, namespaceSelected, getNamespace, clusters.currentCluster]);
 
+  useEffect(() => {
+    setStateNamespace(namespaceSelected);
+  }, [namespaceSelected]);
+
   const toggleOpen = () => setOpen(!open);
   const selectCluster = (event: React.ChangeEvent<HTMLSelectElement>) =>
     setStateCluster(event.target.value);
@@ -81,7 +85,9 @@ function ContextSelector({
                   </label>
                   <CdsIcon size="sm" shape="file-group" inverse={true} />
                   <label htmlFor="namespaces" className="kubeapps-dropdown-text">
-                    {namespaceSelected}
+                    {namespaceSelected === definedNamespaces.all
+                      ? "All Namespaces"
+                      : namespaceSelected}
                   </label>
                 </div>
               </div>
@@ -136,6 +142,9 @@ function ContextSelector({
                     </option>
                   );
                 })}
+                <option key="kubeapps-dropdown-namespace-_all" value={definedNamespaces.all}>
+                  All Namespaces
+                </option>
               </select>
             </div>
           </div>

--- a/dashboard/src/components/Header/Header.v2.tsx
+++ b/dashboard/src/components/Header/Header.v2.tsx
@@ -10,29 +10,15 @@ import Menu from "./Menu";
 
 interface IHeaderProps {
   authenticated: boolean;
-  fetchNamespaces: (cluster: string) => void;
   logout: () => void;
   clusters: IClustersState;
   defaultNamespace: string;
   appVersion: string;
   push: (path: string) => void;
-  setNamespace: (ns: string) => void;
-  createNamespace: (cluster: string, ns: string) => Promise<boolean>;
-  getNamespace: (cluster: string, ns: string) => void;
 }
 
 function Header(props: IHeaderProps) {
-  const {
-    appVersion,
-    clusters,
-    authenticated: showNav,
-    defaultNamespace,
-    fetchNamespaces,
-    createNamespace,
-    getNamespace,
-    setNamespace,
-    logout,
-  } = props;
+  const { appVersion, clusters, authenticated: showNav, defaultNamespace, logout } = props;
   const cluster = clusters.clusters[clusters.currentCluster];
 
   const routesToRender = [
@@ -75,14 +61,7 @@ function Header(props: IHeaderProps) {
           )}
           {showNav && (
             <section className="header-actions">
-              <ContextSelector
-                clusters={clusters}
-                fetchNamespaces={fetchNamespaces}
-                getNamespace={getNamespace}
-                createNamespace={createNamespace}
-                defaultNamespace={defaultNamespace}
-                setNamespace={setNamespace}
-              />
+              <ContextSelector />
               <Menu
                 clusters={clusters}
                 defaultNamespace={defaultNamespace}

--- a/dashboard/src/shared/specs/mountWrapper.tsx
+++ b/dashboard/src/shared/specs/mountWrapper.tsx
@@ -4,10 +4,10 @@ import { cloneDeep } from "lodash";
 import * as React from "react";
 import { Provider } from "react-redux";
 import { BrowserRouter as Router } from "react-router-dom";
+import { IClustersState } from "reducers/cluster";
+import { operatorsInitialState } from "reducers/operators";
 import configureMockStore, { MockStore } from "redux-mock-store";
 import thunk from "redux-thunk";
-
-import { operatorsInitialState } from "reducers/operators";
 import { IAppRepository, ISecret, IStoreState } from "../../shared/types";
 
 const mockStore = configureMockStore([thunk]);
@@ -23,7 +23,13 @@ export const initialState = {
   },
   clusters: {
     currentCluster: "default-cluster",
-  },
+    clusters: {
+      "default-cluster": {
+        currentNamespace: "default",
+        namespaces: ["default", "other"],
+      },
+    },
+  } as IClustersState,
   repos: {
     errors: {},
     repos: [] as IAppRepository[],


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Added the item for "All Namespaces" in the context selector as we have it today:

![Screenshot from 2020-09-08 13-32-08](https://user-images.githubusercontent.com/4025665/92471164-c4c92280-f1d7-11ea-949e-96f1a71d8f13.png)

For the moment I am just matching current functionality, it's not the goal to rethink about the desired UX.

I have also fixed a small bug I noticed. The `select` input for the namespace were showing the wrong namespace when the namespace was changed outside the selector (for example when clicking on a link).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1907

