### PR TITLE
Force selection of a single namespace

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.v2.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.v2.test.tsx
@@ -4,6 +4,7 @@ import FilterGroup from "components/FilterGroup/FilterGroup";
 import InfoCard from "components/InfoCard/InfoCard.v2";
 import Alert from "components/js/Alert";
 import { act } from "react-dom/test-utils";
+import { definedNamespaces } from "shared/Namespace";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
 import { IChart, IChartState, IClusterServiceVersion } from "../../shared/types";
 import SearchFilter from "../SearchFilter/SearchFilter.v2";
@@ -113,6 +114,15 @@ it("behaves like a loading wrapper", () => {
     <Catalog {...populatedProps} charts={{ isFetching: true, items: [], selected: {} } as any} />,
   );
   expect(wrapper.find("LoadingWrapper")).toExist();
+});
+
+it("shows a message if the namespace has not been selected", () => {
+  const wrapper = mountWrapper(
+    defaultStore,
+    <Catalog {...populatedProps} namespace={definedNamespaces.all} />,
+  );
+  expect(wrapper).toIncludeText("A valid namespace should be selected");
+  expect(wrapper.find(".filters-menu")).not.toExist();
 });
 
 describe("filters by the searched item", () => {

--- a/dashboard/src/components/Catalog/Catalog.v2.tsx
+++ b/dashboard/src/components/Catalog/Catalog.v2.tsx
@@ -10,6 +10,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Link } from "react-router-dom";
 import { IFeatureFlags } from "shared/Config";
+import { definedNamespaces } from "shared/Namespace";
 import { app } from "shared/url";
 import { IChartState, IClusterServiceVersion } from "../../shared/types";
 import { escapeRegExp } from "../../shared/utils";
@@ -199,7 +200,16 @@ function Catalog(props: ICatalogProps) {
             An error occurred while fetching the catalog: {error.message}
           </Alert>
         )}
-        {charts.length === 0 && csvs.length === 0 ? (
+        {namespace === definedNamespaces.all ? (
+          <div className="empty-catalog">
+            <CdsIcon shape="file-group" />
+            <h4>A valid namespace should be selected.</h4>
+            <p>
+              In order to show the catalog of applications available, a namespace must be selected
+              using the selector in the top right corner.
+            </p>
+          </div>
+        ) : charts.length === 0 && csvs.length === 0 ? (
           <div className="empty-catalog">
             <CdsIcon shape="bundle" />
             <p>The current catalog is empty.</p>

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.v2.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.v2.test.tsx
@@ -5,6 +5,7 @@ import * as ReactRedux from "react-redux";
 
 import Alert from "components/js/Alert";
 import { act } from "react-dom/test-utils";
+import { definedNamespaces } from "shared/Namespace";
 import { IChartState, IChartVersion } from "../../shared/types";
 import * as url from "../../shared/url";
 import DeploymentFormBody from "../DeploymentFormBody/DeploymentFormBody.v2";
@@ -180,4 +181,16 @@ it("triggers a deployment when submitting the form", async () => {
     schema,
   );
   expect(push).toHaveBeenCalledWith(url.app.apps.get("default", "default", "my-release"));
+});
+
+it("hides the form if no namespace is selected", async () => {
+  const wrapper = mount(
+    <DeploymentForm
+      {...defaultProps}
+      selected={{ versions, version: versions[0] }}
+      namespace={definedNamespaces.all}
+    />,
+  );
+  expect(wrapper.find(Alert)).toIncludeText("Namespace not selected");
+  expect(wrapper.find("form")).not.toExist();
 });

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.v2.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.v2.tsx
@@ -16,6 +16,7 @@ import Column from "components/js/Column";
 import Row from "components/js/Row";
 import { useDispatch } from "react-redux";
 import "react-tabs/style/react-tabs.css";
+import { definedNamespaces } from "shared/Namespace";
 
 export interface IDeploymentFormProps {
   chartNamespace: string;
@@ -128,35 +129,42 @@ function DeploymentForm({
           </Column>
           <Column span={9}>
             {error && <Alert theme="danger">An error occurred: {error.message}</Alert>}
-            <form onSubmit={handleDeploy}>
-              <div>
-                <label
-                  htmlFor="releaseName"
-                  className="deployment-form-label deployment-form-label-text-param"
-                >
-                  Name
-                </label>
-                <input
-                  id="releaseName"
-                  pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
-                  title="Use lower case alphanumeric characters, '-' or '.'"
-                  className="clr-input deployment-form-text-input"
-                  onChange={handleReleaseNameChange}
-                  value={releaseName}
-                  required={true}
+            {namespace === definedNamespaces.all ? (
+              <Alert theme="danger">
+                Namespace not selected. Please select a namespace using the selector in the top
+                right corner.
+              </Alert>
+            ) : (
+              <form onSubmit={handleDeploy}>
+                <div>
+                  <label
+                    htmlFor="releaseName"
+                    className="deployment-form-label deployment-form-label-text-param"
+                  >
+                    Name
+                  </label>
+                  <input
+                    id="releaseName"
+                    pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+                    title="Use lower case alphanumeric characters, '-' or '.'"
+                    className="clr-input deployment-form-text-input"
+                    onChange={handleReleaseNameChange}
+                    value={releaseName}
+                    required={true}
+                  />
+                </div>
+                <DeploymentFormBody
+                  deploymentEvent="install"
+                  chartID={chartID}
+                  chartVersion={chartVersion}
+                  chartsIsFetching={chartsIsFetching}
+                  selected={selected}
+                  setValues={handleValuesChange}
+                  appValues={appValues}
+                  setValuesModified={setValuesModifiedTrue}
                 />
-              </div>
-              <DeploymentFormBody
-                deploymentEvent="install"
-                chartID={chartID}
-                chartVersion={chartVersion}
-                chartsIsFetching={chartsIsFetching}
-                selected={selected}
-                setValues={handleValuesChange}
-                appValues={appValues}
-                setValuesModified={setValuesModifiedTrue}
-              />
-            </form>
+              </form>
+            )}
           </Column>
         </Row>
       </LoadingWrapper>


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of #2015. If the namespace has not been selected (it's using "All Namespaces"), the catalog shows a warning so it's clear that a namespace should be selected first:

![Screenshot from 2020-09-08 17-50-11](https://user-images.githubusercontent.com/4025665/92499221-e89e5f80-f1fb-11ea-9c39-164740f734ae.png)

In any case, if someone manually introduces the `_all` namespaces in the deployment form, an error is shown:

![Screenshot from 2020-09-08 17-52-25](https://user-images.githubusercontent.com/4025665/92499360-12f01d00-f1fc-11ea-99fd-1e85588b1a65.png)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1907 
