### PR TITLE
Fix bugs for multicluster selector

### DIFF
--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -32,7 +32,12 @@ interface ITestCase {
 }
 
 const actionTestCases: ITestCase[] = [
-  { name: "setNamespace", action: setNamespace, args: ["jack"], payload: "jack" },
+  {
+    name: "setNamespace",
+    action: setNamespace,
+    args: ["default", "jack"],
+    payload: { cluster: "default", namespace: "jack" },
+  },
   {
     name: "receiveNamespces",
     action: receiveNamespaces,

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -13,7 +13,7 @@ export const receiveNamespace = createAction("RECEIVE_NAMESPACE", resolve => {
 });
 
 export const setNamespace = createAction("SET_NAMESPACE", resolve => {
-  return (namespace: string) => resolve(namespace);
+  return (cluster: string, namespace: string) => resolve({ cluster, namespace });
 });
 
 export const postNamespace = createAction("CREATE_NAMESPACE", resolve => {

--- a/dashboard/src/components/Header/ContextSelector.scss
+++ b/dashboard/src/components/Header/ContextSelector.scss
@@ -1,6 +1,7 @@
 .angle {
-  margin-left: -0.5rem;
-  height: 100%;
+  position: absolute;
+  right: 15px;
+  top: 1.2rem;
 }
 
 .kubeapps-dropdown {

--- a/dashboard/src/components/Header/ContextSelector.test.tsx
+++ b/dashboard/src/components/Header/ContextSelector.test.tsx
@@ -70,7 +70,7 @@ it("selects a different namespace", () => {
       .filterWhere(b => b.text() === "Change Context")
       .prop("onClick") as any)();
   });
-  expect(setNamespace).toHaveBeenCalledWith("other");
+  expect(setNamespace).toHaveBeenCalledWith(initialState.clusters.currentCluster, "other");
 });
 
 it("shows the current cluster", () => {

--- a/dashboard/src/components/Header/ContextSelector.tsx
+++ b/dashboard/src/components/Header/ContextSelector.tsx
@@ -48,13 +48,19 @@ function ContextSelector() {
     setStateNamespace(namespaceSelected);
   }, [namespaceSelected]);
 
+  useEffect(() => {
+    setStateNamespace(clusters.clusters[cluster].currentNamespace);
+  }, [clusters.clusters, cluster]);
+
   const toggleOpen = () => setOpen(!open);
-  const selectCluster = (event: React.ChangeEvent<HTMLSelectElement>) =>
+  const selectCluster = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setStateCluster(event.target.value);
+    dispatch(actions.namespace.fetchNamespaces(event.target.value));
+  };
   const selectNamespace = (event: React.ChangeEvent<HTMLSelectElement>) =>
     setStateNamespace(event.target.value);
   const changeContext = () => {
-    dispatch(actions.namespace.setNamespace(namespace));
+    dispatch(actions.namespace.setNamespace(cluster, namespace));
     dispatch(push(app.apps.list(cluster, namespace)));
     setOpen(false);
   };
@@ -67,7 +73,7 @@ function ContextSelector() {
     const created = await dispatch(actions.namespace.createNamespace(cluster, newNS));
     if (created) {
       closeNewNSModal();
-      dispatch(actions.namespace.setNamespace(newNS));
+      dispatch(actions.namespace.setNamespace(cluster, newNS));
       dispatch(push(app.apps.list(cluster, newNS)));
       setOpen(false);
     }

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -149,7 +149,7 @@ it("call setNamespace and getNamespace when selecting a namespace", () => {
   const onChange = namespaceSelector.prop("onChange") as (ns: any) => void;
   onChange("bar");
 
-  expect(setNamespace).toHaveBeenCalledWith("bar");
+  expect(setNamespace).toHaveBeenCalledWith("default", "bar");
   expect(getNamespace).toHaveBeenCalledWith("default", "bar");
   expect(createNamespace).not.toHaveBeenCalled();
 });
@@ -180,7 +180,7 @@ it("doesn't call getNamespace when selecting all namespaces", () => {
   const onChange = namespaceSelector.prop("onChange") as (ns: any) => void;
   onChange("_all");
 
-  expect(setNamespace).toHaveBeenCalledWith("_all");
+  expect(setNamespace).toHaveBeenCalledWith("default", "_all");
   expect(getNamespace).not.toHaveBeenCalled();
 });
 

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -21,7 +21,7 @@ export interface IHeaderProps {
   defaultNamespace: string;
   pathname: string;
   push: (path: string) => void;
-  setNamespace: (ns: string) => void;
+  setNamespace: (cluster: string, ns: string) => void;
   createNamespace: (cluster: string, ns: string) => Promise<boolean>;
   getNamespace: (cluster: string, ns: string) => void;
   featureFlags: IFeatureFlags;
@@ -213,7 +213,7 @@ class Header extends React.Component<IHeaderProps, IHeaderState> {
       getNamespace,
     } = this.props;
     const to = pathname.replace(/\/ns\/[^/]*/, `/ns/${ns}`);
-    setNamespace(ns);
+    setNamespace(currentCluster, ns);
     if (ns !== definedNamespaces.all) {
       getNamespace(currentCluster, ns);
     }

--- a/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
+++ b/dashboard/src/containers/HeaderContainer/HeaderContainer.ts
@@ -35,7 +35,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
       dispatch(actions.namespace.createNamespace(cluster, ns)),
     logout: () => dispatch(actions.auth.logout()),
     push: (path: string) => dispatch(push(path)),
-    setNamespace: (ns: string) => dispatch(actions.namespace.setNamespace(ns)),
+    setNamespace: (cluster: string, ns: string) =>
+      dispatch(actions.namespace.setNamespace(cluster, ns)),
     getNamespace: (cluster: string, ns: string) =>
       dispatch(actions.namespace.getNamespace(cluster, ns)),
   };

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -205,7 +205,7 @@ describe("clusterReducer", () => {
           },
           {
             type: getType(actions.namespace.setNamespace),
-            payload: "default",
+            payload: { cluster: "initial-cluster", namespace: "default" },
           },
         ),
       ).toEqual({

--- a/dashboard/src/reducers/cluster.ts
+++ b/dashboard/src/reducers/cluster.ts
@@ -44,7 +44,11 @@ const clusterReducer = (
 ): IClustersState => {
   switch (action.type) {
     case getType(actions.namespace.receiveNamespace):
-      if (!state.clusters.default.namespaces.includes(action.payload.namespace.metadata.name)) {
+      if (
+        !state.clusters[action.payload.cluster].namespaces.includes(
+          action.payload.namespace.metadata.name,
+        )
+      ) {
         return {
           ...state,
           clusters: {
@@ -75,11 +79,12 @@ const clusterReducer = (
     case getType(actions.namespace.setNamespace):
       return {
         ...state,
+        currentCluster: action.payload.cluster,
         clusters: {
           ...state.clusters,
-          [state.currentCluster]: {
+          [action.payload.cluster]: {
             ...state.clusters[state.currentCluster],
-            currentNamespace: action.payload,
+            currentNamespace: action.payload.namespace,
             error: undefined,
           },
         },


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

I tried the multi-cluster support using the local dev environment to check how it behaves with the new UI. Found several bugs that has been fixed here:

 - When selecting a new cluster, the namespace selector was not being populated with the available namespaces of that selector.
 - The action `setNamespace` was not cluster-aware. This caused a race condition in which that is called before changing the `currentCluster` in the state, causing requesting resources from the wrong cluster.
 - When selection a cluster, a default namespace should be `selected`.
 - The `cluster` state reducer had a hard-coded reference to the `default` cluster.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #1907
