### PR TITLE
Added .Values.frontend.largeClientHeaderBuffers to accommodate large …

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -9,7 +9,7 @@ data:
     server {
       listen 8080;
   {{- if .Values.frontend.largeClientHeaderBuffers }}
-      large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers | quote }}
+      large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers | quote }};
   {{- end }}
   {{- if .Values.enableIPv6 }}
       listen [::]:8080;

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -8,6 +8,9 @@ data:
   vhost.conf: |-
     server {
       listen 8080;
+  {{- if .Values.frontend.largeClientHeaderBuffers }}
+      large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers | quote }}
+  {{- end }}
   {{- if .Values.enableIPv6 }}
       listen [::]:8080;
   {{- end}}

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -9,7 +9,7 @@ data:
     server {
       listen 8080;
   {{- if .Values.frontend.largeClientHeaderBuffers }}
-      large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers | quote }};
+      large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers }};
   {{- end }}
   {{- if .Values.enableIPv6 }}
       listen [::]:8080;

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -41,7 +41,7 @@ data:
     server {
       listen 8080;
   {{- if .Values.frontend.largeClientHeaderBuffers }}
-      large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers | quote }}
+      large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers | quote }};
   {{- end }}
   {{- if .Values.enableIPv6 }}
       listen [::]:8080;

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -40,6 +40,9 @@ data:
 
     server {
       listen 8080;
+  {{- if .Values.frontend.largeClientHeaderBuffers }}
+      large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers | quote }}
+  {{- end }}
   {{- if .Values.enableIPv6 }}
       listen [::]:8080;
   {{- end}}

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -41,7 +41,7 @@ data:
     server {
       listen 8080;
   {{- if .Values.frontend.largeClientHeaderBuffers }}
-      large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers | quote }};
+      large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers }};
   {{- end }}
   {{- if .Values.enableIPv6 }}
       listen [::]:8080;

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -204,9 +204,8 @@ frontend:
   proxypassAccessTokenAsBearer: false
   ## Set large_client_header_buffers in nginx config
   ## Can be required when using OIDC or LDAP due to large cookies
-  ## Example value: "4 32k"
   #
-  largeClientHeaderBuffers: ""
+  largeClientHeaderBuffers: "4 32k"
 
 ## AppRepository Controller is the controller used to manage the repositories to
 ## sync. Set apprepository.initialRepos to configure the initial set of

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -202,6 +202,11 @@ frontend:
   ## Some K8s distributions such as GKE requires it
   ##
   proxypassAccessTokenAsBearer: false
+  ## Set large_client_header_buffers in nginx config
+  ## Can be required when using OIDC or LDAP due to large cookies
+  ## Example value: "4 32k"
+  #
+  largeClientHeaderBuffers: ""
 
 ## AppRepository Controller is the controller used to manage the repositories to
 ## sync. Set apprepository.initialRepos to configure the initial set of


### PR DESCRIPTION
…OIDC and LDAP cookies

### Description of the change

Added a new value in the `frontend` section to allow for the configuration of the nginx `large_client_header_buffers` value. This was an issue internally at my company, and is also brought up in issue #1571.

### Benefits

Allows for configuration of the `large_client_header_buffers` field.

### Possible drawbacks

An additional setting for configuration and documenting.

### Applicable issues

  -  #1571 

### Additional information

It could be preferable to just set this option permanently rather than having it as a configuration option, but I've made it configurable in this pull request.
