### PR TITLE
Workaround to avoid type=button issue

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.v2.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.v2.tsx
@@ -147,9 +147,19 @@ function DeploymentFormBody({
         <CdsButton status="primary" type="submit">
           <CdsIcon shape="deploy" inverse={true} /> Deploy v{version.attributes.version}
         </CdsButton>
-        <CdsButton action="outline" type="button" onClick={openRestoreDefaultValuesModal}>
-          <CdsIcon shape="backup-restore" inverse={true} /> Restore Defaults
-        </CdsButton>
+        {/* TODO(andresmgot): CdsButton "type" property doesn't work, so we need to use a normal <button>
+            https://github.com/vmware/clarity/issues/5038
+          */}
+        <span className="color-icon-info">
+          <button
+            className="btn btn-info-outline"
+            type="button"
+            onClick={openRestoreDefaultValuesModal}
+            style={{ marginTop: "-22px" }}
+          >
+            <CdsIcon shape="backup-restore" /> Restore Defaults
+          </button>
+        </span>
       </div>
     </div>
   );

--- a/dashboard/src/components/OperatorInstanceFormBody/OperatorInstanceFormBody.v2.test.tsx
+++ b/dashboard/src/components/OperatorInstanceFormBody/OperatorInstanceFormBody.v2.test.tsx
@@ -1,4 +1,3 @@
-import { CdsButton } from "@clr/react/button";
 import ConfirmDialog from "components/ConfirmDialog/ConfirmDialog.v2";
 import AdvancedDeploymentForm from "components/DeploymentFormBody/AdvancedDeploymentForm.v2";
 import Alert from "components/js/Alert";
@@ -41,7 +40,7 @@ it("restores the default values", async () => {
   expect(wrapper.find(AdvancedDeploymentForm).prop("appValues")).toBe("not-foo");
 
   const restoreButton = wrapper
-    .find(CdsButton)
+    .find("button")
     .filterWhere(b => b.text().includes("Restore Defaults"));
   act(() => {
     restoreButton.simulate("click");

--- a/dashboard/src/components/OperatorInstanceFormBody/OperatorInstanceFormBody.v2.tsx
+++ b/dashboard/src/components/OperatorInstanceFormBody/OperatorInstanceFormBody.v2.tsx
@@ -122,9 +122,19 @@ function DeploymentFormBody({
           <CdsButton status="primary" type="submit">
             <CdsIcon shape="deploy" inverse={true} /> Deploy
           </CdsButton>
-          <CdsButton action="outline" type="button" onClick={openModal}>
-            <CdsIcon shape="backup-restore" inverse={true} /> Restore Defaults
-          </CdsButton>
+          {/* TODO(andresmgot): CdsButton "type" property doesn't work, so we need to use a normal <button>
+            https://github.com/vmware/clarity/issues/5038
+          */}
+          <span className="color-icon-info">
+            <button
+              className="btn btn-info-outline"
+              type="button"
+              onClick={openModal}
+              style={{ marginTop: "-22px" }}
+            >
+              <CdsIcon shape="backup-restore" /> Restore Defaults
+            </button>
+          </span>
         </div>
       </form>
     </>


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

I noticed this bug, `type="button"` is not taking effect using the React wrapper for Clarity Core components. I may be missing something so I opened an issue for them to check. In the meantime, added this workaround.
