### PR TITLE
add apiVersion check for ingress apiVersion

### DIFF
--- a/chart/kubeapps/templates/ingress.yaml
+++ b/chart/kubeapps/templates/ingress.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.ingress.enabled -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ template "kubeapps.fullname" . }}


### PR DESCRIPTION
Ingress apiVersion extensions/v1beta1 got deprecated and is now removed
in 1.16.

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Its the same approach as the grafana (and prometheus-operator) chart are taking:
https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/ingress.yaml#L6

### Description of the change

It adds a helm based capability check to switch between both apiVersions;

This is possible as the ingress apiVersions are compatible (which is not always the case, see DaemonSet)

This change enables the current Ingress spec to be used in Kubernetes Version >= 1.16 while keeping compatibility to Kubernetes Versions < 1.16.

