### PR TITLE
Remove duplicated label

### DIFF
--- a/chart/kubeapps/templates/kubeops-serviceaccount.yaml
+++ b/chart/kubeapps/templates/kubeops-serviceaccount.yaml
@@ -4,4 +4,3 @@ metadata:
   name: {{ template "kubeapps.kubeops.fullname" . }}
   labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "kubeapps.kubeops.fullname" . }}
-    app.kubernetes.io/name: {{ template "kubeapps.name" . }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

The label `app.kubernetes.io/name` was being duplicated for the kubeops serviceaccount.
