### PR TITLE
Add support for `kubectl alpha debug` for debugging scratch images.

### DIFF
--- a/docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml
@@ -18,3 +18,4 @@ nodes:
         oidc-username-prefix: "oidc:"
         oidc-groups-claim: groups
         oidc-groups-prefix: "oidc:"
+        feature-gates: "EphemeralContainers=true"

--- a/docs/user/manifests/kubeapps-local-dev-apiserver-config.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-apiserver-config.yaml
@@ -19,6 +19,7 @@ nodes:
         oidc-username-prefix: "oidc:"
         oidc-groups-claim: groups
         oidc-groups-prefix: "oidc:"
+        feature-gates: "EphemeralContainers=true"
   extraPortMappings:
   - containerPort: 80
     hostPort: 80


### PR DESCRIPTION
Trying out as it'd be useful for debugging. But when running the debug command, it's just hanging for me at:

```
k -n kubeapps alpha debug -it kubeapps-internal-kubeops-74cd96c749-7jvs5 --image=busybox --target kubeops -- bash
Defaulting debug container name to debugger-ll99d.
```

Need to dig to find out why. The ephemeral containers are being created, I can see them on the pod, it's just not attaching apparently.
