### PR TITLE
Update the release notes removing tiller-based install instructions

### DIFF
--- a/script/release_notes.tpl
+++ b/script/release_notes.tpl
@@ -11,17 +11,9 @@ helm repo update
 
 Install the Kubeapps Helm chart:
 
-For Helm 2:
-
-```
-helm install --name kubeapps --namespace kubeapps bitnami/kubeapps
-```
-
-For Helm 3:
-
 ```
 kubectl create namespace kubeapps
-helm install kubeapps --namespace kubeapps bitnami/kubeapps --set useHelm3=true
+helm install kubeapps --namespace kubeapps bitnami/kubeapps
 ```
 
 To get started with Kubeapps, checkout this [walkthrough](https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md).


### PR DESCRIPTION
### Description of the change

The release notes for the 2.0 beta included the no longer supported tiller-proxy-based install as an option.

This removes that from the template and I've updated the 2.0 beta 1 release notes.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2068

