### PR TITLE
Fix style for several Access URLs

### DIFF
--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
@@ -78,9 +78,11 @@ function flattenIngresses(ingresses: Array<IKubeItem<IResource | IK8sList<IResou
 
 function getAnchors(URLs: string[]) {
   return URLs.map(URL => (
-    <a href={URL} target="_blank" rel="noopener noreferrer" key={URL}>
-      {URL}
-    </a>
+    <div className="margin-b-sm">
+      <a href={URL} target="_blank" rel="noopener noreferrer" key={URL}>
+        {URL}
+      </a>
+    </div>
   ));
 }
 

--- a/dashboard/src/components/AppView/AccessURLTable/__snapshots__/AccessURLTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/AccessURLTable/__snapshots__/AccessURLTable.test.tsx.snap
@@ -125,13 +125,17 @@ exports[`when the app contains ingresses should show the table with available in
                   </span>,
                   "type": "Ingress",
                   "url": Array [
-                    <a
-                      href="http://foo.bar/ready"
-                      rel="noopener noreferrer"
-                      target="_blank"
+                    <div
+                      className="margin-b-sm"
                     >
-                      http://foo.bar/ready
-                    </a>,
+                      <a
+                        href="http://foo.bar/ready"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        http://foo.bar/ready
+                      </a>
+                    </div>,
                   ],
                 },
               ]
@@ -214,13 +218,17 @@ exports[`when the app contains ingresses should show the table with available in
                       </span>,
                       "type": "Ingress",
                       "url": Array [
-                        <a
-                          href="http://foo.bar/ready"
-                          rel="noopener noreferrer"
-                          target="_blank"
+                        <div
+                          className="margin-b-sm"
                         >
-                          http://foo.bar/ready
-                        </a>,
+                          <a
+                            href="http://foo.bar/ready"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            http://foo.bar/ready
+                          </a>
+                        </div>,
                       ],
                     }
                   }
@@ -230,14 +238,18 @@ exports[`when the app contains ingresses should show the table with available in
                       className=""
                       key="0-url"
                     >
-                      <a
-                        href="http://foo.bar/ready"
-                        key="http://foo.bar/ready"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                      <div
+                        className="margin-b-sm"
                       >
-                        http://foo.bar/ready
-                      </a>
+                        <a
+                          href="http://foo.bar/ready"
+                          key="http://foo.bar/ready"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          http://foo.bar/ready
+                        </a>
+                      </div>
                     </td>
                     <td
                       className=""
@@ -674,13 +686,17 @@ exports[`when the app contains services and ingresses should show the table with
                   </span>,
                   "type": "Service LoadBalancer",
                   "url": Array [
-                    <a
-                      href="http://1.2.3.4:8080"
-                      rel="noopener noreferrer"
-                      target="_blank"
+                    <div
+                      className="margin-b-sm"
                     >
-                      http://1.2.3.4:8080
-                    </a>,
+                      <a
+                        href="http://1.2.3.4:8080"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        http://1.2.3.4:8080
+                      </a>
+                    </div>,
                   ],
                 },
                 Object {
@@ -711,13 +727,17 @@ exports[`when the app contains services and ingresses should show the table with
                   </span>,
                   "type": "Ingress",
                   "url": Array [
-                    <a
-                      href="http://foo.bar/ready"
-                      rel="noopener noreferrer"
-                      target="_blank"
+                    <div
+                      className="margin-b-sm"
                     >
-                      http://foo.bar/ready
-                    </a>,
+                      <a
+                        href="http://foo.bar/ready"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        http://foo.bar/ready
+                      </a>
+                    </div>,
                   ],
                 },
               ]
@@ -779,13 +799,17 @@ exports[`when the app contains services and ingresses should show the table with
                       </span>,
                       "type": "Service LoadBalancer",
                       "url": Array [
-                        <a
-                          href="http://1.2.3.4:8080"
-                          rel="noopener noreferrer"
-                          target="_blank"
+                        <div
+                          className="margin-b-sm"
                         >
-                          http://1.2.3.4:8080
-                        </a>,
+                          <a
+                            href="http://1.2.3.4:8080"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            http://1.2.3.4:8080
+                          </a>
+                        </div>,
                       ],
                     }
                   }
@@ -795,14 +819,18 @@ exports[`when the app contains services and ingresses should show the table with
                       className=""
                       key="0-url"
                     >
-                      <a
-                        href="http://1.2.3.4:8080"
-                        key="http://1.2.3.4:8080"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                      <div
+                        className="margin-b-sm"
                       >
-                        http://1.2.3.4:8080
-                      </a>
+                        <a
+                          href="http://1.2.3.4:8080"
+                          key="http://1.2.3.4:8080"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          http://1.2.3.4:8080
+                        </a>
+                      </div>
                     </td>
                     <td
                       className=""
@@ -869,13 +897,17 @@ exports[`when the app contains services and ingresses should show the table with
                       </span>,
                       "type": "Ingress",
                       "url": Array [
-                        <a
-                          href="http://foo.bar/ready"
-                          rel="noopener noreferrer"
-                          target="_blank"
+                        <div
+                          className="margin-b-sm"
                         >
-                          http://foo.bar/ready
-                        </a>,
+                          <a
+                            href="http://foo.bar/ready"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            http://foo.bar/ready
+                          </a>
+                        </div>,
                       ],
                     }
                   }
@@ -885,14 +917,18 @@ exports[`when the app contains services and ingresses should show the table with
                       className=""
                       key="1-url"
                     >
-                      <a
-                        href="http://foo.bar/ready"
-                        key="http://foo.bar/ready"
-                        rel="noopener noreferrer"
-                        target="_blank"
+                      <div
+                        className="margin-b-sm"
                       >
-                        http://foo.bar/ready
-                      </a>
+                        <a
+                          href="http://foo.bar/ready"
+                          key="http://foo.bar/ready"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          http://foo.bar/ready
+                        </a>
+                      </div>
                     </td>
                     <td
                       className=""

--- a/dashboard/src/components/Layout/Layout.scss
+++ b/dashboard/src/components/Layout/Layout.scss
@@ -197,3 +197,7 @@
     cursor: pointer;
   }
 }
+
+.margin-b-sm {
+  margin-bottom: 0.3rem;
+}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Fix the style for the Access URL table when there is more than one URL per svc/ingress (before it was shown everything in the same line without spaces):

![Screenshot from 2020-09-28 12-49-09](https://user-images.githubusercontent.com/4025665/94423900-aa0c1d00-0189-11eb-93a4-221920c19181.png)
