### PR TITLE
Fix wrong namespace when requesting chart info

### DIFF
--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -63,6 +63,7 @@ describe("fetches applications", () => {
       const appsResponse = [
         {
           releaseName: "foobar",
+          namespace: "ns-1",
           chartMetadata: { name: "foo", version: "1.0.0", appVersion: "0.1.0" },
         },
       ];
@@ -94,6 +95,14 @@ describe("fetches applications", () => {
         },
       ];
       await store.dispatch(actions.apps.fetchAppsWithUpdateInfo("default-c", "default-ns", false));
+      // It should use the app namespace
+      expect(Chart.listWithFilters).toHaveBeenCalledWith(
+        "default-c",
+        "ns-1",
+        "foo",
+        "1.0.0",
+        "0.1.0",
+      );
       expect(store.getActions()).toEqual(expectedActions);
     });
 

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -16,7 +16,6 @@ beforeEach(() => {
   const state: IAppState = {
     isFetching: false,
     items: [],
-    listingAll: false,
   };
   store = mockStore({
     apps: {
@@ -37,25 +36,14 @@ describe("fetches applications", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-  it("fetches all applications", async () => {
+  it("fetches applications", async () => {
     const expectedActions = [
-      { type: getType(actions.apps.listApps), payload: true },
+      { type: getType(actions.apps.listApps) },
       { type: getType(actions.apps.receiveAppList), payload: [] },
     ];
-    await store.dispatch(actions.apps.fetchAppsWithUpdateInfo("default-cluster", "default", true));
+    await store.dispatch(actions.apps.fetchAppsWithUpdateInfo("default-cluster", "default"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(listAppsMock.mock.calls[0]).toEqual(["default-cluster", "default", true]);
-  });
-  it("fetches default applications", async () => {
-    const expectedActions = [
-      { type: getType(actions.apps.listApps), payload: false },
-      { type: getType(actions.apps.receiveAppList), payload: [] },
-    ];
-    await store.dispatch(
-      actions.apps.fetchAppsWithUpdateInfo("default-cluster", "default-ns", false),
-    );
-    expect(store.getActions()).toEqual(expectedActions);
-    expect(listAppsMock.mock.calls[0]).toEqual(["default-cluster", "default-ns", false]);
+    expect(listAppsMock.mock.calls[0]).toEqual(["default-cluster", "default"]);
   });
 
   describe("fetches chart updates", () => {
@@ -78,7 +66,7 @@ describe("fetches applications", () => {
       Chart.listWithFilters = jest.fn().mockReturnValue(chartUpdatesResponse);
       App.listApps = jest.fn().mockReturnValue(appsResponse);
       const expectedActions = [
-        { type: getType(actions.apps.listApps), payload: false },
+        { type: getType(actions.apps.listApps) },
         { type: getType(actions.apps.receiveAppList), payload: appsResponse },
         { type: getType(actions.apps.requestAppUpdateInfo) },
         {
@@ -94,7 +82,7 @@ describe("fetches applications", () => {
           },
         },
       ];
-      await store.dispatch(actions.apps.fetchAppsWithUpdateInfo("default-c", "default-ns", false));
+      await store.dispatch(actions.apps.fetchAppsWithUpdateInfo("default-c", "default-ns"));
       // It should use the app namespace
       expect(Chart.listWithFilters).toHaveBeenCalledWith(
         "default-c",
@@ -124,7 +112,7 @@ describe("fetches applications", () => {
       Chart.listWithFilters = jest.fn().mockReturnValue(chartUpdatesResponse);
       App.listApps = jest.fn().mockReturnValue(appsResponse);
       const expectedActions = [
-        { type: getType(actions.apps.listApps), payload: false },
+        { type: getType(actions.apps.listApps) },
         { type: getType(actions.apps.receiveAppList), payload: appsResponse },
         { type: getType(actions.apps.requestAppUpdateInfo) },
         {
@@ -140,7 +128,7 @@ describe("fetches applications", () => {
           },
         },
       ];
-      await store.dispatch(actions.apps.fetchAppsWithUpdateInfo("default-c", "default-ns", false));
+      await store.dispatch(actions.apps.fetchAppsWithUpdateInfo("default-c", "default-ns"));
       expect(store.getActions()).toEqual(expectedActions);
     });
 
@@ -160,7 +148,7 @@ describe("fetches applications", () => {
       Chart.listWithFilters = jest.fn().mockReturnValue(chartUpdatesResponse);
       App.listApps = jest.fn().mockReturnValue(appsResponse);
       const expectedActions = [
-        { type: getType(actions.apps.listApps), payload: false },
+        { type: getType(actions.apps.listApps) },
         { type: getType(actions.apps.receiveAppList), payload: appsResponse },
         { type: getType(actions.apps.requestAppUpdateInfo) },
         {
@@ -177,7 +165,7 @@ describe("fetches applications", () => {
           },
         },
       ];
-      await store.dispatch(actions.apps.fetchAppsWithUpdateInfo("default-c", "default-ns", false));
+      await store.dispatch(actions.apps.fetchAppsWithUpdateInfo("default-c", "default-ns"));
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -22,9 +22,7 @@ export const receiveApps = createAction("RECEIVE_APPS", resolve => {
   return (apps: hapi.release.Release[]) => resolve(apps);
 });
 
-export const listApps = createAction("REQUEST_APP_LIST", resolve => {
-  return (listingAll: boolean) => resolve(listingAll);
-});
+export const listApps = createAction("REQUEST_APP_LIST");
 
 export const receiveAppList = createAction("RECEIVE_APP_LIST", resolve => {
   return (apps: IAppOverview[]) => resolve(apps);
@@ -215,15 +213,14 @@ export function deleteApp(
 export function fetchApps(
   cluster: string,
   ns?: string,
-  all: boolean = false,
 ): ThunkAction<Promise<IAppOverview[]>, IStoreState, null, AppsAction> {
   return async dispatch => {
     if (ns && ns === definedNamespaces.all) {
       ns = undefined;
     }
-    dispatch(listApps(all));
+    dispatch(listApps());
     try {
-      const apps = await App.listApps(cluster, ns, all);
+      const apps = await App.listApps(cluster, ns);
       dispatch(receiveAppList(apps));
       return apps;
     } catch (e) {
@@ -235,11 +232,10 @@ export function fetchApps(
 
 export function fetchAppsWithUpdateInfo(
   cluster: string,
-  namespace: string,
-  all: boolean = false,
+  namespaceOrAll: string,
 ): ThunkAction<Promise<void>, IStoreState, null, AppsAction> {
   return async dispatch => {
-    const apps = await dispatch(fetchApps(cluster, namespace, all));
+    const apps = await dispatch(fetchApps(cluster, namespaceOrAll));
     apps.forEach(app =>
       dispatch(
         getAppUpdateInfo(

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -244,7 +244,7 @@ export function fetchAppsWithUpdateInfo(
       dispatch(
         getAppUpdateInfo(
           cluster,
-          namespace,
+          app.namespace,
           app.releaseName,
           app.chartMetadata.name,
           app.chartMetadata.version,

--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -149,6 +149,7 @@ context("when apps available", () => {
         listOverview: [
           {
             releaseName: "foo",
+            namespace: "bar",
             chartMetadata: {
               name: "bar",
               version: "1.0.0",
@@ -174,7 +175,7 @@ context("when apps available", () => {
     );
     const itemList = wrapper.find(AppListItem);
     expect(itemList).toExist();
-    expect(itemList.key()).toBe("foo");
+    expect(itemList.key()).toBe("bar/foo");
   });
 });
 
@@ -190,6 +191,7 @@ it("filters apps", () => {
             listOverview: [
               {
                 releaseName: "foo",
+                namespace: "foobar",
                 chartMetadata: {
                   name: "foobar",
                   version: "1.0.0",
@@ -199,6 +201,7 @@ it("filters apps", () => {
               } as IAppOverview,
               {
                 releaseName: "bar",
+                namespace: "foobar",
                 chartMetadata: {
                   name: "foobar",
                   version: "1.0.0",
@@ -215,7 +218,7 @@ it("filters apps", () => {
       ,
     </Router>,
   );
-  expect(wrapper.find(AppListItem).key()).toBe("bar");
+  expect(wrapper.find(AppListItem).key()).toBe("foobar/bar");
 });
 
 context("when custom resources available", () => {

--- a/dashboard/src/components/AppList/AppListGrid.tsx
+++ b/dashboard/src/components/AppList/AppListGrid.tsx
@@ -52,7 +52,7 @@ function AppListGrid(props: IAppListProps) {
     <Row>
       <>
         {filteredReleases.map(r => {
-          return <AppListItem key={r.releaseName} app={r} cluster={cluster} />;
+          return <AppListItem key={`${r.namespace}/${r.releaseName}`} app={r} cluster={cluster} />;
         })}
         {filteredCRs.map(r => {
           const csv = props.csvs.find(c =>

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -52,7 +52,7 @@ function AppListItem(props: IAppListItemProps) {
   }
   return (
     <InfoCard
-      key={app.releaseName}
+      key={`${app.namespace}/${app.releaseName}`}
       link={url.app.apps.get(cluster, app.namespace, app.releaseName)}
       title={app.releaseName}
       icon={icon}

--- a/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
+++ b/dashboard/src/components/AppList/__snapshots__/AppList.test.tsx.snap
@@ -132,6 +132,7 @@ exports[`when apps available matches the snapshot 1`] = `
               "name": "bar",
               "version": "1.0.0",
             },
+            "namespace": "bar",
             "releaseName": "foo",
             "status": "deployed",
           },

--- a/dashboard/src/containers/AppListContainer/AppListContainer.tsx
+++ b/dashboard/src/containers/AppListContainer/AppListContainer.tsx
@@ -26,8 +26,8 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    fetchAppsWithUpdateInfo: (cluster: string, ns: string, all: boolean) =>
-      dispatch(actions.apps.fetchAppsWithUpdateInfo(cluster, ns, all)),
+    fetchAppsWithUpdateInfo: (cluster: string, ns: string) =>
+      dispatch(actions.apps.fetchAppsWithUpdateInfo(cluster, ns)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
     getCustomResources: (cluster: string, namespace: string) =>
       dispatch(actions.operators.getResources(cluster, namespace)),

--- a/dashboard/src/reducers/apps.test.ts
+++ b/dashboard/src/reducers/apps.test.ts
@@ -17,7 +17,6 @@ describe("appsReducer", () => {
     initialState = {
       isFetching: false,
       items: [],
-      listingAll: false,
     };
   });
 
@@ -34,15 +33,13 @@ describe("appsReducer", () => {
 
     it("toggles the listAll state", () => {
       let state = appsReducer(undefined, {
-        payload: true,
         type: actionTypes.listApps as any,
       });
-      expect(state).toEqual({ ...initialState, isFetching: true, listingAll: true });
+      expect(state).toEqual({ ...initialState, isFetching: true });
       state = appsReducer(state, {
-        payload: false,
         type: actionTypes.listApps as any,
       });
-      expect(state).toEqual({ ...initialState, isFetching: true, listingAll: false });
+      expect(state).toEqual({ ...initialState, isFetching: true });
     });
 
     describe("receieveAppUpdateInfo", () => {

--- a/dashboard/src/reducers/apps.ts
+++ b/dashboard/src/reducers/apps.ts
@@ -8,7 +8,6 @@ import { IAppState, IRelease } from "../shared/types";
 export const initialState: IAppState = {
   isFetching: false,
   items: [],
-  listingAll: false,
 };
 
 const appsReducer = (
@@ -27,7 +26,7 @@ const appsReducer = (
     case getType(actions.apps.selectApp):
       return { ...state, isFetching: false, selected: action.payload };
     case getType(actions.apps.listApps):
-      return { ...state, isFetching: true, listingAll: action.payload };
+      return { ...state, isFetching: true };
     case getType(actions.apps.receiveAppList):
       return { ...state, isFetching: false, listOverview: action.payload };
     case getType(actions.apps.requestAppUpdateInfo):

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -24,22 +24,16 @@ describe("App", () => {
     [
       {
         description: "should request all the releases if no namespace is given",
-        expectedURL: `${KUBEOPS_ROOT_URL}/clusters/defaultc/releases`,
+        expectedURL: `${KUBEOPS_ROOT_URL}/clusters/defaultc/releases?statuses=all`,
       },
       {
-        description: "should request the releases of a namespace",
-        expectedURL: `${KUBEOPS_ROOT_URL}/clusters/defaultc/namespaces/default/releases`,
-        namespace: "default",
-      },
-      {
-        all: true,
         description: "should request the releases of a namespace with any status",
         expectedURL: `${KUBEOPS_ROOT_URL}/clusters/defaultc/namespaces/default/releases?statuses=all`,
         namespace: "default",
       },
     ].forEach(t => {
       it(t.description, async () => {
-        expect(await App.listApps("defaultc", t.namespace, t.all)).toEqual(apps);
+        expect(await App.listApps("defaultc", t.namespace)).toEqual(apps);
         expect(moxios.requests.mostRecent().url).toBe(t.expectedURL);
       });
     });

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -82,13 +82,11 @@ export class App {
     return data;
   }
 
-  public static async listApps(cluster: string, namespace?: string, allStatuses?: boolean) {
+  public static async listApps(cluster: string, namespace?: string) {
     let endpoint = namespace
       ? url.kubeops.releases.list(cluster, namespace)
       : url.kubeops.releases.listAll(cluster);
-    if (allStatuses) {
-      endpoint += "?statuses=all";
-    }
+    endpoint += "?statuses=all";
     const { data } = await axiosWithAuth.get<{ data: IAppOverview[] }>(endpoint);
     return data.data;
   }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -349,7 +349,6 @@ export interface IAppState {
   deleteError?: Error;
   // currently items are always Helm releases
   items: IRelease[];
-  listingAll: boolean;
   listOverview?: IAppOverview[];
   selected?: IRelease;
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Fix an issue causing the request for the chart to use the current namespace (`_all` if all namespaces is selected) rather than the app namespace.

Apart from that, I found a small bug that two releases in different namespaces were using the same `key` in the list.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2075
