### PR TITLE
Check namespace when listing operators

### DIFF
--- a/dashboard/src/components/OperatorList/OperatorItems.tsx
+++ b/dashboard/src/components/OperatorList/OperatorItems.tsx
@@ -8,10 +8,9 @@ import { trimDescription } from "shared/utils";
 interface ICatalogItemsProps {
   operators: IResource[];
   cluster: string;
-  namespace: string;
 }
 
-export default function OperatorItems({ operators, cluster, namespace }: ICatalogItemsProps) {
+export default function OperatorItems({ operators, cluster }: ICatalogItemsProps) {
   if (operators.length === 0) {
     return <p>No operator matches the current filter.</p>;
   }
@@ -22,9 +21,13 @@ export default function OperatorItems({ operators, cluster, namespace }: ICatalo
         return (
           <InfoCard
             key={operator.metadata.name}
-            link={app.operators.view(cluster, namespace, operator.metadata.name)}
+            link={app.operators.view(cluster, operator.metadata.namespace, operator.metadata.name)}
             title={operator.metadata.name}
-            icon={api.operators.operatorIcon(cluster, namespace, operator.metadata.name)}
+            icon={api.operators.operatorIcon(
+              cluster,
+              operator.metadata.namespace,
+              operator.metadata.name,
+            )}
             info={`v${channel?.currentCSVDesc.version}`}
             tag1Content={operator.status.provider.name}
             description={trimDescription(channel?.currentCSVDesc.annotations.description || "")}

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -10,6 +10,7 @@ import { push } from "connected-react-router";
 import { flatten, get, intersection, uniq, without } from "lodash";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { definedNamespaces } from "shared/Namespace";
 import { app } from "shared/url";
 import { IPackageManifest, IPackageManifestStatus, IStoreState } from "../../shared/types";
 import { escapeRegExp } from "../../shared/utils";
@@ -223,7 +224,16 @@ export default function OperatorList({
                 An error occurred while fetching Operators: {error.message}
               </Alert>
             )}
-            {operators.length === 0 ? (
+            {namespace === definedNamespaces.all ? (
+              <div className="empty-catalog">
+                <CdsIcon shape="file-group" />
+                <h4>A valid namespace should be selected.</h4>
+                <p>
+                  In order to show the catalog of Operators available, a namespace must be selected
+                  using the selector in the top right corner.
+                </p>
+              </div>
+            ) : operators.length === 0 ? (
               <div className="section-not-found">
                 <div>
                   <CdsIcon shape="bundle" size="64" />
@@ -308,21 +318,13 @@ export default function OperatorList({
                       <>
                         <h3>Installed</h3>
                         <Row>
-                          <OperatorItems
-                            operators={installedOperators}
-                            cluster={cluster}
-                            namespace={namespace}
-                          />
+                          <OperatorItems operators={installedOperators} cluster={cluster} />
                         </Row>
                       </>
                     )}
                     <h3>Available Operators</h3>
                     <Row>
-                      <OperatorItems
-                        operators={availableOperators}
-                        cluster={cluster}
-                        namespace={namespace}
-                      />
+                      <OperatorItems operators={availableOperators} cluster={cluster} />
                     </Row>
                   </>
                 </Column>


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Similar to the catalog, Operators should be browsed using a namespace (if not, the final form would allow you to install them in the namespace `_all`). Also noticed that the icons where being fetched using the current namespace rather than the operator namespace (not that relevant when `_all` cannot be selected).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - found while investigating #2076
