### PR TITLE
Use cluster ServiceToken to retrieve operator logos

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -32,8 +32,8 @@ enableIPv6: false
 #   apiServiceURL: https://second-cluster:6443
 #   # certificateAuthorityData is required for secure communication with the additional API server.
 #   certificateAuthorityData: LS0tLS1CRUdJ...
-#   # serviceToken is an optional token configured to allow LIST namespaces only on the additional cluster
-#   # so that the UI can present a list of (only) those namespaces to which the user has access.
+#   # serviceToken is an optional token configured to allow LIST namespaces and packagemanifests (operators) only on the additional cluster
+#   # so that the UI can present a list of (only) those namespaces to which the user has access and the available operators.
 #   serviceToken: ...
 clusters:
   - name: default

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -41,7 +41,7 @@ function getDefaultChannel(packageStatus: IPackageManifestStatus) {
 
 function getCategories(packageStatus: IPackageManifestStatus) {
   const channel = getDefaultChannel(packageStatus);
-  return get(channel, "currentCSVDesc.annotations.categories", [])
+  return get(channel, "currentCSVDesc.annotations.categories", "Unknown")
     .split(",")
     .map((c: string) => c.trim());
 }

--- a/docs/user/deploying-to-multiple-clusters.md
+++ b/docs/user/deploying-to-multiple-clusters.md
@@ -101,7 +101,7 @@ kubectl --kubeconfig ~/.kube/path-to-kube-confnig-file config view --raw -o json
 
 Alternatively, for a development with private API server URLs, you can omit the `certificateAuthorityData` and instead include the field `insecure: true` for a cluster and Kubeapps will not try to verify the secure connection.
 
-A serviceToken is not required but provides a better user experience, enabling users viewing the cluster to see the namespaces to which they have access (only) when they use the namespace selector. The service token should be configured with RBAC so that it can only list namespaces on the cluster. You can refer to the [example used for a local development environment](/docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml).
+A serviceToken is not required but provides a better user experience, enabling users viewing the cluster to see the namespaces to which they have access (only) when they use the namespace selector. It's also used to retrieve icons of the available operators if the OLM is enabled. The service token should be configured with RBAC so that it can  list those resources. You can refer to the [example used for a local development environment](/docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml).
 
 Your Kubeapps installation will also need to be [configured to use OIDC for authentication](/docs/user/using-an-OIDC-provider.md) with a client-id for your chosen provider.
 

--- a/docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml
@@ -9,6 +9,13 @@ rules:
       - namespaces
     verbs:
       - list
+  - apiGroups:
+      - "packages.operators.coreos.com/v1"
+    resources:
+      - packagemanifests
+    verbs:
+      - list
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/integration/jest.environment.js
+++ b/integration/jest.environment.js
@@ -8,7 +8,7 @@ const {
   retryAttempts,
   endpoint,
   waitTimeout,
-  screenshotsFolder
+  screenshotsFolder,
 } = require("./args");
 
 // Create an environment to store a screenshot of the page if the current test
@@ -30,12 +30,13 @@ class ScreenshotOnFailureEnvironment extends PuppeteerEnvironment {
     try {
       // Check the server is up before running the test suite
       console.log(
-        `Waiting ${endpoint} to be ready before running the tests (${waitTimeout /
-          1000}s)`
+        `Waiting ${endpoint} to be ready before running the tests (${
+          waitTimeout / 1000
+        }s)`
       );
       await waitOn({
         resources: [endpoint],
-        timeout: waitTimeout
+        timeout: waitTimeout,
       });
       console.log(`${endpoint} is ready!`);
     } catch (err) {
@@ -52,9 +53,33 @@ class ScreenshotOnFailureEnvironment extends PuppeteerEnvironment {
     await this.global.page.setViewport({
       width: 1200,
       height: 780,
-      deviceScaleFactor: 1
+      deviceScaleFactor: 1,
     });
     await this.global.page.setDefaultTimeout(8000);
+    this.global.page
+      .on("console", async (message) => {
+        if (message.type() === "error") {
+          console.error(`${message.type().toUpperCase()} ${message.text()}`);
+          // Code from https://github.com/puppeteer/puppeteer/issues/3397#issuecomment-429325514
+          const args = await message.args();
+          args.forEach(async (arg) => {
+            const val = await arg.jsonValue();
+            // value is serializable
+            if (JSON.stringify(val) !== JSON.stringify({})) console.log(val);
+            // value is unserializable (or an empty oject)
+            else {
+              const { type, subtype, description } = arg._remoteObject;
+              console.log(
+                `type: ${type}, subtype: ${subtype}, description:\n ${description}`
+              );
+            }
+          });
+        }
+      })
+      .on("pageerror", ({ message }) => console.log(message))
+      .on("requestfailed", (request) =>
+        console.log(`${request.failure().errorText} ${request.url()}`)
+      );
   }
 
   async teardown() {
@@ -72,7 +97,7 @@ class ScreenshotOnFailureEnvironment extends PuppeteerEnvironment {
           .replace(/ /g, "-");
         // Take a screenshot at the point of failure
         await this.global.page.screenshot({
-          path: path.join(__dirname, `${screenshotsFolder}/${testName}.png`)
+          path: path.join(__dirname, `${screenshotsFolder}/${testName}.png`),
         });
       }
     }

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -288,7 +288,11 @@ func (c *Client) parseDetailsForHTTPClient(details *Details, userAuthToken strin
 	}
 	if details.AppRepositoryResourceNamespace == c.kubeappsNamespace {
 		// If we're parsing a global repository (from the kubeappsNamespace), use a service client.
-		client = c.appRepoHandler.AsSVC()
+		// AppRepositories are only allowed in the default cluster for the moment
+		client, err = c.appRepoHandler.AsSVC(c.kubeappsCluster)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("unable to get app repository %q: %v", details.AppRepositoryResourceName, err)
+		}
 	}
 	appRepo, err := client.GetAppRepository(details.AppRepositoryResourceName, details.AppRepositoryResourceNamespace)
 	if err != nil {
@@ -394,7 +398,7 @@ func getRegistrySecretsPerDomain(appRepoSecrets []string, cluster, namespace, to
 			return nil, err
 		}
 
-		for key, _ := range dockerConfigJSON.Auths {
+		for key := range dockerConfigJSON.Auths {
 			secretsPerDomain[key] = secretName
 		}
 

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -291,7 +291,7 @@ func (c *Client) parseDetailsForHTTPClient(details *Details, userAuthToken strin
 		// AppRepositories are only allowed in the default cluster for the moment
 		client, err = c.appRepoHandler.AsSVC(c.kubeappsCluster)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("unable to get app repository %q: %v", details.AppRepositoryResourceName, err)
+			return nil, nil, nil, fmt.Errorf("unable to create clientset: %v", err)
 		}
 	}
 	appRepo, err := client.GetAppRepository(details.AppRepositoryResourceName, details.AppRepositoryResourceNamespace)

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -237,9 +237,15 @@ func GetNamespaces(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, req
 // GetOperatorLogo return the list of namespaces
 func GetOperatorLogo(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		ns := mux.Vars(req)["namespace"]
 		name := mux.Vars(req)["name"]
-		logo, err := kubeHandler.AsSVC().GetOperatorLogo(ns, name)
+		ns, requestCluster := getNamespaceAndCluster(req)
+		clientset, err := kubeHandler.AsSVC(requestCluster)
+		if err != nil {
+			returnK8sError(err, w)
+			return
+		}
+
+		logo, err := clientset.GetOperatorLogo(ns, name)
 		if err != nil {
 			JSONError(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -41,8 +41,8 @@ func (c *FakeHandler) AsUser(token, cluster string) (handler, error) {
 }
 
 // AsSVC fakes using current svcaccount
-func (c *FakeHandler) AsSVC() handler {
-	return c
+func (c *FakeHandler) AsSVC(cluster string) (handler, error) {
+	return c, nil
 }
 
 // ListAppRepositories fake

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -545,8 +545,12 @@ func TestDeleteAppRepository(t *testing.T) {
 				},
 			}
 
-			cli, _ := handler.AsSVC("cluster")
-			err := cli.DeleteAppRepository(tc.repoName, tc.requestNamespace)
+			cli, err := handler.AsSVC("cluster")
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			err = cli.DeleteAppRepository(tc.repoName, tc.requestNamespace)
 
 			if got, want := errorCodeForK8sError(t, err), tc.expectedErrorCode; got != want {
 				t.Errorf("got: %d, want: %d", got, want)

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -530,9 +530,23 @@ func TestDeleteAppRepository(t *testing.T) {
 				clientsetForConfig: func(*rest.Config) (combinedClientsetInterface, error) { return cs, nil },
 				kubeappsNamespace:  kubeappsNamespace,
 				svcClientset:       cs,
+				clustersConfig: ClustersConfig{
+					KubeappsClusterName: "cluster",
+					Clusters: map[string]ClusterConfig{
+						"cluster": {
+							Name:                     "cluster",
+							APIServiceURL:            "fake",
+							CertificateAuthorityData: "fake",
+							CAFile:                   "",
+							ServiceToken:             "fake",
+							Insecure:                 true,
+						},
+					},
+				},
 			}
 
-			err := handler.AsSVC().DeleteAppRepository(tc.repoName, tc.requestNamespace)
+			cli, _ := handler.AsSVC("cluster")
+			err := cli.DeleteAppRepository(tc.repoName, tc.requestNamespace)
 
 			if got, want := errorCodeForK8sError(t, err), tc.expectedErrorCode; got != want {
 				t.Errorf("got: %d, want: %d", got, want)


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Similar to the approach when retrieving namespaces in other clusters, where a internal service token is used, use that token to retrieve logos. Note that it's not possible to use the user token because the logos are requested as `img` `src` so no authentication info is given for that request.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2076

