### PR TITLE
Enable watching only the namespace in which Kubeapps is running.

### DIFF
--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -53,7 +53,7 @@ spec:
             {{- if .Values.apprepository.crontab }}
             - --crontab={{ .Values.apprepository.crontab }}
             {{- end }}
-            - --repos-per-namespace
+            - --repos-per-namespace={{ .Values.apprepository.watchAllNamespaces}}
           {{- if .Values.apprepository.resources }}
           resources: {{- toYaml .Values.apprepository.resources | nindent 12 }}
           {{- end }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -288,6 +288,10 @@ apprepository:
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: {}
+  ## The controller watches all namespaces by default to support separate AppRepositories per namespace.
+  ## Switch this off only if you require running multiple instances of Kubeapps in different namespaces
+  ## without each instance watching AppRepositories of each other.
+  watchAllNamespaces: true
 
 ## Hooks are used to perform actions like populating apprepositories
 ## or creating required resources during installation or upgrade

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -93,7 +93,7 @@ func init() {
 	flag.StringVar(&repoSyncImage, "repo-sync-image", "quay.io/helmpack/chart-repo:latest", "container repo/image to use in CronJobs")
 	flag.StringVar(&repoSyncCommand, "repo-sync-cmd", "/chart-repo", "command used to sync/delete repos for repo-sync-image")
 	flag.StringVar(&namespace, "namespace", "kubeapps", "Namespace to discover AppRepository resources")
-	flag.BoolVar(&reposPerNamespace, "repos-per-namespace", true, "DEPRECATED: This flag will be removed in a future release.")
+	flag.BoolVar(&reposPerNamespace, "repos-per-namespace", true, "Defaults to watch for repos in all namespaces. Switch to false to watch only the configured namespace.")
 	flag.StringVar(&dbURL, "database-url", "localhost", "Database URL")
 	flag.StringVar(&dbUser, "database-user", "root", "Database user")
 	flag.StringVar(&dbName, "database-name", "charts", "Database name")


### PR DESCRIPTION
### Description of the change

Follows on from #2084 and the discussion there.

I initially didn't want to expose this via a chart option, but @andresmgot pointed out that there's another case where this would be useful: a cluster setup for training and learning where different users each have Kubeapps installed in their own namespace (in which case, we wouldn't want each installation picking up the app repositories of the other installations).
