### PR TITLE
Fix initialRepos setup when there are multiple secrets

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 4.0.2
+version: 4.0.3
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/apprepositories-secret.yaml
+++ b/chart/kubeapps/templates/apprepositories-secret.yaml
@@ -16,5 +16,6 @@ data:
   authorizationHeader: |-
     {{ .authorizationHeader | b64enc }}
   {{- end }}
+---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Reported in slack:

https://kubernetes.slack.com/archives/C9D3TSUG4/p1601819799005800

If several initialRepos have an associated secret, only the last one gets created. The three dashes line was (accidentally?) removed in #1299.
