### PR TITLE
Enable and use endpoint for listing appRepositories

### DIFF
--- a/chart/kubeapps/templates/kubeops-rbac.yaml
+++ b/chart/kubeapps/templates/kubeops-rbac.yaml
@@ -20,6 +20,7 @@ rules:
       - apprepositories
     verbs:
       - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -5,8 +5,10 @@ import * as url from "./url";
 
 export class AppRepository {
   public static async list(cluster: string, namespace: string) {
-    const { data } = await axiosWithAuth.get(AppRepository.getSelfLink(cluster, namespace));
-    return data;
+    const {
+      data: { appRepository },
+    } = await axiosWithAuth.get(url.backend.apprepositories.list(cluster, namespace));
+    return appRepository;
   }
 
   public static async get(cluster: string, name: string, namespace: string) {

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -78,6 +78,7 @@ export const backend = {
       `api/v1/clusters/${cluster}/namespaces/${namespace}/apprepositories`,
     create: (cluster: string, namespace: string) =>
       backend.apprepositories.base(cluster, namespace),
+    list: (cluster: string, namespace: string) => backend.apprepositories.base(cluster, namespace),
     validate: (cluster: string) => `${backend.apprepositories.base(cluster, "kubeapps")}/validate`,
     delete: (cluster: string, name: string, namespace: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -275,6 +275,7 @@ func SetupDefaultRoutes(r *mux.Router, clustersConfig kube.ClustersConfig) error
 	r.Methods("DELETE").Path("/namespaces/{namespace}/apprepositories/{name}").Handler(http.HandlerFunc(DeleteAppRepository(backendHandler)))
 	r.Methods("GET").Path("/namespaces/{namespace}/operator/{name}/logo").Handler(http.HandlerFunc(GetOperatorLogo(backendHandler)))
 	r.Methods("GET").Path("/clusters/{cluster}/namespaces").Handler(http.HandlerFunc(GetNamespaces(backendHandler)))
+	r.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/apprepositories").Handler(http.HandlerFunc(ListAppRepositories(backendHandler)))
 	r.Methods("POST").Path("/clusters/{cluster}/namespaces/{namespace}/apprepositories").Handler(http.HandlerFunc(CreateAppRepository(backendHandler)))
 	r.Methods("POST").Path("/clusters/{cluster}/namespaces/{namespace}/apprepositories/validate").Handler(http.HandlerFunc(ValidateAppRepository(backendHandler)))
 	r.Methods("PUT").Path("/clusters/{cluster}/namespaces/{namespace}/apprepositories/{name}").Handler(http.HandlerFunc(UpdateAppRepository(backendHandler)))


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Use `kubeops` for retrieving appRepositories. This allows to retrieve global app repositories for any user.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2098
