### PR TITLE
Fix setting number values in form

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/TextParam.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/TextParam.test.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
-import { defaultStore, mountWrapper } from "shared/specs/mountWrapper";
 import { IBasicFormParam } from "shared/types";
 import TextParam from "./TextParam";
 
@@ -188,10 +187,7 @@ it("should forward the proper value when using a select", () => {
 });
 
 it("a change in the param property should update the current value", () => {
-  const wrapper = mountWrapper(
-    defaultStore,
-    <TextParam {...stringProps} param={{ ...stringParam, value: "" }} />,
-  );
+  const wrapper = mount(<TextParam {...stringProps} param={{ ...stringParam, value: "" }} />);
   const input = wrapper.find("input");
   expect(input.prop("value")).toBe("");
 
@@ -201,5 +197,22 @@ it("a change in the param property should update the current value", () => {
       value: "foo",
     },
   });
-  expect(input.prop("value")).toBe("");
+  wrapper.update();
+  expect(wrapper.find("input").prop("value")).toBe("foo");
+});
+
+it("a change in a number param property should update the current value", () => {
+  const numberParam = { path: "replicas", value: 0, type: "number" } as IBasicFormParam;
+  const wrapper = mount(<TextParam {...stringProps} param={numberParam} />);
+  const input = wrapper.find("input");
+  expect(input.prop("value")).toBe(0);
+
+  wrapper.setProps({
+    param: {
+      ...numberParam,
+      value: 1,
+    },
+  });
+  wrapper.update();
+  expect(wrapper.find("input").prop("value")).toBe(1);
 });

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/TextParam.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/TextParam.tsx
@@ -1,4 +1,4 @@
-import { isEmpty } from "lodash";
+import { isEmpty, isNumber } from "lodash";
 import React, { useEffect, useState } from "react";
 import { IBasicFormParam } from "shared/types";
 
@@ -35,7 +35,7 @@ function TextParam({ id, param, label, inputType, handleBasicFormParamChange }: 
   };
 
   useEffect(() => {
-    if (!isEmpty(param.value) && !valueModified) {
+    if ((isNumber(param.value) || !isEmpty(param.value)) && !valueModified) {
       setValue(param.value);
     }
   }, [valueModified, param.value]);


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Found that the default value for number values was not being set in the form (e.g. `replicas: 1`). Turned out that `isEmpty(1)` returns `true`.
