### PR TITLE
Select the first namespace available by default

### DIFF
--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -43,15 +43,16 @@ export type NamespaceAction = ActionType<typeof allActions[number]>;
 
 export function fetchNamespaces(
   cluster: string,
-): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
+): ThunkAction<Promise<string[]>, IStoreState, null, NamespaceAction> {
   return async dispatch => {
     try {
       const namespaceList = await Namespace.list(cluster);
       const namespaceStrings = namespaceList.namespaces.map((n: IResource) => n.metadata.name);
       dispatch(receiveNamespaces(cluster, namespaceStrings));
+      return namespaceStrings;
     } catch (e) {
       dispatch(errorNamespaces(cluster, e, "list"));
-      return;
+      return [];
     }
   };
 }

--- a/dashboard/src/reducers/auth.test.ts
+++ b/dashboard/src/reducers/auth.test.ts
@@ -19,7 +19,7 @@ describe("authReducer", () => {
       authenticated: false,
       authenticating: false,
       oidcAuthenticated: false,
-      defaultNamespace: "_all",
+      defaultNamespace: "",
     };
   });
 
@@ -40,7 +40,7 @@ describe("authReducer", () => {
             payload: { authenticated: e, oidc: false, defaultNamespace: "" },
             type: actionTypes.setAuthenticated as any,
           }),
-        ).toEqual({ ...initialState, authenticated: e });
+        ).toEqual({ ...initialState, authenticated: e, defaultNamespace: "_all" });
       });
     });
 
@@ -85,12 +85,13 @@ describe("authReducer", () => {
       expect(
         authReducer(initialState, {
           type: actionTypes.setAuthenticated as any,
-          payload: { authenticated: true, oidc: true, defaultNamespace: "" },
+          payload: { authenticated: true, oidc: true, defaultNamespace: "_all" },
         }),
       ).toEqual({
         ...initialState,
         authenticated: true,
         oidcAuthenticated: true,
+        defaultNamespace: "_all",
       });
     });
 

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -130,7 +130,7 @@ describe("Auth", () => {
       expect(defaultNamespace).toEqual(customNamespace);
     });
 
-    it("should return _all if the namespace is not present", () => {
+    it("should return an empty string if the namespace is not present", () => {
       const token = jwt.sign(
         {
           iss: "kubernetes/serviceaccount",
@@ -140,15 +140,15 @@ describe("Auth", () => {
 
       const defaultNamespace = Auth.defaultNamespaceFromToken(token);
 
-      expect(defaultNamespace).toEqual("_all");
+      expect(defaultNamespace).toEqual("");
     });
 
-    it("should return default if the token cannot be decoded", () => {
+    it("should return an empty string if the token cannot be decoded", () => {
       const token = "not a jwt token";
 
       const defaultNamespace = Auth.defaultNamespaceFromToken(token);
 
-      expect(defaultNamespace).toEqual("_all");
+      expect(defaultNamespace).toEqual("");
     });
   });
 

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -2,7 +2,6 @@ import Axios, { AxiosResponse } from "axios";
 import * as jwt from "jsonwebtoken";
 import * as url from "shared/url";
 import { IConfig } from "./Config";
-import { definedNamespaces } from "./Namespace";
 
 const AuthTokenKey = "kubeapps_auth_token";
 const AuthTokenOIDCKey = "kubeapps_auth_token_oidc";
@@ -138,9 +137,9 @@ export class Auth {
   public static defaultNamespaceFromToken(token: string) {
     const payload = jwt.decode(token);
     const namespaceKey = "kubernetes.io/serviceaccount/namespace";
-    if (!payload || !payload[namespaceKey]) {
-      return definedNamespaces.all;
+    if (payload && payload[namespaceKey]) {
+      return payload[namespaceKey];
     }
-    return payload[namespaceKey];
+    return "";
   }
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This is a quick workaround to avoid selecting all namespaces by default for users that don't have an associated namespace (OIDC scenario).

It's a workaround since IMO, we should completely remove the current behavior of automatically selecting the namespace from the given token and decouple the namespace selection from the authorization flow but didn't want to include that to be able to improve the UX for the final release of 2.0.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2107
