### PR TITLE
replace oauth2-proxy by louketo-proxy

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -57,21 +57,17 @@ spec:
         {{- if and .Values.authProxy.enabled (not .Values.authProxy.external) }}
         - name: auth-proxy
           args:
-            - --provider={{ required "You must fill \".Values.authProxy.provider\" with the provider. Valid values at https://pusher.github.io/oauth2_proxy/auth-configuration" .Values.authProxy.provider }}
+            - --discovery-url={{ required "You must fill \".Values.authProxy.discoveryURL\" with the URL to retrieve the openid configuration" .Values.authProxy.discoveryURL }}
             - --client-id={{ required "You must fill \".Values.authProxy.clientID\" with the Client ID of the provider" .Values.authProxy.clientID }}
             - --client-secret={{ required "You must fill \".Values.authProxy.clientSecret\" with the Client Secret of the provider" .Values.authProxy.clientSecret }}
-            - --cookie-secret={{ required "You must fill \".Values.authProxy.cookieSecret\" with a 16, 24 or 32 byte base64 encoded seed string for secure cookies" .Values.authProxy.cookieSecret }}
-            - --upstream=http://localhost:8080/
-            - --http-address=0.0.0.0:3000
-            - --email-domain={{ .Values.authProxy.emailDomain }}
-            - --pass-basic-auth=false
-            - --pass-access-token=true
-            - --pass-authorization-header=true
-            - --skip-auth-regex=^\/config\.json$
-            - --skip-auth-regex=^\/favicon.*\.png$
-            - --skip-auth-regex=^\/static\/
-            - --skip-auth-regex=^\/$
-            - --scope=openid email groups
+            - --encryption-key={{ required "You must fill \".Values.authProxy.cookieSecret\" with a 16, 24 or 32 byte base64 encoded seed string for secure cookies" .Values.authProxy.cookieSecret }}
+            - --upstream-url=http://localhost:8080/
+            - --listen=0.0.0.0:3000
+            - --resources=uri=/config.json|white-listed=true
+            - --resources=uri=/favicon*.png|white-listed=true
+            - --resources=uri=/static/*|white-listed=true
+            - --scopes=openid+email+groups
+            - --enable-logout-redirect
             {{- range .Values.authProxy.additionalFlags }}
             - {{ . }}
             {{- end }}

--- a/chart/kubeapps/values.schema.json
+++ b/chart/kubeapps/values.schema.json
@@ -89,26 +89,6 @@
           "title": "Enable OIDC proxy",
           "description": "Use an OIDC provider in order to manage accounts, groups and roles with a single application"
         },
-        "provider": {
-          "type": "string",
-          "form": true,
-          "title": "Identity Provider name",
-          "description": "See https://pusher.github.io/oauth2_proxy/auth-configuration to find available providers",
-          "hidden": {
-            "value": false,
-            "path": "authProxy/enabled"
-          }
-        },
-        "clientID": {
-          "type": "string",
-          "form": true,
-          "title": "Client ID:",
-          "description": "Client ID of the Identity Provider",
-          "hidden": {
-            "value": false,
-            "path": "authProxy/enabled"
-          }
-        },
         "clientSecret": {
           "type": "string",
           "form": true,
@@ -124,6 +104,16 @@
           "form": true,
           "title": "Cookie Secret",
           "description": "Used by OAuth2 Proxy to encrypt any credentials",
+          "hidden": {
+            "value": false,
+            "path": "authProxy/enabled"
+          }
+        },
+        "clientID": {
+          "type": "string",
+          "form": true,
+          "title": "Discovery URL:",
+          "description": "Discovery URL to retrieve the openid configuration",
           "hidden": {
             "value": false,
             "path": "authProxy/enabled"

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -557,17 +557,17 @@ authProxy:
   ## Overridable flags for OAuth URIs to which the Kubeapps frontend redirects for authn.
   ## Useful when serving Kubeapps under a sub path or using an external auth proxy.
   ##
-  oauthLoginURI: /oauth2/start
-  oauthLogoutURI: /oauth2/sign_out
+  oauthLoginURI: /oauth/login
+  oauthLogoutURI: /oauth/logout
   ## The remaining auth proxy values are relevant only if an internal auth-proxy is
   ## being configured by Kubeapps.
-  ## Bitnami OAuth2 Proxy image
-  ## ref: https://hub.docker.com/r/bitnami/oauth2-proxy/tags/
+  ## Louketo Proxy image
+  ## ref: https://quay.io/repository/louketo/louketo-proxy?tag=latest&tab=tags
   ##
   image:
-    registry: docker.io
-    repository: bitnami/oauth2-proxy
-    tag: 6.1.1-debian-10-r12
+    registry: quay.io
+    repository: louketo/louketo-proxy
+    tag: 1.0.0
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -575,25 +575,23 @@ authProxy:
 
   ## Mandatory parameters for the internal auth-proxy.
   ##
-  provider: ""
   clientID: ""
   clientSecret: ""
-  ## cookieSecret is used by oauth2-proxy to encrypt any credentials so that it requires
+  ## Discovery URL to retrieve the openid configuration, example:
+  ## https://keycloak.example.org/auth/realms/example
+  discoveryURL: ""
+  ## cookieSecret is used by louketo-proxy to encrypt any credentials so that it requires
   ## no storage. Note that it must be a particular number of bytes. Recommend using the
   ## following to generate a cookieSecret as per the oauth2 configuration documentation
-  ## at https://pusher.github.io/oauth2_proxy/configuration :
+  ## at https://github.com/louketo/louketo-proxy/blob/master/docs/user-guide.md :
   ## python -c 'import os,base64; print base64.urlsafe_b64encode(os.urandom(16))'
   cookieSecret: ""
-  ## Use "example.com" to restrict logins to emails from example.com
-  emailDomain: "*"
-  ## Additional flags for oauth2-proxy
+  ## Additional flags for louketo-proxy
   ##
   additionalFlags: []
-  # - --ssl-insecure-skip-verify
-  # - --cookie-secure=false
-  # - --scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-platform
-  # - --oidc-issuer-url=https://accounts.google.com # Only needed if provider is oidc
-  ## OAuth2 Proxy containers' resource requests and limits
+  # - --secure-cookie=false
+  # - --scopes=openid+email+groups
+  ## Louketo Proxy containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
   resources:


### PR DESCRIPTION
### Description of the change

This PR replaces oauth2-proxy by [louketo-proxy](https://github.com/louketo/louketo-proxy) (formerly known as keycloak-gatekeeper).

### Benefits

Working integration with Keycloak

### Possible drawbacks

Other providers are not tested and do not guaranteed that they will work

### Applicable issues

  - fixes #2111

### Additional information

This PR provided just for example and does not pretend to be mergedю
Рowever until the better solution for #2111 is found, this is only working method to run kubeapps with internal oauth2 proxy service and Keycloak.
