### PR TITLE
Adapt links in docs

### DIFF
--- a/docs/user/access-control.md
+++ b/docs/user/access-control.md
@@ -17,7 +17,7 @@ Two of the most common authentication strategies for providing a token identifyi
 
 ### OpenID Connect authentication
 
-The most common and secure authentication for users to authenticate with the cluster (and therefore Kubeapps) is to use the built-in Kubernetes support for OpenID Connect. In this setup your clusters trust an OAuth2 provider such as Azure Active Directory, Google OpenID Connect or your own installation of the Dex auth provider. You can read more about [using an OIDC provider with Kubeapps](using-an-OIDC-provider.md).
+The most common and secure authentication for users to authenticate with the cluster (and therefore Kubeapps) is to use the built-in Kubernetes support for OpenID Connect. In this setup your clusters trust an OAuth2 provider such as Azure Active Directory, Google OpenID Connect or your own installation of the Dex auth provider. You can read more about [using an OIDC provider with Kubeapps](../using-an-OIDC-provider.md).
 
 ### Service Account authentication
 

--- a/docs/user/dashboard.md
+++ b/docs/user/dashboard.md
@@ -1,6 +1,6 @@
 # Using the Dashboard
 
-Once you have [installed Kubeapps in your cluster](../../chart/kubeapps/README.md) you can use the Dashboard to start managing and deploying applications in your cluster. Checkout the [Getting Started](getting-started.md) guide to learn how to access the Dashboard and deploy your first application.
+Once you have [installed Kubeapps in your cluster](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps) you can use the Dashboard to start managing and deploying applications in your cluster. Checkout the [Getting Started](../getting-started.md) guide to learn how to access the Dashboard and deploy your first application.
 
 The following sections walk you through some common tasks with the Kubeapps Dashboard.
 
@@ -42,6 +42,6 @@ By default, Kubeapps comes with the Bitnami repository enabled. You can see the 
 
 ![Repositories List](../img/dashboard-repos.png)
 
-Add new repositories (for example, your organization's chart repository) by clicking the "Add App Repository" button. Fill the "Add Repository" form using the repository info. For a detailed guide of how to add app repositories, check [this guide](./private-app-repository.md).
+Add new repositories (for example, your organization's chart repository) by clicking the "Add App Repository" button. Fill the "Add Repository" form using the repository info. For a detailed guide of how to add app repositories, check [this guide](../private-app-repository.md).
 
 ![Adding repository](../img/dashboard-add-repo.png)

--- a/docs/user/deploying-to-multiple-clusters.md
+++ b/docs/user/deploying-to-multiple-clusters.md
@@ -37,10 +37,10 @@ Certain multi-cluster environments, such as Tanzu Kubernetes Grid, have specific
 
 If you are testing the multi-cluster support on a local [Kubernetes-in-Docker cluster](https://kind.sigs.k8s.io/), you can view the example configuration files used for configuring two kind clusters in a local development environment:
 
-* [Kubeapps cluster API server config](/docs/user/manifests/kubeapps-local-dev-apiserver-config.yaml)
-* An [additional cluster API server config](/docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml)
+* [Kubeapps cluster API server config](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-apiserver-config.yaml)
+* An [additional cluster API server config](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml)
 
-These are used with an instance of Dex running in the Kubeapps cluster with a [matching configuration](/docs/user/manifests/kubeapps-local-dev-dex-values.yaml) and Kubeapps itself [configured with its own auth-proxy](/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml).
+These are used with an instance of Dex running in the Kubeapps cluster with a [matching configuration](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-dex-values.yaml) and Kubeapps itself [configured with its own auth-proxy](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml).
 
 Configuring your Kubernetes cluster for OIDC authentication can be tricky, despite the upstream documentation, so be prepared to check the logs of your `kube-apiserver` pod:
 
@@ -66,7 +66,7 @@ kubectl -n kube-system get po kube-apiserver-kubeapps-control-plane -o yaml | gr
     - '--oidc-username-prefix=oidc:'
 ```
 
-For more information about configuring Kubeapps, as opposed to the Kubernetes API server itself, with various OIDC providers see [Using an OIDC provider](/docs/user/using-an-OIDC-provider.md). Similarly, the logs of the Kubeapps frontend `auth-proxy` container will provide more details for debugging authentication requests from Kubeapps itself.
+For more information about configuring Kubeapps, as opposed to the Kubernetes API server itself, with various OIDC providers see [Using an OIDC provider](../using-an-OIDC-provider.md). Similarly, the logs of the Kubeapps frontend `auth-proxy` container will provide more details for debugging authentication requests from Kubeapps itself.
 
 ## A Kubeapps Configuration example
 
@@ -101,9 +101,9 @@ kubectl --kubeconfig ~/.kube/path-to-kube-confnig-file config view --raw -o json
 
 Alternatively, for a development with private API server URLs, you can omit the `certificateAuthorityData` and instead include the field `insecure: true` for a cluster and Kubeapps will not try to verify the secure connection.
 
-A serviceToken is not required but provides a better user experience, enabling users viewing the cluster to see the namespaces to which they have access (only) when they use the namespace selector. It's also used to retrieve icons of the available operators if the OLM is enabled. The service token should be configured with RBAC so that it can  list those resources. You can refer to the [example used for a local development environment](/docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml).
+A serviceToken is not required but provides a better user experience, enabling users viewing the cluster to see the namespaces to which they have access (only) when they use the namespace selector. It's also used to retrieve icons of the available operators if the OLM is enabled. The service token should be configured with RBAC so that it can  list those resources. You can refer to the [example used for a local development environment](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml).
 
-Your Kubeapps installation will also need to be [configured to use OIDC for authentication](/docs/user/using-an-OIDC-provider.md) with a client-id for your chosen provider.
+Your Kubeapps installation will also need to be [configured to use OIDC for authentication](../using-an-OIDC-provider.md) with a client-id for your chosen provider.
 
 ## Clusters with different client-ids
 
@@ -119,7 +119,7 @@ First your OIDC Provider needs to be configured so that tokens issued for the cl
 
 ### Configuring the auth-proxy to request multiple audiences
 
-The second part of the additional configuration is to ensure that when Kubeapps' auth-proxy requests a token that it includes extra scopes, such as `audience:server:client_id:second-cluster` for each additional audience that it requires in the issued token. For example, you can view the [auth-proxy configuration used in the local development environment](/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml) and see the additional scopes included there to ensure that the `second-cluster` and `third-cluster` are included in the audience of the resulting token.
+The second part of the additional configuration is to ensure that when Kubeapps' auth-proxy requests a token that it includes extra scopes, such as `audience:server:client_id:second-cluster` for each additional audience that it requires in the issued token. For example, you can view the [auth-proxy configuration used in the local development environment](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml) and see the additional scopes included there to ensure that the `second-cluster` and `third-cluster` are included in the audience of the resulting token.
 
 ## Updating multi-cluster options
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -18,20 +18,20 @@ kubectl create namespace kubeapps
 helm install kubeapps --namespace kubeapps bitnami/kubeapps
 ```
 
-For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](../../chart/kubeapps/README.md).
+For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps).
 
 The above commands will deploy Kubeapps into the `kubeapps` namespace in your cluster. It may take a few minutes to execute. Once it has been deployed and the Kubeapps pods are running, continue to step 2.
 
 ## Step 2: Create a demo credential with which to access Kubeapps and Kubernetes
 
-For any user-facing installation you should [configure an OAuth2/OIDC provider](using-an-OIDC-provider.md) to enable secure user authentication with Kubeapps and the cluster, but this is quite an overhead to simply try out Kubeapps. Instead, for a simpler way to try out Kubeapps for personal learning, we can create a Kubernetes service account and use that API token to authenticate with the Kubernetes API server via Kubeapps:
+For any user-facing installation you should [configure an OAuth2/OIDC provider](../using-an-OIDC-provider.md) to enable secure user authentication with Kubeapps and the cluster, but this is quite an overhead to simply try out Kubeapps. Instead, for a simpler way to try out Kubeapps for personal learning, we can create a Kubernetes service account and use that API token to authenticate with the Kubernetes API server via Kubeapps:
 
 ```bash
 kubectl create serviceaccount kubeapps-operator
 kubectl create clusterrolebinding kubeapps-operator --clusterrole=cluster-admin --serviceaccount=default:kubeapps-operator
 ```
 
-> **NOTE** It's not recommended to assign users the `cluster-admin` role for Kubeapps production usage. Please refer to the [Access Control](/docs/user/access-control.md) documentation to configure fine-grained access control for users.
+> **NOTE** It's not recommended to assign users the `cluster-admin` role for Kubeapps production usage. Please refer to the [Access Control](../access-control.md) documentation to configure fine-grained access control for users.
 
 To retrieve the token,
 
@@ -78,7 +78,7 @@ Paste the token generated in the previous step to authenticate and access the Ku
 
 ![Dashboard main page](../img/dashboard-home.png)
 
-***Note:*** If you are setting up Kubeapps for other people to access, you will want to use a different service type or setup Ingress rather than using the above `kubectl port-forward`. For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](../../chart/kubeapps/README.md).
+***Note:*** If you are setting up Kubeapps for other people to access, you will want to use a different service type or setup Ingress rather than using the above `kubectl port-forward`. For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps).
 
 ## Step 4: Deploy WordPress
 
@@ -119,8 +119,7 @@ If you want to uninstall/delete your WordPress application, you can do so by cli
 
 Learn more about Kubeapps with the links below:
 
-- [Detailed installation instructions](../../chart/kubeapps/README.md)
-- [Deploying Operators](./operators.md)
-- [Kubeapps Dashboard documentation](dashboard.md)
-- [Kubeapps components](../architecture/overview.md)
+- [Detailed installation instructions](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps)
+- [Deploying Operators](../operators.md)
+- [Kubeapps Dashboard documentation](../dashboard.md)
 - [Roadmap](https://github.com/kubeapps/kubeapps/wiki/Roadmap)

--- a/docs/user/offline-installation.md
+++ b/docs/user/offline-installation.md
@@ -46,7 +46,7 @@ You will need to follow a similar process for every image present in the values 
 
 By default, Kubeapps install the `bitnami` App Repository. Since, in order to sync that repository, it's necessary to have Internet connection, you will need to mirror it or create your own repository (e.g. using Harbor) and configure it when installing Kubeapps.
 
-For more information about how to create a private repository, follow this [guide](./private-app-repository.md).
+For more information about how to create a private repository, follow this [guide](../private-app-repository.md).
 
 ## 4. Install Kubeapps
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

The goal of this PR is to prepare docs under the `user/` folder to be served in kubeapps.com. When parsing docs outside of Github, some links need to point to the full URL while other require some adaptation in their relative paths. The good thing is that links will still work both when reading them in Github or in the future docs site.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2073 
