### PR TITLE
Fix resource table when working with lists

### DIFF
--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
@@ -29,6 +29,7 @@ const sampleResourceRef = {
 } as ResourceRef;
 
 const deployment = {
+  kind: "Deployment",
   metadata: {
     name: "foo",
   },
@@ -134,4 +135,45 @@ it("renders a table with an error", () => {
   const row = data[0];
   expect(row.name).toEqual("foo");
   expect(wrapper.text()).toContain("Error: Boom!");
+});
+
+it("do not fail if the resources are already populated but the refs not yet", () => {
+  const state = getStore({
+    kube: {
+      items: {
+        "deployment-foo": {
+          isFetching: false,
+          item: deployment as IResource,
+        },
+      },
+    },
+  });
+  const wrapper = mountWrapper(state, <ResourceTable {...defaultProps} resourceRefs={[]} />);
+  expect(wrapper.find(Table)).not.toExist();
+});
+
+it("renders the table with two entries with a list reference", () => {
+  const state = getStore({
+    kube: {
+      items: {
+        "deployment-foo": {
+          isFetching: false,
+          item: {
+            items: [
+              deployment as IResource,
+              { ...deployment, metadata: { name: "bar" } } as IResource,
+            ],
+          },
+        },
+      },
+    },
+  });
+  const wrapper = mountWrapper(
+    state,
+    <ResourceTable
+      {...defaultProps}
+      resourceRefs={[{ ...sampleResourceRef, name: "" } as ResourceRef]}
+    />,
+  );
+  expect(wrapper.find(Table).prop("data")).toHaveLength(2);
 });

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.tsx
@@ -91,7 +91,7 @@ function ResourceTable({ id, title, resourceRefs }: IResourceTableProps) {
     () =>
       resources.map((resource, index) => {
         // When the resourceRef is a list, the list of references will be just one
-        const ref = resourceRefs[index] || resourceRefs[0];
+        const ref = resourceRefs.length === 1 ? resourceRefs[0] : resourceRefs[index];
         if (ref) {
           return getData(
             ref.name,

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.tsx
@@ -83,17 +83,25 @@ function ResourceTable({ id, title, resourceRefs }: IResourceTableProps) {
     flattenResources(resourceRefs, state.kube.items),
   );
 
-  const columns = useMemo(() => getColumns(resourceRefs[0]), [resourceRefs]);
+  const columns = useMemo(
+    () => (resourceRefs.length ? getColumns(resourceRefs[0]) : OtherResourceColumns),
+    [resourceRefs],
+  );
   const data = useMemo(
     () =>
-      resources.map((resource, index) =>
-        getData(
-          resourceRefs[index].name,
-          columns.map(c => c.accessor),
-          columns.map(c => c.getter),
-          resource,
-        ),
-      ),
+      resources.map((resource, index) => {
+        // When the resourceRef is a list, the list of references will be just one
+        const ref = resourceRefs[index] || resourceRefs[0];
+        if (ref) {
+          return getData(
+            ref.name,
+            columns.map(c => c.accessor),
+            columns.map(c => c.getter),
+            resource,
+          );
+        }
+        return {};
+      }),
     [columns, resourceRefs, resources],
   );
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

At the moment, the code was assuming that there were one resource reference per resource in the state. Sometimes the reference points to a list so there will be more resources than references.

This PR also handles the case in which there are no references at all (but this is not happening IRL).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2120
