### PR TITLE
Avoid double v prefix in the AppList

### DIFF
--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -79,3 +79,19 @@ it("should add a second label with the app update available", () => {
   const tooltip = wrapper.find(Tooltip);
   expect(tooltip.text()).toBe("New App Version: 1.1.0");
 });
+
+it("doesn't include a double v prefix", () => {
+  const props = {
+    ...defaultProps,
+    app: {
+      ...defaultProps.app,
+      chartMetadata: {
+        name: "foo",
+        appVersion: "v1.0.0",
+      },
+      updateInfo: {},
+    },
+  } as IAppListItemProps;
+  const wrapper = mountWrapper(defaultStore, <AppListItem {...props} />);
+  expect(wrapper.find("span").findWhere(s => s.text() === "App: foo v1.0.0")).toExist();
+});

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -60,7 +60,9 @@ function AppListItem(props: IAppListItemProps) {
         <div>
           <span>
             App: {app.chartMetadata.name}{" "}
-            {app.chartMetadata.appVersion ? `v${app.chartMetadata.appVersion}` : ""}
+            {app.chartMetadata.appVersion
+              ? `v${app.chartMetadata.appVersion.replace(/^v/, "")}`
+              : ""}
           </span>
           <br />
           <span>Chart: {app.chartMetadata.version}</span>

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -71,7 +71,7 @@ replaceImage() {
 updateRepo() {
     local targetRepo=${1:?}
     local targetTag=${2:?}
-    local targetTagWithoutV=${targetTag/v/}
+    local targetTagWithoutV=${targetTag#v}
     local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
     local chartYaml="${targetChartPath}/Chart.yaml"
     if [ ! -f "${chartYaml}" ]; then

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -71,6 +71,7 @@ replaceImage() {
 updateRepo() {
     local targetRepo=${1:?}
     local targetTag=${2:?}
+    local targetTagWithoutV=${targetTag/v/}
     local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
     local chartYaml="${targetChartPath}/Chart.yaml"
     if [ ! -f "${chartYaml}" ]; then
@@ -80,7 +81,7 @@ updateRepo() {
     rm -rf "${targetChartPath}"
     cp -R "${KUBEAPPS_CHART_DIR}" "${targetChartPath}"
     # Update Chart.yaml with new version
-    sed -i.bk 's/appVersion: DEVEL/appVersion: '"${targetTag}"'/g' "${chartYaml}"
+    sed -i.bk 's/appVersion: DEVEL/appVersion: '"${targetTagWithoutV}"'/g' "${chartYaml}"
     rm "${targetChartPath}/Chart.yaml.bk"
     # Replace images for the latest available
     replaceImage dashboard "${targetChartPath}/values.yaml"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

The appVersion field in the `Chart.yaml` may contain already the `v` prefix, and we are prefixing another `v` again:

![Screenshot from 2020-10-22 13-04-18](https://user-images.githubusercontent.com/4025665/96864844-5d0a2680-1469-11eb-91db-85bd67cbdf41.png)

In any case, the `appVersion` doesn't need that prefix so I am also removing it from our chart release process.

### Applicable issues

I'd swear I fixed this already but I couldn't find it, maybe I forgot to create the PR :thinking: 
