### PR TITLE
Fix typo in AccessURLTable

### DIFF
--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.tsx
@@ -166,7 +166,7 @@ export default function AccessURLTable({ ingressRefs, serviceRefs }: IAccessURLT
       .concat(
         allIngresses.map(ingress => {
           return {
-            url: ingress.item ? getAnchors(GetURLItemFromIngress(ingress.item).URLs) : "Unkown",
+            url: ingress.item ? getAnchors(GetURLItemFromIngress(ingress.item).URLs) : "Unknown",
             type: "Ingress",
             notes: ingress.error ? (
               <span>Error: {ingress.error.message}</span>

--- a/dashboard/src/components/AppView/AccessURLTable/__snapshots__/AccessURLTable.test.tsx.snap
+++ b/dashboard/src/components/AppView/AccessURLTable/__snapshots__/AccessURLTable.test.tsx.snap
@@ -457,7 +457,7 @@ exports[`when the app contains resources with errors displays the error 1`] = `
                     could not find Ingress
                   </span>,
                   "type": "Ingress",
-                  "url": "Unkown",
+                  "url": "Unknown",
                 },
               ]
             }
@@ -517,7 +517,7 @@ exports[`when the app contains resources with errors displays the error 1`] = `
                         could not find Ingress
                       </span>,
                       "type": "Ingress",
-                      "url": "Unkown",
+                      "url": "Unknown",
                     }
                   }
                 >
@@ -526,7 +526,7 @@ exports[`when the app contains resources with errors displays the error 1`] = `
                       className=""
                       key="0-url"
                     >
-                      Unkown
+                      Unknown
                     </td>
                     <td
                       className=""

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.tsx
@@ -67,7 +67,7 @@ function getData(
     });
     return data;
   }
-  data[accessors[1]] = <span>Unkown</span>;
+  data[accessors[1]] = <span>Unknown</span>;
   return;
 }
 


### PR DESCRIPTION
### Description of the change

Minor typo, changing `Unkown` to `Unknown` in the links of the access table.

### Benefits

No functional improvement in this PR, just fixing a typo.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
