### PR TITLE
Restore v prefix in app configmap

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -44,7 +44,7 @@ data:
     {
       "kubeappsCluster": "{{ template "kubeapps.kubeappsCluster" . -}}",
       "kubeappsNamespace": "{{ .Release.Namespace }}",
-      "appVersion": "{{ .Chart.AppVersion }}",
+      "appVersion": "v{{ .Chart.AppVersion }}",
       "authProxyEnabled": {{ .Values.authProxy.enabled }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

After #2123, we have removed the `v` prefix from the chart appVersion. The problem is that we are using that version to generate some links to the documentation (e.g. `href={https://github.com/kubeapps/kubeapps/blob/${appVersion}/docs/user/getting-started.md}`) so we need to match the GitHub tag there.
