### PR TITLE
Consistent semver usage of @clr/ui dependency

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -5,8 +5,6 @@ COPY package.json yarn.lock /app/
 RUN yarn install --frozen-lockfile
 
 RUN mkdir /app/src
-RUN curl -L https://unpkg.com/@bitnami/hex@3.2.0/dist/hex.min.css > /app/src/hex.min.css
-RUN curl -L https://unpkg.com/@clr/ui@4.0.1/clr-ui.min.css > /app/src/clr-ui.min.css
 COPY . /app
 RUN yarn run prettier-check && yarn run ts-compile-check
 RUN yarn run build

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,8 +6,9 @@
   "dependencies": {
     "@clr/city": "^1.1.0",
     "@clr/core": "^4.0.1",
+    "@clr/icons": "^4.0.4",
     "@clr/react": "^4.0.1",
-    "@clr/ui": "^2.3.4",
+    "@clr/ui": "^4.0.1",
     "@types/diff": "^4.0.2",
     "@types/js-yaml": "^3.10.1",
     "@types/json-schema": "^7.0.3",

--- a/dashboard/src/components/Layout/Clarity.tsx
+++ b/dashboard/src/components/Layout/Clarity.tsx
@@ -32,7 +32,7 @@ import {
 import "@clr/core/icon/register.js";
 import * as React from "react";
 
-import "../../clr-ui.min.css";
+import "../../../node_modules/@clr/ui/clr-ui.min.css";
 
 Icons.addIcons(
   angleIcon,

--- a/dashboard/src/components/Layout/Clarity.tsx
+++ b/dashboard/src/components/Layout/Clarity.tsx
@@ -32,7 +32,7 @@ import {
 import "@clr/core/icon/register.js";
 import * as React from "react";
 
-import "../../../node_modules/@clr/ui/clr-ui.min.css";
+import "@clr/ui/clr-ui.min.css";
 
 Icons.addIcons(
   angleIcon,

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -1257,6 +1257,11 @@
     css-vars-ponyfill "^2.3.2"
     normalize.css "^8.0.1"
 
+"@clr/icons@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@clr/icons/-/icons-4.0.4.tgz#36e447116940eed708a915e4f9a1d8ce3390dc06"
+  integrity sha512-1snMF963n5CTWhE3FKbk/sLsGMGastLqzyRDT4YjNt4H/9b3sv+z9svkoptmUK8j+m52ByORcnKtf8711XDNHQ==
+
 "@clr/react@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@clr/react/-/react-4.0.1.tgz#7c1921cb41c2a12151b16b41bc43fef6ffee9f0d"
@@ -1268,10 +1273,10 @@
     "@clr/city" "^1.1.0"
     normalize.css "^8.0.1"
 
-"@clr/ui@^2.3.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@clr/ui/-/ui-2.4.4.tgz#f120dfa5f440634e556db14bbebe596488cfba6a"
-  integrity sha512-u164Mkwb7Jb4nwQhF1r28rEEqNbnVIAnrAsG/4ef1LrHGOJCFychswXTNYy8f9zpNixX6GZwgq6TzIrFGsRcfw==
+"@clr/ui@^4.0.1":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@clr/ui/-/ui-4.0.4.tgz#dcdeb012abe99bd0873867ffb83a98d328b64dcf"
+  integrity sha512-9lCtH/PkUZaZDKj2PsIxOC7he4PXrbpJCsUC8gcQZm7sYNLRcHPBEaUAPHAA7SBf+6+v4UxogAZ/N9/lnPndDg==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"


### PR DESCRIPTION
### Description of the change

For newcomers developers, it is a bit weird to have to manually include the Clarity dependency (as dockerfile did). Despite the docs mentions the only command to run the dashboard is `yarn install` and `yarn run start`, it was necessary to manually put the clarity `clr-ui.min.css` file.
What's more, the clarity dependency was already included in the package.json, but with major version = 2 (instead of 4).

This PR removes every manual importation of the  `clr-ui.min.css` file (and the old one from the HEX UI) and changes the importation to the `node_modules` folder (`../../../node_modules/@clr/ui/clr-ui.min.css` instead of `../../clr-ui.min.css`).

### Benefits

Since developers already have to exec `yarn install` in order to install the required deps, including Clarity in the list of deps improves traceability and enhances the dev experience for newcomers.

### Possible drawbacks

Dockerfile relied on a very specific version of Clarity instead of leveraging from the semver. This PR sets the clarity dep in `^4.0.1`, that is, anything 4.X.X will be accepted.

### Applicable issues

N/A

### Additional information

If this PR does not become accepted, a change in the Dashboard developer documentarios will be required to explain that is required to manually add a dependency.
