### PR TITLE
Broken links docs fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 All authors to the project retain copyright to their work. However, to ensure
 that they are only submitting work that they have rights to, we are requiring
-everyone to acknowldge this by signing their work.
+everyone to acknowledge this by signing their work.
 
 Any copyright notices in this repo should specify the authors as "the contributors".
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Kubeapps is a web-based UI for deploying and managing applications in Kubernetes
 - Inspect, upgrade and delete Helm-based applications installed in the cluster
 - Add custom and private chart repositories (supports [ChartMuseum](https://github.com/helm/chartmuseum) and [JFrog Artifactory](https://www.jfrog.com/confluence/display/RTF/Helm+Chart+Repositories))
 - Browse and deploy [Kubernetes Operators](https://operatorhub.io/).
-- Secure authentication to Kubeapps using an [OAuth2/OIDC provider](https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md)
-- Secure authorization based on Kubernetes [Role-Based Access Control](https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md)
+- Secure authentication to Kubeapps using an [OAuth2/OIDC provider](./docs/user/using-an-OIDC-provider.md)
+- Secure authorization based on Kubernetes [Role-Based Access Control](./docs/user/access-control.md)
 
 ## Quick Start
 
@@ -21,25 +21,25 @@ kubectl create namespace kubeapps
 helm install kubeapps --namespace kubeapps bitnami/kubeapps
 ``` 
 
-***Note:*** Kubeapps 2.0 and onwards supports Helm 3 only. While only the Helm 3 API is supported, in most cases, charts made for Helm 2 will still work. For detailed instructions on how to install and use Kubeapps follow the [Getting Started Guide](docs/user/getting-started.md).
+***Note:*** Kubeapps 2.0 and onwards supports Helm 3 only. While only the Helm 3 API is supported, in most cases, charts made for Helm 2 will still work. For detailed instructions on how to install and use Kubeapps follow the [Getting Started Guide](./docs/user/getting-started.md).
 
 ## Developer Documentation
 
 Please refer to:
 
-- The [Kubeapps Build Guide](docs/developer/build.md) for instructions on setting up the build environment and building Kubeapps from source.
-- The [Kubeapps Developer Documentation](docs/developer/README.md) for instructions on setting up the developer environment for developing on Kubeapps and its components.
+- The [Kubeapps Build Guide](./docs/developer/build.md) for instructions on setting up the build environment and building Kubeapps from source.
+- The [Kubeapps Developer Documentation](./docs/developer/README.md) for instructions on setting up the developer environment for developing on Kubeapps and its components.
 
 ## Next Steps
 
-If you have followed the instructions for [installing Kubeapps](docs/user/getting-started.md) check how to [use Kubeapps](docs/user/dashboard.md) to easily manage your applications running in your cluster, or [look under the hood to see what's included in Kubeapps](docs/architecture/overview.md).
+If you have followed the instructions for [installing Kubeapps](./docs/user/getting-started.md) check how to [use Kubeapps](./docs/user/dashboard.md) to easily manage your applications running in your cluster, or [look under the hood to see what's included in Kubeapps](./docs/architecture/overview.md).
 
 ## Useful Resources
 
-- [Walkthrough for first-time users](docs/user/getting-started.md)
+- [Walkthrough for first-time users](./docs/user/getting-started.md)
 - [Detailed installation instructions](chart/kubeapps/README.md)
-- [Kubeapps Dashboard documentation](docs/user/dashboard.md)
-- [Kubeapps components](docs/architecture/overview.md)
+- [Kubeapps Dashboard documentation](./docs/user/dashboard.md)
+- [Kubeapps components](./docs/architecture/overview.md)
 - [Roadmap](https://github.com/kubeapps/kubeapps/wiki/Roadmap)
 
 ## Differences from Monocular

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -8,8 +8,8 @@
 - Inspect, upgrade and delete Helm-based applications installed in the cluster
 - Add custom and private chart repositories (supports [ChartMuseum](https://github.com/helm/chartmuseum) and [JFrog Artifactory](https://www.jfrog.com/confluence/display/RTF/Helm+Chart+Repositories))
 - Browse and deploy [Kubernetes Operators](https://operatorhub.io/).
-- Secure authentication to Kubeapps using an [OAuth2/OIDC provider](https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md)
-- Secure authorization based on Kubernetes [Role-Based Access Control](https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md)
+- Secure authentication to Kubeapps using an [OAuth2/OIDC provider](../../docs/user/using-an-OIDC-provider.md)
+- Secure authorization based on Kubernetes [Role-Based Access Control](../../docs/user/access-control.md)
 
 ## TL;DR
 
@@ -45,7 +45,7 @@ The command deploys Kubeapps on the Kubernetes cluster in the `kubeapps` namespa
 
 > **Caveat**: Only one Kubeapps installation is supported per namespace
 
-Once you have installed Kubeapps follow the [Getting Started Guide](https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md) for additional information on how to access and use Kubeapps.
+Once you have installed Kubeapps follow the [Getting Started Guide](../../docs/user/getting-started.md) for additional information on how to access and use Kubeapps.
 
 ## Parameters
 
@@ -75,11 +75,11 @@ By default, Kubeapps will track the [community Helm charts](https://github.com/h
 
 ### Enabling Operators
 
-Since v1.9.0 (and by default since v2.0), Kubeapps supports to deploy and manage Operators within its dashboard. More information about how to enable and use this feature can be found in [this guide](https://github.com/kubeapps/kubeapps/blob/master/docs/user/operators.md).
+Since v1.9.0 (and by default since v2.0), Kubeapps supports to deploy and manage Operators within its dashboard. More information about how to enable and use this feature can be found in [this guide](./docs/user/operators.md).
 
 ### Exposing Externally
 
-> **Note**: The Kubeapps frontend sets up a proxy to the Kubernetes API service which means that when exposing the Kubeapps service to a network external to the Kubernetes cluster (perhaps on an internal or public network), the Kubernetes API will also be exposed for authenticated requests from that network. It is highly recommended that you [use an OAuth2/OIDC provider with Kubeapps](https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md) to ensure that your authentication proxy is exposed rather than the Kubeapps frontend. This ensures that only the configured users trusted by your Identity Provider will be able to reach the Kubeapps frontend and therefore the Kubernetes API. Kubernetes service token authentication should only be used for users for demonstration purposes only, not production environments.
+> **Note**: The Kubeapps frontend sets up a proxy to the Kubernetes API service which means that when exposing the Kubeapps service to a network external to the Kubernetes cluster (perhaps on an internal or public network), the Kubernetes API will also be exposed for authenticated requests from that network. It is highly recommended that you [use an OAuth2/OIDC provider with Kubeapps](./docs/user/using-an-OIDC-provider.md) to ensure that your authentication proxy is exposed rather than the Kubeapps frontend. This ensures that only the configured users trusted by your Identity Provider will be able to reach the Kubeapps frontend and therefore the Kubernetes API. Kubernetes service token authentication should only be used for users for demonstration purposes only, not production environments.
 
 #### LoadBalancer Service
 
@@ -103,7 +103,7 @@ Most likely you will only want to have one hostname that maps to this Kubeapps i
 
 ##### Annotations
 
-For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers. Annotations can be set using `ingress.annotations`.
+For annotations, please see [this document](./docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers. Annotations can be set using `ingress.annotations`.
 
 ##### TLS
 

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -8,8 +8,8 @@
 - Inspect, upgrade and delete Helm-based applications installed in the cluster
 - Add custom and private chart repositories (supports [ChartMuseum](https://github.com/helm/chartmuseum) and [JFrog Artifactory](https://www.jfrog.com/confluence/display/RTF/Helm+Chart+Repositories))
 - Browse and deploy [Kubernetes Operators](https://operatorhub.io/).
-- Secure authentication to Kubeapps using an [OAuth2/OIDC provider](../../docs/user/using-an-OIDC-provider.md)
-- Secure authorization based on Kubernetes [Role-Based Access Control](../../docs/user/access-control.md)
+- Secure authentication to Kubeapps using an [OAuth2/OIDC provider](https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md)
+- Secure authorization based on Kubernetes [Role-Based Access Control](https://github.com/kubeapps/kubeapps/blob/master/docs/user/access-control.md)
 
 ## TL;DR
 
@@ -45,7 +45,7 @@ The command deploys Kubeapps on the Kubernetes cluster in the `kubeapps` namespa
 
 > **Caveat**: Only one Kubeapps installation is supported per namespace
 
-Once you have installed Kubeapps follow the [Getting Started Guide](../../docs/user/getting-started.md) for additional information on how to access and use Kubeapps.
+Once you have installed Kubeapps follow the [Getting Started Guide](https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md) for additional information on how to access and use Kubeapps.
 
 ## Parameters
 
@@ -75,11 +75,11 @@ By default, Kubeapps will track the [community Helm charts](https://github.com/h
 
 ### Enabling Operators
 
-Since v1.9.0 (and by default since v2.0), Kubeapps supports to deploy and manage Operators within its dashboard. More information about how to enable and use this feature can be found in [this guide](./docs/user/operators.md).
+Since v1.9.0 (and by default since v2.0), Kubeapps supports to deploy and manage Operators within its dashboard. More information about how to enable and use this feature can be found in [this guide](https://github.com/kubeapps/kubeapps/blob/master/docs/user/operators.md).
 
 ### Exposing Externally
 
-> **Note**: The Kubeapps frontend sets up a proxy to the Kubernetes API service which means that when exposing the Kubeapps service to a network external to the Kubernetes cluster (perhaps on an internal or public network), the Kubernetes API will also be exposed for authenticated requests from that network. It is highly recommended that you [use an OAuth2/OIDC provider with Kubeapps](./docs/user/using-an-OIDC-provider.md) to ensure that your authentication proxy is exposed rather than the Kubeapps frontend. This ensures that only the configured users trusted by your Identity Provider will be able to reach the Kubeapps frontend and therefore the Kubernetes API. Kubernetes service token authentication should only be used for users for demonstration purposes only, not production environments.
+> **Note**: The Kubeapps frontend sets up a proxy to the Kubernetes API service which means that when exposing the Kubeapps service to a network external to the Kubernetes cluster (perhaps on an internal or public network), the Kubernetes API will also be exposed for authenticated requests from that network. It is highly recommended that you [use an OAuth2/OIDC provider with Kubeapps](https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md) to ensure that your authentication proxy is exposed rather than the Kubeapps frontend. This ensures that only the configured users trusted by your Identity Provider will be able to reach the Kubeapps frontend and therefore the Kubernetes API. Kubernetes service token authentication should only be used for users for demonstration purposes only, not production environments.
 
 #### LoadBalancer Service
 
@@ -103,7 +103,7 @@ Most likely you will only want to have one hostname that maps to this Kubeapps i
 
 ##### Annotations
 
-For annotations, please see [this document](./docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers. Annotations can be set using `ingress.annotations`.
+For annotations, please see [this document](https://github.com/kubeapps/kubeapps/blob/master/docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers. Annotations can be set using `ingress.annotations`.
 
 ##### TLS
 
@@ -147,7 +147,7 @@ The first command removes most of the Kubernetes components associated with the 
 
 > **NOTE**: If you delete the CRD for `apprepositories.kubeapps.com` it will delete the repositories for **all** the installed instances of `kubeapps`. This will break existing installations of `kubeapps` if they exist.
 
-If you have dedicated a namespace only for Kubeapps you can completely clean remaining completed/failed jobs or any stale resources by deleting the namespace
+If you have dedicated a namespace only for Kubeapps you can completely clean the remaining completed/failed jobs or any stale resources by deleting the namespace
 
 ```bash
 kubectl delete namespace kubeapps
@@ -179,7 +179,7 @@ Or:
 Error: namespaces "kubeapps" is forbidden: User "system:serviceaccount:kube-system:default" cannot get namespaces in the namespace "kubeapps"
 ```
 
-It is possible, though uncommon, that your cluster does not have Role Based Access Control (RBAC) enabled. To check if your cluster has RBAC you can execute:
+It is possible, though uncommon, that your cluster does not have Role-Based Access Control (RBAC) enabled. To check if your cluster has RBAC you can execute:
 
 ```bash
 kubectl api-versions
@@ -195,7 +195,7 @@ helm install --name kubeapps --namespace kubeapps bitnami/kubeapps --set rbac.cr
 
 It is possible that when upgrading Kubeapps an error appears. That can be caused by a breaking change in the new chart or because the current chart installation is in an inconsistent state. If you find issues upgrading Kubeapps you can follow these steps:
 
-> Note: This steps assume that you have installed Kubeapps in the namespace `kubeapps` using the name `kubeapps`. If that is not the case replace the command with your namespace and/or name.
+> Note: These steps assume that you have installed Kubeapps in the namespace `kubeapps` using the name `kubeapps`. If that is not the case replace the command with your namespace and/or name.
 
 > Note: If you are upgrading from 1.X to 2.X see the [following section](#upgrading-to-2-0).
 
@@ -247,8 +247,8 @@ After that you should be able to access the new version of Kubeapps. If the abov
 Kubeapps 2.0 (Chart version 4.0.0) introduces some breaking changes:
 
  - Helm 2 is no longer supported. If you are still using some Helm 2 charts, [migrate them with the available tools](https://helm.sh/docs/topics/v2_v3_migration/). Note that some charts (but not all of them) may require to be migrated to the [new Chart specification (v2)](https://helm.sh/docs/topics/charts/#the-apiversion-field). If you are facing any issue managing this migration and Kubeapps, please open a new issue!
- - MongoDB is not longer supported. Since 2.0, the only database supported is PostgreSQL.
- - PosgreSQL chart dependency has been upgraded to a new major version.
+ - MongoDB is no longer supported. Since 2.0, the only database supported is PostgreSQL.
+ - PostgreSQL chart dependency has been upgraded to a new major version.
 
 Due to the last point, it's necessary to run a command before upgrading to Kubeapps 2.0:
 

--- a/docs/architecture/design-proposals/README.md
+++ b/docs/architecture/design-proposals/README.md
@@ -1,13 +1,21 @@
 # Design Proposals
 
-This folder contain documents/links used to design new features for Kubeapps.
+This folder contains documents/links used to design new features for Kubeapps.
 
 # Links
 
-- Authentication (AuthN) and Authorization (AuthZ)
+- Authentication (AuthN) and Authorization (AuthZ):
     - [Introduction](./authentication-and-authorization.md)
     - [OAuth 2 - OpenID Connect (OIDC) Support](https://docs.google.com/document/d/1YZzLtIbS2copQJgspFiMd0eAhpyt8u19MUSDEvH2X4g)
-- [Dashboard Error Handling](./dashboard/error-handling/error-handling.md)
+- Dashboard:
+    - [Dashboard Error Handling](./dashboard/error-handling/error-handling.md)
+    - [Simpler deployments](./dashboard/deployment-improvements.md)
+    - [Improve UX in application view](./dashboard/application-view-revamp.md)
+    - [Upgrade to Clarity design](./clarity-ui.md)
 - [Notify Available Chart Updates](https://docs.google.com/document/d/1oG9nerd5CurWSIwH33kKCsOCtkSFMgcm8SuTJyuSnxs/)
-- [Simpler deployments](./dashboard/deployment-improvements.md)
-- [Third party integration for adding a chart repository](./third-party-add-repository)
+- [Operators support](./operators-support-poc.md)
+- [Third party integration for adding a chart repository](./third-party-add-repository.md)
+- [Replacing MongoDB support](./replacing-mongodb.md)
+- [Helm 3 support](./helm3.md)
+- [Multicluster support](./multi-cluster-support.md)
+

--- a/docs/architecture/design-proposals/helm3.md
+++ b/docs/architecture/design-proposals/helm3.md
@@ -14,7 +14,7 @@ We see no reason to implement a proxy for Helm 3, but rather what we call an age
 
 ## Authentication
 
-Since Helm 2 is built on the assumption that the Tiller service runs in-cluster with its own service account (and ["does not provide a way to map user credentials to specific permissions within Kubernetes"](https://helm.sh/docs/securing_installation/#tiller-and-user-permissions)), the only thing Kubeapps was required to provide for authentication with Tiller (when using TLS) was the `ca.crt` file.
+Since Helm 2 is built on the assumption that the Tiller service runs in-cluster with its own service account (and ["does not provide a way to map user credentials to specific permissions within Kubernetes"](https://v2.helm.sh/docs/securing_installation/#tiller-and-user-permissions)), the only thing Kubeapps was required to provide for authentication with Tiller (when using TLS) was the `ca.crt` file.
 For this reason, Kubeapps currently (with Helm 2) authenticates with the Kubernetes API server using the user's bearer token not only when talking directly to the API server, but also to verify permissions before making any request to Tiller.
 
 With Helm 3, all authentication will be handled by the Kubernetes API Server, so none of the above should be an issue.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -19,11 +19,11 @@ Check more details about the implementation in [this document](/docs/developer/k
 
 ### Apprepository CRD and Controller
 
-Chart repositories in Kubeapps are managed with a `CustomResourceDefinition` called `apprepositories.kubeapps.com`. Each repository added to Kubeapps is an object of type `AppRepository` and the `apprepository-controller` will watch for changes on those type of objects to update the list of available charts to deploy.
+Chart repositories in Kubeapps are managed with a `CustomResourceDefinition` called `apprepositories.kubeapps.com`. Each repository added to Kubeapps is an object of type `AppRepository` and the `apprepository-controller` will watch for changes on those types of objects to update the list of available charts to deploy.
 
 ### `asset-syncer`
 
-The `asset-syncer` component is tool that scans a Helm chart repository and populates chart metadata in a database. This metadata is then served by the `assetsvc` component. Check more details about the implementation in this [document](/docs/developer/asset-syncer.md).
+The `asset-syncer` component is a tool that scans a Helm chart repository and populates chart metadata in a database. This metadata is then served by the `assetsvc` component. Check more details about the implementation in this [document](/docs/developer/asset-syncer.md).
 
 ### `assetsvc`
 

--- a/docs/developer/apprepository-controller.md
+++ b/docs/developer/apprepository-controller.md
@@ -8,7 +8,7 @@ The `apprepository-controller` is a Kubernetes controller for managing Helm char
 - [Make](https://www.gnu.org/software/make/)
 - [Go programming language](https://golang.org/dl/)
 - [Docker CE](https://www.docker.com/community-edition)
-- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/pick-right-solution/)
+- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [Telepresence](https://telepresence.io)
 

--- a/docs/developer/asset-syncer.md
+++ b/docs/developer/asset-syncer.md
@@ -8,7 +8,7 @@ The `asset-syncer` component is a tool that scans a Helm chart repository and po
 - [Make](https://www.gnu.org/software/make/)
 - [Go programming language](https://golang.org/dl/)
 - [Docker CE](https://www.docker.com/community-edition)
-- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/pick-right-solution/). [Minikube](https://github.com/kubernetes/minikbue) is recommended.
+- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/). [Minikube](https://github.com/kubernetes/minikbue) is recommended.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [Telepresence](https://telepresence.io)
 

--- a/docs/developer/asset-syncer.md
+++ b/docs/developer/asset-syncer.md
@@ -8,7 +8,7 @@ The `asset-syncer` component is a tool that scans a Helm chart repository and po
 - [Make](https://www.gnu.org/software/make/)
 - [Go programming language](https://golang.org/dl/)
 - [Docker CE](https://www.docker.com/community-edition)
-- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/). [Minikube](https://github.com/kubernetes/minikbue) is recommended.
+- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/). [Minikube](https://github.com/kubernetes/minikube) is recommended.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [Telepresence](https://telepresence.io)
 

--- a/docs/developer/assetsvc.md
+++ b/docs/developer/assetsvc.md
@@ -8,7 +8,7 @@ The `assetsvc` component is a micro-service that creates an API endpoint for acc
 - [Make](https://www.gnu.org/software/make/)
 - [Go programming language](https://golang.org/dl/)
 - [Docker CE](https://www.docker.com/community-edition)
-- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/pick-right-solution/). [Minikube](https://github.com/kubernetes/minikbue) is recommended.
+- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/). [Minikube](https://github.com/kubernetes/minikube) is recommended.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [Telepresence](https://telepresence.io)
 

--- a/docs/developer/dashboard.md
+++ b/docs/developer/dashboard.md
@@ -7,7 +7,7 @@ The dashboard is the main UI component of the Kubeapps project. Written in Javas
 - [Git](https://git-scm.com/)
 - [Node 8.x](https://nodejs.org/)
 - [Yarn](https://yarnpkg.com)
-- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/pick-right-solution/)
+- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [Docker CE](https://www.docker.com/community-edition)
 - [Telepresence](https://telepresence.io)

--- a/docs/developer/kubeops.md
+++ b/docs/developer/kubeops.md
@@ -8,7 +8,7 @@ The `kubeops` component is a micro-service that creates an API endpoint for acce
 - [Make](https://www.gnu.org/software/make/)
 - [Go programming language](https://golang.org/dl/)
 - [Docker CE](https://www.docker.com/community-edition)
-- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/pick-right-solution/). [Minikube](https://github.com/kubernetes/minikbue) is recommended.
+- [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/). [Minikube](https://github.com/kubernetes/minikube) is recommended.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
 ## Download the Kubeapps source code

--- a/docs/developer/testing-environment.md
+++ b/docs/developer/testing-environment.md
@@ -13,7 +13,7 @@ This guide aims to provide the instructions to easily setup the environment to t
 
 ## Prerequisites
 
-- [Kubernetes cluster (v1.12+)](https://kubernetes.io/docs/setup/pick-right-solution/).
+- [Kubernetes cluster (v1.12+)](https://kubernetes.io/docs/setup/).
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - [Helm client](https://helm.sh/docs/intro/install/).
 

--- a/docs/developer/testing-environment.md
+++ b/docs/developer/testing-environment.md
@@ -4,10 +4,9 @@ This guide explains how to setup your environment to test Kubeapps integration w
 
 ## Background
 
-Kubeapps can be integrated with other services to extend its capabilities. Find more information about these integrations in the links below:
+Kubeapps can be integrated with other services to extend its capabilities. Find more information about these integrations in the link below:
 
 - [Using Private App Repositories with Kubeapps](../user/private-app-repository.md).
-- [Kubernetes Service Catalog Kubeapps Integration](../user/service-catalog.md).
 
 This guide aims to provide the instructions to easily setup the environment to test these integrations.
 

--- a/docs/user/access-control.md
+++ b/docs/user/access-control.md
@@ -85,7 +85,7 @@ kubectl create -n ${KUBEAPPS_NAMESPACE} rolebinding example-kubeapps-repositorie
 
 > Note: There is also a cluster-role for just allowing people to read app repositories: `kubeapps:${KUBEAPPS_NAMESPACE}:apprepositories-read`.
 
-The above command command allows people to create app repositories in the Kubeapps namespace, these are called "Global Repositories" since they will be available in any namespace Kubeapps is available. On the other hand, it's also possible to create "Namespaced Repositories" that will be available just in a single namespace. For doing so, users need to have permissions to create app repositories in those namespaces. Read the next section to know how to create those roles.
+The above command allows people to create app repositories in the Kubeapps namespace, these are called "Global Repositories" since they will be available in any namespace Kubeapps is available. On the other hand, it's also possible to create "Namespaced Repositories" that will be available just in a single namespace. For doing so, users need to have permissions to create app repositories in those namespaces. Read the next section to know how to create those roles.
 
 ### Assigning roles across multiple namespaces
 

--- a/docs/user/access-control.md
+++ b/docs/user/access-control.md
@@ -17,7 +17,7 @@ Two of the most common authentication strategies for providing a token identifyi
 
 ### OpenID Connect authentication
 
-The most common and secure authentication for users to authenticate with the cluster (and therefore Kubeapps) is to use the built-in Kubernetes support for OpenID Connect. In this setup your clusters trust an OAuth2 provider such as Azure Active Directory, Google OpenID Connect or your own installation of the Dex auth provider. You can read more about [using an OIDC provider with Kubeapps](../using-an-OIDC-provider.md).
+The most common and secure authentication for users to authenticate with the cluster (and therefore Kubeapps) is to use the built-in Kubernetes support for OpenID Connect. In this setup your clusters trust an OAuth2 provider such as Azure Active Directory, Google OpenID Connect or your own installation of the Dex auth provider. You can read more about [using an OIDC provider with Kubeapps](./using-an-OIDC-provider.md).
 
 ### Service Account authentication
 

--- a/docs/user/dashboard.md
+++ b/docs/user/dashboard.md
@@ -1,6 +1,6 @@
 # Using the Dashboard
 
-Once you have [installed Kubeapps in your cluster](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps) you can use the Dashboard to start managing and deploying applications in your cluster. Checkout the [Getting Started](../getting-started.md) guide to learn how to access the Dashboard and deploy your first application.
+Once you have [installed Kubeapps in your cluster](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps) you can use the Dashboard to start managing and deploying applications in your cluster. Checkout the [Getting Started](./getting-started.md) guide to learn how to access the Dashboard and deploy your first application.
 
 The following sections walk you through some common tasks with the Kubeapps Dashboard.
 
@@ -42,6 +42,6 @@ By default, Kubeapps comes with the Bitnami repository enabled. You can see the 
 
 ![Repositories List](../img/dashboard-repos.png)
 
-Add new repositories (for example, your organization's chart repository) by clicking the "Add App Repository" button. Fill the "Add Repository" form using the repository info. For a detailed guide of how to add app repositories, check [this guide](../private-app-repository.md).
+Add new repositories (for example, your organization's chart repository) by clicking the "Add App Repository" button. Fill the "Add Repository" form using the repository info. For a detailed guide of how to add app repositories, check [this guide](./private-app-repository.md).
 
 ![Adding repository](../img/dashboard-add-repo.png)

--- a/docs/user/deploying-to-multiple-clusters.md
+++ b/docs/user/deploying-to-multiple-clusters.md
@@ -72,7 +72,7 @@ For more information about configuring Kubeapps, as opposed to the Kubernetes AP
 
 Once you have the cluster configuration for OIDC authentication sorted, we then need to ensure that Kubeapps is aware of the different clusters to which it can deploy applications.
 
-The `clusters` option available in the Kubeapps' chart `values.yaml` is a list of yaml maps, each defining at least the name you are assigning to the cluster as well as the api service URL for each additional cluster. For example, in the following configuration:
+The `clusters` option available in the Kubeapps' chart `values.yaml` is a list of yaml maps, each defining at least the name you are assigning to the cluster as well as the API service URL for each additional cluster. For example, in the following configuration:
 
 ```yaml
 clusters:
@@ -86,7 +86,7 @@ clusters:
    serviceToken: ...
 ```
 
-`default` is the name you are assigning to the cluster on which Kubeapps is itself installed. You can only define at most one cluster without an `apiServiceURL` corresponding to the cluster on which Kubeapps is installed, or don't provide one at all if you don't want users targeting the cluster on which Kubeapps is installed. For each additional clusters the `name` and `apiServiceURL` are the only required items.
+`default` is the name you are assigning to the cluster on which Kubeapps is itself installed. You can only define at most one cluster without an `apiServiceURL` corresponding to the cluster on which Kubeapps is installed, or don't provide one at all if you don't want users targeting the cluster on which Kubeapps is installed. For each additional cluster the `name` and `apiServiceURL` are the only required items.
 
 Note that the apiServiceURL can be a public or internal URL, the only restrictions being that:
 

--- a/docs/user/deploying-to-multiple-clusters.md
+++ b/docs/user/deploying-to-multiple-clusters.md
@@ -37,10 +37,10 @@ Certain multi-cluster environments, such as Tanzu Kubernetes Grid, have specific
 
 If you are testing the multi-cluster support on a local [Kubernetes-in-Docker cluster](https://kind.sigs.k8s.io/), you can view the example configuration files used for configuring two kind clusters in a local development environment:
 
-* [Kubeapps cluster API server config](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-apiserver-config.yaml)
-* An [additional cluster API server config](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml)
+* [Kubeapps cluster API server config](https://github.com/kubeapps/kubeapps/blob/master/docs/user/manifests/kubeapps-local-dev-apiserver-config.yaml)
+* An [additional cluster API server config](https://github.com/kubeapps/kubeapps/blob/master/docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml)
 
-These are used with an instance of Dex running in the Kubeapps cluster with a [matching configuration](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-dex-values.yaml) and Kubeapps itself [configured with its own auth-proxy](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml).
+These are used with an instance of Dex running in the Kubeapps cluster with a [matching configuration](https://github.com/kubeapps/kubeapps/blob/master/docs/user/manifests/kubeapps-local-dev-dex-values.yaml) and Kubeapps itself [configured with its own auth-proxy](https://github.com/kubeapps/kubeapps/blob/master/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml).
 
 Configuring your Kubernetes cluster for OIDC authentication can be tricky, despite the upstream documentation, so be prepared to check the logs of your `kube-apiserver` pod:
 
@@ -101,7 +101,7 @@ kubectl --kubeconfig ~/.kube/path-to-kube-confnig-file config view --raw -o json
 
 Alternatively, for a development with private API server URLs, you can omit the `certificateAuthorityData` and instead include the field `insecure: true` for a cluster and Kubeapps will not try to verify the secure connection.
 
-A serviceToken is not required but provides a better user experience, enabling users viewing the cluster to see the namespaces to which they have access (only) when they use the namespace selector. It's also used to retrieve icons of the available operators if the OLM is enabled. The service token should be configured with RBAC so that it can  list those resources. You can refer to the [example used for a local development environment](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml).
+A serviceToken is not required but provides a better user experience, enabling users viewing the cluster to see the namespaces to which they have access (only) when they use the namespace selector. It's also used to retrieve icons of the available operators if the OLM is enabled. The service token should be configured with RBAC so that it can  list those resources. You can refer to the [example used for a local development environment](https://github.com/kubeapps/kubeapps/blob/master/docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml).
 
 Your Kubeapps installation will also need to be [configured to use OIDC for authentication](./using-an-OIDC-provider.md) with a client-id for your chosen provider.
 
@@ -119,7 +119,7 @@ First your OIDC Provider needs to be configured so that tokens issued for the cl
 
 ### Configuring the auth-proxy to request multiple audiences
 
-The second part of the additional configuration is to ensure that when Kubeapps' auth-proxy requests a token that it includes extra scopes, such as `audience:server:client_id:second-cluster` for each additional audience that it requires in the issued token. For example, you can view the [auth-proxy configuration used in the local development environment](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml) and see the additional scopes included there to ensure that the `second-cluster` and `third-cluster` are included in the audience of the resulting token.
+The second part of the additional configuration is to ensure that when Kubeapps' auth-proxy requests a token that it includes extra scopes, such as `audience:server:client_id:second-cluster` for each additional audience that it requires in the issued token. For example, you can view the [auth-proxy configuration used in the local development environment](https://github.com/kubeapps/kubeapps/blob/master/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml) and see the additional scopes included there to ensure that the `second-cluster` and `third-cluster` are included in the audience of the resulting token.
 
 ## Updating multi-cluster options
 

--- a/docs/user/deploying-to-multiple-clusters.md
+++ b/docs/user/deploying-to-multiple-clusters.md
@@ -20,7 +20,7 @@ To use the multi-cluster support in Kubeapps, you must first setup your clusters
 
 ### Configuring your Kubernetes API servers for OIDC
 
-The multi-cluster feature requires that each of your Kubernetes API servers trusts the same OpenID Connect provider, whether that be a specific commercial OAuth2 provider such as Google, Azure or Github, or an instance of [Dex](https://github.com/dexidp/dex/blob/master/Documentation/kubernetes.md). After you have selected your OIDC provider you will need to configure at least one OAuth2 client to use. For example, if you are using Dex, you could use the following Dex configuration to create a single client id which can be used by your API servers:
+The multi-cluster feature requires that each of your Kubernetes API servers trusts the same OpenID Connect provider, whether that be a specific commercial OAuth2 provider such as Google, Azure or Github, or an instance of [Dex](https://dexidp.io/docs/kubernetes/). After you have selected your OIDC provider you will need to configure at least one OAuth2 client to use. For example, if you are using Dex, you could use the following Dex configuration to create a single client id which can be used by your API servers:
 
 ```yaml
   staticClients:
@@ -66,7 +66,7 @@ kubectl -n kube-system get po kube-apiserver-kubeapps-control-plane -o yaml | gr
     - '--oidc-username-prefix=oidc:'
 ```
 
-For more information about configuring Kubeapps, as opposed to the Kubernetes API server itself, with various OIDC providers see [Using an OIDC provider](../using-an-OIDC-provider.md). Similarly, the logs of the Kubeapps frontend `auth-proxy` container will provide more details for debugging authentication requests from Kubeapps itself.
+For more information about configuring Kubeapps, as opposed to the Kubernetes API server itself, with various OIDC providers see [Using an OIDC provider](./using-an-OIDC-provider.md). Similarly, the logs of the Kubeapps frontend `auth-proxy` container will provide more details for debugging authentication requests from Kubeapps itself.
 
 ## A Kubeapps Configuration example
 
@@ -103,7 +103,7 @@ Alternatively, for a development with private API server URLs, you can omit the 
 
 A serviceToken is not required but provides a better user experience, enabling users viewing the cluster to see the namespaces to which they have access (only) when they use the namespace selector. It's also used to retrieve icons of the available operators if the OLM is enabled. The service token should be configured with RBAC so that it can  list those resources. You can refer to the [example used for a local development environment](https://github.com/kubeapps/kubeapps/tree/master/docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml).
 
-Your Kubeapps installation will also need to be [configured to use OIDC for authentication](../using-an-OIDC-provider.md) with a client-id for your chosen provider.
+Your Kubeapps installation will also need to be [configured to use OIDC for authentication](./using-an-OIDC-provider.md) with a client-id for your chosen provider.
 
 ## Clusters with different client-ids
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -97,7 +97,7 @@ Once you have the Kubeapps Dashboard up and running, you can start deploying app
 
   ![WordPress installation](../img/wordpress-installation.png)
 
-- Click the "Deploy" button. The application will be deployed. You will be able to track the new Helm deployment directly from the browser. The status will be shown at the top, including the access URL and any secret includded with the app. You can also look at the individual resources lower in the page. It will also show the number of ready pods. If you run your cursor over the status, you can see the workloads and number of ready and total pods within them.
+- Click the "Deploy" button. The application will be deployed. You will be able to track the new Helm deployment directly from the browser. The status will be shown at the top, including the access URL and any secret included with the app. You can also look at the individual resources lower in the page. It will also show the number of ready pods. If you run your cursor over the status, you can see the workloads and number of ready and total pods within them.
 
   ![WordPress deployment](../img/wordpress-deployment.png)
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -78,7 +78,7 @@ Paste the token generated in the previous step to authenticate and access the Ku
 
 ![Dashboard main page](../img/dashboard-home.png)
 
-***Note:*** If you are setting up Kubeapps for other people to access, you will want to use a different service type or setup Ingress rather than using the above `kubectl port-forward`. For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](../../chart/kubeapps/README.md).
+***Note:*** If you are setting up Kubeapps for other people to access, you will want to use a different service type or setup Ingress rather than using the above `kubectl port-forward`. For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps)
 
 
 ## Step 4: Deploy WordPress
@@ -120,7 +120,7 @@ If you want to uninstall/delete your WordPress application, you can do so by cli
 
 Learn more about Kubeapps with the links below:
 
-- [Detailed installation instructions](../../chart/kubeapps/README.md)
+- [Detailed installation instructions](https://github.com/kubeapps/kubeapps/blob/master/chart/kubeapps/README.md)
 - [Deploying Operators](./operators.md)
 - [Kubeapps Dashboard documentation](./dashboard.md)
 - [Roadmap](https://github.com/kubeapps/kubeapps/wiki/Roadmap)

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -119,7 +119,7 @@ If you want to uninstall/delete your WordPress application, you can do so by cli
 
 Learn more about Kubeapps with the links below:
 
-- [Detailed installation instructions](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps)
-- [Deploying Operators](../operators.md)
-- [Kubeapps Dashboard documentation](../dashboard.md)
+- [Detailed installation instructions](../../chart/kubeapps/README.md)
+- [Deploying Operators](./operators.md)
+- [Kubeapps Dashboard documentation](./dashboard.md)
 - [Roadmap](https://github.com/kubeapps/kubeapps/wiki/Roadmap)

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -24,14 +24,14 @@ The above commands will deploy Kubeapps into the `kubeapps` namespace in your cl
 
 ## Step 2: Create a demo credential with which to access Kubeapps and Kubernetes
 
-For any user-facing installation you should [configure an OAuth2/OIDC provider](../using-an-OIDC-provider.md) to enable secure user authentication with Kubeapps and the cluster, but this is quite an overhead to simply try out Kubeapps. Instead, for a simpler way to try out Kubeapps for personal learning, we can create a Kubernetes service account and use that API token to authenticate with the Kubernetes API server via Kubeapps:
+For any user-facing installation you should [configure an OAuth2/OIDC provider](./using-an-OIDC-provider.md) to enable secure user authentication with Kubeapps and the cluster, but this is quite an overhead to simply try out Kubeapps. Instead, for a simpler way to try out Kubeapps for personal learning, we can create a Kubernetes service account and use that API token to authenticate with the Kubernetes API server via Kubeapps:
 
 ```bash
 kubectl create serviceaccount kubeapps-operator
 kubectl create clusterrolebinding kubeapps-operator --clusterrole=cluster-admin --serviceaccount=default:kubeapps-operator
 ```
 
-> **NOTE** It's not recommended to assign users the `cluster-admin` role for Kubeapps production usage. Please refer to the [Access Control](../access-control.md) documentation to configure fine-grained access control for users.
+> **NOTE** It's not recommended to assign users the `cluster-admin` role for Kubeapps production usage. Please refer to the [Access Control](./access-control.md) documentation to configure fine-grained access control for users.
 
 To retrieve the token,
 
@@ -78,7 +78,8 @@ Paste the token generated in the previous step to authenticate and access the Ku
 
 ![Dashboard main page](../img/dashboard-home.png)
 
-***Note:*** If you are setting up Kubeapps for other people to access, you will want to use a different service type or setup Ingress rather than using the above `kubectl port-forward`. For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps).
+***Note:*** If you are setting up Kubeapps for other people to access, you will want to use a different service type or setup Ingress rather than using the above `kubectl port-forward`. For detailed information on installing, configuring and upgrading Kubeapps, checkout the [chart README](../../chart/kubeapps/README.md).
+
 
 ## Step 4: Deploy WordPress
 

--- a/docs/user/offline-installation.md
+++ b/docs/user/offline-installation.md
@@ -46,7 +46,7 @@ You will need to follow a similar process for every image present in the values 
 
 By default, Kubeapps install the `bitnami` App Repository. Since, in order to sync that repository, it's necessary to have Internet connection, you will need to mirror it or create your own repository (e.g. using Harbor) and configure it when installing Kubeapps.
 
-For more information about how to create a private repository, follow this [guide](../private-app-repository.md).
+For more information about how to create a private repository, follow this [guide](./private-app-repository.md).
 
 ## 4. Install Kubeapps
 

--- a/docs/user/operators.md
+++ b/docs/user/operators.md
@@ -2,7 +2,7 @@
 
 This guide will walk you through the process of enabling support for Operators in Kubeapps and deploy an Operator instance.
 
-In this tutorial we will be using the the [Operator Lifecycle Manager (OLM)](https://github.com/operator-framework/operator-lifecycle-manager) to expose the Operators from the [OperatorHub](https://operatorhub.io/).
+In this tutorial we will be using the [Operator Lifecycle Manager (OLM)](https://github.com/operator-framework/operator-lifecycle-manager) to expose the Operators from the [OperatorHub](https://operatorhub.io/).
 
 ## Prerequisites
 
@@ -40,7 +40,7 @@ Let's deploy the "Akka Cluster Operator". When clicking on it, the information a
 
   ![Operators View](../img/operator-view.png)
 
-When clicking on the Deploy button, a form to deploy the operator will be displayed. There are two type of Operators: Global and namespaced. Namespaced Operators will be available in a single namespace while global Operators across the cluster. In this case, we are installing a global Operator:
+When clicking on the Deploy button, a form to deploy the operator will be displayed. There are two types of Operators: Global and namespaced. Namespaced Operators will be available in a single namespace while global Operators across the cluster. In this case, we are installing a global Operator:
 
   ![Operator Deployment Form](../img/operator-deployment.png)
 

--- a/docs/user/private-app-repository.md
+++ b/docs/user/private-app-repository.md
@@ -79,7 +79,7 @@ Once you create the repository you can click on the link for the specific reposi
 
 ### ChartMuseum: Authentication/Authorization
 
-It is possible to configure ChartMuseum to use authentication with two different mechanism:
+It is possible to configure ChartMuseum to use authentication with two different mechanisms:
 
 - Using HTTP [basic authentication](https://chartmuseum.com/docs/#basic-auth) (user/password). To use this feature, it's needed to:
   - Specify the parameters `secret.AUTH_USER` and `secret.AUTH_PASS` when deploying the ChartMuseum.
@@ -135,7 +135,7 @@ Click the project name to view the project details page, then click 'Helm Charts
 
 <img src="../img/harbor-list-charts.png" width="600px">
 
-Click 'UPLOAD' button to upload the Helm chart you previously created. You can also use helm command to upload chart too.
+Click 'UPLOAD' button to upload the Helm chart you previously created. You can also use helm command to upload the chart too.
 
 <img src="../img/harbor-upload-chart.png" width="500px">
 
@@ -152,7 +152,7 @@ Once you create the repository you can click on the link for the specific reposi
 It is possible to configure Harbor to use HTTP basic authentication:
 
   - When creating a new project for serving as the helm chart repository in Harbor, set the `Access Level` of the project to non public. This enforces authentication to access the charts in the chart repository via Helm CLI or other clients.
-  - When `Adding App Repository` in Kubeapps, select `Basic Auth` for `Authorization` and specifiy the username and password for Harbor.
+  - When `Adding App Repository` in Kubeapps, select `Basic Auth` for `Authorization` and specify the username and password for Harbor.
 
 ## Artifactory
 
@@ -164,7 +164,7 @@ To install Artifactory with Kubeapps first add the JFrog repository to Kubeapps.
 
 <img src="../img/jfrog-repository.png" alt="JFrog repository" width="300px">
 
-Then click on the JFrog repository and deploy Artifactory. For detailed installation instructions, check its [README](https://github.com/jfrog/charts/tree/master/stable/artifactory). If you don't have any further requirement, the default values will work.
+Then click on the JFrog repository and deploy Artifactory. For detailed installation instructions, check its [README](https://github.com/jfrog/charts/tree/master/stable/artifactory). If you don't have any further requirements, the default values will work.
 
 When deployed, in the setup wizard, select "Helm" to initialize a repository:
 

--- a/docs/user/private-app-repository.md
+++ b/docs/user/private-app-repository.md
@@ -90,7 +90,7 @@ It is possible to configure ChartMuseum to use authentication with two different
 
 [Harbor](https://github.com/goharbor/harbor) is an open source trusted cloud native registry project that stores, signs, and scans content, e.g. Docker images. Harbor is hosted by the [Cloud Native Computing Foundation](https://cncf.io/). Since version 1.6.0, Harbor is a composite cloud native registry which supports both container image management and Helm chart management. Harbor integrates [ChartMuseum](https://chartmuseum.com) to provide the Helm chart repository functionality. The access to Helm Charts in a Harbor Chart Repository can be controlled via Role-Based Access Control.
 
-To use Harbor with Kubeapps, first deploy the [Bitnami Harbor Helm Chart](https://github.com/bitnami/charts/tree/master/bitnami/harbor) from the `bitnami` repository (alternatively you can deploy Harbor using [Harbor offline installer](https://github.com/goharbor/harbor/blob/master/docs/installation_guide.md#downloading-the-installer)):
+To use Harbor with Kubeapps, first deploy the [Bitnami Harbor Helm Chart](https://github.com/bitnami/charts/tree/master/bitnami/harbor) from the `bitnami` repository (alternatively you can deploy Harbor using [Harbor offline installer](https://goharbor.io/docs/2.1.0/install-config/download-installer/)):
 
 <img src="../img/harbor-chart.png" alt="Harbor Chart" width="300px">
 
@@ -139,7 +139,7 @@ Click 'UPLOAD' button to upload the Helm chart you previously created. You can a
 
 <img src="../img/harbor-upload-chart.png" width="500px">
 
-Please refer to ['Manage Helm Charts in Harbor'](https://github.com/goharbor/harbor/blob/master/docs/user_guide.md#manage-helm-charts) for more details.
+Please refer to ['Manage Helm Charts in Harbor'](https://goharbor.io/docs/2.1.0/working-with-projects/working-with-images/managing-helm-charts) for more details.
 
 ### Harbor: Configure the repository in Kubeapps
 

--- a/docs/user/using-an-OIDC-provider.md
+++ b/docs/user/using-an-OIDC-provider.md
@@ -1,6 +1,6 @@
 # Using an OAuth2/OIDC Provider with Kubeapps
 
-OpenID Connect (OIDC) is a simple identity layer on top of the OAuth 2.0 protocol which allows clients to verify the identity of an user based on the authentication performed by an authorization server, as well as to obtain basic profile information about the user.
+OpenID Connect (OIDC) is a simple identity layer on top of the OAuth 2.0 protocol which allows clients to verify the identity of a user based on the authentication performed by an authorization server, as well as to obtain basic profile information about the user.
 
 It is possible to configure your Kubernetes cluster to use an OIDC provider in order to manage accounts, groups and roles with a single application. Additionally, some managed Kubernetes environments enable authenticating via plain OAuth2 (GKE).
 This guide will explain how you can use an existing OAuth2 provider, including OIDC, to authenticate users within Kubeapps.

--- a/docs/user/using-an-OIDC-provider.md
+++ b/docs/user/using-an-OIDC-provider.md
@@ -29,7 +29,7 @@ For Kubeapps to use an Identity Provider it's necessary to configure at least th
 
 **Note**: Depending on the configuration of the Identity Provider more parameters may be needed.
 
-Kubeapps uses [OAuth2 Proxy](https://github.com/pusher/oauth2_proxy) to handle the OAuth2/OpenIDConnect authentication. The following sections explain how you can find the parameters above for some of the identity providers tested. If you have configured your cluster to use an Identity Provider you will already know some of these parameters. More detailed information can be found on the [OAuth2 Proxy Auth configuration page](https://pusher.github.io/oauth2_proxy/auth-configuration).
+Kubeapps uses [OAuth2 Proxy](https://github.com/oauth2-proxy/oauth2-proxy) to handle the OAuth2/OpenIDConnect authentication. The following sections explain how you can find the parameters above for some of the identity providers tested. If you have configured your cluster to use an Identity Provider you will already know some of these parameters. More detailed information can be found on the [OAuth2 Proxy Auth configuration page](https://oauth2-proxy.github.io/oauth2-proxy/auth-configuration).
 
 ### Keycloak
 
@@ -67,7 +67,7 @@ In the case of Google we can use an OAuth 2.0 client ID. You can find more infor
 
 ## Deploying a proxy to access Kubeapps
 
-The main difference in the authentication is that instead of accessing the Kubeapps service, we will be accessing an oauth2 proxy service that is in charge of authenticating users with the identity provider and injecting the required credentials in the requests to Kubeapps. There are a number of available solutions for this use-case, like [keycloak-gatekeeper](https://github.com/keycloak/keycloak-gatekeeper) and [oauth2_proxy](https://github.com/pusher/oauth2_proxy). For this guide we will use `oauth2_proxy` since it supports both OIDC and plain OAuth2 for many providers.
+The main difference in the authentication is that instead of accessing the Kubeapps service, we will be accessing an oauth2 proxy service that is in charge of authenticating users with the identity provider and injecting the required credentials in the requests to Kubeapps. There are a number of available solutions for this use-case, like [keycloak-gatekeeper](https://github.com/keycloak/keycloak-gatekeeper) and [oauth2_proxy](https://github.com/oauth2-proxy/oauth2-proxy). For this guide we will use `oauth2_proxy` since it supports both OIDC and plain OAuth2 for many providers.
 
 Once the proxy is accessible, you will be redirected to the identity provider to authenticate. After successfully authenticating, you will be redirected to Kubeapps and be authenticated with your user's OIDC token.
 
@@ -94,7 +94,7 @@ helm install kubeapps bitnami/kubeapps \
 
 **Example 2: Using a custom oauth2-proxy provider**
 
-Some of the specific providers that come with `oauth2-proxy` are using OpenIDConnect to obtain the required IDToken and can be used instead of the generic oidc provider. Currently this includes only the GitLab, Google and LoginGov providers (see [OAuth2_Proxy's provider configuration](https://pusher.github.io/oauth2_proxy/auth-configuration) for the full list of OAuth2 providers). The user authentication flow is the same as above, with some small UI differences, such as the default login button is customized to the provider (rather than "Login with OpenID Connect"), or improved presentation when accepting the requested scopes (as is the case with Google, but only visible if you request extra scopes).
+Some of the specific providers that come with `oauth2-proxy` are using OpenIDConnect to obtain the required IDToken and can be used instead of the generic oidc provider. Currently this includes only the GitLab, Google and LoginGov providers (see [OAuth2_Proxy's provider configuration](https://oauth2-proxy.github.io/oauth2-proxy/configuration) for the full list of OAuth2 providers). The user authentication flow is the same as above, with some small UI differences, such as the default login button is customized to the provider (rather than "Login with OpenID Connect"), or improved presentation when accepting the requested scopes (as is the case with Google, but only visible if you request extra scopes).
 
 Here we no longer need to provide the issuer -url as an additional flag:
 
@@ -204,7 +204,7 @@ The above is a sample deployment, depending on the configuration of the Identity
 - `-upstream`: Internal URL for the `kubeapps` service.
 - `-http-address=0.0.0.0:3000`: Listen in all the interfaces.
 
-**NOTE**: If the identity provider is deployed with a self-signed certificate (which may be the case for Keycloak or Dex) you will need to disable the TLS and cookie verification. For doing so you can add the flags `-ssl-insecure-skip-verify` and `--cookie-secure=false` to the deployment above. You can find more options for `oauth2-proxy` [here](https://pusher.github.io/oauth2_proxy/docs/configuration).
+**NOTE**: If the identity provider is deployed with a self-signed certificate (which may be the case for Keycloak or Dex) you will need to disable the TLS and cookie verification. For doing so you can add the flags `-ssl-insecure-skip-verify` and `--cookie-secure=false` to the deployment above. You can find more options for `oauth2-proxy` [here](https://oauth2-proxy.github.io/oauth2-proxy/configuration).
 
 #### Exposing the proxy
 


### PR DESCRIPTION
### Description of the change

Across the years, some external links have changed (e.g., v2 Helm docs, oauth2-proxy was renamed, Harbor moved docs from GitHub, etc.). Besides, a bunch of relative links was pointing to nowhere.
This PR intents to keep up to date the Kubeapps documentation links.

### Benefits

The broken links from the Kubeapps GitHub docs should not exist (al least for, hopefully, a while).

### Possible drawbacks

If any external action is automatically using this docs source in order to generate an external documentation portal, this PR could affect it. Please, check it before merging.

### Applicable issues

No issue 

### Additional information

During this process, I've noticed that contacting the project team belongs to a former member. I didn't take further action, but I suppose it should be changed at some point.

https://github.com/kubeapps/kubeapps/blob/master/CONTRIBUTING.md#enforcement