### PR TITLE
Add a /refresh endpoint for forcing an update in an AppRepository

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -149,22 +149,6 @@ describe("deleteRepo", () => {
 });
 
 describe("resyncRepo", () => {
-  it("dispatches errorRepos if error on #get", async () => {
-    AppRepository.get = jest.fn().mockImplementationOnce(() => {
-      throw new Error("Boom!");
-    });
-
-    const expectedActions = [
-      {
-        type: getType(repoActions.errorRepos),
-        payload: { err: new Error("Boom!"), op: "update" },
-      },
-    ];
-
-    await store.dispatch(repoActions.resyncRepo("foo", "my-namespace"));
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-
   it("dispatches errorRepos if error on #update", async () => {
     AppRepository.resync = jest.fn().mockImplementationOnce(() => {
       throw new Error("Boom!");

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -18,7 +18,7 @@ export class AppRepository {
 
   public static async resync(cluster: string, name: string, namespace: string) {
     const { data } = await axiosWithAuth.post(
-      url.backend.apprepositories.refresh(cluster, name, namespace),
+      url.backend.apprepositories.refresh(cluster, namespace, name),
       null,
     );
     return data;

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -17,12 +17,9 @@ export class AppRepository {
   }
 
   public static async resync(cluster: string, name: string, namespace: string) {
-    const repo = await AppRepository.get(cluster, name, namespace);
-    repo.spec.resyncRequests = repo.spec.resyncRequests || 0;
-    repo.spec.resyncRequests++;
-    const { data } = await axiosWithAuth.put(
-      AppRepository.getSelfLink(cluster, namespace, name),
-      repo,
+    const { data } = await axiosWithAuth.post(
+      url.backend.apprepositories.refresh(cluster, name, namespace),
+      null,
     );
     return data;
   }

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -80,7 +80,7 @@ export const backend = {
       backend.apprepositories.base(cluster, namespace),
     list: (cluster: string, namespace: string) => backend.apprepositories.base(cluster, namespace),
     validate: (cluster: string) => `${backend.apprepositories.base(cluster, "kubeapps")}/validate`,
-    delete: (cluster: string, namespace: string, name: string) =>
+    delete: (cluster: string, name: string, namespace: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,
     refresh: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}/refresh`,

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -80,9 +80,9 @@ export const backend = {
       backend.apprepositories.base(cluster, namespace),
     list: (cluster: string, namespace: string) => backend.apprepositories.base(cluster, namespace),
     validate: (cluster: string) => `${backend.apprepositories.base(cluster, "kubeapps")}/validate`,
-    delete: (cluster: string, name: string, namespace: string) =>
+    delete: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,
-    refresh: (cluster: string, name: string, namespace: string) =>
+    refresh: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}/refresh`,
     update: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -82,6 +82,8 @@ export const backend = {
     validate: (cluster: string) => `${backend.apprepositories.base(cluster, "kubeapps")}/validate`,
     delete: (cluster: string, name: string, namespace: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,
+    refresh: (cluster: string, name: string, namespace: string) =>
+      `${backend.apprepositories.base(cluster, namespace)}/${name}/refresh`,
     update: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,
   },

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -60,6 +60,11 @@ func (c *FakeHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestName
 	return c.CreatedRepo, c.Err
 }
 
+// RefreshAppRepository fake
+func (c *FakeHandler) RefreshAppRepository(repoName string, requestNamespace string) (*v1alpha1.AppRepository, error) {
+	return c.UpdatedRepo, c.Err
+}
+
 // UpdateAppRepository fake
 func (c *FakeHandler) UpdateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error) {
 	return c.UpdatedRepo, c.Err

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -452,7 +452,7 @@ func (a *userHandler) RefreshAppRepository(repoName string, requestNamespace str
 		return nil, err
 	}
 
-	// An updated is forced if the ResyncRequests property changes,
+	// An update is forced if the ResyncRequests property changes,
 	// so we increase it in the retrieved object
 	appRepo.Spec.ResyncRequests++
 

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -166,6 +166,7 @@ type handler interface {
 	ListAppRepositories(requestNamespace string) (*v1alpha1.AppRepositoryList, error)
 	CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error)
 	UpdateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error)
+	RefreshAppRepository(repoName string, requestNamespace string) (*v1alpha1.AppRepository, error)
 	DeleteAppRepository(name, namespace string) error
 	GetNamespaces() ([]corev1.Namespace, error)
 	GetSecret(name, namespace string) (*corev1.Secret, error)
@@ -440,6 +441,32 @@ func (a *userHandler) UpdateAppRepository(appRepoBody io.ReadCloser, requestName
 			return nil, err
 		}
 	}
+	return appRepo, nil
+}
+
+// RefreshAppRepository forces a refresh in a given apprepository (by updating resyncRequests property)
+func (a *userHandler) RefreshAppRepository(repoName string, requestNamespace string) (*v1alpha1.AppRepository, error) {
+	if a.kubeappsNamespace == "" {
+		log.Errorf("attempt to use app repositories handler without kubeappsNamespace configured")
+		return nil, fmt.Errorf("kubeappsNamespace must be configured to enable app repository handler")
+	}
+
+	// retrive the repo object with name=repoName
+	appRepo, err := a.clientset.KubeappsV1alpha1().AppRepositories(requestNamespace).Get(context.TODO(), repoName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// an updated is forced if the ResyncRequests property changes,
+	// so we increase it in the retrieved object
+	appRepo.Spec.ResyncRequests++
+
+	// Update existing repo with the new spec (ie ResyncRequests++)
+	appRepo, err = a.clientset.KubeappsV1alpha1().AppRepositories(requestNamespace).Update(context.TODO(), appRepo, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
 	return appRepo, nil
 }
 

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -446,18 +446,13 @@ func (a *userHandler) UpdateAppRepository(appRepoBody io.ReadCloser, requestName
 
 // RefreshAppRepository forces a refresh in a given apprepository (by updating resyncRequests property)
 func (a *userHandler) RefreshAppRepository(repoName string, requestNamespace string) (*v1alpha1.AppRepository, error) {
-	if a.kubeappsNamespace == "" {
-		log.Errorf("attempt to use app repositories handler without kubeappsNamespace configured")
-		return nil, fmt.Errorf("kubeappsNamespace must be configured to enable app repository handler")
-	}
-
-	// retrive the repo object with name=repoName
+	// Retrieve the repo object with name=repoName
 	appRepo, err := a.clientset.KubeappsV1alpha1().AppRepositories(requestNamespace).Get(context.TODO(), repoName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	// an updated is forced if the ResyncRequests property changes,
+	// An updated is forced if the ResyncRequests property changes,
 	// so we increase it in the retrieved object
 	appRepo.Spec.ResyncRequests++
 


### PR DESCRIPTION
### Description of the change

As discussed in #2062 , an endpoint to trigger a refresh in a given repository was requested. Internally, a refresh is being triggered when resyncRequests property changes. This PR creates an endpoint for doing so.
It also has implications on the frontend side, since it is no longer need to use de old logic (GET the appRepo, increase the resyncRequests and PUT it back).

### Benefits

This PR enables third-party integrations (i.e., Harbor webhooks) to manually trigger an update in a given AppRepository whenever needed.
Furthermore, on the frontend side, we no longer need to perform two requests, one is enough.

### Possible drawbacks

I can't see any negative implications in the short term. Perhaps we should re-think webhook and subscription mechanisms in the future and revisit this /refresh approach

### Applicable issues

  - fixes #2062

### Additional information

For example, a `POST /api/v1/clusters/default/namespaces/kubeapps/apprepositories/bitnami/refresh` will trigger a refresh in the `bitnami` appRepository in the namespace `kubeapps`.
