### PR TITLE
Add search (crtl+F) in ACE editors

### DIFF
--- a/dashboard/src/components/AppView/AppValues/AppValues.tsx
+++ b/dashboard/src/components/AppView/AppValues/AppValues.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import AceEditor from "react-ace";
 
+import "ace-builds/src-noconflict/ext-searchbox";
+import "ace-builds/src-noconflict/mode-yaml";
+import "ace-builds/src-noconflict/theme-xcode";
 import "./AppValues.css";
 
 interface IAppValuesProps {

--- a/dashboard/src/components/DeploymentFormBody/AdvancedDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/AdvancedDeploymentForm.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import AceEditor from "react-ace";
 
+import "ace-builds/src-noconflict/ext-searchbox";
 import "ace-builds/src-noconflict/mode-yaml";
 import "ace-builds/src-noconflict/theme-xcode";
 


### PR DESCRIPTION
### Description of the change

ACE text editors have lots of features out-of-the-box ready to be used. For instance,  the keybind Crtl+F should trigger a search box for searching within the text. However, this feature was not enabled. This PR is to support that.

### Benefits
Crtl+F will now trigger a searchbox to appear.

![image](https://user-images.githubusercontent.com/11535726/98099079-6b0b6e80-1e8f-11eb-92d5-93a4131d61f4.png)


### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

See the full list of ACE modules here: https://github.com/ajaxorg/ace-builds/blob/master/ace-modules.d.ts
