### PR TITLE
Update app manifest to match with actual favicons

### DIFF
--- a/dashboard/public/manifest.json
+++ b/dashboard/public/manifest.json
@@ -4,7 +4,27 @@
   "icons": [
     {
       "src": "favicon.ico",
-      "sizes": "192x192",
+      "sizes": "32x32",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "favicon-16x16.png",
+      "sizes": "16x16",
+      "type": "image/png"
+    },
+    {
+      "src": "favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "favicon-128.png",
+      "sizes": "128x128",
+      "type": "image/png"
+    },
+    {
+      "src": "favicon-196x196.png",
+      "sizes": "196x196",
       "type": "image/png"
     }
   ],


### PR DESCRIPTION
# Description of the change

Wrong favicon declaration was causing a mismatch and, therefore, a console warning was being thrown: `Error while trying to use the following icon from the Manifest: http://localhost:8080/favicon.ico (Resource size is not correct - typo in the Manifest?)`.

This PR simply declares the existing favicons in the manifest.json.

### Benefits

No error is thrown in the console.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
