### PR TITLE
Change ordering in some arguments to "cluster, namespace, other args"

### DIFF
--- a/dashboard/src/actions/catalog.test.tsx
+++ b/dashboard/src/actions/catalog.test.tsx
@@ -323,8 +323,8 @@ describe("removeBinding", () => {
     expect(store.getActions().length).toBe(0);
     expect(ServiceBinding.delete).toHaveBeenCalledWith(
       testArgs.kubeappsCluster,
-      testArgs.bindingName,
       testArgs.namespace,
+      testArgs.bindingName,
     );
   });
 

--- a/dashboard/src/actions/catalog.ts
+++ b/dashboard/src/actions/catalog.ts
@@ -126,7 +126,7 @@ export function removeBinding(
       clusters: { currentCluster },
     } = getState();
     try {
-      await ServiceBinding.delete(currentCluster, name, namespace);
+      await ServiceBinding.delete(currentCluster, namespace, name);
       return true;
     } catch (e) {
       dispatch(errorCatalog(e, "delete"));

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -189,19 +189,19 @@ describe("resyncAllRepos", () => {
     await store.dispatch(
       repoActions.resyncAllRepos([
         {
-          name: "foo",
           namespace: "namespace-1",
+          name: "foo",
         },
         {
-          name: "bar",
           namespace: "namespace-2",
+          name: "bar",
         },
       ]),
     );
 
     expect(appRepoGetMock).toHaveBeenCalledTimes(2);
-    expect(appRepoGetMock.mock.calls[0]).toEqual(["default", "foo", "namespace-1"]);
-    expect(appRepoGetMock.mock.calls[1]).toEqual(["default", "bar", "namespace-2"]);
+    expect(appRepoGetMock.mock.calls[0]).toEqual(["default", "namespace-1", "foo"]);
+    expect(appRepoGetMock.mock.calls[1]).toEqual(["default", "namespace-2", "bar"]);
   });
 });
 

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -125,7 +125,7 @@ export const deleteRepo = (
       },
     } = getState();
     try {
-      await AppRepository.delete(currentCluster, name, namespace);
+      await AppRepository.delete(currentCluster, namespace, name);
       dispatch(fetchRepos(currentNamespace));
       return true;
     } catch (e) {
@@ -144,7 +144,7 @@ export const resyncRepo = (
       clusters: { currentCluster },
     } = getState();
     try {
-      await AppRepository.resync(currentCluster, name, namespace);
+      await AppRepository.resync(currentCluster, namespace, name);
     } catch (e) {
       dispatch(errorRepos(e, "update"));
     }
@@ -187,7 +187,7 @@ export const fetchRepoSecret = (
     const {
       clusters: { currentCluster },
     } = getState();
-    const secret = await Secret.get(currentCluster, name, namespace);
+    const secret = await Secret.get(currentCluster, namespace, name);
     dispatch(receiveReposSecret(secret));
   };
 };
@@ -366,7 +366,7 @@ export function checkChart(
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> {
   return async (dispatch, getState) => {
     dispatch(requestRepo());
-    const appRepository = await AppRepository.get(cluster, repo, repoNamespace);
+    const appRepository = await AppRepository.get(cluster, repoNamespace, repo);
     try {
       await Chart.fetchChartVersions(cluster, repoNamespace, `${repo}/${chartName}`);
       dispatch(receiveRepo(appRepository));

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -11,13 +11,13 @@ export class AppRepository {
     return appRepository;
   }
 
-  public static async get(cluster: string, name: string, namespace: string) {
+  public static async get(cluster: string, namespace: string, name: string) {
     const { data } = await axiosWithAuth.get(AppRepository.getSelfLink(cluster, namespace, name));
     return data;
   }
 
-  public static async resync(cluster: string, name: string, namespace: string) {
-    const repo = await AppRepository.get(cluster, name, namespace);
+  public static async resync(cluster: string, namespace: string, name: string) {
+    const repo = await AppRepository.get(cluster, namespace, name);
     repo.spec.resyncRequests = repo.spec.resyncRequests || 0;
     repo.spec.resyncRequests++;
     const { data } = await axiosWithAuth.put(
@@ -46,9 +46,9 @@ export class AppRepository {
     return data;
   }
 
-  public static async delete(cluster: string, name: string, namespace: string) {
+  public static async delete(cluster: string, namespace: string, name: string) {
     const { data } = await axiosWithAuth.delete(
-      url.backend.apprepositories.delete(cluster, name, namespace),
+      url.backend.apprepositories.delete(cluster, namespace, name),
     );
     return data;
   }

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -14,29 +14,31 @@ export default class Namespace {
     return data;
   }
 
-  public static async create(cluster: string, name: string) {
+  public static async create(cluster: string, namespace: string) {
     const { data } = await axiosWithAuth.post<IResource>(url.api.k8s.namespaces(cluster), {
       apiVersion: "v1",
       kind: "Namespace",
       metadata: {
-        name,
+        name: namespace,
       },
     });
     return data;
   }
 
-  public static async get(cluster: string, name: string) {
+  public static async get(cluster: string, namespace: string) {
     try {
-      const { data } = await axiosWithAuth.get<IResource>(url.api.k8s.namespace(cluster, name));
+      const { data } = await axiosWithAuth.get<IResource>(
+        url.api.k8s.namespace(cluster, namespace),
+      );
       return data;
     } catch (err) {
       switch (err.constructor) {
         case ForbiddenError:
           throw new ForbiddenError(
-            `You don't have sufficient permissions to use the namespace ${name}`,
+            `You don't have sufficient permissions to use the namespace ${namespace}`,
           );
         case NotFoundError:
-          throw new NotFoundError(`Namespace ${name} not found. Create it before using it.`);
+          throw new NotFoundError(`Namespace ${namespace} not found. Create it before using it.`);
         default:
           throw err;
       }

--- a/dashboard/src/shared/Secret.test.ts
+++ b/dashboard/src/shared/Secret.test.ts
@@ -3,7 +3,7 @@ import Secret from "./Secret";
 
 it("gets a secret", async () => {
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: "ok" });
-  await Secret.get("default", "foo", "bar");
+  await Secret.get("default", "bar", "foo");
   expect(axiosWithAuth.get).toHaveBeenCalledWith(
     "api/clusters/default/api/v1/namespaces/bar/secrets/foo",
   );

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -3,7 +3,7 @@ import { IK8sList, ISecret } from "./types";
 import * as url from "./url";
 
 export default class Secret {
-  public static async get(cluster: string, name: string, namespace: string) {
+  public static async get(cluster: string, namespace: string, name: string) {
     const u = url.api.k8s.secret(cluster, namespace, name);
     const { data } = await axiosWithAuth.get<ISecret>(u);
     return data;

--- a/dashboard/src/shared/ServiceBinding.ts
+++ b/dashboard/src/shared/ServiceBinding.ts
@@ -73,7 +73,7 @@ export class ServiceBinding {
     return data;
   }
 
-  public static async delete(cluster: string, name: string, namespace: string) {
+  public static async delete(cluster: string, namespace: string, name: string) {
     const u = this.getLink(cluster, namespace, name);
     return axiosWithAuth.delete(u);
   }

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -80,7 +80,7 @@ export const backend = {
       backend.apprepositories.base(cluster, namespace),
     list: (cluster: string, namespace: string) => backend.apprepositories.base(cluster, namespace),
     validate: (cluster: string) => `${backend.apprepositories.base(cluster, "kubeapps")}/validate`,
-    delete: (cluster: string, name: string, namespace: string) =>
+    delete: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,
     update: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,


### PR DESCRIPTION
### Description of the change

`cluster, others, namespace` and `cluster, namespace, others` orderings were mixed up across the code. This PR review each file using these methods and changes the order properly. Tests changed accordingly.

### Benefits

Now the two first arguments will be `cluster, namespace`. It was quite odd to be constantly mixing these two orderings and may lead to accidental errors due to a parameter misteaching (note normally they are both _string_ so no type alert will be thrown).

### Possible drawbacks

Despite the best effort applied in looking up each method usage, it is slightly possible to have missed some reference.

### Applicable issues

- This PR has been generated after the discussion in PR #2138.

### Additional information

N/A
