### PR TITLE
Update node version in docs

### DIFF
--- a/docs/developer/dashboard.md
+++ b/docs/developer/dashboard.md
@@ -5,7 +5,7 @@ The dashboard is the main UI component of the Kubeapps project. Written in Javas
 ## Prerequisites
 
 - [Git](https://git-scm.com/)
-- [Node 8.x](https://nodejs.org/)
+- [Node 12.x](https://nodejs.org/)
 - [Yarn](https://yarnpkg.com)
 - [Kubernetes cluster (v1.8+)](https://kubernetes.io/docs/setup/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)


### PR DESCRIPTION
### Description of the change

Since we use methods like .flat() a ^11.0.0 version is required. Docker image currently uses 12, so the version in the docs is being updated to match.

### Benefits

Dashboard developers won't get misleading information regarding the proper Node version to use.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A