### PR TITLE
Allow to bypass the oauth loading page

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 4.0.4
+version: 4.0.5
 appVersion: DEVEL
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -48,6 +48,7 @@ data:
       "authProxyEnabled": {{ .Values.authProxy.enabled }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},
+      "authProxySkipLoginPage": {{ .Values.authProxy.skipKubeappsLoginPage }}
       "featureFlags": {{ .Values.featureFlags | toJson }},
       "clusters": {{ template "kubeapps.clusterNames" . }}
     }

--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -48,7 +48,7 @@ data:
       "authProxyEnabled": {{ .Values.authProxy.enabled }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},
-      "authProxySkipLoginPage": {{ .Values.authProxy.skipKubeappsLoginPage }}
+      "authProxySkipLoginPage": {{ .Values.authProxy.skipKubeappsLoginPage }},
       "featureFlags": {{ .Values.featureFlags | toJson }},
       "clusters": {{ template "kubeapps.clusterNames" . }}
     }

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -559,6 +559,11 @@ authProxy:
   ##
   oauthLoginURI: /oauth2/start
   oauthLogoutURI: /oauth2/sign_out
+
+  ## Skip the Kubeapps login page when using OIDC and directly redirect to the IdP
+  ##
+  skipKubeappsLoginPage: false
+
   ## The remaining auth proxy values are relevant only if an internal auth-proxy is
   ## being configured by Kubeapps.
   ## Bitnami OAuth2 Proxy image

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -3,6 +3,7 @@
   "kubeappsNamespace": "kubeapps",
   "appVersion": "DEVEL",
   "authProxyEnabled": false,
+  "authProxySkipLoginPage": false,
   "oauthLoginURI": "/oauth2/start",
   "oauthLogoutURI": "/oauth2/sign_out",
   "clusters": ["default"]

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -99,10 +99,9 @@ export function checkCookieAuthentication(
     const isAuthed = await Auth.isAuthenticatedWithCookie(cluster);
     if (isAuthed) {
       await dispatch(authenticate(cluster, "", true));
-      return true;
     } else {
       dispatch(setAuthenticated(false, false, ""));
-      return false;
     }
+    return isAuthed;
   };
 }

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -90,7 +90,7 @@ export function expireSession(): ThunkAction<Promise<void>, IStoreState, null, A
 
 export function checkCookieAuthentication(
   cluster: string,
-): ThunkAction<Promise<void>, IStoreState, null, AuthAction> {
+): ThunkAction<Promise<boolean>, IStoreState, null, AuthAction> {
   return async dispatch => {
     // The call to authenticate below will also dispatch authenticating,
     // but we dispatch it early so that the login screen is shown as
@@ -99,8 +99,10 @@ export function checkCookieAuthentication(
     const isAuthed = await Auth.isAuthenticatedWithCookie(cluster);
     if (isAuthed) {
       await dispatch(authenticate(cluster, "", true));
+      return true;
     } else {
       dispatch(setAuthenticated(false, false, ""));
+      return false;
     }
   };
 }

--- a/dashboard/src/components/LoginForm/__snapshots__/LoginForm.test.tsx.snap
+++ b/dashboard/src/components/LoginForm/__snapshots__/LoginForm.test.tsx.snap
@@ -1,37 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`oauth login form renders a login button link 1`] = `
-<div
-  className="login-wrapper"
->
-  <form
-    className="login clr-form"
-    onSubmit={[Function]}
-  >
-    <OAuthLogin
-      oauthLoginURI="/sign/in"
-    />
-    <div
-      className="login-moreinfo"
-    >
-      <a
-        href="https://github.com/kubeapps/kubeapps/blob/devel/docs/user/access-control.md"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        <CdsIcon
-          shape="info-circle"
-        />
-        More Info
-      </a>
-    </div>
-  </form>
-</div>
-`;
-
 exports[`token login form displays an error if the authentication error is passed 1`] = `
 <LoginForm
   appVersion="devel"
+  authProxySkipLoginPage={false}
   authenticate={[MockFunction]}
   authenticated={false}
   authenticating={false}
@@ -150,36 +122,6 @@ exports[`token login form displays an error if the authentication error is passe
     </form>
   </div>
 </LoginForm>
-`;
-
-exports[`token login form renders a token login form 1`] = `
-<div
-  className="login-wrapper"
->
-  <form
-    className="login clr-form"
-    onSubmit={[Function]}
-  >
-    <TokenLogin
-      handleTokenChange={[Function]}
-      token=""
-    />
-    <div
-      className="login-moreinfo"
-    >
-      <a
-        href="https://github.com/kubeapps/kubeapps/blob/devel/docs/user/access-control.md"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        <CdsIcon
-          shape="info-circle"
-        />
-        More Info
-      </a>
-    </div>
-  </form>
-</div>
 `;
 
 exports[`while authenticating loading spinner matches the snapshot 1`] = `

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -37,6 +37,7 @@ const makeStore = (
     appVersion: "",
     oauthLogoutURI: "",
     clusters: [],
+    authProxySkipLoginPage: false,
   };
   const clusters: IClustersState = {
     currentCluster: "default",

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.ts
@@ -8,7 +8,7 @@ import { IStoreState } from "../../shared/types";
 
 function mapStateToProps({
   auth: { authenticated, authenticating, authenticationError },
-  config: { authProxyEnabled, oauthLoginURI, appVersion },
+  config: { authProxyEnabled, oauthLoginURI, appVersion, authProxySkipLoginPage },
   clusters,
 }: IStoreState) {
   return {
@@ -17,6 +17,7 @@ function mapStateToProps({
     authenticationError,
     cluster: clusters.currentCluster,
     oauthLoginURI: authProxyEnabled ? oauthLoginURI : "",
+    authProxySkipLoginPage,
     appVersion,
   };
 }

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -321,6 +321,7 @@ describe("clusterReducer", () => {
         ui: "hex",
       },
       clusters: ["additionalCluster1", "additionalCluster2"],
+      authProxySkipLoginPage: false,
     } as IConfig;
     it("re-writes the clusters to match the config.clusters state", () => {
       expect(

--- a/dashboard/src/reducers/config.ts
+++ b/dashboard/src/reducers/config.ts
@@ -15,6 +15,7 @@ export const initialState: IConfigState = {
   authProxyEnabled: false,
   oauthLoginURI: "",
   oauthLogoutURI: "",
+  authProxySkipLoginPage: false,
   clusters: [],
 };
 

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -170,6 +170,7 @@ describe("Auth", () => {
         kubeappsNamespace: "ns",
         appVersion: "2",
         clusters: [],
+        authProxySkipLoginPage: false,
       });
 
       expect(mockedAssign).toBeCalledWith(oauthLogoutURI);
@@ -185,6 +186,7 @@ describe("Auth", () => {
         kubeappsNamespace: "ns",
         appVersion: "2",
         clusters: [],
+        authProxySkipLoginPage: false,
       });
 
       expect(mockedAssign).toBeCalledWith("/oauth2/sign_out");

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -8,6 +8,7 @@ export interface IConfig {
   authProxyEnabled: boolean;
   oauthLoginURI: string;
   oauthLogoutURI: string;
+  authProxySkipLoginPage: boolean;
   error?: Error;
   clusters: string[];
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

As per #2109, allow users to configure Kubeapps so it skips the login/welcome page and redirect directly to the OAuth login URI.

To use it, a value is exposed in the chart: `--set authProxy.skipKubeappsLoginPage=true`.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2109 
