### PR TITLE
2144 pull secrets in jobs fix

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -258,11 +258,3 @@ Returns a JSON list of cluster names only (without sensitive tokens etc.)
     {{- end }}
     {{- $sanitizedClusters | toJson }}
 {{- end -}}
-
-{{/*
-Returns a comma separated string from a list
-*/}}
-{{- define "kubeapps.joinListWithComma" -}}
-{{- $local := dict "first" true -}}
-{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
-{{- end -}}

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -258,3 +258,11 @@ Returns a JSON list of cluster names only (without sensitive tokens etc.)
     {{- end }}
     {{- $sanitizedClusters | toJson }}
 {{- end -}}
+
+{{/*
+Returns a comma separated string from a list
+*/}}
+{{- define "kubeapps.joinListWithComma" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -43,8 +43,10 @@ spec:
           args:
             - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
             - --repo-sync-image={{ template "kubeapps.image" (list .Values.apprepository.syncImage .Values.global) }}
-            {{- if .Values.global.imagePullSecrets }}
+            {{- if .Values.global}} 
+              {{- if.Values.global.imagePullSecrets }}
             - --repo-sync-image-pullsecrets={{- include "kubeapps.joinListWithComma" .Values.global.imagePullSecrets}}
+              {{- end}}
             {{- end}}
             - --repo-sync-cmd=/asset-syncer
             - --namespace={{ .Release.Namespace }}

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -43,11 +43,13 @@ spec:
           args:
             - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
             - --repo-sync-image={{ template "kubeapps.image" (list .Values.apprepository.syncImage .Values.global) }}
-            {{- if .Values.global}} 
-              {{- if.Values.global.imagePullSecrets }}
-            - --repo-sync-image-pullsecrets={{- include "kubeapps.joinListWithComma" .Values.global.imagePullSecrets}}
-              {{- end}}
-            {{- end}}
+           {{- if .Values.global }}
+             {{- if.Values.global.imagePullSecrets }}
+               {{- range $key, $value := .Values.global.imagePullSecrets }}
+            -  --repo-sync-image-pullsecrets={{ $value | quote }}
+               {{- end }}
+             {{- end }}
+           {{- end }}
             - --repo-sync-cmd=/asset-syncer
             - --namespace={{ .Release.Namespace }}
             - --database-secret-name={{ .Values.postgresql.existingSecret }}

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -43,6 +43,9 @@ spec:
           args:
             - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
             - --repo-sync-image={{ template "kubeapps.image" (list .Values.apprepository.syncImage .Values.global) }}
+            {{- if .Values.global.imagePullSecrets }}
+            - --repo-sync-image-pullsecrets={{- include "kubeapps.joinListWithComma" .Values.global.imagePullSecrets}}
+            {{- end}}
             - --repo-sync-cmd=/asset-syncer
             - --namespace={{ .Release.Namespace }}
             - --database-secret-name={{ .Values.postgresql.existingSecret }}

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -13,20 +13,7 @@ import (
 )
 
 func Test_newCronJob(t *testing.T) {
-	kubeconfig := ""
-	masterURL := ""
-	repoSyncImage := "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
-	repoSyncImagePullSecrets := []string{}
-	repoSyncCommand := "/chart-repo"
-	kubeappsNamespace := "kubeapps"
-	reposPerNamespace := true
-	dbURL := "postgresql.kubeapps"
-	dbUser := "admin"
-	dbName := "assets"
-	dbSecretName := "postgresql"
-	dbSecretKey := "postgresql-root-password"
-	userAgentComment := ""
-	crontab := "*/10 * * * *"
+	defaultConfig := makeDefaultConfig()
 
 	tests := []struct {
 		name     string
@@ -37,20 +24,20 @@ func Test_newCronJob(t *testing.T) {
 		{
 			"my-charts",
 			Config{
-				Kubeconfig:               kubeconfig,
-				MasterURL:                masterURL,
-				RepoSyncImage:            repoSyncImage,
-				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
-				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        kubeappsNamespace,
-				ReposPerNamespace:        reposPerNamespace,
-				DBURL:                    dbURL,
-				DBUser:                   dbUser,
-				DBName:                   dbName,
-				DBSecretName:             dbSecretName,
-				DBSecretKey:              dbSecretKey,
-				UserAgentComment:         userAgentComment,
-				Crontab:                  crontab,
+				Kubeconfig:               defaultConfig.Kubeconfig,
+				MasterURL:                defaultConfig.MasterURL,
+				RepoSyncImage:            defaultConfig.RepoSyncImage,
+				RepoSyncImagePullSecrets: defaultConfig.RepoSyncImagePullSecrets,
+				RepoSyncCommand:          defaultConfig.RepoSyncCommand,
+				KubeappsNamespace:        defaultConfig.KubeappsNamespace,
+				ReposPerNamespace:        defaultConfig.ReposPerNamespace,
+				DBURL:                    defaultConfig.DBURL,
+				DBUser:                   defaultConfig.DBUser,
+				DBName:                   defaultConfig.DBName,
+				DBSecretName:             defaultConfig.DBSecretName,
+				DBSecretKey:              defaultConfig.DBSecretKey,
+				UserAgentComment:         defaultConfig.UserAgentComment,
+				Crontab:                  defaultConfig.Crontab,
 			},
 			&apprepov1alpha1.AppRepository{
 				TypeMeta: metav1.TypeMeta{
@@ -104,7 +91,7 @@ func Test_newCronJob(t *testing.T) {
 									Containers: []corev1.Container{
 										{
 											Name:            "sync",
-											Image:           repoSyncImage,
+											Image:           defaultConfig.RepoSyncImage,
 											ImagePullPolicy: "IfNotPresent",
 											Command:         []string{"/chart-repo"},
 											Args: []string{
@@ -137,18 +124,18 @@ func Test_newCronJob(t *testing.T) {
 		{
 			"my-charts with auth, userAgent and crontab configuration",
 			Config{
-				Kubeconfig:               kubeconfig,
-				MasterURL:                masterURL,
-				RepoSyncImage:            repoSyncImage,
-				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
-				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        kubeappsNamespace,
-				ReposPerNamespace:        reposPerNamespace,
-				DBURL:                    dbURL,
-				DBUser:                   dbUser,
-				DBName:                   dbName,
-				DBSecretName:             dbSecretName,
-				DBSecretKey:              dbSecretKey,
+				Kubeconfig:               defaultConfig.Kubeconfig,
+				MasterURL:                defaultConfig.MasterURL,
+				RepoSyncImage:            defaultConfig.RepoSyncImage,
+				RepoSyncImagePullSecrets: defaultConfig.RepoSyncImagePullSecrets,
+				RepoSyncCommand:          defaultConfig.RepoSyncCommand,
+				KubeappsNamespace:        defaultConfig.KubeappsNamespace,
+				ReposPerNamespace:        defaultConfig.ReposPerNamespace,
+				DBURL:                    defaultConfig.DBURL,
+				DBUser:                   defaultConfig.DBUser,
+				DBName:                   defaultConfig.DBName,
+				DBSecretName:             defaultConfig.DBSecretName,
+				DBSecretKey:              defaultConfig.DBSecretKey,
 				UserAgentComment:         "kubeapps/v2.3",
 				Crontab:                  "*/20 * * * *",
 			},
@@ -208,7 +195,7 @@ func Test_newCronJob(t *testing.T) {
 									Containers: []corev1.Container{
 										{
 											Name:            "sync",
-											Image:           repoSyncImage,
+											Image:           defaultConfig.RepoSyncImage,
 											ImagePullPolicy: "IfNotPresent",
 											Command:         []string{"/chart-repo"},
 											Args: []string{
@@ -247,18 +234,18 @@ func Test_newCronJob(t *testing.T) {
 		{
 			"a cronjob for an app repo in another namespace references the repo secret in kubeapps",
 			Config{
-				Kubeconfig:               kubeconfig,
-				MasterURL:                masterURL,
-				RepoSyncImage:            repoSyncImage,
-				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
-				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        kubeappsNamespace,
-				ReposPerNamespace:        reposPerNamespace,
-				DBURL:                    dbURL,
-				DBUser:                   dbUser,
-				DBName:                   dbName,
-				DBSecretName:             dbSecretName,
-				DBSecretKey:              dbSecretKey,
+				Kubeconfig:               defaultConfig.Kubeconfig,
+				MasterURL:                defaultConfig.MasterURL,
+				RepoSyncImage:            defaultConfig.RepoSyncImage,
+				RepoSyncImagePullSecrets: defaultConfig.RepoSyncImagePullSecrets,
+				RepoSyncCommand:          defaultConfig.RepoSyncCommand,
+				KubeappsNamespace:        defaultConfig.KubeappsNamespace,
+				ReposPerNamespace:        defaultConfig.ReposPerNamespace,
+				DBURL:                    defaultConfig.DBURL,
+				DBUser:                   defaultConfig.DBUser,
+				DBName:                   defaultConfig.DBName,
+				DBSecretName:             defaultConfig.DBSecretName,
+				DBSecretKey:              defaultConfig.DBSecretKey,
 				UserAgentComment:         "kubeapps/v2.3",
 				Crontab:                  "*/20 * * * *",
 			},
@@ -309,7 +296,7 @@ func Test_newCronJob(t *testing.T) {
 									Containers: []corev1.Container{
 										{
 											Name:            "sync",
-											Image:           repoSyncImage,
+											Image:           defaultConfig.RepoSyncImage,
 											ImagePullPolicy: "IfNotPresent",
 											Command:         []string{"/chart-repo"},
 											Args: []string{
@@ -350,12 +337,12 @@ func Test_newCronJob(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.config.UserAgentComment != "" {
-				userAgentComment = tt.config.UserAgentComment
-				defer func() { userAgentComment = "" }()
+				defaultConfig.UserAgentComment = tt.config.UserAgentComment
+				defer func() { defaultConfig.UserAgentComment = "" }()
 			}
 			if tt.config.Crontab != "" {
-				crontab = tt.config.Crontab
-				defer func() { crontab = "" }()
+				defaultConfig.Crontab = tt.config.Crontab
+				defer func() { defaultConfig.Crontab = "" }()
 			}
 			result := newCronJob(tt.apprepo, tt.config)
 			if got, want := *result, tt.expected; !cmp.Equal(want, got) {
@@ -366,20 +353,7 @@ func Test_newCronJob(t *testing.T) {
 }
 
 func Test_newSyncJob(t *testing.T) {
-	kubeconfig := ""
-	masterURL := ""
-	repoSyncImage := "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
-	repoSyncImagePullSecrets := []string{}
-	repoSyncCommand := "/chart-repo"
-	kubeappsNamespace := "kubeapps"
-	reposPerNamespace := true
-	dbURL := "postgresql.kubeapps"
-	dbUser := "admin"
-	dbName := "assets"
-	dbSecretName := "postgresql"
-	dbSecretKey := "postgresql-root-password"
-	userAgentComment := ""
-	crontab := "*/10 * * * *"
+	defaultConfig := makeDefaultConfig()
 
 	tests := []struct {
 		name     string
@@ -390,19 +364,19 @@ func Test_newSyncJob(t *testing.T) {
 		{
 			"my-charts",
 			Config{
-				Kubeconfig:               kubeconfig,
-				MasterURL:                masterURL,
-				RepoSyncImage:            repoSyncImage,
-				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
-				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        kubeappsNamespace,
-				ReposPerNamespace:        reposPerNamespace,
-				DBURL:                    dbURL,
-				DBUser:                   dbUser,
-				DBName:                   dbName,
-				DBSecretName:             dbSecretName,
-				DBSecretKey:              dbSecretKey,
-				UserAgentComment:         userAgentComment,
+				Kubeconfig:               defaultConfig.Kubeconfig,
+				MasterURL:                defaultConfig.MasterURL,
+				RepoSyncImage:            defaultConfig.RepoSyncImage,
+				RepoSyncImagePullSecrets: defaultConfig.RepoSyncImagePullSecrets,
+				RepoSyncCommand:          defaultConfig.RepoSyncCommand,
+				KubeappsNamespace:        defaultConfig.KubeappsNamespace,
+				ReposPerNamespace:        defaultConfig.ReposPerNamespace,
+				DBURL:                    defaultConfig.DBURL,
+				DBUser:                   defaultConfig.DBUser,
+				DBName:                   defaultConfig.DBName,
+				DBSecretName:             defaultConfig.DBSecretName,
+				DBSecretKey:              defaultConfig.DBSecretKey,
+				UserAgentComment:         defaultConfig.UserAgentComment,
 				Crontab:                  "*/20 * * * *",
 			},
 			&apprepov1alpha1.AppRepository{
@@ -450,7 +424,7 @@ func Test_newSyncJob(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
-									Image:           repoSyncImage,
+									Image:           defaultConfig.RepoSyncImage,
 									ImagePullPolicy: "IfNotPresent",
 									Command:         []string{"/chart-repo"},
 									Args: []string{
@@ -481,20 +455,20 @@ func Test_newSyncJob(t *testing.T) {
 		{
 			"an app repository in another namespace results in jobs without owner references",
 			Config{
-				Kubeconfig:               kubeconfig,
-				MasterURL:                masterURL,
-				RepoSyncImage:            repoSyncImage,
-				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
-				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        kubeappsNamespace,
-				ReposPerNamespace:        reposPerNamespace,
-				DBURL:                    dbURL,
-				DBUser:                   dbUser,
-				DBName:                   dbName,
-				DBSecretName:             dbSecretName,
-				DBSecretKey:              dbSecretKey,
-				UserAgentComment:         userAgentComment,
-				Crontab:                  crontab,
+				Kubeconfig:               defaultConfig.Kubeconfig,
+				MasterURL:                defaultConfig.MasterURL,
+				RepoSyncImage:            defaultConfig.RepoSyncImage,
+				RepoSyncImagePullSecrets: defaultConfig.RepoSyncImagePullSecrets,
+				RepoSyncCommand:          defaultConfig.RepoSyncCommand,
+				KubeappsNamespace:        defaultConfig.KubeappsNamespace,
+				ReposPerNamespace:        defaultConfig.ReposPerNamespace,
+				DBURL:                    defaultConfig.DBURL,
+				DBUser:                   defaultConfig.DBUser,
+				DBName:                   defaultConfig.DBName,
+				DBSecretName:             defaultConfig.DBSecretName,
+				DBSecretKey:              defaultConfig.DBSecretKey,
+				UserAgentComment:         defaultConfig.UserAgentComment,
+				Crontab:                  defaultConfig.Crontab,
 			},
 			&apprepov1alpha1.AppRepository{
 				TypeMeta: metav1.TypeMeta{
@@ -531,7 +505,7 @@ func Test_newSyncJob(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
-									Image:           repoSyncImage,
+									Image:           defaultConfig.RepoSyncImage,
 									ImagePullPolicy: "IfNotPresent",
 									Command:         []string{"/chart-repo"},
 									Args: []string{
@@ -562,20 +536,20 @@ func Test_newSyncJob(t *testing.T) {
 		{
 			"my-charts with auth and userAgent comment",
 			Config{
-				Kubeconfig:               kubeconfig,
-				MasterURL:                masterURL,
-				RepoSyncImage:            repoSyncImage,
-				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
-				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        kubeappsNamespace,
-				ReposPerNamespace:        reposPerNamespace,
-				DBURL:                    dbURL,
-				DBUser:                   dbUser,
-				DBName:                   dbName,
-				DBSecretName:             dbSecretName,
-				DBSecretKey:              dbSecretKey,
+				Kubeconfig:               defaultConfig.Kubeconfig,
+				MasterURL:                defaultConfig.MasterURL,
+				RepoSyncImage:            defaultConfig.RepoSyncImage,
+				RepoSyncImagePullSecrets: defaultConfig.RepoSyncImagePullSecrets,
+				RepoSyncCommand:          defaultConfig.RepoSyncCommand,
+				KubeappsNamespace:        defaultConfig.KubeappsNamespace,
+				ReposPerNamespace:        defaultConfig.ReposPerNamespace,
+				DBURL:                    defaultConfig.DBURL,
+				DBUser:                   defaultConfig.DBUser,
+				DBName:                   defaultConfig.DBName,
+				DBSecretName:             defaultConfig.DBSecretName,
+				DBSecretKey:              defaultConfig.DBSecretKey,
 				UserAgentComment:         "kubeapps/v2.3",
-				Crontab:                  crontab,
+				Crontab:                  defaultConfig.Crontab,
 			},
 			&apprepov1alpha1.AppRepository{
 				TypeMeta: metav1.TypeMeta{
@@ -626,7 +600,7 @@ func Test_newSyncJob(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
-									Image:           repoSyncImage,
+									Image:           defaultConfig.RepoSyncImage,
 									ImagePullPolicy: "IfNotPresent",
 									Command:         []string{"/chart-repo"},
 									Args: []string{
@@ -663,20 +637,20 @@ func Test_newSyncJob(t *testing.T) {
 		{
 			"my-charts with a customCA",
 			Config{
-				Kubeconfig:               kubeconfig,
-				MasterURL:                masterURL,
-				RepoSyncImage:            repoSyncImage,
-				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
-				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        kubeappsNamespace,
-				ReposPerNamespace:        reposPerNamespace,
-				DBURL:                    dbURL,
-				DBUser:                   dbUser,
-				DBName:                   dbName,
-				DBSecretName:             dbSecretName,
-				DBSecretKey:              dbSecretKey,
-				UserAgentComment:         userAgentComment,
-				Crontab:                  crontab,
+				Kubeconfig:               defaultConfig.Kubeconfig,
+				MasterURL:                defaultConfig.MasterURL,
+				RepoSyncImage:            defaultConfig.RepoSyncImage,
+				RepoSyncImagePullSecrets: defaultConfig.RepoSyncImagePullSecrets,
+				RepoSyncCommand:          defaultConfig.RepoSyncCommand,
+				KubeappsNamespace:        defaultConfig.KubeappsNamespace,
+				ReposPerNamespace:        defaultConfig.ReposPerNamespace,
+				DBURL:                    defaultConfig.DBURL,
+				DBUser:                   defaultConfig.DBUser,
+				DBName:                   defaultConfig.DBName,
+				DBSecretName:             defaultConfig.DBSecretName,
+				DBSecretKey:              defaultConfig.DBSecretKey,
+				UserAgentComment:         defaultConfig.UserAgentComment,
+				Crontab:                  defaultConfig.Crontab,
 			},
 			&apprepov1alpha1.AppRepository{
 				TypeMeta: metav1.TypeMeta{
@@ -728,7 +702,7 @@ func Test_newSyncJob(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
-									Image:           repoSyncImage,
+									Image:           defaultConfig.RepoSyncImage,
 									ImagePullPolicy: "IfNotPresent",
 									Command:         []string{"/chart-repo"},
 									Args: []string{
@@ -773,20 +747,20 @@ func Test_newSyncJob(t *testing.T) {
 		{
 			"my-charts with a customCA and auth header",
 			Config{
-				Kubeconfig:               kubeconfig,
-				MasterURL:                masterURL,
-				RepoSyncImage:            repoSyncImage,
-				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
-				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        kubeappsNamespace,
-				ReposPerNamespace:        reposPerNamespace,
-				DBURL:                    dbURL,
-				DBUser:                   dbUser,
-				DBName:                   dbName,
-				DBSecretName:             dbSecretName,
-				DBSecretKey:              dbSecretKey,
-				UserAgentComment:         userAgentComment,
-				Crontab:                  crontab,
+				Kubeconfig:               defaultConfig.Kubeconfig,
+				MasterURL:                defaultConfig.MasterURL,
+				RepoSyncImage:            defaultConfig.RepoSyncImage,
+				RepoSyncImagePullSecrets: defaultConfig.RepoSyncImagePullSecrets,
+				RepoSyncCommand:          defaultConfig.RepoSyncCommand,
+				KubeappsNamespace:        defaultConfig.KubeappsNamespace,
+				ReposPerNamespace:        defaultConfig.ReposPerNamespace,
+				DBURL:                    defaultConfig.DBURL,
+				DBUser:                   defaultConfig.DBUser,
+				DBName:                   defaultConfig.DBName,
+				DBSecretName:             defaultConfig.DBSecretName,
+				DBSecretKey:              defaultConfig.DBSecretKey,
+				UserAgentComment:         defaultConfig.UserAgentComment,
+				Crontab:                  defaultConfig.Crontab,
 			},
 			&apprepov1alpha1.AppRepository{
 				TypeMeta: metav1.TypeMeta{
@@ -841,7 +815,7 @@ func Test_newSyncJob(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
-									Image:           repoSyncImage,
+									Image:           defaultConfig.RepoSyncImage,
 									ImagePullPolicy: "IfNotPresent",
 									Command:         []string{"/chart-repo"},
 									Args: []string{
@@ -891,20 +865,20 @@ func Test_newSyncJob(t *testing.T) {
 		{
 			"my-charts with a custom pod template",
 			Config{
-				Kubeconfig:               kubeconfig,
-				MasterURL:                masterURL,
-				RepoSyncImage:            repoSyncImage,
-				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
-				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        kubeappsNamespace,
-				ReposPerNamespace:        reposPerNamespace,
-				DBURL:                    dbURL,
-				DBUser:                   dbUser,
-				DBName:                   dbName,
-				DBSecretName:             dbSecretName,
-				DBSecretKey:              dbSecretKey,
-				UserAgentComment:         userAgentComment,
-				Crontab:                  crontab,
+				Kubeconfig:               defaultConfig.Kubeconfig,
+				MasterURL:                defaultConfig.MasterURL,
+				RepoSyncImage:            defaultConfig.RepoSyncImage,
+				RepoSyncImagePullSecrets: defaultConfig.RepoSyncImagePullSecrets,
+				RepoSyncCommand:          defaultConfig.RepoSyncCommand,
+				KubeappsNamespace:        defaultConfig.KubeappsNamespace,
+				ReposPerNamespace:        defaultConfig.ReposPerNamespace,
+				DBURL:                    defaultConfig.DBURL,
+				DBUser:                   defaultConfig.DBUser,
+				DBName:                   defaultConfig.DBName,
+				DBSecretName:             defaultConfig.DBSecretName,
+				DBSecretKey:              defaultConfig.DBSecretKey,
+				UserAgentComment:         defaultConfig.UserAgentComment,
+				Crontab:                  defaultConfig.Crontab,
 			},
 			&apprepov1alpha1.AppRepository{
 				TypeMeta: metav1.TypeMeta{
@@ -972,7 +946,7 @@ func Test_newSyncJob(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
-									Image:           repoSyncImage,
+									Image:           defaultConfig.RepoSyncImage,
 									ImagePullPolicy: "IfNotPresent",
 									Command:         []string{"/chart-repo"},
 									Args: []string{
@@ -1006,8 +980,8 @@ func Test_newSyncJob(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.config.UserAgentComment != "" {
-				userAgentComment = tt.config.UserAgentComment
-				defer func() { userAgentComment = "" }()
+				defaultConfig.UserAgentComment = tt.config.UserAgentComment
+				defer func() { defaultConfig.UserAgentComment = "" }()
 			}
 
 			result := newSyncJob(tt.apprepo, tt.config)
@@ -1019,20 +993,7 @@ func Test_newSyncJob(t *testing.T) {
 }
 
 func Test_newCleanupJob(t *testing.T) {
-	kubeconfig := ""
-	masterURL := ""
-	repoSyncImage := "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
-	repoSyncImagePullSecrets := []string{}
-	repoSyncCommand := "/chart-repo"
-	kubeappsNamespace := "kubeapps"
-	reposPerNamespace := true
-	dbURL := "postgresql.kubeapps"
-	dbUser := "admin"
-	dbName := "assets"
-	dbSecretName := "postgresql"
-	dbSecretKey := "postgresql-root-password"
-	userAgentComment := ""
-	crontab := "*/10 * * * *"
+	defaultConfig := makeDefaultConfig()
 
 	tests := []struct {
 		name          string
@@ -1046,20 +1007,20 @@ func Test_newCleanupJob(t *testing.T) {
 			"my-charts",
 			"kubeapps",
 			Config{
-				Kubeconfig:               kubeconfig,
-				MasterURL:                masterURL,
-				RepoSyncImage:            repoSyncImage,
-				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
-				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        kubeappsNamespace,
-				ReposPerNamespace:        reposPerNamespace,
-				DBURL:                    dbURL,
-				DBUser:                   dbUser,
-				DBName:                   dbName,
-				DBSecretName:             dbSecretName,
-				DBSecretKey:              dbSecretKey,
-				UserAgentComment:         userAgentComment,
-				Crontab:                  crontab,
+				Kubeconfig:               defaultConfig.Kubeconfig,
+				MasterURL:                defaultConfig.MasterURL,
+				RepoSyncImage:            defaultConfig.RepoSyncImage,
+				RepoSyncImagePullSecrets: defaultConfig.RepoSyncImagePullSecrets,
+				RepoSyncCommand:          defaultConfig.RepoSyncCommand,
+				KubeappsNamespace:        defaultConfig.KubeappsNamespace,
+				ReposPerNamespace:        defaultConfig.ReposPerNamespace,
+				DBURL:                    defaultConfig.DBURL,
+				DBUser:                   defaultConfig.DBUser,
+				DBName:                   defaultConfig.DBName,
+				DBSecretName:             defaultConfig.DBSecretName,
+				DBSecretKey:              defaultConfig.DBSecretKey,
+				UserAgentComment:         defaultConfig.UserAgentComment,
+				Crontab:                  defaultConfig.Crontab,
 			},
 			batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1073,7 +1034,7 @@ func Test_newCleanupJob(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:            "delete",
-									Image:           repoSyncImage,
+									Image:           defaultConfig.RepoSyncImage,
 									ImagePullPolicy: "IfNotPresent",
 									Command:         []string{"/chart-repo"},
 									Args: []string{
@@ -1170,4 +1131,22 @@ func TestObjectBelongsTo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func makeDefaultConfig() Config {
+	return Config{
+		Kubeconfig:               "",
+		MasterURL:                "",
+		RepoSyncImage:            "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2",
+		RepoSyncImagePullSecrets: []string{},
+		RepoSyncCommand:          "/chart-repo",
+		KubeappsNamespace:        "kubeapps",
+		ReposPerNamespace:        true,
+		DBURL:                    "postgresql.kubeapps",
+		DBUser:                   "admin",
+		DBName:                   "assets",
+		DBSecretName:             "postgresql",
+		DBSecretKey:              "postgresql-root-password",
+		UserAgentComment:         "",
+		Crontab:                  "*/10 * * * *"}
 }

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -18,7 +18,7 @@ func Test_newCronJob(t *testing.T) {
 	repoSyncImage := "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
 	repoSyncImagePullSecrets := []string{}
 	repoSyncCommand := "/chart-repo"
-	namespace := "kubeapps"
+	kubeappsNamespace := "kubeapps"
 	reposPerNamespace := true
 	dbURL := "postgresql.kubeapps"
 	dbUser := "admin"
@@ -42,7 +42,7 @@ func Test_newCronJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        namespace,
+				KubeappsNamespace:        kubeappsNamespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -142,7 +142,7 @@ func Test_newCronJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        namespace,
+				KubeappsNamespace:        kubeappsNamespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -252,7 +252,7 @@ func Test_newCronJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        namespace,
+				KubeappsNamespace:        kubeappsNamespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -371,7 +371,7 @@ func Test_newSyncJob(t *testing.T) {
 	repoSyncImage := "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
 	repoSyncImagePullSecrets := []string{}
 	repoSyncCommand := "/chart-repo"
-	namespace := "kubeapps"
+	kubeappsNamespace := "kubeapps"
 	reposPerNamespace := true
 	dbURL := "postgresql.kubeapps"
 	dbUser := "admin"
@@ -395,7 +395,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        namespace,
+				KubeappsNamespace:        kubeappsNamespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -486,7 +486,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        namespace,
+				KubeappsNamespace:        kubeappsNamespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -567,7 +567,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        namespace,
+				KubeappsNamespace:        kubeappsNamespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -668,7 +668,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        namespace,
+				KubeappsNamespace:        kubeappsNamespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -778,7 +778,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        namespace,
+				KubeappsNamespace:        kubeappsNamespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -896,7 +896,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        namespace,
+				KubeappsNamespace:        kubeappsNamespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -1024,7 +1024,7 @@ func Test_newCleanupJob(t *testing.T) {
 	repoSyncImage := "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
 	repoSyncImagePullSecrets := []string{}
 	repoSyncCommand := "/chart-repo"
-	namespace := "kubeapps"
+	kubeappsNamespace := "kubeapps"
 	reposPerNamespace := true
 	dbURL := "postgresql.kubeapps"
 	dbUser := "admin"
@@ -1051,7 +1051,7 @@ func Test_newCleanupJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				KubeappsNamespace:        namespace,
+				KubeappsNamespace:        kubeappsNamespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -1102,7 +1102,11 @@ func Test_newCleanupJob(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := newCleanupJob(tt.repoName, tt.config)
+			result := newCleanupJob(&apprepov1alpha1.AppRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.repoName,
+					Namespace: tt.repoNamespace,
+				}}, tt.config)
 			if got, want := *result, tt.expected; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -13,20 +13,21 @@ import (
 )
 
 func Test_newCronJob(t *testing.T) {
-	var kubeconfig = ""
-	var masterURL = ""
-	var repoSyncImage = "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
-	var repoSyncImagePullSecrets = make(arrayFlags, 0, 0)
-	var repoSyncCommand = "/chart-repo"
-	var namespace = "kubeapps"
-	var reposPerNamespace = true
-	var dbURL = "postgresql.kubeapps"
-	var dbUser = "admin"
-	var dbName = "assets"
-	var dbSecretName = "postgresql"
-	var dbSecretKey = "postgresql-root-password"
-	var userAgentComment = ""
-	var crontab = "*/10 * * * *"
+	kubeconfig := ""
+	masterURL := ""
+	repoSyncImage := "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
+	repoSyncImagePullSecrets := []string{}
+	repoSyncCommand := "/chart-repo"
+	namespace := "kubeapps"
+	reposPerNamespace := true
+	dbURL := "postgresql.kubeapps"
+	dbUser := "admin"
+	dbName := "assets"
+	dbSecretName := "postgresql"
+	dbSecretKey := "postgresql-root-password"
+	userAgentComment := ""
+	crontab := "*/10 * * * *"
+
 	tests := []struct {
 		name     string
 		config   Config
@@ -41,7 +42,7 @@ func Test_newCronJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				Namespace:                namespace,
+				KubeappsNamespace:        namespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -141,7 +142,7 @@ func Test_newCronJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				Namespace:                namespace,
+				KubeappsNamespace:        namespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -251,7 +252,7 @@ func Test_newCronJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				Namespace:                namespace,
+				KubeappsNamespace:        namespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -356,7 +357,7 @@ func Test_newCronJob(t *testing.T) {
 				crontab = tt.config.Crontab
 				defer func() { crontab = "" }()
 			}
-			result := newCronJob(tt.apprepo, tt.config.Namespace, tt.config)
+			result := newCronJob(tt.apprepo, tt.config)
 			if got, want := *result, tt.expected; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}
@@ -365,20 +366,20 @@ func Test_newCronJob(t *testing.T) {
 }
 
 func Test_newSyncJob(t *testing.T) {
-	var kubeconfig = ""
-	var masterURL = ""
-	var repoSyncImage = "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
-	var repoSyncImagePullSecrets = make(arrayFlags, 0, 0)
-	var repoSyncCommand = "/chart-repo"
-	var namespace = "kubeapps"
-	var reposPerNamespace = true
-	var dbURL = "postgresql.kubeapps"
-	var dbUser = "admin"
-	var dbName = "assets"
-	var dbSecretName = "postgresql"
-	var dbSecretKey = "postgresql-root-password"
-	var userAgentComment = ""
-	var crontab = "*/10 * * * *"
+	kubeconfig := ""
+	masterURL := ""
+	repoSyncImage := "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
+	repoSyncImagePullSecrets := []string{}
+	repoSyncCommand := "/chart-repo"
+	namespace := "kubeapps"
+	reposPerNamespace := true
+	dbURL := "postgresql.kubeapps"
+	dbUser := "admin"
+	dbName := "assets"
+	dbSecretName := "postgresql"
+	dbSecretKey := "postgresql-root-password"
+	userAgentComment := ""
+	crontab := "*/10 * * * *"
 
 	tests := []struct {
 		name     string
@@ -394,7 +395,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				Namespace:                namespace,
+				KubeappsNamespace:        namespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -485,7 +486,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				Namespace:                namespace,
+				KubeappsNamespace:        namespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -566,7 +567,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				Namespace:                namespace,
+				KubeappsNamespace:        namespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -667,7 +668,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				Namespace:                namespace,
+				KubeappsNamespace:        namespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -777,7 +778,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				Namespace:                namespace,
+				KubeappsNamespace:        namespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -895,7 +896,7 @@ func Test_newSyncJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				Namespace:                namespace,
+				KubeappsNamespace:        namespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -1009,7 +1010,7 @@ func Test_newSyncJob(t *testing.T) {
 				defer func() { userAgentComment = "" }()
 			}
 
-			result := newSyncJob(tt.apprepo, tt.config.Namespace, tt.config)
+			result := newSyncJob(tt.apprepo, tt.config)
 			if got, want := *result, tt.expected; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}
@@ -1018,20 +1019,20 @@ func Test_newSyncJob(t *testing.T) {
 }
 
 func Test_newCleanupJob(t *testing.T) {
-	var kubeconfig = ""
-	var masterURL = ""
-	var repoSyncImage = "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
-	var repoSyncImagePullSecrets = make(arrayFlags, 0, 0)
-	var repoSyncCommand = "/chart-repo"
-	var namespace = "kubeapps"
-	var reposPerNamespace = true
-	var dbURL = "postgresql.kubeapps"
-	var dbUser = "admin"
-	var dbName = "assets"
-	var dbSecretName = "postgresql"
-	var dbSecretKey = "postgresql-root-password"
-	var userAgentComment = ""
-	var crontab = "*/10 * * * *"
+	kubeconfig := ""
+	masterURL := ""
+	repoSyncImage := "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
+	repoSyncImagePullSecrets := []string{}
+	repoSyncCommand := "/chart-repo"
+	namespace := "kubeapps"
+	reposPerNamespace := true
+	dbURL := "postgresql.kubeapps"
+	dbUser := "admin"
+	dbName := "assets"
+	dbSecretName := "postgresql"
+	dbSecretKey := "postgresql-root-password"
+	userAgentComment := ""
+	crontab := "*/10 * * * *"
 
 	tests := []struct {
 		name          string
@@ -1050,7 +1051,7 @@ func Test_newCleanupJob(t *testing.T) {
 				RepoSyncImage:            repoSyncImage,
 				RepoSyncImagePullSecrets: repoSyncImagePullSecrets,
 				RepoSyncCommand:          repoSyncCommand,
-				Namespace:                namespace,
+				KubeappsNamespace:        namespace,
 				ReposPerNamespace:        reposPerNamespace,
 				DBURL:                    dbURL,
 				DBUser:                   dbUser,
@@ -1101,7 +1102,7 @@ func Test_newCleanupJob(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := newCleanupJob(tt.repoName, tt.repoNamespace, tt.config)
+			result := newCleanupJob(tt.repoName, tt.config)
 			if got, want := *result, tt.expected; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -17,6 +17,7 @@ func Test_newCronJob(t *testing.T) {
 	dbName = "assets"
 	dbUser = "admin"
 	dbSecretName = "postgresql"
+	repoSyncImagePullSecrets = "foo,bar,foobar"
 	const kubeappsNamespace = "kubeapps"
 	tests := []struct {
 		name             string
@@ -75,7 +76,8 @@ func Test_newCronJob(t *testing.T) {
 									},
 								},
 								Spec: corev1.PodSpec{
-									RestartPolicy: "OnFailure",
+									ImagePullSecrets: getImagePullSecretsRefs(),
+									RestartPolicy:    "OnFailure",
 									Containers: []corev1.Container{
 										{
 											Name:            "sync",
@@ -165,7 +167,8 @@ func Test_newCronJob(t *testing.T) {
 									},
 								},
 								Spec: corev1.PodSpec{
-									RestartPolicy: "OnFailure",
+									ImagePullSecrets: getImagePullSecretsRefs(),
+									RestartPolicy:    "OnFailure",
 									Containers: []corev1.Container{
 										{
 											Name:            "sync",
@@ -252,7 +255,8 @@ func Test_newCronJob(t *testing.T) {
 									},
 								},
 								Spec: corev1.PodSpec{
-									RestartPolicy: "OnFailure",
+									ImagePullSecrets: getImagePullSecretsRefs(),
+									RestartPolicy:    "OnFailure",
 									Containers: []corev1.Container{
 										{
 											Name:            "sync",
@@ -319,6 +323,7 @@ func Test_newSyncJob(t *testing.T) {
 	dbName = "assets"
 	dbUser = "admin"
 	dbSecretName = "postgresql"
+	repoSyncImagePullSecrets = "foo,bar,foobar"
 	const kubeappsNamespace = "kubeapps"
 	tests := []struct {
 		name             string
@@ -369,7 +374,8 @@ func Test_newSyncJob(t *testing.T) {
 							},
 						},
 						Spec: corev1.PodSpec{
-							RestartPolicy: "OnFailure",
+							ImagePullSecrets: getImagePullSecretsRefs(),
+							RestartPolicy:    "OnFailure",
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -435,7 +441,8 @@ func Test_newSyncJob(t *testing.T) {
 							},
 						},
 						Spec: corev1.PodSpec{
-							RestartPolicy: "OnFailure",
+							ImagePullSecrets: getImagePullSecretsRefs(),
+							RestartPolicy:    "OnFailure",
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -515,7 +522,8 @@ func Test_newSyncJob(t *testing.T) {
 							},
 						},
 						Spec: corev1.PodSpec{
-							RestartPolicy: "OnFailure",
+							ImagePullSecrets: getImagePullSecretsRefs(),
+							RestartPolicy:    "OnFailure",
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -602,7 +610,8 @@ func Test_newSyncJob(t *testing.T) {
 							},
 						},
 						Spec: corev1.PodSpec{
-							RestartPolicy: "OnFailure",
+							ImagePullSecrets: getImagePullSecretsRefs(),
+							RestartPolicy:    "OnFailure",
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -700,7 +709,8 @@ func Test_newSyncJob(t *testing.T) {
 							},
 						},
 						Spec: corev1.PodSpec{
-							RestartPolicy: "OnFailure",
+							ImagePullSecrets: getImagePullSecretsRefs(),
+							RestartPolicy:    "OnFailure",
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -777,7 +787,8 @@ func Test_newSyncJob(t *testing.T) {
 							},
 						},
 						Spec: corev1.PodSpec{
-							Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{}}},
+							ImagePullSecrets: getImagePullSecretsRefs(),
+							Affinity:         &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{}}},
 							Containers: []corev1.Container{
 								{
 									Env: []corev1.EnvVar{
@@ -815,8 +826,9 @@ func Test_newSyncJob(t *testing.T) {
 							},
 						},
 						Spec: corev1.PodSpec{
-							Affinity:      &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{}}},
-							RestartPolicy: "OnFailure",
+							ImagePullSecrets: getImagePullSecretsRefs(),
+							Affinity:         &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{}}},
+							RestartPolicy:    "OnFailure",
 							Containers: []corev1.Container{
 								{
 									Name:            "sync",
@@ -872,6 +884,7 @@ func Test_newCleanupJob(t *testing.T) {
 	dbName = "assets"
 	dbUser = "admin"
 	dbSecretName = "postgresql"
+	repoSyncImagePullSecrets = "foo,bar,foobar"
 	const kubeappsNamespace = "kubeapps"
 
 	tests := []struct {
@@ -892,7 +905,8 @@ func Test_newCleanupJob(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							RestartPolicy: "Never",
+							ImagePullSecrets: getImagePullSecretsRefs(),
+							RestartPolicy:    "Never",
 							Containers: []corev1.Container{
 								{
 									Name:            "delete",

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -31,19 +31,20 @@ import (
 )
 
 var (
-	masterURL         string
-	kubeconfig        string
-	repoSyncImage     string
-	repoSyncCommand   string
-	namespace         string
-	dbURL             string
-	dbUser            string
-	dbName            string
-	dbSecretName      string
-	dbSecretKey       string
-	userAgentComment  string
-	crontab           string
-	reposPerNamespace bool
+	masterURL                string
+	kubeconfig               string
+	repoSyncImage            string
+	repoSyncImagePullSecrets string
+	repoSyncCommand          string
+	namespace                string
+	dbURL                    string
+	dbUser                   string
+	dbName                   string
+	dbSecretName             string
+	dbSecretKey              string
+	userAgentComment         string
+	crontab                  string
+	reposPerNamespace        bool
 )
 
 func main() {
@@ -91,6 +92,7 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&repoSyncImage, "repo-sync-image", "quay.io/helmpack/chart-repo:latest", "container repo/image to use in CronJobs")
+	flag.StringVar(&repoSyncImagePullSecrets, "repo-sync-image-pullsecrets", "", "optional reference to secrets in the same namespace to use for pulling the image used by this pod")
 	flag.StringVar(&repoSyncCommand, "repo-sync-cmd", "/chart-repo", "command used to sync/delete repos for repo-sync-image")
 	flag.StringVar(&namespace, "namespace", "kubeapps", "Namespace to discover AppRepository resources")
 	flag.BoolVar(&reposPerNamespace, "repos-per-namespace", true, "Defaults to watch for repos in all namespaces. Switch to false to watch only the configured namespace.")

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -160,11 +160,6 @@ func main() {
 func getImagePullSecretsRefs(imagePullSecretsRefsArr []string) []corev1.LocalObjectReference {
 	var imagePullSecretsRefs []corev1.LocalObjectReference
 
-	// if no repoSyncImagePullSecrets arg passed, return nil, as usual
-	if len(imagePullSecretsRefsArr) == 0 {
-		return nil
-	}
-
 	// getting and appending a []LocalObjectReference for each ImagePullSecret passed
 	for _, imagePullSecretName := range imagePullSecretsRefsArr {
 		imagePullSecretsRefs = append(imagePullSecretsRefs, corev1.LocalObjectReference{Name: imagePullSecretName})

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -33,7 +33,7 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-// Config contains al the flags passed through the command line
+// Config contains all the flags passed through the command line
 // besides, it contains the []LocalObjectReference for the PullSecrets
 // so they can be shared across the jobs
 type Config struct {
@@ -93,9 +93,9 @@ func main() {
 	conf, output, err := parseFlags(os.Args[0], os.Args[1:])
 
 	if err != nil {
-		log.Fatal("got error:", err)
-		log.Fatal("output:\n", output)
-		os.Exit(1)
+		log.Fatal("error parsing command-line arguments: ", err)
+		log.Fatal(output)
+		log.Exit(1)
 	}
 
 	log.WithFields(log.Fields{

--- a/cmd/apprepository-controller/main_test.go
+++ b/cmd/apprepository-controller/main_test.go
@@ -23,7 +23,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 				RepoSyncImage:            "quay.io/helmpack/chart-repo:latest",
 				RepoSyncImagePullSecrets: nil,
 				RepoSyncCommand:          "/chart-repo",
-				Namespace:                "kubeapps",
+				KubeappsNamespace:        "kubeapps",
 				ReposPerNamespace:        true,
 				DBURL:                    "localhost",
 				DBUser:                   "root",
@@ -37,7 +37,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 		},
 		{
 			"pullSecrets with spaces",
-			[]string{
+			[]string{ // note trailing spaces
 				"--repo-sync-image-pullsecrets=s1, s2",
 				"--repo-sync-image-pullsecrets= s3",
 			},
@@ -45,10 +45,10 @@ func TestParseFlagsCorrect(t *testing.T) {
 				Kubeconfig:               "",
 				MasterURL:                "",
 				RepoSyncImage:            "quay.io/helmpack/chart-repo:latest",
-				RepoSyncImagePullSecrets: arrayFlags{"s1", " s2", "s3"},
-				ImagePullSecretsRefs:     []v1.LocalObjectReference{{Name: "s1"}, {Name: " s2"}, {Name: "s3"}},
+				RepoSyncImagePullSecrets: []string{"s1", " s2", " s3"},
+				ImagePullSecretsRefs:     []v1.LocalObjectReference{{Name: "s1"}, {Name: " s2"}, {Name: " s3"}},
 				RepoSyncCommand:          "/chart-repo",
-				Namespace:                "kubeapps",
+				KubeappsNamespace:        "kubeapps",
 				ReposPerNamespace:        true,
 				DBURL:                    "localhost",
 				DBUser:                   "root",
@@ -83,10 +83,10 @@ func TestParseFlagsCorrect(t *testing.T) {
 				Kubeconfig:               "foo01",
 				MasterURL:                "foo02",
 				RepoSyncImage:            "foo03",
-				RepoSyncImagePullSecrets: arrayFlags{"s1", "s2", "s3"},
+				RepoSyncImagePullSecrets: []string{"s1", "s2", "s3"},
 				ImagePullSecretsRefs:     []v1.LocalObjectReference{{Name: "s1"}, {Name: "s2"}, {Name: "s3"}},
 				RepoSyncCommand:          "foo04",
-				Namespace:                "foo05",
+				KubeappsNamespace:        "foo05",
 				ReposPerNamespace:        false,
 				DBURL:                    "foo06",
 				DBUser:                   "foo07",
@@ -127,26 +127,23 @@ func TestParseFlagsError(t *testing.T) {
 		{
 			"non-existent flag",
 			[]string{"--foo"},
-			"flag provided but not defined",
+			"unknown flag: --foo",
 		},
 		{
 			"flag with worng value type",
 			[]string{"--repos-per-namespace=3"},
-			"invalid boolean value",
+			"flag: strconv.ParseBool",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(strings.Join(tt.args, " "), func(t *testing.T) {
-			conf, output, err := parseFlags("prog", tt.args)
+			conf, _, err := parseFlags("prog", tt.args)
 			if conf != nil {
 				t.Errorf("conf got %v, want nil", conf)
 			}
 			if strings.Index(err.Error(), tt.errstr) < 0 {
 				t.Errorf("err got %q, want to find %q", err.Error(), tt.errstr)
-			}
-			if strings.Index(output, "Usage of prog") < 0 {
-				t.Errorf("output got %q", output)
 			}
 		})
 	}

--- a/cmd/apprepository-controller/main_test.go
+++ b/cmd/apprepository-controller/main_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestParseFlagsCorrect(t *testing.T) {
+	var tests = []struct {
+		name string
+		args []string
+		conf Config
+	}{
+		{
+			"no arguments returns default flag values",
+			[]string{},
+			Config{
+				Kubeconfig:               "",
+				MasterURL:                "",
+				RepoSyncImage:            "quay.io/helmpack/chart-repo:latest",
+				RepoSyncImagePullSecrets: nil,
+				RepoSyncCommand:          "/chart-repo",
+				Namespace:                "kubeapps",
+				ReposPerNamespace:        true,
+				DBURL:                    "localhost",
+				DBUser:                   "root",
+				DBName:                   "charts",
+				DBSecretName:             "kubeapps-db",
+				DBSecretKey:              "postgresql-root-password",
+				UserAgentComment:         "",
+				Crontab:                  "*/10 * * * *",
+				Args:                     []string{},
+			},
+		},
+		{
+			"pullSecrets with spaces",
+			[]string{
+				"--repo-sync-image-pullsecrets=s1, s2",
+				"--repo-sync-image-pullsecrets= s3",
+			},
+			Config{
+				Kubeconfig:               "",
+				MasterURL:                "",
+				RepoSyncImage:            "quay.io/helmpack/chart-repo:latest",
+				RepoSyncImagePullSecrets: arrayFlags{"s1", " s2", "s3"},
+				ImagePullSecretsRefs:     []v1.LocalObjectReference{{Name: "s1"}, {Name: " s2"}, {Name: "s3"}},
+				RepoSyncCommand:          "/chart-repo",
+				Namespace:                "kubeapps",
+				ReposPerNamespace:        true,
+				DBURL:                    "localhost",
+				DBUser:                   "root",
+				DBName:                   "charts",
+				DBSecretName:             "kubeapps-db",
+				DBSecretKey:              "postgresql-root-password",
+				UserAgentComment:         "",
+				Crontab:                  "*/10 * * * *",
+				Args:                     []string{},
+			},
+		},
+		{
+			"all arguments are captured",
+			[]string{
+				"--kubeconfig", "foo01",
+				"--master", "foo02",
+				"--repo-sync-image", "foo03",
+				"--repo-sync-image-pullsecrets", "s1,s2",
+				"--repo-sync-image-pullsecrets", "s3",
+				"--repo-sync-cmd", "foo04",
+				"--namespace", "foo05",
+				"--repos-per-namespace=false",
+				"--database-url", "foo06",
+				"--database-user", "foo07",
+				"--database-name", "foo08",
+				"--database-secret-name", "foo09",
+				"--database-secret-key", "foo10",
+				"--user-agent-comment", "foo11",
+				"--crontab", "foo12",
+			},
+			Config{
+				Kubeconfig:               "foo01",
+				MasterURL:                "foo02",
+				RepoSyncImage:            "foo03",
+				RepoSyncImagePullSecrets: arrayFlags{"s1", "s2", "s3"},
+				ImagePullSecretsRefs:     []v1.LocalObjectReference{{Name: "s1"}, {Name: "s2"}, {Name: "s3"}},
+				RepoSyncCommand:          "foo04",
+				Namespace:                "foo05",
+				ReposPerNamespace:        false,
+				DBURL:                    "foo06",
+				DBUser:                   "foo07",
+				DBName:                   "foo08",
+				DBSecretName:             "foo09",
+				DBSecretKey:              "foo10",
+				UserAgentComment:         "foo11",
+				Crontab:                  "foo12",
+				Args:                     []string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, " "), func(t *testing.T) {
+			conf, output, err := parseFlags("program", tt.args)
+			conf.ImagePullSecretsRefs = getImagePullSecretsRefs(conf.RepoSyncImagePullSecrets)
+
+			if err != nil {
+				t.Errorf("err got:\n%v\nwant nil", err)
+			}
+			if output != "" {
+				t.Errorf("output got:\n%q\nwant empty", output)
+			}
+			if got, want := *conf, tt.conf; !cmp.Equal(want, got) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func TestParseFlagsError(t *testing.T) {
+	var tests = []struct {
+		name   string
+		args   []string
+		errstr string
+	}{
+		{
+			"non-existent flag",
+			[]string{"--foo"},
+			"flag provided but not defined",
+		},
+		{
+			"flag with worng value type",
+			[]string{"--repos-per-namespace=3"},
+			"invalid boolean value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, " "), func(t *testing.T) {
+			conf, output, err := parseFlags("prog", tt.args)
+			if conf != nil {
+				t.Errorf("conf got %v, want nil", conf)
+			}
+			if strings.Index(err.Error(), tt.errstr) < 0 {
+				t.Errorf("err got %q, want to find %q", err.Error(), tt.errstr)
+			}
+			if strings.Index(output, "Usage of prog") < 0 {
+				t.Errorf("output got %q", output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of the change

The problem described in #2144 and replicated following the steps in https://github.com/kubeapps/kubeapps/issues/2144#issuecomment-724805837 is pretty straightforward to be solved. `ImagePullSecrets` value is not being passed through the created jobs.

In order to make apprepository-controller accept this value, it should be passed as new arg param in the go binary.
For this purpose, the param `repo-sync-image-pullsecrets` has been created. It accepts a list of comma separated values with then names of the secrets used as ImagePullSecrets.

For this param to work, it is necessary that the Helm chart properly handles the values.global.imagePullSecrets. This PR also introduces a change in the chart for generating a comma-separated list based on the list of ImagePullSecrets.


### Benefits

We henceforth will be able to perform an installation of Kubeapps in an air-gapped environment since every component is able to be retrieved locally if necessary.

An offline installation (supposing the registry is already populated) will be as simple as executing:
`helm install kubeapps ./<MY_LOCAL_PREDOWNLOADED_KUBEAPPS_FOLDER> --set global.imageRegistry=MY_REGISTRY_URL> --set global.imagePullSecrets[0]=<MY_IMAGEPULLSECRET>`

### Possible drawbacks

I'm not aware if setting the` global.imagePullSecrets` value in Helm is the only valid option. Maybe this PR will not work for users setting manually ImagePullSecrets directly in the YAML (since the helper function for generating the comma-separated argument is precisely using global.imagePullSecrets).

### Applicable issues

  - fixes #2144

### Additional information

N/A
