### PR TITLE
[bitnami/kubeapps] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/chart/kubeapps/Chart.lock
+++ b/chart/kubeapps/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.0.0
+digest: sha256:f8c58847aa69098396a2c24071459d6da8790b499590ebee84cc3cbe25fe2167
+generated: "2020-11-18T15:24:50.839372537Z"

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -1,19 +1,23 @@
-apiVersion: v1
-name: kubeapps
-version: 4.0.5
+annotations:
+  category: Infrastructure
+apiVersion: v2
 appVersion: DEVEL
+dependencies:
+  - name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: '10.X.X'
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
+home: https://kubeapps.com
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png
 keywords:
   - helm
   - dashboard
   - service catalog
   - deployment
-home: https://kubeapps.com
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-annotations:
-  category: Infrastructure
+version: 5.0.0

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -252,12 +252,21 @@ After that you should be able to access the new version of Kubeapps. If the abov
 - Move dependency information from the *requirements.yaml* to the *Chart.yaml*
 - After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
 - The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+- In the case of PostgreSQL subchart, apart from the same changes that are described in this section, there are also other major changes due to the master/slave nomenclature was replaced by primary/readReplica. [Here](https://github.com/bitnami/charts/pull/4385) you can find more information about the changes introduced.
 
 **Considerations when upgrading to this version**
 
 - If you want to upgrade to this version from a previous one installed with Helm 3, you shouldn't face any issues
 - If you want to upgrade to this version using Helm 2, this scenario is not supported as this version doesn't support Helm 2 anymore
 - If you installed the previous version with Helm 2 and wants to upgrade to this version with Helm 3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm 2 to 3
+
+Apart from the previous considerations, due to the PostgreSQL major version bump, it's necessary to remove the existing statefulsets:
+
+> Note: The command below assumes that Kubeapps has been deployed in the kubeapps namespace using "kubeapps" as release name, if that's not the case, adapt the command accordingly.
+
+```console
+$ kubectl delete statefulset -n kubeapps kubeapps-postgresql-master kubeapps-postgresql-slave
+```
 
 **Useful links**
 

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -242,7 +242,7 @@ kubectl apply -f <repo name>.yaml
 
 After that you should be able to access the new version of Kubeapps. If the above doesn't work for you or you run into any other issues please open an [issue](https://github.com/kubeapps/kubeapps/issues/new).
 
-### Upgrading to 5.0.0
+### Upgrading to 2.0.1 (Chart 5.0.0)
 
 [On November 13, 2020, Helm 2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm 3 and to be consistent with the Helm project itself regarding the Helm 2 EOL.
 
@@ -256,11 +256,9 @@ After that you should be able to access the new version of Kubeapps. If the abov
 
 **Considerations when upgrading to this version**
 
-- If you want to upgrade to this version from a previous one installed with Helm 3, you shouldn't face any issues
 - If you want to upgrade to this version using Helm 2, this scenario is not supported as this version doesn't support Helm 2 anymore
 - If you installed the previous version with Helm 2 and wants to upgrade to this version with Helm 3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm 2 to 3
-
-Apart from the previous considerations, due to the PostgreSQL major version bump, it's necessary to remove the existing statefulsets:
+- If you want to upgrade to this version from a previous one installed with Helm 3, you shouldn't face any issues related to the new `apiVersion`. Due to the PostgreSQL major version bump, it's necessary to remove the existing statefulsets:
 
 > Note: The command below assumes that Kubeapps has been deployed in the kubeapps namespace using "kubeapps" as release name, if that's not the case, adapt the command accordingly.
 

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -244,7 +244,7 @@ After that you should be able to access the new version of Kubeapps. If the abov
 
 ### Upgrading to 5.0.0
 
-[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+[On November 13, 2020, Helm 2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm 3 and to be consistent with the Helm project itself regarding the Helm 2 EOL.
 
 **What changes were introduced in this major version?**
 
@@ -255,9 +255,9 @@ After that you should be able to access the new version of Kubeapps. If the abov
 
 **Considerations when upgrading to this version**
 
-- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
-- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
-- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+- If you want to upgrade to this version from a previous one installed with Helm 3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm 2, this scenario is not supported as this version doesn't support Helm 2 anymore
+- If you installed the previous version with Helm 2 and wants to upgrade to this version with Helm 3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm 2 to 3
 
 **Useful links**
 

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -242,6 +242,29 @@ kubectl apply -f <repo name>.yaml
 
 After that you should be able to access the new version of Kubeapps. If the above doesn't work for you or you run into any other issues please open an [issue](https://github.com/kubeapps/kubeapps/issues/new).
 
+### Upgrading to 5.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+
 ### Upgrading to 2.0
 
 Kubeapps 2.0 (Chart version 4.0.0) introduces some breaking changes:

--- a/chart/kubeapps/requirements.lock
+++ b/chart/kubeapps/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 9.7.0
-digest: sha256:59b00415d7f4ae845e8c6ce82f773a5757cb6baf2123b9b2ca1cfeae249cc1c3
-generated: "2020-09-22T16:41:01.728915048+02:00"

--- a/chart/kubeapps/requirements.yaml
+++ b/chart/kubeapps/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: postgresql
-    version: ">= 9.7.0"
-    repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically (standardization for all Bitnami Helm Charts)
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_
- There is a new PostgreSQL subchart major version containing the same changes described here about the apiVersion and also a terminology renaming from master/slave to primary/read

**Possible drawbacks**

Helm v2 is no longer supported