### PR TITLE
Restore input style

### DIFF
--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.scss
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.scss
@@ -6,16 +6,6 @@
   h2 {
     margin-top: 0;
   }
-  .clr-control-container {
-    width: 100%;
-    padding-right: 2rem;
-    .clr-input {
-      width: 100%;
-    }
-    textarea {
-      width: 100%;
-    }
-  }
   .clr-form-description {
     font-size: smaller;
     strong {

--- a/dashboard/src/components/Layout/Layout.scss
+++ b/dashboard/src/components/Layout/Layout.scss
@@ -205,7 +205,6 @@
 .clr-control-container {
   width: 100%;
   margin-top: 0.3rem;
-  padding-right: 0;
   .clr-input-wrapper {
     max-width: 100%;
     .clr-input {

--- a/dashboard/src/components/Layout/Layout.scss
+++ b/dashboard/src/components/Layout/Layout.scss
@@ -201,3 +201,18 @@
 .margin-b-sm {
   margin-bottom: 0.3rem;
 }
+
+.clr-control-container {
+  width: 100%;
+  margin-top: 0.3rem;
+  padding-right: 0;
+  .clr-input-wrapper {
+    max-width: 100%;
+    .clr-input {
+      width: 100%;
+    }
+  }
+  textarea {
+    width: 100%;
+  }
+}

--- a/dashboard/src/components/OperatorNew/OperatorNew.scss
+++ b/dashboard/src/components/OperatorNew/OperatorNew.scss
@@ -6,7 +6,3 @@
     margin-top: -0.1rem;
   }
 }
-
-.clr-control-container {
-  margin-top: 0.3rem;
-}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Refactor some style regarding form inputs. With the latest changes (importing the CSS package only), I noticed that the input size got shrank.

Before:
![Screenshot from 2020-11-11 17-26-19](https://user-images.githubusercontent.com/4025665/98837262-0ded5b00-2443-11eb-8ddb-0c3136e7aa6d.png)

Fixed:
![Screenshot from 2020-11-11 17-26-10](https://user-images.githubusercontent.com/4025665/98837281-1180e200-2443-11eb-8091-36dd3a5e4922.png)
