### PR TITLE
Bump CRD from v1beta1 to v1 (k8s  1.16+)

### DIFF
--- a/chart/kubeapps/crds/apprepository-crd.yaml
+++ b/chart/kubeapps/crds/apprepository-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apprepositories.kubeapps.com

--- a/chart/kubeapps/templates/apprepository-crd.yaml
+++ b/chart/kubeapps/templates/apprepository-crd.yaml
@@ -1,7 +1,7 @@
 {{- if not (.Capabilities.APIVersions.Has "kubeapps.com/v1alpha1") -}}
 # The condition above will be true if another instance of Kubeapps is
 # already installed
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apprepositories.kubeapps.com

--- a/cmd/apprepository-controller/artifacts/examples/crd.yaml
+++ b/cmd/apprepository-controller/artifacts/examples/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apprepositories.kubeapps.com


### PR DESCRIPTION
### Description of the change

In k8s 1.16+ a deprecation warning of `apiextensions.k8s.io/v1beta1` in favor of `apiextensions.k8s.io/v1` appeared. In 1.22+ it will be fully deprecated.

This PR bumps `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1`.

### Benefits

Users won't get a deprecation warning. Besides, k8s 1.22+ users still will be able to install Kubeapps.

### Possible drawbacks

Prior to <1.16 it won't be compatible (but these versions already reached EOL).

### Applicable issues

N/A

### Additional information

Perhaps it should be landed with other chart-related PRs to also bump up the chart version.
