### PR TITLE
Store the last namespace used in the browser storage

### DIFF
--- a/dashboard/src/actions/auth.test.tsx
+++ b/dashboard/src/actions/auth.test.tsx
@@ -5,6 +5,7 @@ import { getType } from "typesafe-actions";
 import actions from ".";
 import { Auth } from "../shared/Auth";
 import Namespace from "../shared/Namespace";
+import * as NS from "../shared/Namespace";
 
 const defaultCluster = "default";
 const mockStore = configureMockStore([thunk]);
@@ -28,6 +29,7 @@ beforeEach(() => {
   Namespace.list = jest.fn(async () => {
     return { namespaces: [] };
   });
+  jest.spyOn(NS, "unsetStoredNamespace");
 
   store = mockStore({
     auth: {
@@ -144,5 +146,12 @@ describe("OIDC authentication", () => {
       expect(localStorage.removeItem).toBeCalled();
       expect(document.location.assign).toBeCalledWith("/log/out");
     });
+  });
+});
+
+describe("logout", () => {
+  it("unsets the stored namespace", async () => {
+    await store.dispatch(actions.auth.logout());
+    expect(NS.unsetStoredNamespace).toHaveBeenCalled();
   });
 });

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -1,4 +1,5 @@
 import { ThunkAction } from "redux-thunk";
+import * as Namespace from "shared/Namespace";
 import { ActionType, createAction } from "typesafe-actions";
 
 import { Auth } from "../shared/Auth";
@@ -62,6 +63,7 @@ export function logout(): ThunkAction<
       dispatch(setAuthenticated(false, false));
       dispatch(clearClusters());
     }
+    Namespace.unsetStoredNamespace();
   };
 }
 

--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -12,6 +12,7 @@ import {
   receiveNamespaces,
   requestNamespace,
   setNamespace,
+  setNamespaceState,
 } from "./namespace";
 
 const mockStore = configureMockStore([thunk]);
@@ -34,7 +35,7 @@ interface ITestCase {
 const actionTestCases: ITestCase[] = [
   {
     name: "setNamespace",
-    action: setNamespace,
+    action: setNamespaceState,
     args: ["default", "jack"],
     payload: { cluster: "default", namespace: "jack" },
   },
@@ -167,5 +168,30 @@ describe("getNamespace", () => {
     const r = await store.dispatch(getNamespace("default-c", "default-ns"));
     expect(r).toBe(false);
     expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe("setNamespace", () => {
+  beforeEach(() => {
+    localStorage.setItem = jest.fn();
+    localStorage.getItem = jest.fn();
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("dispatches namespace set", async () => {
+    const expectedActions = [
+      {
+        type: getType(setNamespaceState),
+        payload: { cluster: "default-c", namespace: "default-ns" },
+      },
+    ];
+    await store.dispatch(setNamespace("default-c", "default-ns"));
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "kubeapps_namespace",
+      '{"default-c":"default-ns"}',
+    );
   });
 });

--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -172,14 +172,6 @@ describe("getNamespace", () => {
 });
 
 describe("setNamespace", () => {
-  beforeEach(() => {
-    localStorage.setItem = jest.fn();
-    localStorage.getItem = jest.fn();
-  });
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   it("dispatches namespace set", async () => {
     const expectedActions = [
       {

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -2,7 +2,7 @@ import { ThunkAction } from "redux-thunk";
 
 import { ActionType, createAction } from "typesafe-actions";
 
-import Namespace from "../shared/Namespace";
+import Namespace, { setStoredNamespace } from "../shared/Namespace";
 import { IResource, IStoreState } from "../shared/types";
 
 export const requestNamespace = createAction("REQUEST_NAMESPACE", resolve => {
@@ -12,7 +12,7 @@ export const receiveNamespace = createAction("RECEIVE_NAMESPACE", resolve => {
   return (cluster: string, namespace: IResource) => resolve({ cluster, namespace });
 });
 
-export const setNamespace = createAction("SET_NAMESPACE", resolve => {
+export const setNamespaceState = createAction("SET_NAMESPACE", resolve => {
   return (cluster: string, namespace: string) => resolve({ cluster, namespace });
 });
 
@@ -33,7 +33,7 @@ export const clearClusters = createAction("CLEAR_CLUSTERS");
 const allActions = [
   requestNamespace,
   receiveNamespace,
-  setNamespace,
+  setNamespaceState,
   receiveNamespaces,
   errorNamespaces,
   clearClusters,
@@ -88,5 +88,15 @@ export function getNamespace(
       dispatch(errorNamespaces(cluster, e, "get"));
       return false;
     }
+  };
+}
+
+export function setNamespace(
+  cluster: string,
+  ns: string,
+): ThunkAction<Promise<void>, IStoreState, null, NamespaceAction> {
+  return async dispatch => {
+    setStoredNamespace(cluster, ns);
+    dispatch(setNamespaceState(cluster, ns));
   };
 }

--- a/dashboard/src/reducers/charts.test.ts
+++ b/dashboard/src/reducers/charts.test.ts
@@ -34,7 +34,7 @@ describe("chartReducer", () => {
 
     expect(
       chartsReducer(undefined, {
-        type: getType(actions.namespace.setNamespace) as any,
+        type: getType(actions.namespace.setNamespaceState) as any,
       }),
     ).toEqual({ ...initialState });
   });
@@ -51,7 +51,7 @@ describe("chartReducer", () => {
           },
         },
         {
-          type: getType(actions.namespace.setNamespace) as any,
+          type: getType(actions.namespace.setNamespaceState) as any,
         },
       ),
     ).toEqual({ ...initialState });

--- a/dashboard/src/reducers/charts.ts
+++ b/dashboard/src/reducers/charts.ts
@@ -88,7 +88,7 @@ const chartsReducer = (
         isFetching: false,
         selected: chartsSelectedReducer(state.selected, action),
       };
-    case getType(actions.namespace.setNamespace):
+    case getType(actions.namespace.setNamespaceState):
       return { ...initialState };
     default:
   }

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -215,7 +215,6 @@ describe("clusterReducer", () => {
     });
   });
 
-  // let spyOnGetItem: jest.SpyInstance;
   context("when RECEIVE_NAMESPACES", () => {
     afterEach(() => {
       jest.restoreAllMocks();

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -154,7 +154,7 @@ describe("clusterReducer", () => {
             },
           },
           {
-            type: getType(actions.namespace.setNamespace),
+            type: getType(actions.namespace.setNamespaceState),
             payload: { cluster: "initial-cluster", namespace: "default" },
           },
         ),
@@ -215,7 +215,12 @@ describe("clusterReducer", () => {
     });
   });
 
+  // let spyOnGetItem: jest.SpyInstance;
   context("when RECEIVE_NAMESPACES", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it("updates the namespace list and clears error", () => {
       expect(
         clusterReducer(
@@ -288,7 +293,6 @@ describe("clusterReducer", () => {
           },
         },
       } as IClustersState);
-      jest.restoreAllMocks();
     });
 
     it("defaults to the first namespace if the one in token is not available", () => {
@@ -322,7 +326,6 @@ describe("clusterReducer", () => {
           },
         },
       } as IClustersState);
-      jest.restoreAllMocks();
     });
 
     it("gets the existing current namespace", () => {
@@ -350,6 +353,74 @@ describe("clusterReducer", () => {
         clusters: {
           other: {
             currentNamespace: "three",
+            namespaces: ["one", "two", "three"],
+            error: undefined,
+          },
+        },
+      } as IClustersState);
+    });
+
+    it("gets the stored namespace", () => {
+      jest
+        .spyOn(window.localStorage.__proto__, "getItem")
+        .mockReturnValueOnce('{"other": "three"}');
+      expect(
+        clusterReducer(
+          {
+            ...initialTestState,
+            clusters: {
+              other: {
+                currentNamespace: "",
+                namespaces: [],
+              },
+            },
+          } as IClustersState,
+          {
+            type: getType(actions.namespace.receiveNamespaces),
+            payload: {
+              cluster: "other",
+              namespaces: ["one", "two", "three"],
+            },
+          },
+        ),
+      ).toEqual({
+        ...initialTestState,
+        clusters: {
+          other: {
+            currentNamespace: "three",
+            namespaces: ["one", "two", "three"],
+            error: undefined,
+          },
+        },
+      } as IClustersState);
+    });
+
+    it("ignores the stored namespace if it's not available", () => {
+      jest.spyOn(window.localStorage.__proto__, "getItem").mockReturnValueOnce('{"other": "four"}');
+      expect(
+        clusterReducer(
+          {
+            ...initialTestState,
+            clusters: {
+              other: {
+                currentNamespace: "",
+                namespaces: [],
+              },
+            },
+          } as IClustersState,
+          {
+            type: getType(actions.namespace.receiveNamespaces),
+            payload: {
+              cluster: "other",
+              namespaces: ["one", "two", "three"],
+            },
+          },
+        ),
+      ).toEqual({
+        ...initialTestState,
+        clusters: {
+          other: {
+            currentNamespace: "one",
             namespaces: ["one", "two", "three"],
             error: undefined,
           },

--- a/dashboard/src/reducers/cluster.ts
+++ b/dashboard/src/reducers/cluster.ts
@@ -73,6 +73,7 @@ const clusterReducer = (
             ...state.clusters[action.payload.cluster],
             namespaces: action.payload.namespaces,
             currentNamespace: getCurrentNamespace(
+              action.payload.cluster,
               state.clusters[action.payload.cluster].currentNamespace,
               action.payload.namespaces,
             ),
@@ -80,7 +81,7 @@ const clusterReducer = (
           },
         },
       };
-    case getType(actions.namespace.setNamespace):
+    case getType(actions.namespace.setNamespaceState):
       return {
         ...state,
         currentCluster: action.payload.cluster,

--- a/dashboard/src/reducers/operators.test.ts
+++ b/dashboard/src/reducers/operators.test.ts
@@ -34,7 +34,7 @@ describe("catalogReducer", () => {
       requestOperators: getType(actions.operators.requestOperators),
       receiveOperators: getType(actions.operators.receiveOperators),
       errorOperators: getType(actions.operators.errorOperators),
-      setNamespace: getType(actions.namespace.setNamespace),
+      setNamespaceState: getType(actions.namespace.setNamespaceState),
       requestOperator: getType(actions.operators.requestOperator),
       receiveOperator: getType(actions.operators.receiveOperator),
       requestCSVs: getType(actions.operators.requestCSVs),
@@ -165,7 +165,7 @@ describe("catalogReducer", () => {
 
         expect(
           operatorReducer(undefined, {
-            type: actionTypes.setNamespace as any,
+            type: actionTypes.setNamespaceState as any,
           }),
         ).toEqual({ ...initialState });
       });
@@ -187,7 +187,7 @@ describe("catalogReducer", () => {
               operators: [{} as any],
             },
             {
-              type: actionTypes.setNamespace as any,
+              type: actionTypes.setNamespaceState as any,
             },
           ),
         ).toEqual({ ...initialState });

--- a/dashboard/src/reducers/operators.ts
+++ b/dashboard/src/reducers/operators.ts
@@ -209,7 +209,7 @@ const catalogReducer = (
         isOLMInstalled: state.isOLMInstalled,
         errors: { operator: {}, csv: {}, resource: {}, subscriptions: {} },
       };
-    case getType(actions.namespace.setNamespace):
+    case getType(actions.namespace.setNamespaceState):
       return { ...operatorsInitialState, isOLMInstalled: state.isOLMInstalled };
     default:
       return { ...state };

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -1,8 +1,7 @@
-import { axiosWithAuth } from "./AxiosInstance";
-import * as url from "./url";
-
 import { Auth } from "./Auth";
+import { axiosWithAuth } from "./AxiosInstance";
 import { ForbiddenError, IResource, NotFoundError } from "./types";
+import * as url from "./url";
 
 export default class Namespace {
   public static async list(cluster: string) {
@@ -52,10 +51,34 @@ export const definedNamespaces = {
   all: "_all",
 };
 
-export function getCurrentNamespace(currentNS: string, availableNS: string[]) {
+// The namespace information will contain a map[cluster]:namespace with the default namespaces
+const namespaceKey = "kubeapps_namespace";
+
+function getStoredNamespace(cluster: string) {
+  const ns = localStorage.getItem(namespaceKey) || "{}";
+  return JSON.parse(ns)[cluster] || "";
+}
+
+export function setStoredNamespace(cluster: string, namespace: string) {
+  const ns: string = localStorage.getItem(namespaceKey) || "{}";
+  const nsObject = JSON.parse(ns);
+  nsObject[cluster] = namespace;
+  localStorage.setItem(namespaceKey, JSON.stringify(nsObject));
+}
+
+export function unsetStoredNamespace() {
+  localStorage.removeItem(namespaceKey);
+}
+
+export function getCurrentNamespace(cluster: string, currentNS: string, availableNS: string[]) {
   if (currentNS) {
     // If a namespace has been already selected, use it
     return currentNS;
+  }
+  // Try to get the latest namespace used
+  const storedNS = getStoredNamespace(cluster);
+  if (storedNS && availableNS.includes(storedNS)) {
+    return storedNS;
   }
   // Try to get a namespace from the auth token
   const tokenNS = Auth.defaultNamespaceFromToken(Auth.getAuthToken() || "");

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -1,3 +1,4 @@
+import { get } from "lodash";
 import { Auth } from "./Auth";
 import { axiosWithAuth } from "./AxiosInstance";
 import { ForbiddenError, IResource, NotFoundError } from "./types";
@@ -54,16 +55,25 @@ export const definedNamespaces = {
 // The namespace information will contain a map[cluster]:namespace with the default namespaces
 const namespaceKey = "kubeapps_namespace";
 
-function getStoredNamespace(cluster: string) {
+function parseStoredNS() {
   const ns = localStorage.getItem(namespaceKey) || "{}";
-  return JSON.parse(ns)[cluster] || "";
+  let parsedNS = {};
+  try {
+    parsedNS = JSON.parse(ns);
+  } catch (e) {
+    // The stored value should be a json object, if not, ignore it
+  }
+  return parsedNS;
+}
+
+function getStoredNamespace(cluster: string) {
+  return get(parseStoredNS(), cluster, "");
 }
 
 export function setStoredNamespace(cluster: string, namespace: string) {
-  const ns: string = localStorage.getItem(namespaceKey) || "{}";
-  const nsObject = JSON.parse(ns);
-  nsObject[cluster] = namespace;
-  localStorage.setItem(namespaceKey, JSON.stringify(nsObject));
+  const ns = parseStoredNS();
+  ns[cluster] = namespace;
+  localStorage.setItem(namespaceKey, JSON.stringify(ns));
 }
 
 export function unsetStoredNamespace() {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Another item for #2018, store the latest namespace used in the browser so it's easier to resume previous work.

When logging out of the system (or when the session expires), this information is cleaned up.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2018
