### PR TITLE
Fix version retrieval when pushing commit

### DIFF
--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -106,7 +106,7 @@ commitAndPushChanges() {
         cd -
         return 1
     fi
-    local chartVersion=$(grep -w version: ${chartYaml} | awk '{print $2}')
+    local chartVersion=$(grep -e '^version:' ${chartYaml} | awk '{print $2}')
     git add --all .
     git commit -m "kubeapps: bump chart version to $chartVersion"
     # NOTE: This expects to have a loaded SSH key


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

When syncing the chart with the bitnami repo, the version in the commit message is wrong since it's picking the PosgreSQL dependency:

https://github.com/bitnami/charts/commit/cbe4ff5431459d4f037d905aa9ed2cbc89e6c16a

Note that the `Chart.yaml` now contains both versions:

```yaml
dependencies:
  - name: postgresql
    repository: https://charts.bitnami.com/bitnami
    version: '10.X.X'
name: kubeapps
version: 5.0.0
```

