### PR TITLE
Hide all-namespace switch if not allowed

### DIFF
--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -8,6 +8,7 @@ import LoadingWrapper from "components/LoadingWrapper";
 import SearchFilter from "components/SearchFilter/SearchFilter";
 import * as qs from "qs";
 import { act } from "react-dom/test-utils";
+import { Kube } from "shared/Kube";
 import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
 import { FetchError, IAppOverview, IStoreState } from "../../shared/types";
 import Alert from "../js/Alert";
@@ -29,6 +30,9 @@ beforeEach(() => {
   };
   const mockDispatch = jest.fn();
   spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
+  Kube.canI = jest.fn().mockReturnValue({
+    then: jest.fn(f => f(true)),
+  });
 });
 
 afterEach(() => {
@@ -75,6 +79,14 @@ context("when changing props", () => {
     });
     expect(fetchAppsWithUpdateInfo).toHaveBeenCalledWith("default-cluster", "");
     expect(getCustomResources).toHaveBeenCalledWith("default-cluster", "");
+  });
+
+  it("should hide the all-namespace switch if the user doesn't have permissions", async () => {
+    Kube.canI = jest.fn().mockReturnValue({
+      then: jest.fn((f: any) => f(false)),
+    });
+    const wrapper = mountWrapper(defaultStore, <AppList />);
+    expect(wrapper.find("input[type='checkbox']")).not.toExist();
   });
 });
 

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
+import { Kube } from "shared/Kube";
 import { IStoreState } from "../../shared/types";
 import * as url from "../../shared/url";
 import PageHeader from "../PageHeader/PageHeader";
@@ -35,6 +36,7 @@ function AppList() {
 
   const [searchFilter, setSearchFilter] = useState("");
   const [allNS, setAllNS] = useState(false);
+  const [canSetAllNS, setCanSetAllNS] = useState(false);
   const [namespace, setNamespace] = useState(currentNamespace);
   const toggleListAllNS = () => {
     submitFilters(!allNS);
@@ -74,6 +76,12 @@ function AppList() {
   }, [dispatch, cluster, namespace]);
 
   useEffect(() => {
+    // In order to be able to list applications in all namespaces, it's necessary to be able
+    // to list/get secrets in all of them.
+    Kube.canI(cluster, "", "secrets", "list", "").then(allowed => setCanSetAllNS(allowed));
+  }, [cluster]);
+
+  useEffect(() => {
     setSearchFilter(searchQuery);
   }, [searchQuery]);
 
@@ -94,16 +102,18 @@ function AppList() {
               value={searchFilter}
               submitFilters={submitSearchFilter}
             />
-            <CdsToggleGroup className="flex-v-center">
-              <CdsToggle>
-                <label>Show apps in all namespaces</label>
-                <input
-                  type="checkbox"
-                  onChange={toggleListAllNS}
-                  checked={allNSQuery === "yes" || allNS}
-                />
-              </CdsToggle>
-            </CdsToggleGroup>
+            {canSetAllNS && (
+              <CdsToggleGroup className="flex-v-center">
+                <CdsToggle>
+                  <label>Show apps in all namespaces</label>
+                  <input
+                    type="checkbox"
+                    onChange={toggleListAllNS}
+                    checked={allNSQuery === "yes" || allNS}
+                  />
+                </CdsToggle>
+              </CdsToggleGroup>
+            )}
           </>
         }
         buttons={[


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Depends on: #2179

Normal users won't have permission to list apps in all namespaces so hide the switch in that case.
