### PR TITLE
Add documentation for the Makefile scripts

### DIFF
--- a/docs/developer/using-makefiles.md
+++ b/docs/developer/using-makefiles.md
@@ -1,0 +1,53 @@
+# How to set up the environment using the provided makefiles
+
+The main file is [Makefile](https://github.com/kubeapps/kubeapps/blob/master/Makefile), which will compile and prepare the production assets for then generating a set of Docker images. It is the starting point when you want to build the Kubeapps different components.
+
+For setting up the environment for running Kubeapps, we also provide (as it) makefiles for:
+* Creating a multicluster environment with Kind ([cluster-kind.mk](https://github.com/kubeapps/kubeapps/blob/master/script/cluster-kind.mk))
+* Deploying and configuring the components for getting Kubeapps running with OIDC login using Dex ([deploy-dev.mk](https://github.com/kubeapps/kubeapps/blob/master/script/deploy-dev.mk)).
+
+## Makefile for generating images
+
+### Commands
+
+Find below a list of the most used commands:
+
+``` bash
+make # will make all the kubeapps images
+make kubeapps/dashboard
+make kubeapps/apprepository-controller
+make kubeapps/kubeops
+make kubeapps/assetsvc
+make kubeapps/asset-syncer
+```
+
+> You can set the image tag manually: `IMAGE_TAG=myTag make`
+
+## Makefile for setting up the environment
+
+### Prerequisites
+
+* Install `mkcert`; you gan get it from the [official repository](https://github.com/FiloSottile/mkcert/releases).
+* Get the Kind network IP and replace it when necessary.
+    * Retrieve the IP by executing  `kubectl --namespace=kube-system get pods -o wide | grep kube-apiserver-kubeapps-control-plane  | awk '{print $6}'`
+    * Replace `172.18.0.2` with the previous IP the following files:
+        * [kubeapps-local-dev-additional-apiserver-config.yaml](../user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml)
+        * [kubeapps-local-dev-additional-kind-cluster.yaml](../user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml)
+        * [kubeapps-local-dev-apiserver-config.yaml](../user/manifests/kubeapps-local-dev-apiserver-config.yaml)
+        * [kubeapps-local-dev-auth-proxy-values.yaml](../user/manifests/kubeapps-local-dev-auth-proxy-values.yaml)
+        * [kubeapps-local-dev-dex-values.yaml](../user/manifests/kubeapps-local-dev-dex-values.yaml)
+### Commands
+
+```bash
+# Create two cluster with RBAC and Nginx Ingress controller
+# and configure the kube apiserver with the oidc flags
+make multi-cluster-kind
+
+# Install dex (identity service using OIDC),
+# install openldap and add default users,
+# generate certs for tls,
+# and deploy kubeapps with the proper configuration 
+make deploy-dev
+```
+
+> Many commands are using `...|| true`, so you will have to manually make sure that every command is, indeed, running OK by checking the logs.

--- a/docs/developer/using-makefiles.md
+++ b/docs/developer/using-makefiles.md
@@ -1,10 +1,12 @@
-# How to set up the environment using the provided makefiles
+# How to set up the environment using the provided makefile targets
 
 The main file is [Makefile](https://github.com/kubeapps/kubeapps/blob/master/Makefile), which will compile and prepare the production assets for then generating a set of Docker images. It is the starting point when you want to build the Kubeapps different components.
 
-For setting up the environment for running Kubeapps, we also provide (as it) makefiles for:
+For setting up the environment for running Kubeapps, we also provide (as is) makefile targets for:
 * Creating a multicluster environment with Kind ([cluster-kind.mk](https://github.com/kubeapps/kubeapps/blob/master/script/cluster-kind.mk))
 * Deploying and configuring the components for getting Kubeapps running with OIDC login using Dex ([deploy-dev.mk](https://github.com/kubeapps/kubeapps/blob/master/script/deploy-dev.mk)).
+
+> Disclaimer: these files are not being actively maintained, as they are solely intended for helping Kubeapp developers to set up the environment. If you are a contributor and you are having troubles, please feel free to [open an issue](https://github.com/kubeapps/kubeapps/issues/new).
 
 ## Makefile for generating images
 
@@ -27,10 +29,15 @@ make kubeapps/asset-syncer
 
 ### Prerequisites
 
-* Install `mkcert`; you gan get it from the [official repository](https://github.com/FiloSottile/mkcert/releases).
+* Install `mkcert`; you can get it from the [official repository](https://github.com/FiloSottile/mkcert/releases).
 * Get the Kind network IP and replace it when necessary.
-    * Retrieve the IP by executing  `kubectl --namespace=kube-system get pods -o wide | grep kube-apiserver-kubeapps-control-plane  | awk '{print $6}'`
-    * Replace `172.18.0.2` with the previous IP the following files:
+    * Retrieve the IP for Dex:
+    It is a requirement to discover the nodes IP address on the bridge network so that Dex can be reached both inside and outside the cluster at the same address. 
+    You can get this IP by inspecting the kind network (`docker network inspect kind`) and setting the value as **the next available IP on that network**.
+    
+        * Another way to do so is to execute `kubectl --namespace=kube-system get pods -o wide | grep kube-apiserver-kubeapps-control-plane  | awk '{print $6}'`, but it won't work unless you exec `make delete-cluster-kind && make cluster-kind`, as some of these files (the apiserver-config ones) are config for the cluster apiserver itself, which has to know where to find dex.
+
+    * Then, replace `172.18.0.2` with the previous IP the following files:
         * [kubeapps-local-dev-additional-apiserver-config.yaml](../user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml)
         * [kubeapps-local-dev-additional-kind-cluster.yaml](../user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml)
         * [kubeapps-local-dev-apiserver-config.yaml](../user/manifests/kubeapps-local-dev-apiserver-config.yaml)
@@ -49,5 +56,3 @@ make multi-cluster-kind
 # and deploy kubeapps with the proper configuration 
 make deploy-dev
 ```
-
-> Many commands are using `...|| true`, so you will have to manually make sure that every command is, indeed, running OK by checking the logs.

--- a/docs/developer/using-makefiles.md
+++ b/docs/developer/using-makefiles.md
@@ -31,13 +31,15 @@ make kubeapps/asset-syncer
 
 * Install `mkcert`; you can get it from the [official repository](https://github.com/FiloSottile/mkcert/releases).
 * Get the Kind network IP and replace it when necessary.
-    * Retrieve the IP for Dex:
+    * Retrieve the node's IP address on the kind bridge network so it can be used by Dex:
     It is a requirement to discover the nodes IP address on the bridge network so that Dex can be reached both inside and outside the cluster at the same address. 
-    You can get this IP by inspecting the kind network (`docker network inspect kind`) and setting the value as **the next available IP on that network**.
+    You can get this IP by inspecting the kind network (`docker network inspect kind`) and setting the value as **the next available IP on that network**
+    (if you don't already have any kind clusters launched, this will be the first address after the gateway, ie. something like 172.x.0.2).
     
-        * Another way to do so is to execute `kubectl --namespace=kube-system get pods -o wide | grep kube-apiserver-kubeapps-control-plane  | awk '{print $6}'`, but it won't work unless you exec `make delete-cluster-kind && make cluster-kind`, as some of these files (the apiserver-config ones) are config for the cluster apiserver itself, which has to know where to find dex.
+        * Another way to do so is to start the environment with `make cluster-kind` and manually verify the IP address by executing `kubectl --namespace=kube-system get pods -o wide | grep kube-apiserver-kubeapps-control-plane  | awk '{print $6}'`, but you will need to re-create the cluster after you've updated the config files (below) by executing `make delete-cluster-kind`, as some of these files (the apiserver-config ones) are config for the cluster apiserver itself, which has to know where to find dex.
 
     * Then, replace `172.18.0.2` with the previous IP the following files:
+        * [script/deploy-dev.mk](../../script/deploy-dev.mk)
         * [kubeapps-local-dev-additional-apiserver-config.yaml](../user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml)
         * [kubeapps-local-dev-additional-kind-cluster.yaml](../user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml)
         * [kubeapps-local-dev-apiserver-config.yaml](../user/manifests/kubeapps-local-dev-apiserver-config.yaml)

--- a/script/cluster-kind.mk
+++ b/script/cluster-kind.mk
@@ -15,15 +15,15 @@ ${CLUSTER_CONFIG}:
 		--name ${CLUSTER_NAME} \
 		--config=./docs/user/manifests/kubeapps-local-dev-apiserver-config.yaml \
 		--retain \
-		--wait 10s || true
-	kubectl apply --kubeconfig=${CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml || true
-	kubectl apply --kubeconfig=${CLUSTER_CONFIG} -f ./docs/user/manifests/ingress-nginx-kind-with-large-proxy-buffers.yaml || true
+		--wait 10s
+	kubectl apply --kubeconfig=${CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
+	kubectl apply --kubeconfig=${CLUSTER_CONFIG} -f ./docs/user/manifests/ingress-nginx-kind-with-large-proxy-buffers.yaml
 	# TODO: need to add wait for condition=exists or similar - https://github.com/kubernetes/kubernetes/issues/83242
 	sleep 5
 	kubectl wait --kubeconfig=${CLUSTER_CONFIG} --namespace ingress-nginx \
 		--for=condition=ready pod \
 		--selector=app.kubernetes.io/component=controller \
-		--timeout=120s || true
+		--timeout=120s
 
 cluster-kind: ${CLUSTER_CONFIG}
 
@@ -31,10 +31,10 @@ cluster-kind: ${CLUSTER_CONFIG}
 # reuse the key and cert from the apiserver, which already includes v3 extensions
 # for the correct alternative name (using the IP address).
 devel/dex.crt:
-	docker cp kubeapps-control-plane:/etc/kubernetes/pki/apiserver.crt ./devel/dex.crt || true
+	docker cp kubeapps-control-plane:/etc/kubernetes/pki/apiserver.crt ./devel/dex.crt
 
 devel/dex.key:
-	docker cp kubeapps-control-plane:/etc/kubernetes/pki/apiserver.key ./devel/dex.key || true
+	docker cp kubeapps-control-plane:/etc/kubernetes/pki/apiserver.key ./devel/dex.key
 
 ${ADDITIONAL_CLUSTER_CONFIG}: devel/dex.crt
 	kind create cluster \
@@ -42,9 +42,9 @@ ${ADDITIONAL_CLUSTER_CONFIG}: devel/dex.crt
 		--name ${ADDITIONAL_CLUSTER_NAME} \
 		--config=./docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml \
 		--retain \
-		--wait 10s || true
-	kubectl apply --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml || true
-	kubectl apply --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml || true
+		--wait 10s
+	kubectl apply --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
+	kubectl apply --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml
 
 additional-cluster-kind: ${ADDITIONAL_CLUSTER_CONFIG}
 

--- a/script/cluster-kind.mk
+++ b/script/cluster-kind.mk
@@ -15,15 +15,15 @@ ${CLUSTER_CONFIG}:
 		--name ${CLUSTER_NAME} \
 		--config=./docs/user/manifests/kubeapps-local-dev-apiserver-config.yaml \
 		--retain \
-		--wait 10s
-	kubectl apply --kubeconfig=${CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
-	kubectl apply --kubeconfig=${CLUSTER_CONFIG} -f ./docs/user/manifests/ingress-nginx-kind-with-large-proxy-buffers.yaml
+		--wait 10s || true
+	kubectl apply --kubeconfig=${CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml || true
+	kubectl apply --kubeconfig=${CLUSTER_CONFIG} -f ./docs/user/manifests/ingress-nginx-kind-with-large-proxy-buffers.yaml || true
 	# TODO: need to add wait for condition=exists or similar - https://github.com/kubernetes/kubernetes/issues/83242
 	sleep 5
 	kubectl wait --kubeconfig=${CLUSTER_CONFIG} --namespace ingress-nginx \
 		--for=condition=ready pod \
 		--selector=app.kubernetes.io/component=controller \
-		--timeout=120s
+		--timeout=120s || true
 
 cluster-kind: ${CLUSTER_CONFIG}
 
@@ -31,10 +31,10 @@ cluster-kind: ${CLUSTER_CONFIG}
 # reuse the key and cert from the apiserver, which already includes v3 extensions
 # for the correct alternative name (using the IP address).
 devel/dex.crt:
-	kubectl -n kube-system cp kube-apiserver-kubeapps-control-plane:etc/kubernetes/pki/apiserver.crt ./devel/dex.crt
+	docker cp kubeapps-control-plane:/etc/kubernetes/pki/apiserver.crt ./devel/dex.crt || true
 
 devel/dex.key:
-	kubectl -n kube-system cp kube-apiserver-kubeapps-control-plane:etc/kubernetes/pki/apiserver.key ./devel/dex.key
+	docker cp kubeapps-control-plane:/etc/kubernetes/pki/apiserver.key ./devel/dex.key || true
 
 ${ADDITIONAL_CLUSTER_CONFIG}: devel/dex.crt
 	kind create cluster \
@@ -42,9 +42,9 @@ ${ADDITIONAL_CLUSTER_CONFIG}: devel/dex.crt
 		--name ${ADDITIONAL_CLUSTER_NAME} \
 		--config=./docs/user/manifests/kubeapps-local-dev-additional-apiserver-config.yaml \
 		--retain \
-		--wait 10s
-	kubectl apply --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml
-	kubectl apply --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml
+		--wait 10s || true
+	kubectl apply --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml || true
+	kubectl apply --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG} -f ./docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml || true
 
 additional-cluster-kind: ${ADDITIONAL_CLUSTER_CONFIG}
 

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -5,33 +5,34 @@
 # that has been setup with OIDC support (see ./cluster-kind.mk)
 
 deploy-dex: devel/dex.crt devel/dex.key
-	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace dex || true
+	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace dex
 	kubectl --kubeconfig=${CLUSTER_CONFIG} -n dex create secret tls dex-web-server-tls \
 		--key ./devel/dex.key \
-		--cert ./devel/dex.crt || true
-	helm --kubeconfig=${CLUSTER_CONFIG} repo add stable https://charts.helm.sh/stable || true
-	helm --kubeconfig=${CLUSTER_CONFIG} install dex stable/dex --namespace dex  --values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml || true
+		--cert ./devel/dex.crt
+	helm --kubeconfig=${CLUSTER_CONFIG} repo add stable https://charts.helm.sh/stable
+	helm --kubeconfig=${CLUSTER_CONFIG} install dex stable/dex --namespace dex  --values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
 
 deploy-openldap:
-	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace ldap || true
+	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace ldap
+	helm --kubeconfig=${CLUSTER_CONFIG} repo add stable https://charts.helm.sh/stable
 	helm --kubeconfig=${CLUSTER_CONFIG} install ldap stable/openldap --namespace ldap \
-		--values ./docs/user/manifests/kubeapps-local-dev-openldap-values.yaml || true
+		--values ./docs/user/manifests/kubeapps-local-dev-openldap-values.yaml
 
 # Get mkcert from https://github.com/FiloSottile/mkcert/releases
 devel/localhost-cert.pem:
-	mkcert -key-file ./devel/localhost-key.pem -cert-file ./devel/localhost-cert.pem localhost 172.19.0.2 || true
+	mkcert -key-file ./devel/localhost-key.pem -cert-file ./devel/localhost-cert.pem localhost 172.19.0.2
 
 deploy-dependencies: deploy-dex deploy-openldap devel/localhost-cert.pem
-	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace kubeapps || true
+	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace kubeapps
 	kubectl --kubeconfig=${CLUSTER_CONFIG} -n kubeapps create secret tls localhost-tls \
 		--key ./devel/localhost-key.pem \
-		--cert ./devel/localhost-cert.pem || true
+		--cert ./devel/localhost-cert.pem
 
 deploy-dev-kubeapps: 
 	helm --kubeconfig=${CLUSTER_CONFIG} install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
-		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml || true
+		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
 
 deploy-dev: deploy-dependencies deploy-dev-kubeapps
 	@echo "\nYou can now simply open your browser at https://localhost/ to access Kubeapps!"
@@ -44,14 +45,14 @@ deploy-dev: deploy-dependencies deploy-dev-kubeapps
 	@echo "to authenticate with the corresponding permissions."
 
 reset-dev-kubeapps:
-	helm --kubeconfig=${CLUSTER_CONFIG} -n kubeapps delete kubeapps || true
-	kubectl -kubeconfig=${CLUSTER_CONFIG} delete jobs -n kubeapps --all || true
-	kubectl delete namespace --wait kubeapps || true
+	helm --kubeconfig=${CLUSTER_CONFIG} -n kubeapps delete kubeapps
+	kubectl -kubeconfig=${CLUSTER_CONFIG} delete jobs -n kubeapps --all
+	kubectl delete namespace --wait kubeapps
 
 reset-dev:
-	helm --kubeconfig=${CLUSTER_CONFIG} -n kubeapps delete kubeapps || true
+	helm --kubeconfig=${CLUSTER_CONFIG} -n kubeapps delete kubeapps  || true
 	kubectl -kubeconfig=${CLUSTER_CONFIG} delete jobs -n kubeapps --all || true
-	helm --kubeconfig=${CLUSTER_CONFIG} -n dex delete dex || true
+	helm --kubeconfig=${CLUSTER_CONFIG} -n dex delete dex  || true
 	helm --kubeconfig=${CLUSTER_CONFIG} -n ldap delete ldap || true
 	kubectl delete namespace --wait dex ldap kubeapps || true
 

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -5,32 +5,35 @@
 # that has been setup with OIDC support (see ./cluster-kind.mk)
 
 deploy-dex: devel/dex.crt devel/dex.key
-	kubectl create namespace dex
-	kubectl -n dex create secret tls dex-web-server-tls \
+	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace dex || true
+	kubectl --kubeconfig=${CLUSTER_CONFIG} -n dex create secret tls dex-web-server-tls \
 		--key ./devel/dex.key \
-		--cert ./devel/dex.crt
-	helm install dex stable/dex --namespace dex --version 2.13.0 \
-		--values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
+		--cert ./devel/dex.crt || true
+	helm --kubeconfig=${CLUSTER_CONFIG} repo add stable https://charts.helm.sh/stable || true
+	helm --kubeconfig=${CLUSTER_CONFIG} install dex stable/dex --namespace dex  --values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml || true
 
 deploy-openldap:
-	kubectl create namespace ldap
-	helm install ldap stable/openldap --namespace ldap \
-		--values ./docs/user/manifests/kubeapps-local-dev-openldap-values.yaml
+	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace ldap || true
+	helm --kubeconfig=${CLUSTER_CONFIG} install ldap stable/openldap --namespace ldap \
+		--values ./docs/user/manifests/kubeapps-local-dev-openldap-values.yaml || true
 
+# Get mkcert from https://github.com/FiloSottile/mkcert/releases
 devel/localhost-cert.pem:
-	mkcert -key-file ./devel/localhost-key.pem -cert-file ./devel/localhost-cert.pem localhost 172.18.0.2
+	mkcert -key-file ./devel/localhost-key.pem -cert-file ./devel/localhost-cert.pem localhost 172.19.0.2 || true
 
 deploy-dependencies: deploy-dex deploy-openldap devel/localhost-cert.pem
-	kubectl create namespace kubeapps
-	kubectl -n kubeapps create secret tls localhost-tls \
+	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace kubeapps || true
+	kubectl --kubeconfig=${CLUSTER_CONFIG} -n kubeapps create secret tls localhost-tls \
 		--key ./devel/localhost-key.pem \
-		--cert ./devel/localhost-cert.pem
+		--cert ./devel/localhost-cert.pem || true
 
-deploy-dev: deploy-dependencies
-	helm install kubeapps ./chart/kubeapps --namespace kubeapps \
+deploy-dev-kubeapps: 
+	helm --kubeconfig=${CLUSTER_CONFIG} install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
-		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
+		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml || true
+
+deploy-dev: deploy-dependencies deploy-dev-kubeapps
 	@echo "\nYou can now simply open your browser at https://localhost/ to access Kubeapps!"
 	@echo "When logging in, you will be redirected to dex (with a self-signed cert) and can login with email as either of"
 	@echo "  kubeapps-operator@example.com:password"
@@ -40,10 +43,16 @@ deploy-dev: deploy-dependencies
 	@echo "  kubeapps-user-ldap@example.org:password"
 	@echo "to authenticate with the corresponding permissions."
 
+reset-dev-kubeapps:
+	helm --kubeconfig=${CLUSTER_CONFIG} -n kubeapps delete kubeapps || true
+	kubectl -kubeconfig=${CLUSTER_CONFIG} delete jobs -n kubeapps --all || true
+	kubectl delete namespace --wait kubeapps || true
+
 reset-dev:
-	helm -n kubeapps delete kubeapps || true
-	helm -n dex delete dex || true
-	helm -n ldap delete ldap || true
+	helm --kubeconfig=${CLUSTER_CONFIG} -n kubeapps delete kubeapps || true
+	kubectl -kubeconfig=${CLUSTER_CONFIG} delete jobs -n kubeapps --all || true
+	helm --kubeconfig=${CLUSTER_CONFIG} -n dex delete dex || true
+	helm --kubeconfig=${CLUSTER_CONFIG} -n ldap delete ldap || true
 	kubectl delete namespace --wait dex ldap kubeapps || true
 
-.PHONY: deploy-dex deploy-dependencies deploy-dev deploy-openldap reset-dev update-apiserver-etc-hosts
+.PHONY: deploy-dex deploy-dependencies deploy-dev deploy-openldap reset-dev

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -20,7 +20,7 @@ deploy-openldap:
 
 # Get mkcert from https://github.com/FiloSottile/mkcert/releases
 devel/localhost-cert.pem:
-	mkcert -key-file ./devel/localhost-key.pem -cert-file ./devel/localhost-cert.pem localhost 172.19.0.2
+	mkcert -key-file ./devel/localhost-key.pem -cert-file ./devel/localhost-cert.pem localhost 172.18.0.2
 
 deploy-dependencies: deploy-dex deploy-openldap devel/localhost-cert.pem
 	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace kubeapps
@@ -45,13 +45,10 @@ deploy-dev: deploy-dependencies deploy-dev-kubeapps
 	@echo "to authenticate with the corresponding permissions."
 
 reset-dev-kubeapps:
-	helm --kubeconfig=${CLUSTER_CONFIG} -n kubeapps delete kubeapps
-	kubectl -kubeconfig=${CLUSTER_CONFIG} delete jobs -n kubeapps --all
 	kubectl delete namespace --wait kubeapps
 
 reset-dev:
 	helm --kubeconfig=${CLUSTER_CONFIG} -n kubeapps delete kubeapps  || true
-	kubectl -kubeconfig=${CLUSTER_CONFIG} delete jobs -n kubeapps --all || true
 	helm --kubeconfig=${CLUSTER_CONFIG} -n dex delete dex  || true
 	helm --kubeconfig=${CLUSTER_CONFIG} -n ldap delete ldap || true
 	kubectl delete namespace --wait dex ldap kubeapps || true


### PR DESCRIPTION
### Description of the change

Starting setting up the environment for the OIDC auth mode is not a straightforward task for beginners. Despite there exists a bunch of scripts in a Makefile to do so, they are not documented at all.
This PR is to simply add some hints and comments on how to use these scripts.
Furthermore, it also updates the Makefile file itself, otherwise, I wasn't able to run it.

### Benefits

Newcomers developers will set up the OIDC env more easily.

### Possible drawbacks

The changes in the .mk scripts are not tested. It 'just works' in my machine. Any suggestion to improve them is welcomed.

### Applicable issues

- Related to https://github.com/kubeapps/kubeapps/issues/2177, but just because I needed to set up this OIDC env to write the docs.

### Additional information

N/A
