### PR TITLE
Add FAQ section in the chart readme (+ focus on subpath and OIDC)

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -155,16 +155,16 @@ kubectl delete namespace kubeapps
 
 ## FAQ
 
-- [How to install Kubeapps for demo purposes?](#how-to-install-kubeapps-for-demo-purposes-)
-- [How to install Kubeapps in production scenarios?](#how-to-install-kubeapps-in-production-scenarios-)
-- [How to use Kubeapps?](#how-to-use-kubeapps-)
+- [How to install Kubeapps for demo purposes?](#how-to-install-kubeapps-for-demo-purposes)
+- [How to install Kubeapps in production scenarios?](#how-to-install-kubeapps-in-production-scenarios)
+- [How to use Kubeapps?](#how-to-use-kubeapps)
 - [How to configure Kubeapps with Ingress](#how-to-configure-kubeapps-with-ingress)
   * [Serving Kubeapps in a subpath](#serving-kubeapps-in-a-subpath)
-- [Can Kubeapps be installed in more than one cluster?](#can-kubeapps-be-installed-in-more-than-one-cluster-)
-- [How to install Kubeapps without Internet connection?](#how-to-install-kubeapps-without-internet-connection-)
-- [Does Kubeapps support private repositories?](#does-kubeapps-support-private-repositories-)
-- [Does Kubeapps support Operators?](#does-kubeapps-support-operators-)
-- [More questions?](#more-questions-)
+- [Can Kubeapps be installed in more than one cluster?](#can-kubeapps-be-installed-in-more-than-one-cluster)
+- [How to install Kubeapps without Internet connection?](#how-to-install-kubeapps-without-internet-connection)
+- [Does Kubeapps support private repositories?](#does-kubeapps-support-private-repositories)
+- [Does Kubeapps support Operators?](#does-kubeapps-support-operators)
+- [More questions?](#more-questions)
 
 ### How to install Kubeapps for demo purposes?
 

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -103,7 +103,7 @@ To enable ingress integration, please set `ingress.enabled` to `true`
 
 Most likely you will only want to have one hostname that maps to this Kubeapps installation (use the `ingress.hostname` parameter to set the hostname), however, it is possible to have more than one host. To facilitate this, the `ingress.extraHosts` object is an array.
 
-For instance, if you plan to serve Kubeapps under a subpath (eg., `example.com/subpath`), you will have to set `ingress.extraHosts[0].name="example.com"` and `ingress.extraHosts[0].path="/subpath"`
+If you plan to serve Kubeapps under a subpath (eg., `example.com/subpath`), you will have to disable the default path by setting `ingress.hostname=""` and the enter the hostname and path in the extraHost array; for instance: `ingress.extraHosts[0].name="example.com"` and `ingress.extraHosts[0].path="/subpath"`
 ##### Annotations
 
 For annotations, please see [this document](https://github.com/kubeapps/kubeapps/blob/master/docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers. Annotations can be set using `ingress.annotations`.
@@ -199,12 +199,11 @@ You may want to serve Kubeapps with a subpath, for instance `http://example.com/
 ```bash
 helm install kubeapps --namespace kubeapps \
     --set ingress.enabled=true
+    --set ingress.hostname=""
     --set ingress.extraHosts[0].name="console.example.com"
     --set ingress.extraHosts[0].path="/catalog"
     bitnami/kubeapps
 ```
-> This will also create an additional ingress rule serving Kubeapps at `kubeapps.local/`. In case you don't want it, you can always patch the ingress object generated before (where we just set the `ingress.hostname`) by executing: `kubectl patch ingress kubeapps -n kubeapps --type=json -p='[{"op": "replace", "path": "/spec/rules/0/http/paths/0/path", "value":"/subpath"}]'`
-
 Besides, if you are using the OAuth2/OIDC login (more information at the [using an OIDC provider documentation](https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md)), you will need, also, to configure the different URLs:
 
 ```bash

--- a/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml
@@ -4,6 +4,9 @@ authProxy:
   clientID: default
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
   cookieSecret: bm90LWdvb2Qtc2VjcmV0Cg==
+  #  If you are serving Kubeapps under a subpath "example.com/subpath", both oauthLoginURI and oauthLogoutURI have to be changed
+  # oauthLoginURI: /subpath/oauth2/login
+  # oauthLogoutURI: /subpath/oauth2/logout
   additionalFlags:
     - --oidc-issuer-url=https://172.18.0.2:32000
     # Overwrite the scope option to include the other cluster's clientids in the audience.
@@ -12,3 +15,5 @@ authProxy:
     - --ssl-insecure-skip-verify=true
     # If you need to access the actual token in the frontend for testing, uncomment the following.
     # - --set-authorization-header=true
+    # If you are serving Kubeapps under a subpath "example.com/subpath" it would be "proxy-prefix=/subpath/oauth2"
+    # - --proxy-prefix=/subpath/oauth2

--- a/docs/user/using-an-OIDC-provider.md
+++ b/docs/user/using-an-OIDC-provider.md
@@ -92,6 +92,14 @@ helm install kubeapps bitnami/kubeapps \
   --set authProxy.additionalFlags="{--cookie-secure=false,--oidc-issuer-url=https://accounts.google.com}" \
 ```
 
+> If you are serving Kubeapps under a subpath (eg., "example.com/subpath") you also need to set the `authProxy.oauthLoginURI` and `authProxy.oauthLogoutURI` flags, as well as the additional flag `--proxy-prefix`. For instance:
+
+```bash
+ --set authProxy.oauthLoginURI="/subpath/oauth2/login" \
+ --set authProxy.oauthLogoutURI="/subpath/oauth2/logout" \
+ --set authProxy.additionalFlags="{<other flags>,--proxy-prefix=/subpath/oauth2}"\
+```
+
 **Example 2: Using a custom oauth2-proxy provider**
 
 Some of the specific providers that come with `oauth2-proxy` are using OpenIDConnect to obtain the required IDToken and can be used instead of the generic oidc provider. Currently this includes only the GitLab, Google and LoginGov providers (see [OAuth2_Proxy's provider configuration](https://oauth2-proxy.github.io/oauth2-proxy/configuration) for the full list of OAuth2 providers). The user authentication flow is the same as above, with some small UI differences, such as the default login button is customized to the provider (rather than "Login with OpenID Connect"), or improved presentation when accepting the requested scopes (as is the case with Google, but only visible if you request extra scopes).
@@ -107,6 +115,13 @@ helm install kubeapps bitnami/kubeapps \
   --set authProxy.clientSecret=my-client-secret \
   --set authProxy.cookieSecret=$(echo "not-good-secret" | base64) \
   --set authProxy.additionalFlags="{--cookie-secure=false}"
+```
+> If you are serving Kubeapps under a subpath (eg., "example.com/subpath") you also need to set the `authProxy.oauthLoginURI` and `authProxy.oauthLogoutURI` flags, as well as the additional flag `--proxy-prefix`. For instance:
+
+```bash
+ --set authProxy.oauthLoginURI="/subpath/oauth2/login" \
+ --set authProxy.oauthLogoutURI="/subpath/oauth2/logout" \
+ --set authProxy.additionalFlags="{<other flags>,--proxy-prefix=/subpath/oauth2}"\
 ```
 
 **Example 3: Authentication for Kubeapps on a GKE cluster**
@@ -130,7 +145,13 @@ helm install kubeapps bitnami/kubeapps \
   --set authProxy.additionalFlags="{--cookie-secure=false,--scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-platform}" \
   --set frontend.proxypassAccessTokenAsBearer=true
 ```
+> If you are serving Kubeapps under a subpath (eg., "example.com/subpath") you also need to set the `authProxy.oauthLoginURI` and `authProxy.oauthLogoutURI` flags, as well as the additional flag `--proxy-prefix`. For instance:
 
+```bash
+ --set authProxy.oauthLoginURI="/subpath/oauth2/login" \
+ --set authProxy.oauthLogoutURI="/subpath/oauth2/logout" \
+ --set authProxy.additionalFlags="{<other flags>,--proxy-prefix=/subpath/oauth2}"\
+```
 ### Manual deployment
 
 In case you want to manually deploy the proxy, first you will create a Kubernetes deployment and service for the proxy. For the snippet below, you need to set the environment variables `AUTH_PROXY_CLIENT_ID`, `AUTH_PROXY_CLIENT_SECRET`, `AUTH_PROXY_DISCOVERY_URL` with the information from the IdP and `KUBEAPPS_NAMESPACE`.
@@ -175,6 +196,7 @@ spec:
         - -pass-basic-auth=false
         - -pass-access-token=true
         - -pass-authorization-header=true
+         - proxy-prefix=/oauth2
         image: bitnami/oauth2-proxy
         imagePullPolicy: IfNotPresent
         name: kubeapps-auth-proxy
@@ -203,6 +225,7 @@ The above is a sample deployment, depending on the configuration of the Identity
 - `-client-id`, `-client-secret` and `-oidc-issuer-url`: Client ID, Secret and IdP URL as stated in the section above.
 - `-upstream`: Internal URL for the `kubeapps` service.
 - `-http-address=0.0.0.0:3000`: Listen in all the interfaces.
+- `-proxy-prefix=/oauth2`: If you are serving Kubeapps under a subpath, with this parameter the default prefix can be changed.
 
 **NOTE**: If the identity provider is deployed with a self-signed certificate (which may be the case for Keycloak or Dex) you will need to disable the TLS and cookie verification. For doing so you can add the flags `-ssl-insecure-skip-verify` and `--cookie-secure=false` to the deployment above. You can find more options for `oauth2-proxy` [here](https://oauth2-proxy.github.io/oauth2-proxy/configuration).
 

--- a/docs/user/using-an-OIDC-provider.md
+++ b/docs/user/using-an-OIDC-provider.md
@@ -75,7 +75,16 @@ The next sections explain how you can deploy this proxy either using the Kubeapp
 
 ### Using the chart
 
-Kubeapps chart allows you to automatically deploy the proxy for you as a sidecar container if you specify the necessary flags. In a nutshell you need to enable the feature and set the client ID, secret and the IdP URL. The following examples use Google as the Identity Provider, modify the flags below to adapt them:
+Kubeapps chart allows you to automatically deploy the proxy for you as a sidecar container if you specify the necessary flags. In a nutshell you need to enable the feature and set the client ID, secret and the IdP URL. The following examples use Google as the Identity Provider, modify the flags below to adapt them.
+
+> If you are serving Kubeapps under a subpath (eg., "example.com/subpath") you will also need to set the `authProxy.oauthLoginURI` and `authProxy.oauthLogoutURI` flags, as well as the additional flag `--proxy-prefix`. For instance:
+
+```bash
+  # ... other OIDC flags 
+ --set authProxy.oauthLoginURI="/subpath/oauth2/login" \
+ --set authProxy.oauthLogoutURI="/subpath/oauth2/logout" \
+ --set authProxy.additionalFlags="{<other flags>,--proxy-prefix=/subpath/oauth2}"\
+```
 
 **Example 1: Using the OIDC provider**
 
@@ -90,14 +99,6 @@ helm install kubeapps bitnami/kubeapps \
   --set authProxy.clientSecret=my-client-secret \
   --set authProxy.cookieSecret=$(echo "not-good-secret" | base64) \
   --set authProxy.additionalFlags="{--cookie-secure=false,--oidc-issuer-url=https://accounts.google.com}" \
-```
-
-> If you are serving Kubeapps under a subpath (eg., "example.com/subpath") you also need to set the `authProxy.oauthLoginURI` and `authProxy.oauthLogoutURI` flags, as well as the additional flag `--proxy-prefix`. For instance:
-
-```bash
- --set authProxy.oauthLoginURI="/subpath/oauth2/login" \
- --set authProxy.oauthLogoutURI="/subpath/oauth2/logout" \
- --set authProxy.additionalFlags="{<other flags>,--proxy-prefix=/subpath/oauth2}"\
 ```
 
 **Example 2: Using a custom oauth2-proxy provider**
@@ -115,13 +116,6 @@ helm install kubeapps bitnami/kubeapps \
   --set authProxy.clientSecret=my-client-secret \
   --set authProxy.cookieSecret=$(echo "not-good-secret" | base64) \
   --set authProxy.additionalFlags="{--cookie-secure=false}"
-```
-> If you are serving Kubeapps under a subpath (eg., "example.com/subpath") you also need to set the `authProxy.oauthLoginURI` and `authProxy.oauthLogoutURI` flags, as well as the additional flag `--proxy-prefix`. For instance:
-
-```bash
- --set authProxy.oauthLoginURI="/subpath/oauth2/login" \
- --set authProxy.oauthLogoutURI="/subpath/oauth2/logout" \
- --set authProxy.additionalFlags="{<other flags>,--proxy-prefix=/subpath/oauth2}"\
 ```
 
 **Example 3: Authentication for Kubeapps on a GKE cluster**
@@ -144,13 +138,6 @@ helm install kubeapps bitnami/kubeapps \
   --set authProxy.cookieSecret=$(echo "not-good-secret" | base64) \
   --set authProxy.additionalFlags="{--cookie-secure=false,--scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-platform}" \
   --set frontend.proxypassAccessTokenAsBearer=true
-```
-> If you are serving Kubeapps under a subpath (eg., "example.com/subpath") you also need to set the `authProxy.oauthLoginURI` and `authProxy.oauthLogoutURI` flags, as well as the additional flag `--proxy-prefix`. For instance:
-
-```bash
- --set authProxy.oauthLoginURI="/subpath/oauth2/login" \
- --set authProxy.oauthLogoutURI="/subpath/oauth2/logout" \
- --set authProxy.additionalFlags="{<other flags>,--proxy-prefix=/subpath/oauth2}"\
 ```
 ### Manual deployment
 

--- a/docs/user/using-an-OIDC-provider.md
+++ b/docs/user/using-an-OIDC-provider.md
@@ -139,6 +139,7 @@ helm install kubeapps bitnami/kubeapps \
   --set authProxy.additionalFlags="{--cookie-secure=false,--scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/cloud-platform}" \
   --set frontend.proxypassAccessTokenAsBearer=true
 ```
+
 ### Manual deployment
 
 In case you want to manually deploy the proxy, first you will create a Kubernetes deployment and service for the proxy. For the snippet below, you need to set the environment variables `AUTH_PROXY_CLIENT_ID`, `AUTH_PROXY_CLIENT_SECRET`, `AUTH_PROXY_DISCOVERY_URL` with the information from the IdP and `KUBEAPPS_NAMESPACE`.


### PR DESCRIPTION
After the question received in https://github.com/kubeapps/kubeapps/issues/2152 we noticed there was no documentation explaining how to set up Kubeapps to be accessed in a subpath (eg., console.example.com/catalog).


### Description of the change

This PR adds a new FAQ section in the chart readme and, specifically, focuses upon explaining the changes in different parts to have a running Kubeapps with OIDC under a subpath.
Besides the `authProxy.oauth{Login|Logout}URI` flags already documented, Dex has to be configured with the `--proxy-prefix=/subpath/oauth2` flag

### Benefits

Users deploying Kubeapps with OIDC under a subpath will have docs to do so.

### Possible drawbacks

Despite I have manually tested the basic functionality was working fine, perhaps there exists some problem we are not aware of yet (such as the chart names containing slashes).

### Applicable issues

- Related https://github.com/kubeapps/kubeapps/issues/2152
- Fixes https://github.com/kubeapps/kubeapps/issues/2177

### Additional information

N/A
