### PR TITLE
Change scope of uniqChartList from all to a single repo

### DIFF
--- a/cmd/assetsvc/handler.go
+++ b/cmd/assetsvc/handler.go
@@ -100,13 +100,15 @@ func min(a, b int) int {
 
 func uniqChartList(charts []*models.Chart) []*models.Chart {
 	// We will keep track of unique digest:chart to avoid duplicates
-	chartDigests := map[string]bool{}
+	// chartDigests records when we process a specific chart digest for a specific repository.
+	chartDigests := map[string]map[string]bool{}
 	res := []*models.Chart{}
 	for _, c := range charts {
 		digest := c.ChartVersions[0].Digest
 		// Filter out the chart if we've seen the same digest before
-		if _, ok := chartDigests[digest]; !ok {
-			chartDigests[digest] = true
+		if _, ok := chartDigests[digest][c.Repo.Name]; !ok {
+			chartDigests[digest] = map[string]bool{}
+			chartDigests[digest][c.Repo.Name] = true
 			res = append(res, c)
 		}
 	}

--- a/cmd/assetsvc/handler_test.go
+++ b/cmd/assetsvc/handler_test.go
@@ -925,7 +925,7 @@ func Test_findLatestChart(t *testing.T) {
 			t.Errorf("Expecting %v, received %v", chart, data[0].ID)
 		}
 	})
-	t.Run("ignores duplicated chart", func(t *testing.T) {
+	t.Run("includes duplicated chart", func(t *testing.T) {
 		charts := []*models.Chart{
 			{Name: "foo", ID: "stable/foo", Repo: &models.Repo{Name: "bar"}, ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0", Digest: "123"}}},
 			{Name: "foo", ID: "bitnami/foo", Repo: &models.Repo{Name: "bar"}, ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0", Digest: "123"}}},
@@ -966,12 +966,12 @@ func Test_findLatestChart(t *testing.T) {
 		}
 		data := *b.Data
 
-		assert.Equal(t, len(data), 1, "it should return a single chart")
+		assert.Equal(t, len(data), 2, "it should return every chart")
 		if data[0].ID != charts[0].ID {
 			t.Errorf("Expecting %v, received %v", charts[0], data[0].ID)
 		}
 	})
-	t.Run("includes duplicated charts when showDuplicates param set", func(t *testing.T) {
+	t.Run("includes duplicated charts always", func(t *testing.T) {
 		charts := []*models.Chart{
 			{Name: "foo", ID: "stable/foo", Repo: &models.Repo{Name: "bar"}, ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0", Digest: "123"}}},
 			{Name: "foo", ID: "bitnami/foo", Repo: &models.Repo{Name: "bar"}, ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0", Digest: "123"}}},
@@ -995,7 +995,7 @@ func Test_findLatestChart(t *testing.T) {
 			WillReturnRows(rows)
 
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/charts?showDuplicates=true&name="+charts[0].Name+"&version="+reqVersion+"&appversion="+reqAppVersion, nil)
+		req := httptest.NewRequest("GET", "/charts?&name="+charts[0].Name+"&version="+reqVersion+"&appversion="+reqAppVersion, nil)
 		params := Params{
 			"chartName":  charts[0].Name,
 			"version":    reqVersion,

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -45,9 +45,7 @@ func setupRoutes() http.Handler {
 	apiv1 := r.PathPrefix(pathPrefix).Subrouter()
 	// TODO: mnelson: Seems we could use path per endpoint handling empty params? Check.
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts").Queries("name", "{chartName}", "version", "{version}", "appversion", "{appversion}").Handler(WithParams(listChartsWithFilters))
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts").Queries("name", "{chartName}", "version", "{version}", "appversion", "{appversion}", "showDuplicates", "{showDuplicates}").Handler(WithParams(listChartsWithFilters))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts").Handler(WithParams(listCharts))
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts").Queries("showDuplicates", "{showDuplicates}").Handler(WithParams(listCharts))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}").Handler(WithParams(listCharts))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}").Handler(WithParams(getChart))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}/versions").Handler(WithParams(listChartVersions))

--- a/cmd/assetsvc/postgres_db_test.go
+++ b/cmd/assetsvc/postgres_db_test.go
@@ -212,7 +212,6 @@ func TestGetPaginatedChartList(t *testing.T) {
 		existingCharts map[string]map[string][]models.Chart
 		namespace      string
 		repo           string
-		showDups       bool
 		expectedCharts []*models.Chart
 		expectedErr    error
 	}{
@@ -241,7 +240,6 @@ func TestGetPaginatedChartList(t *testing.T) {
 					},
 				},
 			},
-			showDups: true,
 			expectedCharts: []*models.Chart{
 				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 			},
@@ -265,7 +263,6 @@ func TestGetPaginatedChartList(t *testing.T) {
 			},
 			repo:      "",
 			namespace: namespaceName,
-			showDups:  true,
 			expectedCharts: []*models.Chart{
 				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 				&models.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
@@ -295,7 +292,6 @@ func TestGetPaginatedChartList(t *testing.T) {
 			},
 			repo:      "",
 			namespace: namespaceName,
-			showDups:  true,
 			expectedCharts: []*models.Chart{
 				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 				&models.Chart{ID: "global-repo/global-chart", Name: "global-chart"},
@@ -321,7 +317,6 @@ func TestGetPaginatedChartList(t *testing.T) {
 			},
 			repo:      "",
 			namespace: "_all",
-			showDups:  true,
 			expectedCharts: []*models.Chart{
 				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 				&models.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
@@ -347,7 +342,6 @@ func TestGetPaginatedChartList(t *testing.T) {
 			},
 			repo:      repoName,
 			namespace: "_all",
-			showDups:  true,
 			expectedCharts: []*models.Chart{
 				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 				&models.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
@@ -367,7 +361,6 @@ func TestGetPaginatedChartList(t *testing.T) {
 			},
 			repo:      "",
 			namespace: namespaceName,
-			showDups:  false,
 			expectedCharts: []*models.Chart{
 				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1", ChartVersions: chartVersions},
 			},
@@ -385,7 +378,7 @@ func TestGetPaginatedChartList(t *testing.T) {
 			}
 
 			// The actual pagination isn't currently implemented as its not yet used by Kubeapps.
-			charts, _, err := pam.getPaginatedChartList(tc.namespace, tc.repo, 1, 10, tc.showDups)
+			charts, _, err := pam.getPaginatedChartList(tc.namespace, tc.repo, 1, 10)
 
 			if got, want := err, tc.expectedErr; got != want {
 				t.Fatalf("got: %+v, want: %+v", got, want)

--- a/cmd/assetsvc/postgres_db_test.go
+++ b/cmd/assetsvc/postgres_db_test.go
@@ -348,7 +348,7 @@ func TestGetPaginatedChartList(t *testing.T) {
 			},
 		},
 		{
-			name: "it removes duplicates when requested",
+			name: "it does not remove duplicates",
 			existingCharts: map[string]map[string][]models.Chart{
 				namespaceName: map[string][]models.Chart{
 					repoName: []models.Chart{
@@ -363,6 +363,7 @@ func TestGetPaginatedChartList(t *testing.T) {
 			namespace: namespaceName,
 			expectedCharts: []*models.Chart{
 				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1", ChartVersions: chartVersions},
+				&models.Chart{ID: "other-repo/same-chart-different-repo", Name: "same-chart-different-repo", ChartVersions: chartVersions},
 			},
 		},
 	}

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -52,7 +52,7 @@ func exists(current []string, str string) bool {
 	return false
 }
 
-func (m *postgresAssetManager) getPaginatedChartList(namespace, repo string, pageNumber, pageSize int, showDuplicates bool) ([]*models.Chart, int, error) {
+func (m *postgresAssetManager) getPaginatedChartList(namespace, repo string, pageNumber, pageSize int) ([]*models.Chart, int, error) {
 	clauses := []string{}
 	queryParams := []interface{}{}
 	if namespace != dbutils.AllNamespaces {
@@ -72,22 +72,6 @@ func (m *postgresAssetManager) getPaginatedChartList(namespace, repo string, pag
 	charts, err := m.QueryAllCharts(dbQuery, queryParams...)
 	if err != nil {
 		return nil, 0, err
-	}
-	if !showDuplicates {
-		// Group by unique digest for the latest version (remove duplicates)
-		uniqueCharts := []*models.Chart{}
-		digests := []string{}
-		for _, c := range charts {
-			if len(c.ChartVersions) == 0 {
-				return nil, 0, fmt.Errorf("chart %q missing chart versions", c.ID)
-			}
-			if !exists(digests, c.ChartVersions[0].Digest) {
-				digests = append(digests, c.ChartVersions[0].Digest)
-				uniqueCharts = append(uniqueCharts, c)
-			}
-		}
-		// TODO(andresmgot): Implement pagination but currently Kubeapps don't support it
-		return uniqueCharts, 1, nil
 	}
 	return charts, 1, nil
 }

--- a/cmd/assetsvc/postgresql_utils_test.go
+++ b/cmd/assetsvc/postgresql_utils_test.go
@@ -174,7 +174,6 @@ func Test_getPaginatedChartList(t *testing.T) {
 		repo               string
 		pageNumber         int
 		pageSize           int
-		showDuplicates     bool
 		expectedCharts     []*models.Chart
 		expectedTotalPages int
 	}{
@@ -184,18 +183,16 @@ func Test_getPaginatedChartList(t *testing.T) {
 			repo:               "bitnami",
 			pageNumber:         1,
 			pageSize:           100,
-			showDuplicates:     true,
 			expectedCharts:     availableCharts,
 			expectedTotalPages: 1,
 		},
 		{
-			name:               "one page withuot duplicates",
+			name:               "one page with duplicates",
 			namespace:          "other-namespace",
 			repo:               "",
 			pageNumber:         1,
 			pageSize:           100,
-			showDuplicates:     false,
-			expectedCharts:     []*models.Chart{availableCharts[0], availableCharts[1]},
+			expectedCharts:     []*models.Chart{availableCharts[0], availableCharts[1], availableCharts[2]},
 			expectedTotalPages: 1,
 		},
 		// TODO(andresmgot): several pages
@@ -221,7 +218,7 @@ func Test_getPaginatedChartList(t *testing.T) {
 				WithArgs(expectedParams...).
 				WillReturnRows(rows)
 
-			charts, totalPages, err := pgManager.getPaginatedChartList(tt.namespace, tt.repo, tt.pageNumber, tt.pageSize, tt.showDuplicates)
+			charts, totalPages, err := pgManager.getPaginatedChartList(tt.namespace, tt.repo, tt.pageNumber, tt.pageSize)
 			if err != nil {
 				t.Fatalf("Found error %v", err)
 			}

--- a/cmd/assetsvc/utils.go
+++ b/cmd/assetsvc/utils.go
@@ -24,7 +24,7 @@ import (
 type assetManager interface {
 	Init() error
 	Close() error
-	getPaginatedChartList(namespace, repo string, pageNumber, pageSize int, showDuplicates bool) ([]*models.Chart, int, error)
+	getPaginatedChartList(namespace, repo string, pageNumber, pageSize int) ([]*models.Chart, int, error)
 	getChart(namespace, chartID string) (models.Chart, error)
 	getChartVersion(namespace, chartID, version string) (models.Chart, error)
 	getChartFiles(namespace, filesID string) (models.ChartFiles, error)


### PR DESCRIPTION
### Description of the change

Make uniqChartList function repo-scoped instead of being unscoped. 

Current behavior leads to this scenario:

1. Add bitnami repo (https://charts.bitnami.com/bitnami)
2. Go to bitnami charts -> there are plenty of charts, eg, "bitnami/wordpress"
3. Add jfrog repo (https://repo.chartcenter.io)
4. Go to bitnami charts -> only 4 charts, there is no longer a "bitnami/wordpress"


### Benefits

Adding a new repo with mirrored charts won't prevent the old repo to still have its charts.

### Possible drawbacks

With this PR, the whole Kubeapps catalog may have duplicated charts in different repositories.

### Applicable issues

Following-up the PR https://github.com/kubeapps/kubeapps/pull/2173#discussion_r531535059

### Additional information

The main point is that, from a UX perspective, the sudden disappearance of a number of charts in an old repo when adding a new one could be misleading and frustrating for users.