### PR TITLE
Filter out dups repos by UID

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -267,10 +267,10 @@ describe("fetchRepos", () => {
     AppRepository.list = jest
       .fn()
       .mockImplementationOnce(() => {
-        return { items: [{ name: "repo1" }] };
+        return { items: [{ name: "repo1", metadata: { uid: "123" } }] };
       })
       .mockImplementationOnce(() => {
-        return { items: [{ name: "repo2" }] };
+        return { items: [{ name: "repo2", metadata: { uid: "321" } }] };
       });
 
     const expectedActions = [
@@ -288,7 +288,51 @@ describe("fetchRepos", () => {
       },
       {
         type: getType(repoActions.receiveRepos),
-        payload: [{ name: "repo1" }, { name: "repo2" }],
+        payload: [
+          { name: "repo1", metadata: { uid: "123" } },
+          { name: "repo2", metadata: { uid: "321" } },
+        ],
+      },
+    ];
+
+    await store.dispatch(repoActions.fetchRepos(namespace, "other-ns"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("fetches duplicated repos from several namespaces and joins them", async () => {
+    AppRepository.list = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        return { items: [{ name: "repo1", metadata: { uid: "123" } }] };
+      })
+      .mockImplementationOnce(() => {
+        return {
+          items: [
+            { name: "repo2", metadata: { uid: "321" } },
+            { name: "repo3", metadata: { uid: "321" } },
+          ],
+        };
+      });
+
+    const expectedActions = [
+      {
+        type: getType(repoActions.requestRepos),
+        payload: namespace,
+      },
+      {
+        type: getType(repoActions.requestRepos),
+        payload: "other-ns",
+      },
+      {
+        type: getType(repoActions.receiveReposSecrets),
+        payload: [],
+      },
+      {
+        type: getType(repoActions.receiveRepos),
+        payload: [
+          { name: "repo1", metadata: { uid: "123" } },
+          { name: "repo2", metadata: { uid: "321" } },
+        ],
       },
     ];
 

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -308,8 +308,8 @@ describe("fetchRepos", () => {
       .mockImplementationOnce(() => {
         return {
           items: [
-            { name: "repo2", metadata: { uid: "321" } }, // same uid
-            { name: "repo3", metadata: { uid: "321" } }, // same uid
+            { name: "repo2", metadata: { uid: "321" } },
+            { name: "repo3", metadata: { uid: "321" } },
           ],
         };
       });
@@ -347,11 +347,10 @@ describe("fetchRepos", () => {
         return { items: [{ name: "repo1", metadata: { uid: "123" } }] };
       })
       .mockImplementationOnce(() => {
-        // will be skipped
         return {
           items: [
             { name: "repo1", metadata: { uid: "321" } },
-            { name: "repo2", metadata: { uid: "123" } }, // same uid
+            { name: "repo2", metadata: { uid: "123" } },
           ],
         };
       });
@@ -359,7 +358,7 @@ describe("fetchRepos", () => {
     const expectedActions = [
       {
         type: getType(repoActions.requestRepos),
-        payload: "other-ns", // just one call to requestRepos
+        payload: "other-ns",
       },
       {
         type: getType(repoActions.receiveReposSecrets),

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -205,10 +205,12 @@ export const fetchRepos = (
         let totalRepos = repos.items;
         await Promise.all(
           otherNamespaces.map(async otherNamespace => {
-            dispatch(requestRepos(otherNamespace));
-            const otherRepos = await AppRepository.list(currentCluster, otherNamespace);
-            // Avoid adding duplicated repos: if two repos have the same uid, filter out
-            totalRepos = uniqBy(totalRepos.concat(otherRepos.items), "metadata.uid");
+            if (namespace !== otherNamespace) {
+              dispatch(requestRepos(otherNamespace));
+              const otherRepos = await AppRepository.list(currentCluster, otherNamespace);
+              // Avoid adding duplicated repos: if two repos have the same uid, filter out
+              totalRepos = uniqBy(totalRepos.concat(otherRepos.items), "metadata.uid");
+            }
           }),
         );
         dispatch(receiveRepos(totalRepos));

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.test.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.test.tsx
@@ -27,6 +27,18 @@ afterEach(() => {
   spyOnUseDispatch.mockRestore();
 });
 
+it("should fetch only the global repository", () => {
+  const fetch = jest.fn();
+  actions.repos = { ...actions.repos, fetchRepos: fetch };
+  const props = {
+    cluster: defaultProps.cluster,
+    namespace: initialState.config.kubeappsNamespace, // global
+    chartName: defaultProps.chartName,
+  };
+  mountWrapper(defaultStore, <SelectRepoForm {...props} />);
+  expect(fetch).toHaveBeenCalledWith(initialState.config.kubeappsNamespace);
+});
+
 it("should fetch repositories", () => {
   const fetch = jest.fn();
   actions.repos = { ...actions.repos, fetchRepos: fetch };

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
@@ -34,7 +34,13 @@ function SelectRepoForm({ cluster, namespace, chartName }: ISelectRepoFormProps)
   const [repoName, setRepoName] = useState(get(repo, "metadata.name", ""));
 
   useEffect(() => {
-    dispatch(actions.repos.fetchRepos(namespace, kubeappsNamespace));
+    if (namespace !== kubeappsNamespace) {
+      // Normal namespace, show local and global repos
+      dispatch(actions.repos.fetchRepos(namespace, kubeappsNamespace));
+    } else {
+      // Global namespace, show global repos only
+      dispatch(actions.repos.fetchRepos(kubeappsNamespace));
+    }
   }, [dispatch, namespace, kubeappsNamespace]);
 
   const handleChartRepoNameChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
### Description of the change

Currently, adding the [bitnami](https://charts.bitnami.com/bitnami) and the [jfrog](https://repo.chartcenter.io) repos, and then trying to upgrade an app, results in the following behavior:
![image](https://user-images.githubusercontent.com/11535726/100604423-d3226880-3306-11eb-98bf-926a804b759c.png)

And the corresponding error in js console: `Encountered two children with the same key, 'kubeapps/jfrog'. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.` 

I guess it is due to an unintended side effect when concatenating
`AppRepository.list(currentCluster, namespace)` and `AppRepository.list(currentCluster, otherNamespace)` because they are global repos and they appear in both listings.

### Benefits

This PR filters out duplicated repos (duplicated= same uid)

### Possible drawbacks

I don't see any problem or drawback at the moment

### Applicable issues

Following-up the PR https://github.com/kubeapps/kubeapps/pull/2173#discussion_r531663523

### Additional information

N/A
