### PR TITLE
Fix CSS display for img-container

### DIFF
--- a/dashboard/src/components/PageHeader/PageHeader.scss
+++ b/dashboard/src/components/PageHeader/PageHeader.scss
@@ -6,7 +6,7 @@
   background-color: white;
 
   .img-container {
-    display: flex;
+    display: contents;
     align-items: center;
     img {
       max-height: 3rem;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

I noticed that some `<img` where not properly rendered when the `src`  is encoded in base64:

![Screenshot from 2020-11-30 12-28-59](https://user-images.githubusercontent.com/4025665/100605267-fac60080-3307-11eb-8d76-609db03fd513.png)

Change the `display` property fixes the issue (the rest of icons keep working as usual)

![Screenshot from 2020-11-30 12-29-15](https://user-images.githubusercontent.com/4025665/100605376-221ccd80-3308-11eb-971a-f80b7e5d653c.png)

