### PR TITLE
Add https module with code to extract target server URL from header.

### DIFF
--- a/cmd/pinniped-proxy/Cargo.lock
+++ b/cmd/pinniped-proxy/Cargo.lock
@@ -100,6 +100,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +275,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +340,12 @@ checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
@@ -412,6 +439,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
 name = "pin-project"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +512,7 @@ dependencies = [
  "pretty_env_logger",
  "structopt",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -659,6 +693,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +800,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +834,18 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "url"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vec_map"

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -18,3 +18,4 @@ pretty_env_logger = "0.4"
 structopt = "0.3"
 # Update to 0.3 once apparent issue with the nascent 0.3.5 is fixed.
 tokio = { version = "0.2", features = ["full"] }
+url = "2.1"

--- a/cmd/pinniped-proxy/src/https.rs
+++ b/cmd/pinniped-proxy/src/https.rs
@@ -1,0 +1,124 @@
+use anyhow::Result;
+use hyper::{HeaderMap, header::HeaderValue};
+use url::Url;
+
+const DEFAULT_K8S_API_SERVER_URL: &str = "https://kubernetes.local";
+const HEADER_K8S_API_SERVER_URL: &str = "PINNIPED_PROXY_API_SERVER_URL";
+const INVALID_SCHEME_ERROR: &'static str = "invalid scheme, https required";
+
+/// validate_url returns a result containing the validated url or an error if it is invalid.
+fn validate_url(u: String) -> Result<String> {
+    let result = Url::parse(&u);
+    match result {
+        Ok(url) => match url.scheme() {
+            "https" => Ok(u),
+            _ => Err(anyhow::anyhow!(INVALID_SCHEME_ERROR)),
+        },
+        Err(e) => Err(anyhow::anyhow!(e)),
+    }
+}
+
+/// get_api_server_url returns a string result from the specified header.
+///
+/// If none is specified we default to the in-cluster K8S API server URL.
+pub fn get_api_server_url(request_headers: &HeaderMap<HeaderValue>) -> Result<String> {
+    match request_headers.get(HEADER_K8S_API_SERVER_URL) {
+        Some(hv) => {
+            // Header values can contain invalid chars.
+            match hv.to_str() {
+                Ok(hv) => validate_url(hv.to_string()),
+                Err(e) => Err(anyhow::anyhow!(e)),
+            }
+        },
+        None => Ok(DEFAULT_K8S_API_SERVER_URL.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_API_SERVER_URL: &str = "https://172.1.18.4";
+
+    #[test]
+    fn test_valid_url_success() -> Result<()> {
+        let valid_url = "https://example.com:8443".to_string();
+        match validate_url(valid_url.clone()) {
+            Ok(u) => {
+                assert_eq!(valid_url, u);
+                Ok(())
+            },
+            Err(e) => anyhow::bail!("got: {:#?}, want: {}", e, valid_url)
+        }
+    }
+
+    #[test]
+    fn test_valid_url_failure() -> Result<()> {
+        let bad_url = "https://example space com".to_string();
+        match validate_url(bad_url) {
+            Ok(u) => anyhow::bail!("got: {}, want: error", u),
+            Err(e) => {
+                assert!(e.is::<url::ParseError>(), "got: {:#?}, want: {}", e, url::ParseError::InvalidDomainCharacter);
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn test_invalid_protocol() -> Result<()>{
+        let invalid_proto = "ftp://example.com".to_string();
+        match validate_url(invalid_proto) {
+            Ok(u) => anyhow::bail!("got: {}, want: error", u),
+            Err(e) => {
+                assert_eq!(INVALID_SCHEME_ERROR, e.to_string(), "got: {:#?}, want: {}", e, INVALID_SCHEME_ERROR);
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn get_api_server_url_success() -> Result<()> {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_K8S_API_SERVER_URL, HeaderValue::from_static(VALID_API_SERVER_URL));
+
+        assert_eq!(get_api_server_url(&headers)?, VALID_API_SERVER_URL.to_string());
+        Ok(())
+    }
+
+    #[test]
+    fn get_api_server_url_invalid() -> Result<()> {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_K8S_API_SERVER_URL, HeaderValue::from_static("not a url"));
+
+        let want = url::ParseError::InvalidDomainCharacter;
+        match get_api_server_url(&headers) {
+            Ok(got) => anyhow::bail!("got: {}, want: {}", got, want),
+            Err(got) => {
+                assert!(got.is::<url::ParseError>(), "got: {:#?}, want: {}", got, want);
+                Ok(())
+            },
+        }
+    }
+
+    #[test]
+    fn get_api_server_url_wrong_scheme() -> Result<()> {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_K8S_API_SERVER_URL, HeaderValue::from_static("http://172.1.2.18"));
+
+        match get_api_server_url(&headers) {
+            Ok(got) => anyhow::bail!("got: {}, want: Err({})", got, INVALID_SCHEME_ERROR),
+            Err(got) => {
+                assert_eq!(got.to_string(), INVALID_SCHEME_ERROR, "got: {:#?}, want: Err({})", got, INVALID_SCHEME_ERROR);
+                Ok(())
+            },
+        }
+    }
+
+    #[test]
+    fn get_api_server_url_default() -> Result<()> {
+        let headers = HeaderMap::new();
+
+        assert_eq!(get_api_server_url(&headers)?, DEFAULT_K8S_API_SERVER_URL.to_string());
+        Ok(())
+    }
+}

--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -7,6 +7,7 @@ use structopt::StructOpt;
 
 // Ensure the root crate is aware of the child modules.
 mod cli;
+mod https;
 mod logging;
 mod service;
 

--- a/cmd/pinniped-proxy/src/service.rs
+++ b/cmd/pinniped-proxy/src/service.rs
@@ -4,11 +4,13 @@ use hyper::{Body, Request, Response};
 use log::info;
 
 use crate::logging;
+use crate::https;
 
 pub async fn proxy(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     let log_data = logging::request_log_data(&req);
 
     // TODO: actual proxying to happen here.
+    let _ = https::get_api_server_url(req.headers());
     let response = Response::new(Body::from("pinniped-proxy stub\n"));
 
     info!("{}", logging::response_log_data(&response, log_data));


### PR DESCRIPTION
### Description of the change

Follows #2195

This PR adds an https module with functionality to extract and validate the k8s api server url from the HTTP headers. No new concepts I don't think, but shows some good examples of using `match` and testing.

### Applicable issues

  - Ref #2181 

### Additional information

Might be a good spot, while reviewing, to read about [Enums and Pattern Matching](https://doc.rust-lang.org/book/ch06-00-enums.html)