### PR TITLE
Add functions to extract cert auth data from headers.

### DIFF
--- a/cmd/pinniped-proxy/Cargo.lock
+++ b/cmd/pinniped-proxy/Cargo.lock
@@ -42,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +513,7 @@ name = "pinniped-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "hyper",
  "log",
  "pretty_env_logger",

--- a/cmd/pinniped-proxy/Cargo.lock
+++ b/cmd/pinniped-proxy/Cargo.lock
@@ -60,6 +60,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "cc"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +93,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +126,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -168,6 +205,17 @@ dependencies = [
  "futures-task",
  "pin-project 1.0.2",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -424,6 +472,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +508,39 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+dependencies = [
+ "bitflags",
+ "cfg-if 0.1.10",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -516,11 +615,24 @@ dependencies = [
  "base64",
  "hyper",
  "log",
+ "native-tls",
  "pretty_env_logger",
  "structopt",
  "tokio",
  "url",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "pretty_env_logger"
@@ -581,6 +693,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +756,48 @@ name = "regex-syntax"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -670,6 +865,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -855,6 +1064,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +1090,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winapi"

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0"
 base64 = "0.13"
 hyper = "0.13"
 log = "0.4"
+native-tls = "0.2"
 pretty_env_logger = "0.4"
 structopt = "0.3"
 # Update to 0.3 once apparent issue with the nascent 0.3.5 is fixed.

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+base64 = "0.13"
 hyper = "0.13"
 log = "0.4"
 pretty_env_logger = "0.4"

--- a/cmd/pinniped-proxy/src/https.rs
+++ b/cmd/pinniped-proxy/src/https.rs
@@ -4,6 +4,7 @@ use url::Url;
 
 const DEFAULT_K8S_API_SERVER_URL: &str = "https://kubernetes.local";
 const HEADER_K8S_API_SERVER_URL: &str = "PINNIPED_PROXY_API_SERVER_URL";
+const HEADER_K8S_API_SERVER_CA_CERT: &str = "PINNIPED_PROXY_API_SERVER_CERT";
 const INVALID_SCHEME_ERROR: &'static str = "invalid scheme, https required";
 
 /// validate_url returns a result containing the validated url or an error if it is invalid.
@@ -34,11 +35,25 @@ pub fn get_api_server_url(request_headers: &HeaderMap<HeaderValue>) -> Result<St
     }
 }
 
+/// get_api_server_cert_auth_data returns a byte vector result containing the base64 decoded value.
+pub fn get_api_server_cert_auth_data(request_headers: &HeaderMap<HeaderValue>) -> Result<Vec<u8>> {
+    match request_headers.get(HEADER_K8S_API_SERVER_CA_CERT) {
+        Some(header_value_b64) => match base64::decode(header_value_b64.as_bytes()) {
+            Ok(data) => Ok(data),
+            Err(e) => Err(anyhow::anyhow!(e)),
+        },
+        None => Err(anyhow::anyhow!("header {} required but not present", HEADER_K8S_API_SERVER_CA_CERT)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     const VALID_API_SERVER_URL: &str = "https://172.1.18.4";
+    const VALID_CERT_BASE64: &'static str = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJd01UQXlOakl6TXpBME5Wb1hEVE13TVRBeU5ESXpNekEwTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT1ZKCnFuOVBFZUp3UDRQYnI0cFo1ZjZKUmliOFZ5a2tOYjV2K1hzTVZER01aWGZLb293Y29IYjFwRWh5d0pzeDFiME4Kd2YvZ1JURi9maEgzT0drRnNQMlV2a0lHVytzNUlBd0sxMFRXYkN5VzAwT3lzVkdLcnl5bHNWcEhCWXBZRGJBcQpkdnQzc0FkcFJZaGlLZSs2NkVTL3dQNTdLV3g0SVdwZko0UGpyejh2NkJBWlptZ3o5ZzRCSFNMQkhpbTVFbTdYClBJTmpKL1RJTXFzVW1PR1ppUUNHR0ptRnQxZ21jQTd3eHZ0ZXg2ckkxSWdFNkh5NW10UzJ3NDZaMCtlVU1RSzgKSE9UdnI5aGFETnhJenVjbkduaFlCT2Z2U2VVaXNCR0pOUm5QbENydWx4b2NSZGI3N20rQUdzWW52QitNd2prVQpEbXNQTWZBelpSRHEwekhzcGEwQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFBWndybXJLa3FVaDJUYld2VHdwSWlOd0o1NzAKaU9lTVl2WWhNakZxTmt6Tk9OUW55c3lPd1laRGJFMDRrV3AxclRLNHVZaUh3NTJUc0cyelJsZ0QzMzNKaEtvUQpIVloyV1hUT3Z5U2RJaWl5bVpKM2N3d0p2T0lhMW5zZnhYY1NJakJnYnNzYXowMndpRCtlazRPdmlRZktjcXJpCnFQbWZabDZDSkk0NU1rd3JwTExFaTZkNVhGbkhDb3d4eklxQjBrUDhwOFlOaGJYWTNYY2JaNElvY2lMemRBamUKQ1l6NXFVSlBlSDJCcHNaM0JXNXRDbjcycGZYazVQUjlYOFRUTHh6aTA4SU9yYjgvRDB4Tnk3emQyMnVjNXM1bwoveXZIeEt6cXBiczVuRXJkT0JFVXNGWnBpUEhaVGc1dExmWlZ4TG00VjNTZzQwRWUyNFd6d09zaDNIOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=";
+
+
 
     #[test]
     fn test_valid_url_success() -> Result<()> {
@@ -120,5 +135,33 @@ mod tests {
 
         assert_eq!(get_api_server_url(&headers)?, DEFAULT_K8S_API_SERVER_URL.to_string());
         Ok(())
+    }
+
+    #[test]
+    fn test_api_server_cert_auth_data_valid() -> Result<()> {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_K8S_API_SERVER_CA_CERT, HeaderValue::from_static(VALID_CERT_BASE64));
+
+        match get_api_server_cert_auth_data(&headers) {
+            Ok(data) => {
+                assert_eq!(data, base64::decode(VALID_CERT_BASE64.as_bytes())?);
+                Ok(())
+            },
+            Err(e) => anyhow::bail!("got {}, want: valid cert data", e),
+        }
+    }
+
+    #[test]
+    fn get_api_server_cert_auth_data_nonb64() -> Result<()> {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_K8S_API_SERVER_CA_CERT, HeaderValue::from_static("not base64 data"));
+
+        match get_api_server_cert_auth_data(&headers) {
+            Err(e) => {
+                assert!(e.is::<base64::DecodeError>(), "got: {:#?}, want: base64::DecodeErro", e);
+                Ok(())
+            },
+            _ => anyhow::bail!("got: valid cert, wanted base64::DecodeError"),
+        }
     }
 }

--- a/cmd/pinniped-proxy/src/service.rs
+++ b/cmd/pinniped-proxy/src/service.rs
@@ -11,6 +11,7 @@ pub async fn proxy(req: Request<Body>) -> Result<Response<Body>, Infallible> {
 
     // TODO: actual proxying to happen here.
     let _ = https::get_api_server_url(req.headers());
+    let _ = https::get_api_server_cert_auth_data(req.headers());
     let response = Response::new(Body::from("pinniped-proxy stub\n"));
 
     info!("{}", logging::response_log_data(&response, log_data));

--- a/cmd/pinniped-proxy/src/service.rs
+++ b/cmd/pinniped-proxy/src/service.rs
@@ -32,7 +32,9 @@ pub async fn proxy(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     Ok(response)
 }
 
-/// handle_error converts an error into a 500 message.
+/// handle_error converts an error into a BAD_REQUEST response.
+/// 
+/// We may need to expand this to give different responses for different errors.
 fn handle_error(e: Error, log_data: logging::LogData) -> Result<Response<Body>, Infallible> {
     let response = Response::builder()
         .status(StatusCode::BAD_REQUEST)

--- a/cmd/pinniped-proxy/src/service.rs
+++ b/cmd/pinniped-proxy/src/service.rs
@@ -1,6 +1,7 @@
 use std::convert::Infallible;
 
-use hyper::{Body, Request, Response};
+use anyhow::Error;
+use hyper::{Body, Request, Response, StatusCode};
 use log::info;
 
 use crate::logging;
@@ -9,12 +10,34 @@ use crate::https;
 pub async fn proxy(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     let log_data = logging::request_log_data(&req);
 
+    let _ = match https::get_api_server_url(req.headers()) {
+        Ok(u) => u,
+        Err(e) => return handle_error(e, log_data),
+    };
+    // TODO: don't call this if we're using https://kubernetes.local, instead
+    // grab the data from the file system.
+    let cert_auth_data = match https::get_api_server_cert_auth_data(req.headers()) {
+        Ok(c) => c,
+        Err(e) => return handle_error(e, log_data),
+    };
+    let _ = match https::cert_for_cert_data(cert_auth_data) {
+        Ok(c) => c,
+        Err(e) => return handle_error(e, log_data),
+    };
     // TODO: actual proxying to happen here.
-    let _ = https::get_api_server_url(req.headers());
-    let _ = https::get_api_server_cert_auth_data(req.headers());
     let response = Response::new(Body::from("pinniped-proxy stub\n"));
 
     info!("{}", logging::response_log_data(&response, log_data));
 
+    Ok(response)
+}
+
+/// handle_error converts an error into a 500 message.
+fn handle_error(e: Error, log_data: logging::LogData) -> Result<Response<Body>, Infallible> {
+    let response = Response::builder()
+        .status(StatusCode::BAD_REQUEST)
+        .body(Body::from(e.to_string())).unwrap();
+    // TODO: Add error to log_data so it can be included (with error context).
+    info!("{}", logging::response_log_data(&response, log_data));
     Ok(response)
 }


### PR DESCRIPTION
### Description of the change

Follows #2198 and adds functions to extract the api server CA cert from the request headers.

I'll follow this up with a change that doesn't require the CA cert in the request headers when targeting the default cluster api server (https://kubernetes.local), as per #2181 .

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fRef: #2181 

### Additional information

Two other changes here:
* adding the `handle_error` function in the service to handle errors with an appropriate HTTP response and use this to handle errors for the 3 `https::` functions so far.
* improve the logging, you can run with `RUST_LOG=debug` and curl the service to see details such as:

```
 INFO  pinniped_proxy > Listening on http://127.0.0.1:3333
 DEBUG hyper::proto::h1::io > read 122 bytes 
 DEBUG hyper::proto::h1::io > parsed 4 headers 
 DEBUG hyper::proto::h1::conn > incoming body is empty 
 DEBUG pinniped_proxy::https  > no PINNIPED_PROXY_API_SERVER_URL header present, defaulting to https://kubernetes.local
 DEBUG pinniped_proxy::https  > failed to base64 decode PINNIPED_PROXY_API_SERVER_CERT header data: Invalid byte 32, offset 3.
 INFO  pinniped_proxy::service > GET / 400 Bad Request
 DEBUG hyper::proto::h1::io    > flushed 111 bytes 
 DEBUG hyper::proto::h1::io    > read 0 bytes 
 DEBUG hyper::proto::h1::conn  > read eof 
```
