### PR TITLE
Add actual proxying (without credential exchange yet)

### DIFF
--- a/cmd/pinniped-proxy/Cargo.lock
+++ b/cmd/pinniped-proxy/Cargo.lock
@@ -329,6 +329,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,9 +422,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -614,11 +627,13 @@ dependencies = [
  "anyhow",
  "base64",
  "hyper",
+ "hyper-tls",
  "log",
  "native-tls",
  "pretty_env_logger",
  "structopt",
  "tokio",
+ "tokio-tls",
  "url",
 ]
 
@@ -956,6 +971,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -14,10 +14,12 @@ edition = "2018"
 anyhow = "1.0"
 base64 = "0.13"
 hyper = "0.13"
+hyper-tls = "0.4"
 log = "0.4"
 native-tls = "0.2"
 pretty_env_logger = "0.4"
 structopt = "0.3"
 # Update to 0.3 once apparent issue with the nascent 0.3.5 is fixed.
 tokio = { version = "0.2", features = ["full"] }
+tokio-tls = "0.3"
 url = "2.1"

--- a/cmd/pinniped-proxy/src/https.rs
+++ b/cmd/pinniped-proxy/src/https.rs
@@ -83,7 +83,10 @@ pub fn cert_for_cert_data(cert_data: Vec<u8>) -> Result<Certificate> {
 /// rewrite_request directs the specified request to the targeted backend api
 /// server.
 pub fn rewrite_request(mut req: Request<hyper::Body>, k8s_api_server_url: String) -> Result<Request<hyper::Body>> {
-    // Update the request URI.
+    // Update the request URI from
+    // http://pinniped-proxy:1234/api/v1/foo?bar
+    // to
+    // https://k8s-api-server-url:5678/api/v1/foo?bar
     let uri_string = format!(
         "{}{}",
         k8s_api_server_url,

--- a/cmd/pinniped-proxy/src/https.rs
+++ b/cmd/pinniped-proxy/src/https.rs
@@ -1,7 +1,13 @@
 use anyhow::Result;
-use hyper::{HeaderMap, header::HeaderValue};
+use hyper::{
+    client::connect::HttpConnector,
+    Client,
+    HeaderMap,
+    header::HeaderValue, Request,
+};
+use hyper_tls::HttpsConnector;
 use log::debug;
-use native_tls::Certificate;
+use native_tls::{Certificate, TlsConnectorBuilder};
 use url::Url;
 
 const DEFAULT_K8S_API_SERVER_URL: &str = "https://kubernetes.local";
@@ -63,6 +69,7 @@ pub fn get_api_server_cert_auth_data(request_headers: &HeaderMap<HeaderValue>) -
     }
 }
 
+/// cert_for_cert_data returns a Certificate result for the provided cert data.
 pub fn cert_for_cert_data(cert_data: Vec<u8>) -> Result<Certificate> {
     match Certificate::from_pem(&cert_data) {
         Ok(c) => Ok(c),
@@ -73,11 +80,56 @@ pub fn cert_for_cert_data(cert_data: Vec<u8>) -> Result<Certificate> {
     }
 }
 
+/// rewrite_request directs the specified request to the targeted backend api
+/// server.
+pub fn rewrite_request(mut req: Request<hyper::Body>, k8s_api_server_url: String) -> Result<Request<hyper::Body>> {
+    // Update the request URI.
+    let uri_string = format!(
+        "{}{}",
+        k8s_api_server_url,
+        req.uri().path_and_query().map(|x| x.as_str()).unwrap_or("")
+    );
+    let uri: hyper::Uri = uri_string.parse()?;
+    *req.uri_mut() = uri.clone();
+
+    // Update the host header.
+    let host: Option<HeaderValue> = match uri.authority() {
+        Some(auth) => {
+            let mut host_header = auth.host().to_string();
+            host_header = match auth.port() {
+                Some(p) => format!("{}:{}", host_header, p),
+                None => host_header,
+            };
+            Some(HeaderValue::from_str(&host_header)?)
+        },
+        None => None,
+    };
+    match host {
+        Some(h) => req.headers_mut().insert("Host", h),
+        None => None,
+    };
+
+    Ok(req)
+}
+
+/// make_https_connector returns the tls-configured http connector.
+pub fn make_https_client(tls_builder: &mut TlsConnectorBuilder) -> Result<Client<HttpsConnector<HttpConnector>>> {
+    let tls = tls_builder.build()?;
+    let tokio_tls = tokio_tls::TlsConnector::from(tls);
+    let mut http = HttpConnector::new();
+    http.enforce_http(false);
+    let mut https = HttpsConnector::<HttpConnector>::from((http, tokio_tls));
+    https.https_only(true);
+    Ok(Client::builder().build::<_, hyper::Body>(https))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hyper::Body;
 
-    const VALID_API_SERVER_URL: &str = "https://172.1.18.4";
+    const VALID_API_SERVER_HOST: &str = "172.1.18.4:12345";
+    const VALID_API_SERVER_URL: &str = "https://172.1.18.4:12345";
     const VALID_CERT_BASE64: &'static str = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJd01UQXlOakl6TXpBME5Wb1hEVE13TVRBeU5ESXpNekEwTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT1ZKCnFuOVBFZUp3UDRQYnI0cFo1ZjZKUmliOFZ5a2tOYjV2K1hzTVZER01aWGZLb293Y29IYjFwRWh5d0pzeDFiME4Kd2YvZ1JURi9maEgzT0drRnNQMlV2a0lHVytzNUlBd0sxMFRXYkN5VzAwT3lzVkdLcnl5bHNWcEhCWXBZRGJBcQpkdnQzc0FkcFJZaGlLZSs2NkVTL3dQNTdLV3g0SVdwZko0UGpyejh2NkJBWlptZ3o5ZzRCSFNMQkhpbTVFbTdYClBJTmpKL1RJTXFzVW1PR1ppUUNHR0ptRnQxZ21jQTd3eHZ0ZXg2ckkxSWdFNkh5NW10UzJ3NDZaMCtlVU1RSzgKSE9UdnI5aGFETnhJenVjbkduaFlCT2Z2U2VVaXNCR0pOUm5QbENydWx4b2NSZGI3N20rQUdzWW52QitNd2prVQpEbXNQTWZBelpSRHEwekhzcGEwQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFBWndybXJLa3FVaDJUYld2VHdwSWlOd0o1NzAKaU9lTVl2WWhNakZxTmt6Tk9OUW55c3lPd1laRGJFMDRrV3AxclRLNHVZaUh3NTJUc0cyelJsZ0QzMzNKaEtvUQpIVloyV1hUT3Z5U2RJaWl5bVpKM2N3d0p2T0lhMW5zZnhYY1NJakJnYnNzYXowMndpRCtlazRPdmlRZktjcXJpCnFQbWZabDZDSkk0NU1rd3JwTExFaTZkNVhGbkhDb3d4eklxQjBrUDhwOFlOaGJYWTNYY2JaNElvY2lMemRBamUKQ1l6NXFVSlBlSDJCcHNaM0JXNXRDbjcycGZYazVQUjlYOFRUTHh6aTA4SU9yYjgvRDB4Tnk3emQyMnVjNXM1bwoveXZIeEt6cXBiczVuRXJkT0JFVXNGWnBpUEhaVGc1dExmWlZ4TG00VjNTZzQwRWUyNFd6d09zaDNIOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=";
 
 
@@ -209,5 +261,19 @@ mod tests {
             },
             _ => anyhow::bail!("got: valid cert, wanted native_tls::Error"),
         }
+    }
+
+    #[test]
+    fn test_rewrite_request_success() -> Result<()> {
+        let mut req = Request::get("http://local.pinniped:9876/foo/bar/zed")
+            .body(Body::empty())
+            .unwrap();
+
+        req = rewrite_request(req, VALID_API_SERVER_URL.into())?;
+
+        let want = format!("{}/foo/bar/zed", VALID_API_SERVER_URL);
+        assert_eq!(want, req.uri().to_string());
+        assert_eq!(VALID_API_SERVER_HOST, req.headers().get("HOST").unwrap().to_str()?);
+        Ok(())
     }
 }

--- a/cmd/pinniped-proxy/src/service.rs
+++ b/cmd/pinniped-proxy/src/service.rs
@@ -2,34 +2,65 @@ use std::convert::Infallible;
 
 use anyhow::Error;
 use hyper::{Body, Request, Response, StatusCode};
-use log::info;
+use log::{error, info};
+use native_tls::TlsConnector;
 
 use crate::logging;
 use crate::https;
 
-pub async fn proxy(req: Request<Body>) -> Result<Response<Body>, Infallible> {
+pub async fn proxy(mut req: Request<Body>) -> Result<Response<Body>, Infallible> {
+
+    let k8s_api_server_url = match https::get_api_server_url(req.headers()) {
+        Ok(u) => u,
+        Err(e) => return handle_error(e, logging::request_log_data(&req)),
+    };
+    req = https::rewrite_request(req, k8s_api_server_url).unwrap();
     let log_data = logging::request_log_data(&req);
 
-    let _ = match https::get_api_server_url(req.headers()) {
-        Ok(u) => u,
-        Err(e) => return handle_error(e, log_data),
-    };
     // TODO: don't call this if we're using https://kubernetes.local, instead
     // grab the data from the file system.
     let cert_auth_data = match https::get_api_server_cert_auth_data(req.headers()) {
         Ok(c) => c,
         Err(e) => return handle_error(e, log_data),
     };
-    let _ = match https::cert_for_cert_data(cert_auth_data) {
+    let k8s_api_cert = match https::cert_for_cert_data(cert_auth_data) {
         Ok(c) => c,
         Err(e) => return handle_error(e, log_data),
     };
-    // TODO: actual proxying to happen here.
-    let response = Response::new(Body::from("pinniped-proxy stub\n"));
 
-    info!("{}", logging::response_log_data(&response, log_data));
+    // Create an https client with which to proxy the request.
+    // We need to construct the TlsConnector for each request so that we can set
+    // the client cert. It'd be nice if we could do the construction once and just
+    // clone to add the client cert?
+    let mut tls_builder = &mut TlsConnector::builder();
+    tls_builder = tls_builder.add_root_certificate(k8s_api_cert.clone());
 
-    Ok(response)
+    // TODO: Call credential exchange fn to set the client auth certs.
+
+    let client = match https::make_https_client(tls_builder) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("{:#?}", e);
+            let response = Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Body::from(e.to_string())).unwrap();
+            return Ok(response);
+        },
+    };
+
+    match client.request(req).await {
+        Ok(r) => {
+            info!("{}", logging::response_log_data(&r, log_data));
+            Ok(r)
+        },
+        Err(e) => {
+            error!("{:#?}", e);
+            let response = Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Body::from(e.to_string())).unwrap();
+            Ok(response)
+        },
+    }
 }
 
 /// handle_error converts an error into a BAD_REQUEST response.


### PR DESCRIPTION
### Description of the change

Adds code to proxy the actual request, even though the credential exchange isn't yet implemented.

Follows #2199

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2181

### Additional information

With this PR you can proxy to your running local k8s api server, all that's missing is the credential exchange.

```
$ curl http://127.0.0.1:3333/api/v1 -H "PINNIPED_PROXY_API_SERVER_URL: https://127.0.0.1:33613" -H "PINNIPED_PROXY_API_SERVER_CERT: $CA_DATA"
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {
    
  },
  "status": "Failure",
  "message": "forbidden: User \"system:anonymous\" cannot get path \"/api/v1\"",
  "reason": "Forbidden",
  "details": {
    
  },
  "code": 403
}
```

with the logs showing:

```
$ RUST_LOG=info cargo run
   Compiling pinniped-proxy v0.1.0 (/home/michael/dev/kubeapps/cmd/pinniped-proxy)
    Finished dev [unoptimized + debuginfo] target(s) in 26.50s
     Running `target/debug/pinniped-proxy`
 INFO  pinniped_proxy > Listening on http://127.0.0.1:3333
 INFO  pinniped_proxy::service > GET https://127.0.0.1:33613/api/v1 403 Forbidden
```

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
