### PR TITLE
Load default cert authority data for kubernetes.default

### DIFF
--- a/cmd/pinniped-proxy/src/cli.rs
+++ b/cmd/pinniped-proxy/src/cli.rs
@@ -12,8 +12,16 @@ pub struct Options {
     #[structopt(
         short = "p",
         long = "port",
+        env = "PINNIPED_PROXY_PORT",
         default_value = "3333",
         help = "Specify the port on which pinniped-proxy listens."
     )]
-    pub port: u16, 
+    pub port: u16,
+    #[structopt(
+        long = "default-ca-cert",
+        env = "PINNIPED_PROXY_DEFAULT_CA_CERT",
+        default_value = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+        help = "Specify the file path to the cert authority for the default api server https://kubernetes.default"
+    )]
+    pub default_ca_cert: String,
 }

--- a/cmd/pinniped-proxy/src/https.rs
+++ b/cmd/pinniped-proxy/src/https.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use crate::pinniped;
 
-pub const DEFAULT_K8S_API_SERVER_URL: &str = "https://kubernetes.local";
+pub const DEFAULT_K8S_API_SERVER_URL: &str = "https://kubernetes.default";
 const HEADER_K8S_API_SERVER_URL: &str = "PINNIPED_PROXY_API_SERVER_URL";
 pub const HEADER_K8S_API_SERVER_CA_CERT: &str = "PINNIPED_PROXY_API_SERVER_CERT";
 const INVALID_SCHEME_ERROR: &'static str = "invalid scheme, https required";

--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
 
     // Load the default certificate authority data on startup once.
     let default_ca_data = fs::read_to_string(opt.default_ca_cert.clone())
-        .with_context(|| format!("error loading default-ca-cert at {}", opt.default_ca_cert))?;
+        .with_context(|| format!("unable to load default-ca-cert at {}", opt.default_ca_cert))?;
 
     // For every incoming connection, we make a new hyper `Service` to handle
     // all incoming HTTP requests on that connection. This is done by passing a

--- a/cmd/pinniped-proxy/src/service.rs
+++ b/cmd/pinniped-proxy/src/service.rs
@@ -27,10 +27,7 @@ pub async fn proxy(mut req: Request<Body>, default_ca_data: Vec<u8>) -> Result<R
     // Recreate the log data now that the request host has been rewritten.
     log_data = logging::request_log_data(&req);
 
-    // TODO: don't call this if we're using https://kubernetes.local, instead
-    // grab the data from the file system.
     let cert_auth_data = match req.headers().get(https::HEADER_K8S_API_SERVER_CA_CERT) {
-        // TODO: update to just pass the header not all the headers.
         Some(header_value_b64) => match https::get_api_server_cert_auth_data(header_value_b64) {
             Ok(c) => c,
             Err(e) => return handle_error(e, StatusCode::BAD_REQUEST, log_data),


### PR DESCRIPTION
### Description of the change

Follows #2206 and updates to load the default cert authority data for use when the request doesn't include this *and* the url is for the https://kubernetes.default url.

### Benefits

Less configuration for the single-cluster use-case.

### Applicable issues

  - ref #2181 - one of the items identified there.

### Additional information

See inline comments.