### PR TITLE
Ensure Kubeops proxies user requests via pinniped proxy when configured.

### DIFF
--- a/cmd/kubeops/main_test.go
+++ b/cmd/kubeops/main_test.go
@@ -19,7 +19,7 @@ func TestParseClusterConfig(t *testing.T) {
 	}{
 		{
 			name:       "parses a single cluster",
-			configJSON: `[{"name": "cluster-2", "apiServiceURL": "https://example.com", "certificateAuthorityData": "Y2EtY2VydC1kYXRhCg==", "serviceToken": "abcd"}]`,
+			configJSON: `[{"name": "cluster-2", "apiServiceURL": "https://example.com", "certificateAuthorityData": "Y2EtY2VydC1kYXRhCg==", "serviceToken": "abcd", "pinnipedProxyURL": "http://172.0.1.18:3333"}]`,
 			expectedConfig: kube.ClustersConfig{
 				Clusters: map[string]kube.ClusterConfig{
 					"cluster-2": {
@@ -27,6 +27,7 @@ func TestParseClusterConfig(t *testing.T) {
 						APIServiceURL:            "https://example.com",
 						CertificateAuthorityData: "ca-cert-data\n",
 						ServiceToken:             "abcd",
+						PinnipedProxyURL:         "http://172.0.1.18:3333",
 					},
 				},
 			},

--- a/cmd/pinniped-proxy/src/main.rs
+++ b/cmd/pinniped-proxy/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
         }
     });
 
-    let addr = ([127, 0, 0, 1], opt.port).into();
+    let addr = ([0, 0, 0, 0], opt.port).into();
 
     let server = Server::bind(&addr).serve(make_svc);
 

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,7 @@ github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -98,12 +98,16 @@ func NewClusterConfig(inClusterConfig *rest.Config, userToken string, cluster st
 			if existingWrapTransport != nil {
 				rt = existingWrapTransport(rt)
 			}
+			headers := map[string][]string{}
+			if clusterConfig.APIServiceURL != "" {
+				headers["PINNIPED_PROXY_API_SERVER_URL"] = []string{clusterConfig.APIServiceURL}
+			}
+			if clusterConfig.CertificateAuthorityData != "" {
+				headers["PINNIPED_PROXY_API_SERVER_CERT"] = []string{clusterConfig.CertificateAuthorityData}
+			}
 			return &pinnipedProxyRoundTripper{
-				headers: map[string][]string{
-					"PINNIPED_PROXY_API_SERVER_URL":  {clusterConfig.APIServiceURL},
-					"PINNIPED_PROXY_API_SERVER_CERT": {clusterConfig.CertificateAuthorityData},
-				},
-				rt: rt,
+				headers: headers,
+				rt:      rt,
 			}
 		}
 		return config, nil

--- a/pkg/kube/pinniped_proxy_roundtripper.go
+++ b/pkg/kube/pinniped_proxy_roundtripper.go
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2020 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package kube
+
+import "net/http"
+
+// pinnipedProxyRoundTripper is a round tripper that additionally sets
+// any required headers for the exchange of credentials and request proxying.
+// See https://github.com/kubernetes/client-go/issues/407
+type pinnipedProxyRoundTripper struct {
+	headers map[string][]string
+
+	rt http.RoundTripper
+}
+
+func (p *pinnipedProxyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+	for k, vv := range p.headers {
+		for _, v := range vv {
+			req.Header.Add(k, v)
+		}
+	}
+	return p.rt.RoundTrip(req)
+}

--- a/pkg/kube/pinniped_proxy_roundtripper_test.go
+++ b/pkg/kube/pinniped_proxy_roundtripper_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright (c) 2020 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package kube
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type fakeRoundTripper struct{}
+
+func (rt *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestPinnipedProxyRoundTripper(t *testing.T) {
+	testCases := []struct {
+		name            string
+		existingHeaders http.Header
+		pinnipedHeaders http.Header
+	}{
+		{
+			name:            "it creates the headers if they don't exist",
+			pinnipedHeaders: http.Header{},
+		},
+		{
+			name: "it sets the pinniped headers",
+			pinnipedHeaders: http.Header{
+				"Some_header_1": []string{"some value 1"},
+				"Some_header_2": []string{"some value 2"},
+			},
+		},
+		{
+			name: "it leaves existing headers intact",
+			existingHeaders: http.Header{
+				"Existing_header_1": []string{"existing value 1"},
+				"Existing_header_2": []string{"existing value 2"},
+			},
+			pinnipedHeaders: http.Header{
+				"Some_header_1": []string{"some value 1"},
+				"Some_header_2": []string{"some value 2"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pprt := pinnipedProxyRoundTripper{
+				headers: tc.pinnipedHeaders,
+				rt:      &fakeRoundTripper{},
+			}
+			req := http.Request{Header: tc.existingHeaders.Clone()}
+
+			_, _ = pprt.RoundTrip(&req)
+
+			if got, want := req.Header, mergeHeaders(tc.existingHeaders, tc.pinnipedHeaders); !cmp.Equal(want, got) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func mergeHeaders(h1, h2 http.Header) http.Header {
+	result := http.Header{}
+	for k, vv := range h1 {
+		for _, v := range vv {
+			result.Add(k, v)
+		}
+	}
+	for k, vv := range h2 {
+		for _, v := range vv {
+			result.Add(k, v)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
### Description of the change

When testing pinniped-proxy with Kubeapps, requests from the browser client to the Kubeapps frontend for the k8s API were successfully proxied via pinniped-proxy, hitting the k8s api server with generated certs which were auth'd by the api server successfully.

But what I hadn't counted on was the requests from the browser client to our Kubeapps frontend for the kubeops service, which creates its own `client-go` kubernetes client set for user requests. This PR ensures that these are also proxied via pinniped-proxy when configured for that cluster.

### Benefits

Kubeops can also successfully interact with the k8s api server of each cluster using pinniped.

### Possible drawbacks

~I still need to do the IRL (in real life) test to ensure this works as expected.~ Edit: finally found and fixed a number of small issues so that this works IRL.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref: #2181 

### Additional information

Follows #2210 which just cleaned up some naming.