### PR TITLE
Add a getChartCategories endpoint

### DIFF
--- a/cmd/assetsvc/handler.go
+++ b/cmd/assetsvc/handler.go
@@ -111,9 +111,9 @@ func getPaginatedChartList(namespace, repo string, pageNumber, pageSize int) (ap
 	return newChartListResponse(charts), meta{totalPages}, err
 }
 
-func getAllChartCategories(namespace, repo string) (apiChartCategoryListResponse, interface{}, error) {
+func getAllChartCategories(namespace, repo string) (apiChartCategoryListResponse, error) {
 	chartCategories, err := manager.getAllChartCategories(namespace, repo)
-	return newChartCategoryListResponse(chartCategories), meta{}, err
+	return newChartCategoryListResponse(chartCategories), err
 }
 
 // listCharts returns a list of charts based on filter params
@@ -154,13 +154,13 @@ func getChartCategories(w http.ResponseWriter, req *http.Request, params Params)
 		return
 	}
 
-	chartCategories, meta, err := getAllChartCategories(namespace, repo)
+	chartCategories, err := getAllChartCategories(namespace, repo)
 	if err != nil {
 		log.WithError(err).Error("could not fetch categories")
 		response.NewErrorResponse(http.StatusInternalServerError, "could not fetch chart categories").Write(w)
 		return
 	}
-	response.NewDataResponseWithMeta(chartCategories, meta).Write(w)
+	response.NewDataResponse(chartCategories).Write(w)
 }
 
 // getChart returns the chart from the given repo

--- a/cmd/assetsvc/handler.go
+++ b/cmd/assetsvc/handler.go
@@ -52,12 +52,7 @@ type apiResponse struct {
 
 type apiListResponse []*apiResponse
 
-type apiChartCategoryResponse struct {
-	Name  string `json:"name"`
-	Count int    `json:"count"`
-}
-
-type apiChartCategoryListResponse []*apiChartCategoryResponse
+type apiChartCategoryListResponse []*models.ChartCategory
 
 type selfLink struct {
 	Self string `json:"self"`
@@ -410,9 +405,8 @@ func newChartResponse(c *models.Chart) *apiResponse {
 	}
 }
 
-func newChartCategoryResponse(c *models.ChartCategory) *apiChartCategoryResponse {
-	return &apiChartCategoryResponse{
-
+func newChartCategoryResponse(c *models.ChartCategory) *models.ChartCategory {
+	return &models.ChartCategory{
 		Name:  c.Name,
 		Count: c.Count,
 	}

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -46,7 +46,9 @@ func setupRoutes() http.Handler {
 	// TODO: mnelson: Seems we could use path per endpoint handling empty params? Check.
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts").Queries("name", "{chartName}", "version", "{version}", "appversion", "{appversion}").Handler(WithParams(listChartsWithFilters))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts").Handler(WithParams(listCharts))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/categories").Handler(WithParams(getChartCategories))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}").Handler(WithParams(listCharts))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/categories").Handler(WithParams(getChartCategories))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}").Handler(WithParams(getChart))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}/versions").Handler(WithParams(listChartVersions))
 	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}/versions/{version}").Handler(WithParams(getChartVersion))

--- a/cmd/assetsvc/main_test.go
+++ b/cmd/assetsvc/main_test.go
@@ -105,41 +105,31 @@ func Test_GetCharts(t *testing.T) {
 	}
 }
 
+// tests the GET /{apiVersion}/clusters/default/namespaces/{namespace}/charts/categories endpoint
+// particularly, it just tests that the endpoint is running the expected count query
 func Test_GetChartCategories(t *testing.T) {
 	ts := httptest.NewServer(setupRoutes())
 	defer ts.Close()
 
 	tests := []struct {
 		name                    string
-		charts                  []*models.Chart
 		expectedChartCategories []*models.ChartCategory
 	}{
 		{
 			"no charts",
-			[]*models.Chart{},
 			[]*models.ChartCategory{},
 		},
 		{
 			"two charts - same category",
-			[]*models.Chart{
-				{Repo: testRepo, ID: "my-repo/my-chart", Category: "cat1", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-				{Repo: testRepo, ID: "my-repo/dokuwiki", Category: "cat1", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
-			},
 			[]*models.ChartCategory{
-				{Name: "cat1", Count: 1},
-				{Name: "cat2", Count: 2},
-				{Name: "cat3", Count: 3},
+				{Name: "cat1", Count: 2},
 			},
 		},
 		{
 			"two charts - different category",
-			[]*models.Chart{
-				{Repo: testRepo, ID: "my-repo/my-chart", Category: "cat1", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-				{Repo: testRepo, ID: "my-repo/dokuwiki", Category: "cat2", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
-			}, []*models.ChartCategory{
+			[]*models.ChartCategory{
 				{Name: "cat1", Count: 1},
-				{Name: "cat2", Count: 2},
-				{Name: "cat3", Count: 3},
+				{Name: "cat2", Count: 1},
 			},
 		},
 	}
@@ -153,7 +143,6 @@ func Test_GetChartCategories(t *testing.T) {
 			for _, chartCategories := range tt.expectedChartCategories {
 				rows.AddRow(chartCategories.Name, chartCategories.Count)
 			}
-
 			mock.ExpectQuery("SELECT (info ->> 'category')*").
 				WithArgs("my-namespace", kubeappsNamespace).
 				WillReturnRows(rows)
@@ -171,6 +160,8 @@ func Test_GetChartCategories(t *testing.T) {
 	}
 }
 
+// tests the GET /{apiVersion}/clusters/default/namespaces/{namespace}/charts/{repo}/categories endpoint
+// particularly, it just tests that the endpoint is running the expected count query
 func Test_GetChartCategoriesRepo(t *testing.T) {
 	ts := httptest.NewServer(setupRoutes())
 	defer ts.Close()
@@ -178,22 +169,16 @@ func Test_GetChartCategoriesRepo(t *testing.T) {
 	tests := []struct {
 		name                    string
 		repo                    string
-		charts                  []*models.Chart
 		expectedChartCategories []*models.ChartCategory
 	}{
 		{
 			"no charts",
 			"my-repo",
-			[]*models.Chart{},
 			[]*models.ChartCategory{},
 		},
 		{
 			"two charts - same category",
 			"my-repo",
-			[]*models.Chart{
-				{Repo: testRepo, ID: "my-repo/my-chart", Category: "cat1", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-				{Repo: testRepo, ID: "my-repo/dokuwiki", Category: "cat1", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
-			},
 			[]*models.ChartCategory{
 				{Name: "cat1", Count: 1},
 				{Name: "cat2", Count: 2},
@@ -203,10 +188,7 @@ func Test_GetChartCategoriesRepo(t *testing.T) {
 		{
 			"two charts - different category",
 			"my-repo",
-			[]*models.Chart{
-				{Repo: testRepo, ID: "my-repo/my-chart", Category: "cat1", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-				{Repo: testRepo, ID: "my-repo/dokuwiki", Category: "cat2", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
-			}, []*models.ChartCategory{
+			[]*models.ChartCategory{
 				{Name: "cat1", Count: 1},
 				{Name: "cat2", Count: 2},
 				{Name: "cat3", Count: 3},
@@ -223,7 +205,6 @@ func Test_GetChartCategoriesRepo(t *testing.T) {
 			for _, chartCategories := range tt.expectedChartCategories {
 				rows.AddRow(chartCategories.Name, chartCategories.Count)
 			}
-
 			mock.ExpectQuery("SELECT (info ->> 'category')*").
 				WithArgs("my-namespace", kubeappsNamespace, tt.repo).
 				WillReturnRows(rows)

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -68,8 +68,7 @@ func (m *postgresAssetManager) getAllChartCategories(namespace, repo string) ([]
 	}
 	repoQuery := ""
 	if len(clauses) > 0 {
-		repoQuery = strings.Join(clauses, " AND ")
-		repoQuery = "WHERE " + repoQuery
+		repoQuery = "WHERE " + strings.Join(clauses, " AND ")
 	}
 	dbQuery := fmt.Sprintf("SELECT (info ->> 'category') AS name, COUNT( (info ->> 'category')) AS count FROM %s %s GROUP BY (info ->> 'category') ORDER BY (info ->> 'category') ASC", dbutils.ChartTable, repoQuery)
 
@@ -93,8 +92,7 @@ func (m *postgresAssetManager) getPaginatedChartList(namespace, repo string, pag
 	}
 	repoQuery := ""
 	if len(clauses) > 0 {
-		repoQuery = strings.Join(clauses, " AND ")
-		repoQuery = "WHERE " + repoQuery
+		repoQuery = "WHERE " + strings.Join(clauses, " AND ")
 	}
 	dbQuery := fmt.Sprintf("SELECT info FROM %s %s ORDER BY info ->> 'name' ASC", dbutils.ChartTable, repoQuery)
 	charts, err := m.QueryAllCharts(dbQuery, queryParams...)

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -55,6 +55,31 @@ func exists(current []string, str string) bool {
 	return false
 }
 
+func (m *postgresAssetManager) getAllChartCategories(namespace, repo string) ([]*models.ChartCategory, error) {
+	clauses := []string{}
+	queryParams := []interface{}{}
+	if namespace != dbutils.AllNamespaces {
+		queryParams = append(queryParams, namespace, m.GetKubeappsNamespace())
+		clauses = append(clauses, "(repo_namespace = $1 OR repo_namespace = $2)")
+	}
+	if repo != "" {
+		queryParams = append(queryParams, repo)
+		clauses = append(clauses, fmt.Sprintf("repo_name = $%d", len(queryParams)))
+	}
+	repoQuery := ""
+	if len(clauses) > 0 {
+		repoQuery = strings.Join(clauses, " AND ")
+		repoQuery = "WHERE " + repoQuery
+	}
+	dbQuery := fmt.Sprintf("SELECT (info ->> 'category') AS name, COUNT( (info ->> 'category')) AS count FROM %s %s GROUP BY (info ->> 'category') ORDER BY (info ->> 'category') ASC", dbutils.ChartTable, repoQuery)
+
+	chartsCategories, err := m.QueryAllChartCategories(dbQuery, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	return chartsCategories, nil
+}
+
 func (m *postgresAssetManager) getPaginatedChartList(namespace, repo string, pageNumber, pageSize int) ([]*models.Chart, int, error) {
 	clauses := []string{}
 	queryParams := []interface{}{}

--- a/cmd/assetsvc/postgresql_utils_test.go
+++ b/cmd/assetsvc/postgresql_utils_test.go
@@ -226,21 +226,22 @@ func Test_getAllChartCategories(t *testing.T) {
 		name                    string
 		namespace               string
 		repo                    string
-		availableCharts         []*models.Chart
 		expectedChartCategories []*models.ChartCategory
 	}{
 		{
-			name:      "oasasasasaepo",
+			name:      "without repo",
+			namespace: "other-namespace",
+			repo:      "",
+			expectedChartCategories: []*models.ChartCategory{
+				{Name: "cat1", Count: 1},
+				{Name: "cat2", Count: 2},
+				{Name: "cat3", Count: 3},
+			},
+		},
+		{
+			name:      "with repo",
 			namespace: "other-namespace",
 			repo:      "bitnami",
-			availableCharts: []*models.Chart{
-				{Name: "foo1", Category: "cat1", Repo: &models.Repo{Name: "bitnami", Namespace: "namespace"}},
-				{Name: "foo21", Category: "cat2", Repo: &models.Repo{Name: "bitnami", Namespace: "namespace"}},
-				{Name: "foo22", Category: "cat2", Repo: &models.Repo{Name: "bitnami", Namespace: "namespace"}},
-				{Name: "foo31", Category: "cat3", Repo: &models.Repo{Name: "bitnami", Namespace: "namespace"}},
-				{Name: "foo32", Category: "cat3", Repo: &models.Repo{Name: "bitnami", Namespace: "namespace"}},
-				{Name: "foo33", Category: "cat3", Repo: &models.Repo{Name: "bitnami", Namespace: "namespace"}},
-			},
 			expectedChartCategories: []*models.ChartCategory{
 				{Name: "cat1", Count: 1},
 				{Name: "cat2", Count: 2},
@@ -260,7 +261,7 @@ func Test_getAllChartCategories(t *testing.T) {
 
 			expectedParams := []driver.Value{"other-namespace", "kubeapps"}
 			if tt.repo != "" {
-				expectedParams = append(expectedParams, "bitnami")
+				expectedParams = append(expectedParams, tt.repo)
 			}
 			mock.ExpectQuery("SELECT (info ->> 'category')*").
 				WithArgs(expectedParams...).

--- a/cmd/assetsvc/utils.go
+++ b/cmd/assetsvc/utils.go
@@ -29,6 +29,7 @@ type assetManager interface {
 	getChartVersion(namespace, chartID, version string) (models.Chart, error)
 	getChartFiles(namespace, filesID string) (models.ChartFiles, error)
 	getChartsWithFilters(namespace, name, version, appVersion string) ([]*models.Chart, error)
+	getAllChartCategories(namespace, repo string) ([]*models.ChartCategory, error)
 }
 
 func newManager(databaseType string, config datastore.Config, kubeappsNamespace string) (assetManager, error) {

--- a/pkg/chart/models/chart.go
+++ b/pkg/chart/models/chart.go
@@ -58,6 +58,13 @@ type Chart struct {
 	ChartVersions   []ChartVersion     `json:"chartVersions"`
 }
 
+// ChartCategory is the representation of the chart category query
+// Note "name" and "count" names are not columns but select aliases
+type ChartCategory struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
 // ChartIconString is a higher-level representation of a chart package
 // TODO(andresmgot) Replace this type when the icon is stored as a binary
 type ChartIconString struct {

--- a/pkg/dbutils/postgresql_utils.go
+++ b/pkg/dbutils/postgresql_utils.go
@@ -51,6 +51,7 @@ type PostgresAssetManagerIface interface {
 	AssetManager
 	QueryOne(target interface{}, query string, args ...interface{}) error
 	QueryAllCharts(query string, args ...interface{}) ([]*models.Chart, error)
+	QueryAllChartCategories(query string, args ...interface{}) ([]*models.ChartCategory, error)
 	InitTables() error
 	InvalidateCache() error
 	EnsureRepoExists(repoNamespace, repoName string) (int, error)
@@ -126,6 +127,29 @@ func (m *PostgresAssetManager) QueryAllCharts(query string, args ...interface{})
 			return nil, err
 		}
 		result = append(result, &chart)
+	}
+	return result, nil
+}
+
+// QueryAllChartCategories performs the query and return the array of all the chart categories
+func (m *PostgresAssetManager) QueryAllChartCategories(query string, args ...interface{}) ([]*models.ChartCategory, error) {
+	rows, err := m.DB.Query(query, args...)
+	if rows != nil {
+		defer rows.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	result := []*models.ChartCategory{}
+	for rows.Next() {
+		var name string
+		var count int
+		err := rows.Scan(&name, &count)
+		if err != nil {
+			return nil, err
+		}
+		chartCategory := models.ChartCategory{Name: name, Count: count}
+		result = append(result, &chartCategory)
 	}
 	return result, nil
 }

--- a/pkg/dbutils/postgresql_utils_test.go
+++ b/pkg/dbutils/postgresql_utils_test.go
@@ -107,4 +107,37 @@ func Test_QueryAll(t *testing.T) {
 	if !cmp.Equal(charts, expectedCharts) {
 		t.Errorf("Unexpected result %v", cmp.Diff(charts, expectedCharts))
 	}
+
+}
+
+func Test_QueryAllChartCategories(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	manager := PostgresAssetManager{
+		connStr: "localhost",
+		DB:      db,
+	}
+	query := "SELECT * from charts"
+	rows := sqlmock.NewRows([]string{"name", "count"}).
+		AddRow("cat1", 1).
+		AddRow("cat2", 2).
+		AddRow("cat3", 3)
+	mock.ExpectQuery("SELECT (info ->> 'category')*").WillReturnRows(rows)
+	charts, err := manager.QueryAllChartCategories(query)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+	expectedCharts := []*models.ChartCategory{
+		{Name: "cat1", Count: 1},
+		{Name: "cat2", Count: 2},
+		{Name: "cat3", Count: 3},
+	}
+	if !cmp.Equal(charts, expectedCharts) {
+		t.Errorf("Unexpected result %v", cmp.Diff(charts, expectedCharts))
+	}
 }

--- a/pkg/dbutils/postgresql_utils_test.go
+++ b/pkg/dbutils/postgresql_utils_test.go
@@ -119,25 +119,25 @@ func Test_QueryAllChartCategories(t *testing.T) {
 		connStr: "localhost",
 		DB:      db,
 	}
-	query := "SELECT * from charts"
+	query := "SELECT (info ->> 'category') AS name, COUNT( (info ->> 'category')) AS count FROM charts WHERE (repo_namespace = 'kubeapps' OR repo_namespace = 'default') GROUP BY (info ->> 'category') ORDER BY (info ->> 'category') ASC"
 	rows := sqlmock.NewRows([]string{"name", "count"}).
 		AddRow("cat1", 1).
 		AddRow("cat2", 2).
 		AddRow("cat3", 3)
 	mock.ExpectQuery("SELECT (info ->> 'category')*").WillReturnRows(rows)
-	charts, err := manager.QueryAllChartCategories(query)
+	chartCategories, err := manager.QueryAllChartCategories(query)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
-	expectedCharts := []*models.ChartCategory{
+	expectedChartCategories := []*models.ChartCategory{
 		{Name: "cat1", Count: 1},
 		{Name: "cat2", Count: 2},
 		{Name: "cat3", Count: 3},
 	}
-	if !cmp.Equal(charts, expectedCharts) {
-		t.Errorf("Unexpected result %v", cmp.Diff(charts, expectedCharts))
+	if !cmp.Equal(chartCategories, expectedChartCategories) {
+		t.Errorf("Unexpected result %v", cmp.Diff(chartCategories, expectedChartCategories))
 	}
 }


### PR DESCRIPTION
### Description of the change

Before this PR, the only way to retrieve the list of distinct chart categories was to fetch all charts and, then, manually retrieves these unique categories. This PR is to add an endpoint for doing so but at the server-side and leveraging from the DB.

The proposed response in this PR is the list of distinct categories (`name`) and the count of charts belonging to each category (`count`). An example is depicted below:
```
{"data":[{"name":"Analytics","count":10},{"name":"ApplicationServer","count":2},{"name":"CertificateAuthority","count":1},{"name":"CMS","count":5},{"name":"CRM","count":2},{"name":"Database","count":12},{"name":"DeveloperTools","count":7},{"name":"E-Commerce","count":3},{"name":"E-Learning","count":1},{"name":"Forum","count":2},{"name":"HumanResourceManagement","count":1},{"name":"Infrastructure","count":24},{"name":"LogManagement","count":1},{"name":"MachineLearning","count":3},{"name":"ProjectManagement","count":2},{"name":"Wiki","count":2},{"name":"WorkFlow","count":1}],"meta":{"totalPages":0}}
```

Particulary, there are two new endpoints:
`/clusters/{cluster}/namespaces/{namespace}/charts/categories`
`/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/categories`

### Benefits

Getting the list of categories no longer will involve a whole fetching every chart at client-side.

### Possible drawbacks

N/A

### Applicable issues

- Related #2174

### Additional information

In the current version of UI we are not displaying the number of charts. I added the count just for providing a more complete response, but I'm open to simply return the `select distinct ...` if you may want to.