### PR TITLE
Fix namespaced initial repos

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -20,4 +20,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 5.0.0
+version: 5.1.0

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -20,4 +20,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 5.1.0
+version: 5.0.1

--- a/chart/kubeapps/templates/apprepositories-secret.yaml
+++ b/chart/kubeapps/templates/apprepositories-secret.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "kubeapps.apprepository-secret.name" . }}
+  {{- if .namespace }}
+  namespace: {{ .namespace }}
+  {{- end }}
   annotations:
     "helm.sh/hook": pre-install
   labels:{{ include "kubeapps.labels" $ | nindent 4 }}
@@ -17,5 +20,25 @@ data:
     {{ .authorizationHeader | b64enc }}
   {{- end }}
 ---
+{{/* credentials are required in the release namespace for syncer jobs */}}
+{{- if .namespace }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .namespace }}-apprepo-{{ .name }}"
+  annotations:
+    "helm.sh/hook": pre-install
+  labels:{{ include "kubeapps.labels" $ | nindent 4 }}
+data:
+  {{- if .caCert }}
+  ca.crt: |-
+    {{ .caCert | b64enc }}
+  {{- end }}
+  {{- if .authorizationHeader }}
+  authorizationHeader: |-
+    {{ .authorizationHeader | b64enc }}
+  {{- end }}
+---
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

For namespaced repos we need to create two identical secrets containing
ca.crt and/or authorizationHeader. We need one in the namespace that the
app repository is scoped to and one in the kubeapps release namespace.

The name of the secret in the kubeapps release namespace is expected to
be of the format {{ .namespace }}-apprepo-{{ .name }} by the
apprepository controller.

Fixes #2233 