### PR TITLE
Fix default value in forms when using hidden

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
@@ -221,7 +221,7 @@ it("should hide an element if it depends on a single param (object)", () => {
   expect(hiddenParam).toExist();
 });
 
-it("should hide an element using hidden path and values even if it is not present in values.yaml", () => {
+it("should hide an element using hidden path and values even if it is not present in values.yaml (simple)", () => {
   const params = [
     {
       default: "a",
@@ -249,6 +249,54 @@ it("should hide an element using hidden path and values even if it is not presen
   const hiddenParam = wrapper.find("div").filterWhere(p => p.prop("hidden") === true);
   expect(hiddenParam).toExist();
   expect(hiddenParam.text()).toBe("b");
+});
+
+it("should hide an element using hidden path and values even if it is not present in values.yaml (different depth levels)", () => {
+  const params = [
+    {
+      default: "a",
+      enum: ["a", "b"],
+      path: "dropdown",
+      type: "string",
+      value: "a",
+    },
+    {
+      hidden: { path: "secondLevelProperties/2dropdown", value: "2b" },
+      path: "a",
+      type: "string",
+    },
+    {
+      hidden: { path: "secondLevelProperties/2dropdown", value: "2a" },
+      path: "b",
+      type: "string",
+    },
+    {
+      default: "2a",
+      enum: ["2a", "2b"],
+      path: "secondLevelProperties/2dropdown",
+      type: "string",
+      value: "2a",
+    },
+    {
+      hidden: { path: "dropdown", value: "b" },
+      path: "secondLevelProperties/2a",
+      type: "string",
+    },
+    {
+      hidden: { path: "dropdown", value: "a" },
+      path: "secondLevelProperties/2b",
+      type: "string",
+    },
+  ] as IBasicFormParam[];
+  const appValues = "";
+  const wrapper = mount(
+    <BasicDeploymentForm {...defaultProps} params={params} appValues={appValues} />,
+  );
+
+  const hiddenParam = wrapper.find("div").filterWhere(p => p.prop("hidden") === true);
+  expect(hiddenParam).toExist();
+  expect(hiddenParam.filterWhere(p => p.text().includes("b"))).toExist();
+  expect(hiddenParam.filterWhere(p => p.text().includes("2b"))).toExist();
 });
 
 it("should hide an element if it depends on multiple params (AND) (object)", () => {

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.test.tsx
@@ -221,6 +221,36 @@ it("should hide an element if it depends on a single param (object)", () => {
   expect(hiddenParam).toExist();
 });
 
+it("should hide an element using hidden path and values even if it is not present in values.yaml", () => {
+  const params = [
+    {
+      default: "a",
+      enum: ["a", "b"],
+      path: "dropdown",
+      type: "string",
+      value: "a",
+    },
+    {
+      hidden: { path: "dropdown", value: "b" },
+      path: "a",
+      type: "string",
+    },
+    {
+      hidden: { path: "dropdown", value: "a" },
+      path: "b",
+      type: "string",
+    },
+  ] as IBasicFormParam[];
+  const appValues = "";
+  const wrapper = mount(
+    <BasicDeploymentForm {...defaultProps} params={params} appValues={appValues} />,
+  );
+
+  const hiddenParam = wrapper.find("div").filterWhere(p => p.prop("hidden") === true);
+  expect(hiddenParam).toExist();
+  expect(hiddenParam.text()).toBe("b");
+});
+
 it("should hide an element if it depends on multiple params (AND) (object)", () => {
   const params = [
     {

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -21,7 +21,7 @@ function BasicDeploymentForm(props: IBasicDeploymentFormProps) {
         const id = `${param.path}-${i}`;
         return (
           <div key={id}>
-            <Param {...props} param={param} id={id} />
+            <Param {...props} otherParams={props.params} param={param} id={id} />
             <hr className="param-separator" />
           </div>
         );

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.tsx
@@ -21,7 +21,7 @@ function BasicDeploymentForm(props: IBasicDeploymentFormProps) {
         const id = `${param.path}-${i}`;
         return (
           <div key={id}>
-            <Param {...props} otherParams={props.params} param={param} id={id} />
+            <Param {...props} allParams={props.params} param={param} id={id} />
             <hr className="param-separator" />
           </div>
         );

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Param.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Param.tsx
@@ -72,7 +72,13 @@ export default function Param({
     paramDeploymentEvent?: DeploymentEvent,
   ): boolean => {
     if (paramDeploymentEvent == null) {
-      return getValue(appValues, path) === (expectedValue ?? true);
+      let val = getValue(appValues, path);
+      // no value is provided, but there is a default one in the schema (hidden.value)
+      // https://github.com/kubeapps/kubeapps/issues/1913
+      if (!val && typeof param.hidden === "object") {
+        val = param.hidden?.value;
+      }
+      return val === (expectedValue ?? true);
     } else {
       return paramDeploymentEvent === deploymentEvent;
     }

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Param.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Param.tsx
@@ -10,8 +10,8 @@ import TextParam from "./TextParam";
 interface IParamProps {
   appValues: string;
   param: IBasicFormParam;
+  allParams: IBasicFormParam[];
   id: string;
-  otherParams: IBasicFormParam[];
   handleBasicFormParamChange: (
     p: IBasicFormParam,
   ) => (e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
@@ -22,7 +22,7 @@ interface IParamProps {
 export default function Param({
   appValues,
   param,
-  otherParams,
+  allParams,
   id,
   handleBasicFormParamChange,
   handleValuesChange,
@@ -68,6 +68,19 @@ export default function Param({
     }
   };
 
+  const getParamMatchingPath = (params: IBasicFormParam[], path: string): any => {
+    let targetParam;
+    for (const p of params) {
+      if (p.path === path) {
+        targetParam = p;
+        break;
+      } else if (p.children && p.children?.length > 0) {
+        targetParam = getParamMatchingPath(p.children, path);
+      }
+    }
+    return targetParam;
+  };
+
   const evalCondition = (
     path: string,
     expectedValue?: any,
@@ -78,7 +91,7 @@ export default function Param({
       // retrieve the value that the property pointed by path should have to be hidden.
       // https://github.com/kubeapps/kubeapps/issues/1913
       if (val === undefined) {
-        const target = otherParams.find(p => p.path === path);
+        const target = getParamMatchingPath(allParams, path);
         val = target?.value;
       }
       return val === (expectedValue ?? true);
@@ -105,6 +118,7 @@ export default function Param({
         handleValuesChange={handleValuesChange}
         appValues={appValues}
         param={param}
+        allParams={allParams}
         deploymentEvent={deploymentEvent}
       />
     );

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Param.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Param.tsx
@@ -11,6 +11,7 @@ interface IParamProps {
   appValues: string;
   param: IBasicFormParam;
   id: string;
+  otherParams: IBasicFormParam[];
   handleBasicFormParamChange: (
     p: IBasicFormParam,
   ) => (e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
@@ -21,6 +22,7 @@ interface IParamProps {
 export default function Param({
   appValues,
   param,
+  otherParams,
   id,
   handleBasicFormParamChange,
   handleValuesChange,
@@ -73,10 +75,11 @@ export default function Param({
   ): boolean => {
     if (paramDeploymentEvent == null) {
       let val = getValue(appValues, path);
-      // no value is provided, but there is a default one in the schema (hidden.value)
+      // retrieve the value that the property pointed by path should have to be hidden.
       // https://github.com/kubeapps/kubeapps/issues/1913
-      if (!val && typeof param.hidden === "object") {
-        val = param.hidden?.value;
+      if (val === undefined) {
+        const target = otherParams.find(p => p.path === path);
+        val = target?.value;
       }
       return val === (expectedValue ?? true);
     } else {

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.test.tsx
@@ -33,6 +33,7 @@ const defaultProps = {
     description: "description of the param",
     type: "object",
   } as IBasicFormParam,
+  allParams: [],
   appValues: "externalDatabase: {}",
   deploymentEvent: "install",
   handleValuesChange: jest.fn(),

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.tsx
@@ -46,6 +46,7 @@ function Subsection({
           return (
             <Param
               param={childrenParam}
+              otherParams={param.children ? param.children : []}
               id={id}
               key={id}
               handleBasicFormParamChange={handleChildrenParamChange}

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Subsection.tsx
@@ -7,6 +7,7 @@ import Param from "./Param";
 export interface ISubsectionProps {
   label: string;
   param: IBasicFormParam;
+  allParams: IBasicFormParam[];
   appValues: string;
   deploymentEvent: DeploymentEvent;
   handleValuesChange: (value: string) => void;
@@ -15,6 +16,7 @@ export interface ISubsectionProps {
 function Subsection({
   label,
   param,
+  allParams,
   appValues,
   deploymentEvent,
   handleValuesChange,
@@ -46,7 +48,7 @@ function Subsection({
           return (
             <Param
               param={childrenParam}
-              otherParams={param.children ? param.children : []}
+              allParams={allParams}
               id={id}
               key={id}
               handleBasicFormParamChange={handleChildrenParamChange}

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
@@ -24,12 +24,7 @@ exports[`renders a basic deployment with a disk size 1`] = `
       key="size-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="size-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "size",
@@ -39,6 +34,11 @@ exports[`renders a basic deployment with a disk size 1`] = `
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="size-0"
         param={
           Object {
             "path": "size",
@@ -399,12 +399,7 @@ exports[`renders a basic deployment with a email 1`] = `
       key="wordpressEmail-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="wordpressEmail-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "wordpressEmail",
@@ -412,6 +407,11 @@ exports[`renders a basic deployment with a email 1`] = `
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="wordpressEmail-0"
         param={
           Object {
             "path": "wordpressEmail",
@@ -493,12 +493,7 @@ exports[`renders a basic deployment with a generic boolean 1`] = `
       key="enableMetrics-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="enableMetrics-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "enableMetrics",
@@ -507,6 +502,11 @@ exports[`renders a basic deployment with a generic boolean 1`] = `
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="enableMetrics-0"
         param={
           Object {
             "path": "enableMetrics",
@@ -697,12 +697,7 @@ exports[`renders a basic deployment with a generic number 1`] = `
       key="replicas-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="replicas-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "replicas",
@@ -711,6 +706,11 @@ exports[`renders a basic deployment with a generic number 1`] = `
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="replicas-0"
         param={
           Object {
             "path": "replicas",
@@ -795,12 +795,7 @@ exports[`renders a basic deployment with a generic string 1`] = `
       key="blogName-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="blogName-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "blogName",
@@ -809,6 +804,11 @@ exports[`renders a basic deployment with a generic string 1`] = `
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="blogName-0"
         param={
           Object {
             "path": "blogName",
@@ -894,12 +894,7 @@ exports[`renders a basic deployment with a integer disk size 1`] = `
       key="size-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="size-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "size",
@@ -909,6 +904,11 @@ exports[`renders a basic deployment with a integer disk size 1`] = `
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="size-0"
         param={
           Object {
             "path": "size",
@@ -1271,12 +1271,7 @@ exports[`renders a basic deployment with a number disk size 1`] = `
       key="size-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="size-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "size",
@@ -1286,6 +1281,11 @@ exports[`renders a basic deployment with a number disk size 1`] = `
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="size-0"
         param={
           Object {
             "path": "size",
@@ -1646,12 +1646,7 @@ exports[`renders a basic deployment with a password 1`] = `
       key="wordpressPassword-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="wordpressPassword-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "wordpressPassword",
@@ -1659,6 +1654,11 @@ exports[`renders a basic deployment with a password 1`] = `
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="wordpressPassword-0"
         param={
           Object {
             "path": "wordpressPassword",
@@ -1739,12 +1739,7 @@ exports[`renders a basic deployment with a username 1`] = `
       key="wordpressUsername-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="wordpressUsername-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "wordpressUsername",
@@ -1752,6 +1747,11 @@ exports[`renders a basic deployment with a username 1`] = `
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="wordpressUsername-0"
         param={
           Object {
             "path": "wordpressUsername",
@@ -1835,12 +1835,7 @@ Second line",
       key="configuration-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="configuration-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "configuration",
@@ -1851,6 +1846,11 @@ Second line",
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="configuration-0"
         param={
           Object {
             "path": "configuration",
@@ -1945,12 +1945,7 @@ exports[`renders a basic deployment with slider parameters 1`] = `
       key="size-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="size-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "size",
@@ -1964,6 +1959,11 @@ exports[`renders a basic deployment with slider parameters 1`] = `
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="size-0"
         param={
           Object {
             "path": "size",
@@ -2351,12 +2351,7 @@ exports[`renders a basic deployment with username, password, email and a generic
       key="wordpressUsername-0"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="wordpressUsername-0"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "wordpressUsername",
@@ -2377,6 +2372,11 @@ exports[`renders a basic deployment with username, password, email and a generic
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="wordpressUsername-0"
         param={
           Object {
             "path": "wordpressUsername",
@@ -2448,12 +2448,7 @@ exports[`renders a basic deployment with username, password, email and a generic
       key="wordpressPassword-1"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="wordpressPassword-1"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "wordpressUsername",
@@ -2474,6 +2469,11 @@ exports[`renders a basic deployment with username, password, email and a generic
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="wordpressPassword-1"
         param={
           Object {
             "path": "wordpressPassword",
@@ -2545,12 +2545,7 @@ exports[`renders a basic deployment with username, password, email and a generic
       key="wordpressEmail-2"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="wordpressEmail-2"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "wordpressUsername",
@@ -2571,6 +2566,11 @@ exports[`renders a basic deployment with username, password, email and a generic
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="wordpressEmail-2"
         param={
           Object {
             "path": "wordpressEmail",
@@ -2642,12 +2642,7 @@ exports[`renders a basic deployment with username, password, email and a generic
       key="blogName-3"
     >
       <Param
-        appValues=""
-        deploymentEvent="install"
-        handleBasicFormParamChange={[MockFunction]}
-        handleValuesChange={[MockFunction]}
-        id="blogName-3"
-        otherParams={
+        allParams={
           Array [
             Object {
               "path": "wordpressUsername",
@@ -2668,6 +2663,11 @@ exports[`renders a basic deployment with username, password, email and a generic
             },
           ]
         }
+        appValues=""
+        deploymentEvent="install"
+        handleBasicFormParamChange={[MockFunction]}
+        handleValuesChange={[MockFunction]}
+        id="blogName-3"
         param={
           Object {
             "path": "blogName",

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/BasicDeploymentForm.test.tsx.snap
@@ -29,6 +29,16 @@ exports[`renders a basic deployment with a disk size 1`] = `
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="size-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "size",
+              "render": "slider",
+              "type": "string",
+              "value": "10Gi",
+            },
+          ]
+        }
         param={
           Object {
             "path": "size",
@@ -394,6 +404,14 @@ exports[`renders a basic deployment with a email 1`] = `
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="wordpressEmail-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "wordpressEmail",
+              "value": "user@example.com",
+            },
+          ]
+        }
         param={
           Object {
             "path": "wordpressEmail",
@@ -480,6 +498,15 @@ exports[`renders a basic deployment with a generic boolean 1`] = `
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="enableMetrics-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "enableMetrics",
+              "type": "boolean",
+              "value": true,
+            },
+          ]
+        }
         param={
           Object {
             "path": "enableMetrics",
@@ -675,6 +702,15 @@ exports[`renders a basic deployment with a generic number 1`] = `
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="replicas-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "replicas",
+              "type": "integer",
+              "value": 1,
+            },
+          ]
+        }
         param={
           Object {
             "path": "replicas",
@@ -764,6 +800,15 @@ exports[`renders a basic deployment with a generic string 1`] = `
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="blogName-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "blogName",
+              "type": "string",
+              "value": "my-blog",
+            },
+          ]
+        }
         param={
           Object {
             "path": "blogName",
@@ -854,6 +899,16 @@ exports[`renders a basic deployment with a integer disk size 1`] = `
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="size-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "size",
+              "render": "slider",
+              "type": "integer",
+              "value": 10,
+            },
+          ]
+        }
         param={
           Object {
             "path": "size",
@@ -1221,6 +1276,16 @@ exports[`renders a basic deployment with a number disk size 1`] = `
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="size-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "size",
+              "render": "slider",
+              "type": "number",
+              "value": 10,
+            },
+          ]
+        }
         param={
           Object {
             "path": "size",
@@ -1586,6 +1651,14 @@ exports[`renders a basic deployment with a password 1`] = `
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="wordpressPassword-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "wordpressPassword",
+              "value": "sserpdrow",
+            },
+          ]
+        }
         param={
           Object {
             "path": "wordpressPassword",
@@ -1671,6 +1744,14 @@ exports[`renders a basic deployment with a username 1`] = `
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="wordpressUsername-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "wordpressUsername",
+              "value": "user",
+            },
+          ]
+        }
         param={
           Object {
             "path": "wordpressUsername",
@@ -1759,6 +1840,17 @@ Second line",
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="configuration-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "configuration",
+              "render": "textArea",
+              "type": "string",
+              "value": "First line
+Second line",
+            },
+          ]
+        }
         param={
           Object {
             "path": "configuration",
@@ -1858,6 +1950,20 @@ exports[`renders a basic deployment with slider parameters 1`] = `
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="size-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "size",
+              "render": "slider",
+              "sliderMax": 100,
+              "sliderMin": 1,
+              "sliderStep": 1,
+              "sliderUnit": "Gi",
+              "type": "string",
+              "value": "10Gi",
+            },
+          ]
+        }
         param={
           Object {
             "path": "size",
@@ -2250,6 +2356,27 @@ exports[`renders a basic deployment with username, password, email and a generic
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="wordpressUsername-0"
+        otherParams={
+          Array [
+            Object {
+              "path": "wordpressUsername",
+              "value": "user",
+            },
+            Object {
+              "path": "wordpressPassword",
+              "value": "sserpdrow",
+            },
+            Object {
+              "path": "wordpressEmail",
+              "value": "user@example.com",
+            },
+            Object {
+              "path": "blogName",
+              "type": "string",
+              "value": "my-blog",
+            },
+          ]
+        }
         param={
           Object {
             "path": "wordpressUsername",
@@ -2326,6 +2453,27 @@ exports[`renders a basic deployment with username, password, email and a generic
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="wordpressPassword-1"
+        otherParams={
+          Array [
+            Object {
+              "path": "wordpressUsername",
+              "value": "user",
+            },
+            Object {
+              "path": "wordpressPassword",
+              "value": "sserpdrow",
+            },
+            Object {
+              "path": "wordpressEmail",
+              "value": "user@example.com",
+            },
+            Object {
+              "path": "blogName",
+              "type": "string",
+              "value": "my-blog",
+            },
+          ]
+        }
         param={
           Object {
             "path": "wordpressPassword",
@@ -2402,6 +2550,27 @@ exports[`renders a basic deployment with username, password, email and a generic
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="wordpressEmail-2"
+        otherParams={
+          Array [
+            Object {
+              "path": "wordpressUsername",
+              "value": "user",
+            },
+            Object {
+              "path": "wordpressPassword",
+              "value": "sserpdrow",
+            },
+            Object {
+              "path": "wordpressEmail",
+              "value": "user@example.com",
+            },
+            Object {
+              "path": "blogName",
+              "type": "string",
+              "value": "my-blog",
+            },
+          ]
+        }
         param={
           Object {
             "path": "wordpressEmail",
@@ -2478,6 +2647,27 @@ exports[`renders a basic deployment with username, password, email and a generic
         handleBasicFormParamChange={[MockFunction]}
         handleValuesChange={[MockFunction]}
         id="blogName-3"
+        otherParams={
+          Array [
+            Object {
+              "path": "wordpressUsername",
+              "value": "user",
+            },
+            Object {
+              "path": "wordpressPassword",
+              "value": "sserpdrow",
+            },
+            Object {
+              "path": "wordpressEmail",
+              "value": "user@example.com",
+            },
+            Object {
+              "path": "blogName",
+              "type": "string",
+              "value": "my-blog",
+            },
+          ]
+        }
         param={
           Object {
             "path": "blogName",

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/Subsection.test.tsx.snap
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/Subsection.test.tsx.snap
@@ -24,6 +24,40 @@ exports[`should render a external database section 1`] = `
     handleValuesChange={[MockFunction]}
     id="externalDatabase.database-0"
     key="externalDatabase.database-0"
+    otherParams={
+      Array [
+        Object {
+          "path": "externalDatabase.database",
+          "type": "string",
+          "value": "bitnami_wordpress",
+        },
+        Object {
+          "path": "externalDatabase.host",
+          "type": "string",
+          "value": "localhost",
+        },
+        Object {
+          "path": "externalDatabase.password",
+          "type": "string",
+        },
+        Object {
+          "path": "externalDatabase.port",
+          "type": "integer",
+          "value": 3306,
+        },
+        Object {
+          "path": "externalDatabase.user",
+          "type": "string",
+          "value": "bn_wordpress",
+        },
+        Object {
+          "path": "mariadb.enabled",
+          "title": "Enable External Database",
+          "type": "boolean",
+          "value": true,
+        },
+      ]
+    }
     param={
       Object {
         "path": "externalDatabase.database",
@@ -39,6 +73,40 @@ exports[`should render a external database section 1`] = `
     handleValuesChange={[MockFunction]}
     id="externalDatabase.host-1"
     key="externalDatabase.host-1"
+    otherParams={
+      Array [
+        Object {
+          "path": "externalDatabase.database",
+          "type": "string",
+          "value": "bitnami_wordpress",
+        },
+        Object {
+          "path": "externalDatabase.host",
+          "type": "string",
+          "value": "localhost",
+        },
+        Object {
+          "path": "externalDatabase.password",
+          "type": "string",
+        },
+        Object {
+          "path": "externalDatabase.port",
+          "type": "integer",
+          "value": 3306,
+        },
+        Object {
+          "path": "externalDatabase.user",
+          "type": "string",
+          "value": "bn_wordpress",
+        },
+        Object {
+          "path": "mariadb.enabled",
+          "title": "Enable External Database",
+          "type": "boolean",
+          "value": true,
+        },
+      ]
+    }
     param={
       Object {
         "path": "externalDatabase.host",
@@ -54,6 +122,40 @@ exports[`should render a external database section 1`] = `
     handleValuesChange={[MockFunction]}
     id="externalDatabase.password-2"
     key="externalDatabase.password-2"
+    otherParams={
+      Array [
+        Object {
+          "path": "externalDatabase.database",
+          "type": "string",
+          "value": "bitnami_wordpress",
+        },
+        Object {
+          "path": "externalDatabase.host",
+          "type": "string",
+          "value": "localhost",
+        },
+        Object {
+          "path": "externalDatabase.password",
+          "type": "string",
+        },
+        Object {
+          "path": "externalDatabase.port",
+          "type": "integer",
+          "value": 3306,
+        },
+        Object {
+          "path": "externalDatabase.user",
+          "type": "string",
+          "value": "bn_wordpress",
+        },
+        Object {
+          "path": "mariadb.enabled",
+          "title": "Enable External Database",
+          "type": "boolean",
+          "value": true,
+        },
+      ]
+    }
     param={
       Object {
         "path": "externalDatabase.password",
@@ -68,6 +170,40 @@ exports[`should render a external database section 1`] = `
     handleValuesChange={[MockFunction]}
     id="externalDatabase.port-3"
     key="externalDatabase.port-3"
+    otherParams={
+      Array [
+        Object {
+          "path": "externalDatabase.database",
+          "type": "string",
+          "value": "bitnami_wordpress",
+        },
+        Object {
+          "path": "externalDatabase.host",
+          "type": "string",
+          "value": "localhost",
+        },
+        Object {
+          "path": "externalDatabase.password",
+          "type": "string",
+        },
+        Object {
+          "path": "externalDatabase.port",
+          "type": "integer",
+          "value": 3306,
+        },
+        Object {
+          "path": "externalDatabase.user",
+          "type": "string",
+          "value": "bn_wordpress",
+        },
+        Object {
+          "path": "mariadb.enabled",
+          "title": "Enable External Database",
+          "type": "boolean",
+          "value": true,
+        },
+      ]
+    }
     param={
       Object {
         "path": "externalDatabase.port",
@@ -83,6 +219,40 @@ exports[`should render a external database section 1`] = `
     handleValuesChange={[MockFunction]}
     id="externalDatabase.user-4"
     key="externalDatabase.user-4"
+    otherParams={
+      Array [
+        Object {
+          "path": "externalDatabase.database",
+          "type": "string",
+          "value": "bitnami_wordpress",
+        },
+        Object {
+          "path": "externalDatabase.host",
+          "type": "string",
+          "value": "localhost",
+        },
+        Object {
+          "path": "externalDatabase.password",
+          "type": "string",
+        },
+        Object {
+          "path": "externalDatabase.port",
+          "type": "integer",
+          "value": 3306,
+        },
+        Object {
+          "path": "externalDatabase.user",
+          "type": "string",
+          "value": "bn_wordpress",
+        },
+        Object {
+          "path": "mariadb.enabled",
+          "title": "Enable External Database",
+          "type": "boolean",
+          "value": true,
+        },
+      ]
+    }
     param={
       Object {
         "path": "externalDatabase.user",
@@ -98,6 +268,40 @@ exports[`should render a external database section 1`] = `
     handleValuesChange={[MockFunction]}
     id="mariadb.enabled-5"
     key="mariadb.enabled-5"
+    otherParams={
+      Array [
+        Object {
+          "path": "externalDatabase.database",
+          "type": "string",
+          "value": "bitnami_wordpress",
+        },
+        Object {
+          "path": "externalDatabase.host",
+          "type": "string",
+          "value": "localhost",
+        },
+        Object {
+          "path": "externalDatabase.password",
+          "type": "string",
+        },
+        Object {
+          "path": "externalDatabase.port",
+          "type": "integer",
+          "value": 3306,
+        },
+        Object {
+          "path": "externalDatabase.user",
+          "type": "string",
+          "value": "bn_wordpress",
+        },
+        Object {
+          "path": "mariadb.enabled",
+          "title": "Enable External Database",
+          "type": "boolean",
+          "value": true,
+        },
+      ]
+    }
     param={
       Object {
         "path": "mariadb.enabled",

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/Subsection.test.tsx.snap
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/__snapshots__/Subsection.test.tsx.snap
@@ -18,46 +18,13 @@ exports[`should render a external database section 1`] = `
     </span>
   </div>
   <Param
+    allParams={Array []}
     appValues="externalDatabase: {}"
     deploymentEvent="install"
     handleBasicFormParamChange={[Function]}
     handleValuesChange={[MockFunction]}
     id="externalDatabase.database-0"
     key="externalDatabase.database-0"
-    otherParams={
-      Array [
-        Object {
-          "path": "externalDatabase.database",
-          "type": "string",
-          "value": "bitnami_wordpress",
-        },
-        Object {
-          "path": "externalDatabase.host",
-          "type": "string",
-          "value": "localhost",
-        },
-        Object {
-          "path": "externalDatabase.password",
-          "type": "string",
-        },
-        Object {
-          "path": "externalDatabase.port",
-          "type": "integer",
-          "value": 3306,
-        },
-        Object {
-          "path": "externalDatabase.user",
-          "type": "string",
-          "value": "bn_wordpress",
-        },
-        Object {
-          "path": "mariadb.enabled",
-          "title": "Enable External Database",
-          "type": "boolean",
-          "value": true,
-        },
-      ]
-    }
     param={
       Object {
         "path": "externalDatabase.database",
@@ -67,46 +34,13 @@ exports[`should render a external database section 1`] = `
     }
   />
   <Param
+    allParams={Array []}
     appValues="externalDatabase: {}"
     deploymentEvent="install"
     handleBasicFormParamChange={[Function]}
     handleValuesChange={[MockFunction]}
     id="externalDatabase.host-1"
     key="externalDatabase.host-1"
-    otherParams={
-      Array [
-        Object {
-          "path": "externalDatabase.database",
-          "type": "string",
-          "value": "bitnami_wordpress",
-        },
-        Object {
-          "path": "externalDatabase.host",
-          "type": "string",
-          "value": "localhost",
-        },
-        Object {
-          "path": "externalDatabase.password",
-          "type": "string",
-        },
-        Object {
-          "path": "externalDatabase.port",
-          "type": "integer",
-          "value": 3306,
-        },
-        Object {
-          "path": "externalDatabase.user",
-          "type": "string",
-          "value": "bn_wordpress",
-        },
-        Object {
-          "path": "mariadb.enabled",
-          "title": "Enable External Database",
-          "type": "boolean",
-          "value": true,
-        },
-      ]
-    }
     param={
       Object {
         "path": "externalDatabase.host",
@@ -116,46 +50,13 @@ exports[`should render a external database section 1`] = `
     }
   />
   <Param
+    allParams={Array []}
     appValues="externalDatabase: {}"
     deploymentEvent="install"
     handleBasicFormParamChange={[Function]}
     handleValuesChange={[MockFunction]}
     id="externalDatabase.password-2"
     key="externalDatabase.password-2"
-    otherParams={
-      Array [
-        Object {
-          "path": "externalDatabase.database",
-          "type": "string",
-          "value": "bitnami_wordpress",
-        },
-        Object {
-          "path": "externalDatabase.host",
-          "type": "string",
-          "value": "localhost",
-        },
-        Object {
-          "path": "externalDatabase.password",
-          "type": "string",
-        },
-        Object {
-          "path": "externalDatabase.port",
-          "type": "integer",
-          "value": 3306,
-        },
-        Object {
-          "path": "externalDatabase.user",
-          "type": "string",
-          "value": "bn_wordpress",
-        },
-        Object {
-          "path": "mariadb.enabled",
-          "title": "Enable External Database",
-          "type": "boolean",
-          "value": true,
-        },
-      ]
-    }
     param={
       Object {
         "path": "externalDatabase.password",
@@ -164,46 +65,13 @@ exports[`should render a external database section 1`] = `
     }
   />
   <Param
+    allParams={Array []}
     appValues="externalDatabase: {}"
     deploymentEvent="install"
     handleBasicFormParamChange={[Function]}
     handleValuesChange={[MockFunction]}
     id="externalDatabase.port-3"
     key="externalDatabase.port-3"
-    otherParams={
-      Array [
-        Object {
-          "path": "externalDatabase.database",
-          "type": "string",
-          "value": "bitnami_wordpress",
-        },
-        Object {
-          "path": "externalDatabase.host",
-          "type": "string",
-          "value": "localhost",
-        },
-        Object {
-          "path": "externalDatabase.password",
-          "type": "string",
-        },
-        Object {
-          "path": "externalDatabase.port",
-          "type": "integer",
-          "value": 3306,
-        },
-        Object {
-          "path": "externalDatabase.user",
-          "type": "string",
-          "value": "bn_wordpress",
-        },
-        Object {
-          "path": "mariadb.enabled",
-          "title": "Enable External Database",
-          "type": "boolean",
-          "value": true,
-        },
-      ]
-    }
     param={
       Object {
         "path": "externalDatabase.port",
@@ -213,46 +81,13 @@ exports[`should render a external database section 1`] = `
     }
   />
   <Param
+    allParams={Array []}
     appValues="externalDatabase: {}"
     deploymentEvent="install"
     handleBasicFormParamChange={[Function]}
     handleValuesChange={[MockFunction]}
     id="externalDatabase.user-4"
     key="externalDatabase.user-4"
-    otherParams={
-      Array [
-        Object {
-          "path": "externalDatabase.database",
-          "type": "string",
-          "value": "bitnami_wordpress",
-        },
-        Object {
-          "path": "externalDatabase.host",
-          "type": "string",
-          "value": "localhost",
-        },
-        Object {
-          "path": "externalDatabase.password",
-          "type": "string",
-        },
-        Object {
-          "path": "externalDatabase.port",
-          "type": "integer",
-          "value": 3306,
-        },
-        Object {
-          "path": "externalDatabase.user",
-          "type": "string",
-          "value": "bn_wordpress",
-        },
-        Object {
-          "path": "mariadb.enabled",
-          "title": "Enable External Database",
-          "type": "boolean",
-          "value": true,
-        },
-      ]
-    }
     param={
       Object {
         "path": "externalDatabase.user",
@@ -262,46 +97,13 @@ exports[`should render a external database section 1`] = `
     }
   />
   <Param
+    allParams={Array []}
     appValues="externalDatabase: {}"
     deploymentEvent="install"
     handleBasicFormParamChange={[Function]}
     handleValuesChange={[MockFunction]}
     id="mariadb.enabled-5"
     key="mariadb.enabled-5"
-    otherParams={
-      Array [
-        Object {
-          "path": "externalDatabase.database",
-          "type": "string",
-          "value": "bitnami_wordpress",
-        },
-        Object {
-          "path": "externalDatabase.host",
-          "type": "string",
-          "value": "localhost",
-        },
-        Object {
-          "path": "externalDatabase.password",
-          "type": "string",
-        },
-        Object {
-          "path": "externalDatabase.port",
-          "type": "integer",
-          "value": 3306,
-        },
-        Object {
-          "path": "externalDatabase.user",
-          "type": "string",
-          "value": "bn_wordpress",
-        },
-        Object {
-          "path": "mariadb.enabled",
-          "title": "Enable External Database",
-          "type": "boolean",
-          "value": true,
-        },
-      ]
-    }
     param={
       Object {
         "path": "mariadb.enabled",


### PR DESCRIPTION
### Description of the change

This PR simply adds a new check when evaluating whether or not a form field should be rendered. If the current `getValue(appValues, path)` is undefined (that is, there is no actual value in the `values.yaml` file) it tries to obtain the value form the hidden property (via `param.hidden?.value`).

### Benefits

Users won't have to specify a value in `values.yaml` if there already exists a default value in `hidden.value` of the `values.schema.json`

### Possible drawbacks

N/A

### Applicable issues

  - fixes #1913

### Additional information

N/A
