### PR TITLE
Fix flaky Go test

### DIFF
--- a/cmd/assetsvc/postgres_db_test.go
+++ b/cmd/assetsvc/postgres_db_test.go
@@ -23,6 +23,7 @@ package main
 
 import (
 	"database/sql"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -401,6 +402,14 @@ func TestGetPaginatedChartList(t *testing.T) {
 	}
 }
 
+// ByID implements sort.Interface for []models.Chart based on
+// the ID field.
+type byID []*models.Chart
+
+func (a byID) Len() int           { return len(a) }
+func (a byID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byID) Less(i, j int) bool { return a[i].ID < a[j].ID }
+
 func TestGetChartsWithFilters(t *testing.T) {
 	pgtest.SkipIfNoDB(t)
 	const (
@@ -505,6 +514,8 @@ func TestGetChartsWithFilters(t *testing.T) {
 				t.Fatalf("%+v", err)
 			}
 
+			sort.Sort(byID(charts))
+			sort.Sort(byID(tc.expectedCharts))
 			if got, want := charts, tc.expectedCharts; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

`master` and other PRs are failing because of this go test:
```
--- FAIL: TestGetChartsWithFilters (0.17s)
    --- FAIL: TestGetChartsWithFilters/returns_charts_from_different_repos_in_the_specific_namespace (0.06s)
        postgres_db_test.go:509: mismatch (-want +got):
              []*models.Chart{
              	&{
            - 		ID:   "repo-name-1/chart-1",
            + 		ID:   "repo-name-2/chart-1",
              		Name: "chart-1",
              		Repo: nil,
              		... // 10 identical fields
              	},
              	&{
            - 		ID:   "repo-name-2/chart-1",
            + 		ID:   "repo-name-1/chart-1",
              		Name: "chart-1",
              		Repo: nil,
              		... // 10 identical fields
              	},
              }
FAIL
FAIL	github.com/kubeapps/kubeapps/cmd/assetsvc	0.990s
FAIL
make: *** [Makefile:36: test-db] Error 1

Exited with code exit status 2
CircleCI received exit code 2
```

I guess this is caused by the update of the golang deps. Ensuring the order of the compared arrays to fix the flakiness.
