### PR TITLE
Use ChartQuery in getChartCategories

### DIFF
--- a/cmd/assetsvc/handler.go
+++ b/cmd/assetsvc/handler.go
@@ -90,8 +90,8 @@ func getPageAndSizeParams(req *http.Request) (int, int) {
 	return int(pageNumberInt), int(pageSizeInt)
 }
 
-func getAllChartCategories(namespace, repo string) (apiChartCategoryListResponse, error) {
-	chartCategories, err := manager.getAllChartCategories(namespace, repo)
+func getAllChartCategories(cq ChartQuery) (apiChartCategoryListResponse, error) {
+	chartCategories, err := manager.getAllChartCategories(cq)
 	return newChartCategoryListResponse(chartCategories), err
 }
 
@@ -109,7 +109,12 @@ func getChartCategories(w http.ResponseWriter, req *http.Request, params Params)
 		return
 	}
 
-	chartCategories, err := getAllChartCategories(namespace, repo)
+	cq := ChartQuery{
+		namespace: namespace,
+		repos:     append(strings.Split(strings.TrimSpace(req.FormValue("repos")), ","), repo),
+	}
+
+	chartCategories, err := getAllChartCategories(cq)
 	if err != nil {
 		log.WithError(err).Error("could not fetch categories")
 		response.NewErrorResponse(http.StatusInternalServerError, "could not fetch chart categories").Write(w)

--- a/cmd/assetsvc/handler.go
+++ b/cmd/assetsvc/handler.go
@@ -90,30 +90,23 @@ func getPageAndSizeParams(req *http.Request) (int, int) {
 	return int(pageNumberInt), int(pageSizeInt)
 }
 
-func extractDecodedNamespaceAndRepoAndVersionParams(params Params) (string, string, string, []string, []error) {
-	paramErr := []string{}
-
-	namespace, namespaceErr := url.PathUnescape(params["namespace"])
-	repo, repoErr := url.PathUnescape(params["repo"])
-	version, versionErr := url.PathUnescape(params["version"])
-
-	if namespaceErr != nil || repoErr != nil || versionErr != nil {
-		errors := []error{}
-		if namespaceErr != nil {
-			paramErr = append(paramErr, params["namespace"])
-			errors = append(errors, namespaceErr)
-		}
-		if repoErr != nil {
-			paramErr = append(paramErr, params["repo"])
-			errors = append(errors, repoErr)
-		}
-		if versionErr != nil {
-			paramErr = append(paramErr, params["version"])
-			errors = append(errors, versionErr)
-		}
-		return namespace, repo, version, paramErr, errors
+func extractDecodedNamespaceAndRepoAndVersionParams(params Params) (string, string, string, string, error) {
+	namespace, err := url.PathUnescape(params["namespace"])
+	if err != nil {
+		return "", "", "", params["namespace"], err
 	}
-	return namespace, repo, version, paramErr, nil
+
+	repo, err := url.PathUnescape(params["repo"])
+	if err != nil {
+		return "", "", "", params["repo"], err
+	}
+
+	version, err := url.PathUnescape(params["version"])
+	if err != nil {
+		return "", "", "", params["version"], err
+	}
+
+	return namespace, repo, version, "", nil
 }
 
 func extractChartQueryFromRequest(namespace, repo string, req *http.Request) ChartQuery {
@@ -148,9 +141,9 @@ func getAllChartCategories(cq ChartQuery) (apiChartCategoryListResponse, error) 
 
 // getChartCategories returns all the distinct chart categories name and count
 func getChartCategories(w http.ResponseWriter, req *http.Request, params Params) {
-	namespace, repo, _, paramErr, errors := extractDecodedNamespaceAndRepoAndVersionParams(params)
-	if errors != nil {
-		handleDecodeError(paramErr, w, errors)
+	namespace, repo, _, paramErr, err := extractDecodedNamespaceAndRepoAndVersionParams(params)
+	if err != nil {
+		handleDecodeError(paramErr, w, err)
 		return
 	}
 	cq := extractChartQueryFromRequest(namespace, repo, req)
@@ -166,9 +159,9 @@ func getChartCategories(w http.ResponseWriter, req *http.Request, params Params)
 
 // getChart returns the chart from the given repo
 func getChart(w http.ResponseWriter, req *http.Request, params Params) {
-	namespace, repo, _, paramErr, errors := extractDecodedNamespaceAndRepoAndVersionParams(params)
-	if errors != nil {
-		handleDecodeError(paramErr, w, errors)
+	namespace, repo, _, paramErr, err := extractDecodedNamespaceAndRepoAndVersionParams(params)
+	if err != nil {
+		handleDecodeError(paramErr, w, err)
 		return
 	}
 	chartID := getChartID(repo, params["chartName"]) // chartName remains encoded
@@ -186,9 +179,9 @@ func getChart(w http.ResponseWriter, req *http.Request, params Params) {
 
 // listChartVersions returns a list of chart versions for the given chart
 func listChartVersions(w http.ResponseWriter, req *http.Request, params Params) {
-	namespace, repo, _, paramErr, errors := extractDecodedNamespaceAndRepoAndVersionParams(params)
-	if errors != nil {
-		handleDecodeError(paramErr, w, errors)
+	namespace, repo, _, paramErr, err := extractDecodedNamespaceAndRepoAndVersionParams(params)
+	if err != nil {
+		handleDecodeError(paramErr, w, err)
 		return
 	}
 	chartID := getChartID(repo, params["chartName"]) // chartName remains encoded
@@ -206,9 +199,9 @@ func listChartVersions(w http.ResponseWriter, req *http.Request, params Params) 
 
 // getChartVersion returns the given chart version
 func getChartVersion(w http.ResponseWriter, req *http.Request, params Params) {
-	namespace, repo, version, paramErr, errors := extractDecodedNamespaceAndRepoAndVersionParams(params)
-	if errors != nil {
-		handleDecodeError(paramErr, w, errors)
+	namespace, repo, version, paramErr, err := extractDecodedNamespaceAndRepoAndVersionParams(params)
+	if err != nil {
+		handleDecodeError(paramErr, w, err)
 		return
 	}
 	chartID := getChartID(repo, params["chartName"]) // chartName remains encoded
@@ -226,9 +219,9 @@ func getChartVersion(w http.ResponseWriter, req *http.Request, params Params) {
 
 // getChartIcon returns the icon for a given chart
 func getChartIcon(w http.ResponseWriter, req *http.Request, params Params) {
-	namespace, repo, _, paramErr, errors := extractDecodedNamespaceAndRepoAndVersionParams(params)
-	if errors != nil {
-		handleDecodeError(paramErr, w, errors)
+	namespace, repo, _, paramErr, err := extractDecodedNamespaceAndRepoAndVersionParams(params)
+	if err != nil {
+		handleDecodeError(paramErr, w, err)
 		return
 	}
 	chartID := getChartID(repo, params["chartName"]) // chartName remains encoded
@@ -256,9 +249,9 @@ func getChartIcon(w http.ResponseWriter, req *http.Request, params Params) {
 
 // getChartVersionReadme returns the README for a given chart
 func getChartVersionReadme(w http.ResponseWriter, req *http.Request, params Params) {
-	namespace, repo, version, paramErr, errors := extractDecodedNamespaceAndRepoAndVersionParams(params)
-	if errors != nil {
-		handleDecodeError(paramErr, w, errors)
+	namespace, repo, version, paramErr, err := extractDecodedNamespaceAndRepoAndVersionParams(params)
+	if err != nil {
+		handleDecodeError(paramErr, w, err)
 		return
 	}
 	fileID := fmt.Sprintf("%s-%s", getChartID(repo, params["chartName"]), version) // chartName remains encoded
@@ -280,9 +273,9 @@ func getChartVersionReadme(w http.ResponseWriter, req *http.Request, params Para
 
 // getChartVersionValues returns the values.yaml for a given chart
 func getChartVersionValues(w http.ResponseWriter, req *http.Request, params Params) {
-	namespace, repo, version, paramErr, errors := extractDecodedNamespaceAndRepoAndVersionParams(params)
-	if errors != nil {
-		handleDecodeError(paramErr, w, errors)
+	namespace, repo, version, paramErr, err := extractDecodedNamespaceAndRepoAndVersionParams(params)
+	if err != nil {
+		handleDecodeError(paramErr, w, err)
 		return
 	}
 	fileID := fmt.Sprintf("%s-%s", getChartID(repo, params["chartName"]), version) // chartName remains encoded
@@ -299,9 +292,9 @@ func getChartVersionValues(w http.ResponseWriter, req *http.Request, params Para
 
 // getChartVersionSchema returns the values.schema.json for a given chart
 func getChartVersionSchema(w http.ResponseWriter, req *http.Request, params Params) {
-	namespace, repo, version, paramErr, errors := extractDecodedNamespaceAndRepoAndVersionParams(params)
-	if errors != nil {
-		handleDecodeError(paramErr, w, errors)
+	namespace, repo, version, paramErr, err := extractDecodedNamespaceAndRepoAndVersionParams(params)
+	if err != nil {
+		handleDecodeError(paramErr, w, err)
 		return
 	}
 	fileID := fmt.Sprintf("%s-%s", getChartID(repo, params["chartName"]), version) // chartName remains encoded
@@ -318,9 +311,9 @@ func getChartVersionSchema(w http.ResponseWriter, req *http.Request, params Para
 
 // listChartsWithFilters returns the list of repos that contains the given chart and the latest version found
 func listChartsWithFilters(w http.ResponseWriter, req *http.Request, params Params) {
-	namespace, repo, _, paramErr, errors := extractDecodedNamespaceAndRepoAndVersionParams(params)
-	if errors != nil {
-		handleDecodeError(paramErr, w, errors)
+	namespace, repo, _, paramErr, err := extractDecodedNamespaceAndRepoAndVersionParams(params)
+	if err != nil {
+		handleDecodeError(paramErr, w, err)
 		return
 	}
 	cq := extractChartQueryFromRequest(namespace, repo, req)
@@ -433,10 +426,8 @@ func newChartVersionListResponse(c *models.Chart) apiListResponse {
 	return cvl
 }
 
-func handleDecodeError(paramErr []string, w http.ResponseWriter, errors []error) {
-	for i, err := range errors {
-		log.WithError(err).Errorf("could not decode param %s", paramErr[i])
-	}
+func handleDecodeError(paramErr string, w http.ResponseWriter, err error) {
+	log.WithError(err).Errorf("could not decode param %s", paramErr)
 	response.NewErrorResponse(http.StatusBadRequest, "could not decode params").Write(w)
 }
 

--- a/cmd/assetsvc/handler_test.go
+++ b/cmd/assetsvc/handler_test.go
@@ -87,12 +87,13 @@ func Test_extractDecodedNamespaceAndRepoAndVersionParams(t *testing.T) {
 		namespace        string
 		repo             string
 		version          string
-		expectedParamErr []string
+		expectedParamErr string
 	}{
-		{"params OK", "namespace", "repo", "version", nil},
-		{"params one error", "%%3", "repo", "version", []string{"%%3"}},
-		{"params two errors", "%%3", "%%3", "version", []string{"%%3", "%%3"}},
-		{"params three errors", "%%3", "%%3", "%%3", []string{"%%3", "%%3", "%%3"}},
+		{"params OK", "namespace", "repo", "version", ""},
+		{"params NOK namespace", "%%1", "repo", "version", "%%1"},
+		{"params NOK repo", "namespace", "%%1", "version", "%%1"},
+		{"params NOK version", "namespace", "repo", "%%1", "%%1"},
+		{"params NOK (returns the first one errored)", "%%1", "%%2", "%%3", "%%1"},
 	}
 
 	for _, tt := range tests {
@@ -103,7 +104,7 @@ func Test_extractDecodedNamespaceAndRepoAndVersionParams(t *testing.T) {
 				"version":   tt.version,
 			}
 			namespace, repo, version, paramErr, _ := extractDecodedNamespaceAndRepoAndVersionParams(params)
-			if tt.expectedParamErr != nil {
+			if tt.expectedParamErr != "" {
 				assert.Equal(t, tt.expectedParamErr, paramErr, "expectedParamErr should be the same")
 			} else {
 				assert.Equal(t, tt.namespace, namespace, "namespace should be the same")

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -47,12 +47,8 @@ func newPGManager(config datastore.Config, kubeappsNamespace string) (assetManag
 	return &postgresAssetManager{m}, nil
 }
 
-func (m *postgresAssetManager) getAllChartCategories(namespace, repo string) ([]*models.ChartCategory, error) {
-	var repos []string
-	if repo != "" {
-		repos = []string{repo}
-	}
-	whereQuery, whereQueryParams := m.generateWhereClause(ChartQuery{namespace: namespace, repos: repos})
+func (m *postgresAssetManager) getAllChartCategories(cq ChartQuery) ([]*models.ChartCategory, error) {
+	whereQuery, whereQueryParams := m.generateWhereClause(cq)
 	dbQuery := fmt.Sprintf("SELECT (info ->> 'category') AS name, COUNT( (info ->> 'category')) AS count FROM %s %s GROUP BY (info ->> 'category') ORDER BY (info ->> 'category') ASC", dbutils.ChartTable, whereQuery)
 
 	chartsCategories, err := m.QueryAllChartCategories(dbQuery, whereQueryParams...)

--- a/cmd/assetsvc/postgresql_utils_test.go
+++ b/cmd/assetsvc/postgresql_utils_test.go
@@ -276,7 +276,7 @@ func Test_getAllChartCategories(t *testing.T) {
 				WithArgs(expectedParams...).
 				WillReturnRows(rows)
 
-			chartCategories, err := pgManager.getAllChartCategories(tt.namespace, tt.repo)
+			chartCategories, err := pgManager.getAllChartCategories(ChartQuery{namespace: tt.namespace, repos: []string{tt.repo}})
 			if err != nil {
 				t.Fatalf("Found error %v", err)
 			}

--- a/cmd/assetsvc/utils.go
+++ b/cmd/assetsvc/utils.go
@@ -28,7 +28,7 @@ type assetManager interface {
 	getChartVersion(namespace, chartID, version string) (models.Chart, error)
 	getChartFiles(namespace, filesID string) (models.ChartFiles, error)
 	getPaginatedChartListWithFilters(cq ChartQuery, pageNumber, pageSize int) ([]*models.Chart, int, error)
-	getAllChartCategories(namespace, repo string) ([]*models.ChartCategory, error)
+	getAllChartCategories(cq ChartQuery) ([]*models.ChartCategory, error)
 }
 
 // ChartQuery is a container for passing the supported query paramters for generating the WHERE query


### PR DESCRIPTION
### Description of the change

`getAllChartCategories` method was not using the `ChartQuery` object to receive the information.. Also, this PR allow using both `?repo` and  `?repos` for backwards compatibility.

### Benefits

Retrieving all distinct categories will work even if we choose a particular repo (o list of repos).

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

- Change initially introduced in https://github.com/kubeapps/kubeapps/pull/2221 but removed from there to keep it as simple as possible.