### PR TITLE
Ensure containers run as as non-root.

### DIFF
--- a/cmd/apprepository-controller/Dockerfile
+++ b/cmd/apprepository-controller/Dockerfile
@@ -14,4 +14,5 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kubeapps/kubeapps/apprepository-controller /apprepository-controller
+USER 1001
 CMD ["/apprepository-controller"]

--- a/cmd/asset-syncer/Dockerfile
+++ b/cmd/asset-syncer/Dockerfile
@@ -6,4 +6,5 @@ RUN CGO_ENABLED=0 go build -a -installsuffix cgo ./cmd/asset-syncer
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kubeapps/kubeapps/asset-syncer /asset-syncer
+USER 1001
 CMD ["/asset-syncer"]

--- a/cmd/assetsvc/Dockerfile
+++ b/cmd/assetsvc/Dockerfile
@@ -16,4 +16,5 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kubeapps/kubeapps/assetsvc /assetsvc
 EXPOSE 8080
+USER 1001
 CMD ["/assetsvc"]

--- a/cmd/kubeops/Dockerfile
+++ b/cmd/kubeops/Dockerfile
@@ -16,4 +16,5 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kubeapps/kubeapps/kubeops /kubeops
 EXPOSE 8080
+USER 1001
 CMD ["/kubeops"]

--- a/cmd/pinniped-proxy/Dockerfile
+++ b/cmd/pinniped-proxy/Dockerfile
@@ -19,8 +19,8 @@ RUN cargo build --release
 # FROM bitnami/minideb:buster-snapshot-20201121T213529Z
 FROM debian:10.6-slim
 RUN apt-get update && apt-get install -y ca-certificates libssl1.1 && rm -rf /var/lib/apt/lists/*
-
 COPY --from=builder /pinniped-proxy/target/release/pinniped-proxy /pinniped-proxy
 
 EXPOSE 3333
+USER 1001
 CMD ["/pinniped-proxy"]


### PR DESCRIPTION
### Description of the change

When running Kubeapps on a TMC cluster with TMC's default settings all our services errored with:

```
  Warning  Failed     1s (x5 over 29s)  kubelet, ip-10-0-1-198.eu-west-1.compute.internal  Error: container has runAsNonRoot and image will run as root
```

### Benefits

If CI doesn't find any side effects, it means Kubeapps can run in security contexts requiring non-root containers without any extra config.

### Possible drawbacks

See what CI says, otherwise none.

