### PR TITLE
Support for closable errors. Add kind-resolution error as closable

### DIFF
--- a/dashboard/src/components/AlertGroup/AlertGroup.test.tsx
+++ b/dashboard/src/components/AlertGroup/AlertGroup.test.tsx
@@ -1,0 +1,39 @@
+import { CdsAlert, CdsAlertGroup } from "@clr/react/alert";
+import { mount } from "enzyme";
+import * as React from "react";
+import { act } from "react-dom/test-utils";
+import AlertGroup from "./AlertGroup";
+
+it("should render children components", () => {
+  const wrapper = mount(<AlertGroup>foo</AlertGroup>);
+  expect(wrapper.text()).toContain("foo");
+});
+
+it("should render alertActions", () => {
+  const wrapper = mount(<AlertGroup alertActions={<div>bar</div>}>foo</AlertGroup>);
+  expect(wrapper.text()).toContain("foo");
+  expect(wrapper.text()).toContain("bar");
+});
+
+it("should close the alert", () => {
+  const wrapper = mount(<AlertGroup closable={true}>foo</AlertGroup>);
+  act(() => {
+    (wrapper.find(CdsAlert).prop("onCloseChange") as any)();
+  });
+  wrapper.update();
+  expect(wrapper.find(CdsAlertGroup).prop("hidden")).toBe(true);
+});
+
+it("should set custom properties", () => {
+  const customProps = {
+    status: "info",
+    type: "flat",
+    size: "sm",
+  };
+  const wrapper = mount(
+    <AlertGroup closable={true} {...(customProps as any)}>
+      foo
+    </AlertGroup>,
+  );
+  expect(wrapper.find(CdsAlertGroup).props()).toMatchObject(customProps);
+});

--- a/dashboard/src/components/AlertGroup/AlertGroup.tsx
+++ b/dashboard/src/components/AlertGroup/AlertGroup.tsx
@@ -1,0 +1,34 @@
+import { AlertGroupTypes, AlertSizes, AlertStatusTypes } from "@clr/core/alert";
+import { CdsAlert, CdsAlertActions, CdsAlertGroup } from "@clr/react/alert";
+import * as React from "react";
+
+export interface IAlertGroupProps {
+  children: React.ReactNode;
+  alertActions?: string | JSX.Element;
+  closable?: boolean;
+  status?: AlertStatusTypes;
+  type?: AlertGroupTypes;
+  size?: AlertSizes;
+}
+
+// Opinionated wrapper of Clarity AlertGroup
+// https://clarity.design/storybook/core/?path=/story/components-alert-group-getting-started--page
+export default function AlertGroup({
+  alertActions,
+  closable,
+  status = "danger",
+  type = "default",
+  size = "default",
+  children,
+}: IAlertGroupProps) {
+  const [closed, setClosed] = React.useState(false);
+  const close = () => setClosed(true);
+  return (
+    <CdsAlertGroup status={status} type={type} hidden={closed} size={size}>
+      <CdsAlert closable={closable} onCloseChange={close}>
+        {children}
+        {alertActions && <CdsAlertActions>{alertActions}</CdsAlertActions>}
+      </CdsAlert>
+    </CdsAlertGroup>
+  );
+}

--- a/dashboard/src/components/AlertGroup/index.tsx
+++ b/dashboard/src/components/AlertGroup/index.tsx
@@ -1,0 +1,3 @@
+import AlertGroup from "./AlertGroup";
+
+export default AlertGroup;

--- a/dashboard/src/components/Header/Header.test.tsx
+++ b/dashboard/src/components/Header/Header.test.tsx
@@ -7,23 +7,17 @@ import { app } from "../../shared/url";
 import Header from "./Header";
 
 let spyOnUseDispatch: jest.SpyInstance;
-const kubeaActions = { ...actions.namespace };
 beforeEach(() => {
   actions.namespace = {
     ...actions.namespace,
     fetchNamespaces: jest.fn(),
     canCreate: jest.fn(),
   };
-  actions.kube = {
-    ...actions.kube,
-    getResourceKinds: jest.fn(),
-  };
   const mockDispatch = jest.fn(res => res);
   spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
 });
 
 afterEach(() => {
-  actions.namespace = { ...kubeaActions };
   spyOnUseDispatch.mockRestore();
   jest.resetAllMocks();
 });
@@ -46,11 +40,6 @@ it("fetch namespaces and the ability to create them", () => {
   mountWrapper(getStore(defaultState), <Header />);
   expect(actions.namespace.fetchNamespaces).toHaveBeenCalled();
   expect(actions.namespace.canCreate).toHaveBeenCalled();
-});
-
-it("fetch resource kinds", () => {
-  mountWrapper(getStore(defaultState), <Header />);
-  expect(actions.kube.getResourceKinds).toHaveBeenCalled();
 });
 
 it("renders the header links and titles", () => {

--- a/dashboard/src/components/Header/Header.tsx
+++ b/dashboard/src/components/Header/Header.tsx
@@ -27,7 +27,6 @@ function Header() {
     if (authenticated && clusters.currentCluster) {
       dispatch(actions.namespace.fetchNamespaces(clusters.currentCluster));
       dispatch(actions.namespace.canCreate(clusters.currentCluster));
-      dispatch(actions.kube.getResourceKinds(clusters.currentCluster));
     }
   }, [dispatch, authenticated, clusters.currentCluster]);
 

--- a/dashboard/src/components/Layout/Layout.scss
+++ b/dashboard/src/components/Layout/Layout.scss
@@ -207,6 +207,10 @@
   margin-bottom: 0.3rem;
 }
 
+.margin-t-sm {
+  margin-top: 0.3rem;
+}
+
 .clr-control-container {
   width: 100%;
   margin-top: 0.3rem;

--- a/dashboard/src/components/Layout/Layout.test.tsx
+++ b/dashboard/src/components/Layout/Layout.test.tsx
@@ -1,0 +1,40 @@
+import actions from "actions";
+import * as React from "react";
+import * as ReactRedux from "react-redux";
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
+import Layout from "./Layout";
+
+let spyOnUseDispatch: jest.SpyInstance;
+const kubeaActions = { ...actions.namespace };
+beforeEach(() => {
+  actions.kube = {
+    ...actions.kube,
+    getResourceKinds: jest.fn(),
+  };
+  const mockDispatch = jest.fn(res => res);
+  spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
+});
+
+afterEach(() => {
+  actions.namespace = { ...kubeaActions };
+  spyOnUseDispatch.mockRestore();
+  jest.resetAllMocks();
+});
+
+const defaultState = {
+  clusters: {
+    currentCluster: "default",
+    clusters: {
+      default: {
+        currentNamespace: "default",
+        namespaces: ["default", "other"],
+      },
+    },
+  },
+  auth: { authenticated: true },
+};
+
+it("fetch resource kinds", () => {
+  mountWrapper(getStore(defaultState), <Layout />);
+  expect(actions.kube.getResourceKinds).toHaveBeenCalled();
+});

--- a/dashboard/src/components/Layout/Layout.tsx
+++ b/dashboard/src/components/Layout/Layout.tsx
@@ -36,9 +36,11 @@ function Layout({ children }: any) {
           <div className="content-area">
             <ErrorBoundaryContainer logout={logout}>
               {kindsError && (
-                <AlertGroup status="warning" closable={true} size="sm">
-                  Unable to retrieve API info: ${kindsError.message}
-                </AlertGroup>
+                <div className="margin-t-sm">
+                  <AlertGroup status="warning" closable={true} size="sm">
+                    Unable to retrieve API info: ${kindsError.message}
+                  </AlertGroup>
+                </div>
               )}
               {children}
             </ErrorBoundaryContainer>

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -18,6 +18,7 @@ describe("kubeReducer", () => {
     receiveResourceFromList: getType(actions.kube.receiveResourceFromList),
     receiveResourceKinds: getType(actions.kube.receiveResourceKinds),
     requestResourceKinds: getType(actions.kube.requestResourceKinds),
+    receiveKindsError: getType(actions.kube.receiveKindsError),
   };
 
   const ref = new ResourceRef(
@@ -237,6 +238,17 @@ describe("kubeReducer", () => {
         expect(newState).toEqual({
           ...initialState,
           kinds,
+        });
+      });
+
+      it("sets an error", () => {
+        const newState = kubeReducer(undefined, {
+          type: actionTypes.receiveKindsError,
+          payload: new Error("nope!"),
+        });
+        expect(newState).toEqual({
+          ...initialState,
+          kindsError: new Error("nope!"),
         });
       });
     });

--- a/dashboard/src/reducers/kube.ts
+++ b/dashboard/src/reducers/kube.ts
@@ -141,8 +141,7 @@ const kubeReducer = (
     case getType(actions.kube.receiveResourceKinds):
       return { ...state, kinds: action.payload };
     case getType(actions.kube.receiveKindsError):
-      // no-op: If unable to get kinds, return the default set
-      return { ...state, kinds: initialKinds };
+      return { ...state, kinds: initialKinds, kindsError: action.payload };
     case getType(actions.kube.receiveResourceFromList):
       const stateListItem = state.items[action.payload.key].item as IK8sList<IResource, {}>;
       const newItem = action.payload.resource as IResource;

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -546,6 +546,7 @@ export interface IKubeState {
   items: { [s: string]: IKubeItem<IResource | IK8sList<IResource, {}>> };
   sockets: { [s: string]: { socket: WebSocket; closeTimer: () => void } };
   kinds: { [kind: string]: IKind };
+  kindsError?: Error;
 }
 
 export interface IBasicFormParam {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of #2234

At the moment, if a request to resolve API kinds fails, we fallback to the default set with a silent error. With this PR, we show a closable warning to inform about the issue:

![Screenshot from 2021-01-15 13-37-21](https://user-images.githubusercontent.com/4025665/104732942-3d1f9180-573e-11eb-864e-91b17c3522d1.png)

### Benefits

Now it's possible to use closable errors :) 
