### PR TITLE
Use repos from state in catalog

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -4,7 +4,7 @@ import FilterGroup from "components/FilterGroup/FilterGroup";
 import InfoCard from "components/InfoCard/InfoCard";
 import Alert from "components/js/Alert";
 import { act } from "react-dom/test-utils";
-import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
+import { defaultStore, getStore, initialState, mountWrapper } from "shared/specs/mountWrapper";
 import { IAppRepository, IChart, IChartState, IClusterServiceVersion } from "../../shared/types";
 import SearchFilter from "../SearchFilter/SearchFilter";
 import Catalog, { filterNames } from "./Catalog";
@@ -27,7 +27,7 @@ const defaultProps = {
   fetchChartCategories: jest.fn(),
   fetchRepos: jest.fn(),
   pushSearchFilter: jest.fn(),
-  cluster: "default",
+  cluster: initialState.config.kubeappsCluster,
   namespace: "kubeapps",
   kubeappsNamespace: "kubeapps",
   csvs: [],
@@ -137,7 +137,7 @@ describe("filters by the searched item", () => {
       (wrapper.find(SearchFilter).prop("onChange") as any)("bar");
     });
     wrapper.update();
-    expect(fetchCharts).toHaveBeenCalledWith("default", "kubeapps", "", 1, 0, "bar");
+    expect(fetchCharts).toHaveBeenCalledWith("default-cluster", "kubeapps", "", 1, 0, "bar");
   });
 });
 
@@ -167,7 +167,7 @@ describe("filters by application type", () => {
       .getActions()
       .find(action => action.type === "@@router/CALL_HISTORY_METHOD");
     expect(historyAction.payload).toEqual({
-      args: ["/c/default/ns/kubeapps/catalog?Type=Charts"],
+      args: ["/c/default-cluster/ns/kubeapps/catalog?Type=Charts"],
       method: "push",
     });
   });
@@ -190,7 +190,7 @@ describe("filters by application type", () => {
       .getActions()
       .find(action => action.type === "@@router/CALL_HISTORY_METHOD");
     expect(historyAction.payload).toEqual({
-      args: ["/c/default/ns/kubeapps/catalog?Type=Operators"],
+      args: ["/c/default-cluster/ns/kubeapps/catalog?Type=Operators"],
       method: "push",
     });
   });
@@ -225,9 +225,54 @@ describe("filters by application repository", () => {
       .find(action => action.type === "@@router/CALL_HISTORY_METHOD");
     expect(fetchRepos).toHaveBeenCalledWith("kubeapps");
     expect(historyAction.payload).toEqual({
-      args: ["/c/default/ns/kubeapps/catalog?Repository=foo"],
+      args: ["/c/default-cluster/ns/kubeapps/catalog?Repository=foo"],
       method: "push",
     });
+  });
+});
+
+it("push filter for repo", () => {
+  const store = getStore({
+    ...defaultStore,
+    repos: { repos: [{ metadata: { name: "foo" } } as IAppRepository] },
+  });
+  const fetchRepos = jest.fn();
+  const wrapper = mountWrapper(store, <Catalog {...populatedProps} fetchRepos={fetchRepos} />);
+  // The repo name is "foo"
+  const input = wrapper.find("input").findWhere(i => i.prop("value") === "foo");
+  input.simulate("change", { target: { value: "foo" } });
+  // It should have pushed with the filter
+  const historyAction = store
+    .getActions()
+    .find(action => action.type === "@@router/CALL_HISTORY_METHOD");
+  expect(fetchRepos).toHaveBeenCalledWith("kubeapps");
+  expect(historyAction.payload).toEqual({
+    args: ["/c/default-cluster/ns/kubeapps/catalog?Repository=foo"],
+    method: "push",
+  });
+});
+
+it("push filter for repo in other ns", () => {
+  const store = getStore({
+    ...defaultStore,
+    repos: { repos: [{ metadata: { name: "foo" } } as IAppRepository] },
+  });
+  const fetchRepos = jest.fn();
+  const wrapper = mountWrapper(
+    store,
+    <Catalog {...populatedProps} namespace={"my-ns"} fetchRepos={fetchRepos} />,
+  );
+  // The repo name is "foo", the ns name is "my-ns"
+  const input = wrapper.find("input").findWhere(i => i.prop("value") === "foo");
+  input.simulate("change", { target: { value: "foo" } });
+  // It should have pushed with the filter
+  const historyAction = store
+    .getActions()
+    .find(action => action.type === "@@router/CALL_HISTORY_METHOD");
+  expect(fetchRepos).toHaveBeenCalledWith("my-ns", true);
+  expect(historyAction.payload).toEqual({
+    args: ["/c/default-cluster/ns/my-ns/catalog?Repository=foo"],
+    method: "push",
   });
 });
 
@@ -261,7 +306,7 @@ describe("filters by operator provider", () => {
       .getActions()
       .find(action => action.type === "@@router/CALL_HISTORY_METHOD");
     expect(historyAction.payload).toEqual({
-      args: ["/c/default/ns/kubeapps/catalog?Provider=you"],
+      args: ["/c/default-cluster/ns/kubeapps/catalog?Provider=you"],
       method: "push",
     });
   });
@@ -319,7 +364,7 @@ describe("filters by category", () => {
       .getActions()
       .find(action => action.type === "@@router/CALL_HISTORY_METHOD");
     expect(historyAction.payload).toEqual({
-      args: ["/c/default/ns/kubeapps/catalog?Category=Database"],
+      args: ["/c/default-cluster/ns/kubeapps/catalog?Category=Database"],
       method: "push",
     });
   });

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -23,6 +23,7 @@ const defaultProps = {
   filter: {},
   fetchCharts: jest.fn(),
   fetchChartCategories: jest.fn(),
+  fetchRepos: jest.fn(),
   pushSearchFilter: jest.fn(),
   cluster: "default",
   namespace: "kubeapps",

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -5,7 +5,7 @@ import InfoCard from "components/InfoCard/InfoCard";
 import Alert from "components/js/Alert";
 import { act } from "react-dom/test-utils";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
-import { IChart, IChartState, IClusterServiceVersion } from "../../shared/types";
+import { IAppRepository, IChart, IChartState, IClusterServiceVersion } from "../../shared/types";
 import SearchFilter from "../SearchFilter/SearchFilter";
 import Catalog, { filterNames } from "./Catalog";
 
@@ -211,8 +211,9 @@ describe("filters by application repository", () => {
   });
 
   it("push filter for repo", () => {
-    const store = getStore({});
-    const wrapper = mountWrapper(store, <Catalog {...populatedProps} />);
+    const store = getStore({ repos: { repos: [{ metadata: { name: "foo" } } as IAppRepository] } });
+    const fetchRepos = jest.fn();
+    const wrapper = mountWrapper(store, <Catalog {...populatedProps} fetchRepos={fetchRepos} />);
     // The repo name is "foo"
     const input = wrapper.find("input").findWhere(i => i.prop("value") === "foo");
     input.simulate("change", { target: { value: "foo" } });
@@ -220,6 +221,7 @@ describe("filters by application repository", () => {
     const historyAction = store
       .getActions()
       .find(action => action.type === "@@router/CALL_HISTORY_METHOD");
+    expect(fetchRepos).toHaveBeenCalledWith("kubeapps");
     expect(historyAction.payload).toEqual({
       args: ["/c/default/ns/kubeapps/catalog?Repository=foo"],
       method: "push",

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -94,16 +94,12 @@ function Catalog(props: ICatalogProps) {
 
   const dispatch = useDispatch();
   const [filters, setFilters] = useState(initialFilterState());
-  const [currentRepo, setCurrentRepo] = useState(
-    propsFilter[filterNames.REPO] ? String(propsFilter[filterNames.REPO]) : "",
-  );
 
   useEffect(() => {
     const newFilters = {};
     Object.keys(propsFilter).forEach(filter => {
       newFilters[filter] = propsFilter[filter]?.toString().split(",");
     });
-    setCurrentRepo(propsFilter[filterNames.REPO] ? String(propsFilter[filterNames.REPO]) : "");
     setFilters({
       ...initialFilterState(),
       ...newFilters,
@@ -146,11 +142,6 @@ function Catalog(props: ICatalogProps) {
   // We do not currently support app repositories on additional clusters.
   const supportedCluster = cluster === kubeappsCluster;
   useEffect(() => {
-    if (!namespace) {
-      // All Namespaces
-      fetchRepos("");
-      return;
-    }
     if (!supportedCluster || namespace === kubeappsNamespace) {
       // Global namespace or other cluster, show global repos only
       fetchRepos(kubeappsNamespace);
@@ -167,9 +158,10 @@ function Catalog(props: ICatalogProps) {
 
   // Only one search filter can be set
   const searchFilter = propsFilter[filterNames.SEARCH]?.toString() || "";
+  const reposFilter = filters[filterNames.REPO]?.join(",") || "";
   useEffect(() => {
-    fetchCharts(cluster, namespace, currentRepo, searchFilter);
-  }, [fetchCharts, cluster, namespace, currentRepo, searchFilter]);
+    fetchCharts(cluster, namespace, reposFilter, searchFilter);
+  }, [fetchCharts, cluster, namespace, reposFilter, searchFilter]);
 
   const setSearchFilter = (searchTerm: string) => {
     const newFilters = {

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -8,10 +8,10 @@ import { push } from "connected-react-router";
 import { flatten, get, intersection, trimStart, uniq, without } from "lodash";
 import { ParsedQs } from "qs";
 import React, { useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { app } from "shared/url";
-import { IChartState, IClusterServiceVersion } from "../../shared/types";
+import { IChartState, IClusterServiceVersion, IStoreState } from "../../shared/types";
 import { escapeRegExp } from "../../shared/utils";
 import LoadingWrapper from "../LoadingWrapper/LoadingWrapper";
 import PageHeader from "../PageHeader/PageHeader";
@@ -38,6 +38,7 @@ interface ICatalogProps {
   namespace: string;
   kubeappsNamespace: string;
   fetchChartCategories: (cluster: string, namespace: string) => void;
+  fetchRepos: (namespace: string, listGlobal?: boolean) => void;
   getCSVs: (cluster: string, namespace: string) => void;
   csvs: IClusterServiceVersion[];
 }
@@ -80,20 +81,29 @@ function Catalog(props: ICatalogProps) {
     cluster,
     namespace,
     fetchChartCategories,
+    fetchRepos,
     getCSVs,
     csvs,
-    repo,
     filter: propsFilter,
   } = props;
 
+  const {
+    repos: { repos },
+    config: { kubeappsCluster, kubeappsNamespace },
+  } = useSelector((state: IStoreState) => state);
+
   const dispatch = useDispatch();
   const [filters, setFilters] = useState(initialFilterState());
+  const [currentRepo, setCurrentRepo] = useState(
+    propsFilter[filterNames.REPO] ? String(propsFilter[filterNames.REPO]) : "",
+  );
 
   useEffect(() => {
     const newFilters = {};
     Object.keys(propsFilter).forEach(filter => {
       newFilters[filter] = propsFilter[filter]?.toString().split(",");
     });
+    setCurrentRepo(propsFilter[filterNames.REPO] ? String(propsFilter[filterNames.REPO]) : "");
     setFilters({
       ...initialFilterState(),
       ...newFilters,
@@ -125,13 +135,30 @@ function Catalog(props: ICatalogProps) {
     pushFilters(filters);
   };
 
-  const allRepos = uniq(charts.map(c => c.attributes.repo.name));
+  const allRepos = uniq(repos.map(c => c.metadata.name));
   const allProviders = uniq(csvs.map(c => c.spec.provider.name));
   const allCategories = uniq(
     categories
       .map(c => categoryToReadable(c.name))
       .concat(flatten(csvs.map(c => getOperatorCategories(c)))),
   ).sort();
+
+  // We do not currently support app repositories on additional clusters.
+  const supportedCluster = cluster === kubeappsCluster;
+  useEffect(() => {
+    if (!namespace) {
+      // All Namespaces
+      fetchRepos("");
+      return;
+    }
+    if (!supportedCluster || namespace === kubeappsNamespace) {
+      // Global namespace or other cluster, show global repos only
+      fetchRepos(kubeappsNamespace);
+      return;
+    }
+    // In other case, fetch global and namespace repos
+    fetchRepos(namespace, true);
+  }, [fetchRepos, supportedCluster, namespace, kubeappsNamespace]);
 
   useEffect(() => {
     fetchChartCategories(cluster, namespace);
@@ -141,8 +168,8 @@ function Catalog(props: ICatalogProps) {
   // Only one search filter can be set
   const searchFilter = propsFilter[filterNames.SEARCH]?.toString() || "";
   useEffect(() => {
-    fetchCharts(cluster, namespace, repo, searchFilter);
-  }, [fetchCharts, cluster, namespace, repo, searchFilter]);
+    fetchCharts(cluster, namespace, currentRepo, searchFilter);
+  }, [fetchCharts, cluster, namespace, currentRepo, searchFilter]);
 
   const setSearchFilter = (searchTerm: string) => {
     const newFilters = {

--- a/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
+++ b/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
@@ -31,6 +31,8 @@ function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) 
       dispatch(actions.charts.fetchCharts(cluster, namespace, repos, query)),
     fetchChartCategories: (cluster: string, namespace: string) =>
       dispatch(actions.charts.fetchChartCategories(cluster, namespace)),
+    fetchRepos: (namespace: string, listGlobal?: boolean) =>
+      dispatch(actions.repos.fetchRepos(namespace, listGlobal)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),
     getCSVs: (cluster: string, namespace: string) =>
       dispatch(actions.operators.getCSVs(cluster, namespace)),


### PR DESCRIPTION
### Description of the change

This PR uses the `repos` property, which already exists in the global state, and adds the component state variable `currentRepo` for tracking the selected repos (used in the /chart request)  

### Benefits

The logic to getting all the repositories will no longer require iterate over the whole list of charts; instead, repos will be retrieved from the state.

### Possible drawbacks

N/A

### Applicable issues

This PR depends on https://github.com/kubeapps/kubeapps/pull/2249 to be merged.

### Additional information

- Change initially introduced in https://github.com/kubeapps/kubeapps/pull/2221 but removed from there to keep it as simple as possible.