### PR TITLE
Add pagination params 

### DIFF
--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -14,6 +14,8 @@ let response: any;
 
 const namespace = "chart-namespace";
 const cluster = "default";
+const defaultPage = 1;
+const defaultSize = 0;
 
 beforeEach(() => {
   store = mockStore();
@@ -39,10 +41,12 @@ describe("fetchCharts", () => {
       { type: getType(actions.charts.requestCharts) },
       { type: getType(actions.charts.receiveCharts), payload: response },
     ];
-    await store.dispatch(actions.charts.fetchCharts(cluster, namespace, "foo"));
+    await store.dispatch(
+      actions.charts.fetchCharts(cluster, namespace, "foo", defaultPage, defaultSize),
+    );
     expect(store.getActions()).toEqual(expectedActions);
     expect(axiosGetMock.mock.calls[0][0]).toBe(
-      `api/assetsvc/v1/clusters/${cluster}/namespaces/${namespace}/charts?&repos=foo`,
+      `api/assetsvc/v1/clusters/${cluster}/namespaces/${namespace}/charts?page=${defaultPage}&size=${defaultSize}&repos=foo`,
     );
   });
 
@@ -52,10 +56,12 @@ describe("fetchCharts", () => {
       { type: getType(actions.charts.requestCharts), payload: "foo" },
       { type: getType(actions.charts.receiveCharts), payload: response },
     ];
-    await store.dispatch(actions.charts.fetchCharts(cluster, namespace, "", "foo"));
+    await store.dispatch(
+      actions.charts.fetchCharts(cluster, namespace, "", defaultPage, defaultSize, "foo"),
+    );
     expect(store.getActions()).toEqual(expectedActions);
     expect(axiosGetMock.mock.calls[0][0]).toBe(
-      `api/assetsvc/v1/clusters/${cluster}/namespaces/${namespace}/charts?&q=foo`,
+      `api/assetsvc/v1/clusters/${cluster}/namespaces/${namespace}/charts?page=${defaultPage}&size=${defaultSize}&q=foo`,
     );
   });
 
@@ -71,7 +77,9 @@ describe("fetchCharts", () => {
       throw new Error("could not find chart");
     });
     axiosWithAuth.get = axiosGetMock;
-    await store.dispatch(actions.charts.fetchCharts(cluster, namespace, "foo"));
+    await store.dispatch(
+      actions.charts.fetchCharts(cluster, namespace, "foo", defaultPage, defaultSize),
+    );
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -84,7 +92,9 @@ describe("fetchCharts", () => {
       throw new Error("something went wrong");
     });
     axiosWithAuth.get = axiosGetMock;
-    await store.dispatch(actions.charts.fetchCharts(cluster, namespace, "foo"));
+    await store.dispatch(
+      actions.charts.fetchCharts(cluster, namespace, "foo", defaultPage, defaultSize),
+    );
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -88,12 +88,14 @@ export function fetchCharts(
   cluster: string,
   namespace: string,
   repos: string,
+  page: number,
+  size: number,
   query?: string,
 ): ThunkAction<Promise<void>, IStoreState, null, ChartsAction> {
   return async dispatch => {
     dispatch(requestCharts(query));
     try {
-      const charts = await Chart.fetchCharts(cluster, namespace, repos, query);
+      const charts = await Chart.fetchCharts(cluster, namespace, repos, page, size, query);
       dispatch(receiveCharts(charts));
     } catch (e) {
       dispatch(errorChart(new FetchError(e.message)));

--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -16,6 +16,8 @@ const defaultChartState = {
   items: [],
   categories: [],
   updatesInfo: {},
+  page: 1,
+  size: 0,
 } as IChartState;
 const defaultProps = {
   charts: defaultChartState,
@@ -134,7 +136,7 @@ describe("filters by the searched item", () => {
       (wrapper.find(SearchFilter).prop("onChange") as any)("bar");
     });
     wrapper.update();
-    expect(fetchCharts).toHaveBeenCalledWith("default", "kubeapps", "", "bar");
+    expect(fetchCharts).toHaveBeenCalledWith("default", "kubeapps", "", 1, 0, "bar");
   });
 });
 

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -33,7 +33,14 @@ interface ICatalogProps {
   charts: IChartState;
   repo: string;
   filter: ParsedQs;
-  fetchCharts: (cluster: string, namespace: string, repos: string, query: string) => void;
+  fetchCharts: (
+    cluster: string,
+    namespace: string,
+    repos: string,
+    page: number,
+    size: number,
+    query?: string,
+  ) => void;
   cluster: string;
   namespace: string;
   kubeappsNamespace: string;
@@ -75,6 +82,8 @@ function Catalog(props: ICatalogProps) {
       selected: { error },
       items: charts,
       categories,
+      page,
+      size,
     },
     fetchCharts,
     cluster,
@@ -141,8 +150,8 @@ function Catalog(props: ICatalogProps) {
   // Only one search filter can be set
   const searchFilter = propsFilter[filterNames.SEARCH]?.toString() || "";
   useEffect(() => {
-    fetchCharts(cluster, namespace, repo, searchFilter);
-  }, [fetchCharts, cluster, namespace, repo, searchFilter]);
+    fetchCharts(cluster, namespace, repo, page, size, searchFilter);
+  }, [fetchCharts, cluster, namespace, repo, page, size, searchFilter]);
 
   const setSearchFilter = (searchTerm: string) => {
     const newFilters = {

--- a/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
+++ b/dashboard/src/containers/CatalogContainer/CatalogContainer.tsx
@@ -27,8 +27,14 @@ function mapStateToProps(
 
 function mapDispatchToProps(dispatch: ThunkDispatch<IStoreState, null, Action>) {
   return {
-    fetchCharts: (cluster: string, namespace: string, repos: string, query?: string) =>
-      dispatch(actions.charts.fetchCharts(cluster, namespace, repos, query)),
+    fetchCharts: (
+      cluster: string,
+      namespace: string,
+      repos: string,
+      page: number,
+      size: number,
+      query?: string,
+    ) => dispatch(actions.charts.fetchCharts(cluster, namespace, repos, page, size, query)),
     fetchChartCategories: (cluster: string, namespace: string) =>
       dispatch(actions.charts.fetchChartCategories(cluster, namespace)),
     pushSearchFilter: (filter: string) => dispatch(actions.shared.pushSearchFilter(filter)),

--- a/dashboard/src/reducers/charts.test.ts
+++ b/dashboard/src/reducers/charts.test.ts
@@ -30,6 +30,8 @@ describe("chartReducer", () => {
         versions: [],
       },
       deployed: {},
+      page: 1,
+      size: 0,
     };
   });
   const error = new Error("Boom");

--- a/dashboard/src/reducers/charts.ts
+++ b/dashboard/src/reducers/charts.ts
@@ -13,6 +13,8 @@ export const initialState: IChartState = {
     versions: [],
   },
   deployed: {},
+  page: 1,
+  size: 0,
 };
 
 const chartsSelectedReducer = (

--- a/dashboard/src/shared/Chart.test.ts
+++ b/dashboard/src/shared/Chart.test.ts
@@ -4,6 +4,8 @@ import Chart from "./Chart";
 
 const clusterName = "cluster-name";
 const namespaceName = "namespace-name";
+const defaultPage = 1;
+const defaultSize = 0;
 
 describe("App", () => {
   beforeEach(() => {
@@ -25,9 +27,11 @@ describe("App", () => {
           cluster: clusterName,
           namespace: namespaceName,
           repos: "",
+          page: defaultPage,
+          size: defaultSize,
           query: "",
         },
-        result: `api/assetsvc/v1/clusters/${clusterName}/namespaces/${namespaceName}/charts?`,
+        result: `api/assetsvc/v1/clusters/${clusterName}/namespaces/${namespaceName}/charts?page=${defaultPage}&size=${defaultSize}`,
       },
       {
         description: "fetch charts url without repos, with query",
@@ -35,9 +39,11 @@ describe("App", () => {
           cluster: clusterName,
           namespace: namespaceName,
           repos: "",
+          page: defaultPage,
+          size: defaultSize,
           query: "cms",
         },
-        result: `api/assetsvc/v1/clusters/${clusterName}/namespaces/${namespaceName}/charts?&q=cms`,
+        result: `api/assetsvc/v1/clusters/${clusterName}/namespaces/${namespaceName}/charts?page=${defaultPage}&size=${defaultSize}&q=cms`,
       },
       {
         description: "fetch charts url with repos, without query",
@@ -45,9 +51,11 @@ describe("App", () => {
           cluster: clusterName,
           namespace: namespaceName,
           repos: "repo1,repo2",
+          page: defaultPage,
+          size: defaultSize,
           query: "",
         },
-        result: `api/assetsvc/v1/clusters/${clusterName}/namespaces/${namespaceName}/charts?&repos=repo1,repo2`,
+        result: `api/assetsvc/v1/clusters/${clusterName}/namespaces/${namespaceName}/charts?page=${defaultPage}&size=${defaultSize}&repos=repo1,repo2`,
       },
       {
         description: "fetch charts url wtih repos, with query",
@@ -55,14 +63,23 @@ describe("App", () => {
           cluster: clusterName,
           namespace: namespaceName,
           repos: "repo1,repo2",
+          page: defaultPage,
+          size: defaultSize,
           query: "cms",
         },
-        result: `api/assetsvc/v1/clusters/${clusterName}/namespaces/${namespaceName}/charts?&q=cms&repos=repo1,repo2`,
+        result: `api/assetsvc/v1/clusters/${clusterName}/namespaces/${namespaceName}/charts?page=${defaultPage}&size=${defaultSize}&q=cms&repos=repo1,repo2`,
       },
     ].forEach(t => {
       it(t.description, async () => {
         expect(
-          await Chart.fetchCharts(t.args.cluster, t.args.namespace, t.args.repos, t.args.query),
+          await Chart.fetchCharts(
+            t.args.cluster,
+            t.args.namespace,
+            t.args.repos,
+            t.args.page,
+            t.args.size,
+            t.args.query,
+          ),
         ).toStrictEqual("ok");
         expect(moxios.requests.mostRecent().url).toStrictEqual(t.result);
       });

--- a/dashboard/src/shared/Chart.ts
+++ b/dashboard/src/shared/Chart.ts
@@ -8,10 +8,12 @@ export default class Chart {
     cluster: string,
     namespace: string,
     repos: string,
+    page: number,
+    size: number,
     query?: string,
   ) {
     const { data } = await axiosWithAuth.get<{ data: IChart[] }>(
-      URL.api.charts.list(cluster, namespace, repos, query),
+      URL.api.charts.list(cluster, namespace, repos, page, size, query),
     );
     return data.data;
   }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -111,6 +111,8 @@ export interface IChartState {
   };
   items: IChart[];
   categories: IChartCategory[];
+  page: number;
+  size: number;
 }
 
 export interface IChartUpdateInfo {

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -117,10 +117,17 @@ export const api = {
       `${api.charts.base(cluster, namespace)}/charts/${id}`,
     getVersion: (cluster: string, namespace: string, id: string, version: string) =>
       `${api.charts.get(cluster, namespace, id)}/versions/${encodeURIComponent(version)}`,
-    list: (cluster: string, namespace: string, repos: string, query?: string) =>
-      `${api.charts.base(cluster, namespace)}/charts?${query ? "&q=" + query : ""}${
-        repos ? `&repos=${repos}` : ""
-      }`,
+    list: (
+      cluster: string,
+      namespace: string,
+      repos: string,
+      page: number,
+      size: number,
+      query?: string,
+    ) =>
+      `${api.charts.base(cluster, namespace)}/charts?page=${page}&size=${size}${
+        query ? "&q=" + query : ""
+      }${repos ? `&repos=${repos}` : ""}`,
     getChartCategories: (cluster: string, namespace: string) =>
       `${api.charts.base(cluster, namespace)}/charts/categories`,
     listVersions: (cluster: string, namespace: string, id: string) =>


### PR DESCRIPTION
### Description of the change

This PR is to introduce the `page` and `size` params (defaulted to `1`, `0`, that is, no pagination whatsoever). The functionality is the very same as the parent branch of this PR.

### Benefits

Not many... just intended for easing the endless scrolling feature.

### Possible drawbacks

N/A

### Applicable issues

This PR depends on https://github.com/kubeapps/kubeapps/pull/2249 to be merged.

### Additional information

- Change initially introduced in https://github.com/kubeapps/kubeapps/pull/2221 but removed from there to keep it as simple as possible.