### PR TITLE
Refactor fetchRepos action

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -263,7 +263,7 @@ describe("fetchRepos", () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
-  it("fetches repos from several namespaces and joins them", async () => {
+  it("fetches additional repos from the global namespace and joins them", async () => {
     AppRepository.list = jest
       .fn()
       .mockImplementationOnce(() => {
@@ -280,7 +280,7 @@ describe("fetchRepos", () => {
       },
       {
         type: getType(repoActions.requestRepos),
-        payload: "other-ns",
+        payload: kubeappsNamespace,
       },
       {
         type: getType(repoActions.receiveReposSecrets),
@@ -295,7 +295,7 @@ describe("fetchRepos", () => {
       },
     ];
 
-    await store.dispatch(repoActions.fetchRepos(namespace, "other-ns"));
+    await store.dispatch(repoActions.fetchRepos(namespace, true));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -321,7 +321,7 @@ describe("fetchRepos", () => {
       },
       {
         type: getType(repoActions.requestRepos),
-        payload: "other-ns",
+        payload: kubeappsNamespace,
       },
       {
         type: getType(repoActions.receiveReposSecrets),
@@ -336,7 +336,7 @@ describe("fetchRepos", () => {
       },
     ];
 
-    await store.dispatch(repoActions.fetchRepos(namespace, "other-ns"));
+    await store.dispatch(repoActions.fetchRepos(namespace, true));
     expect(store.getActions()).toEqual(expectedActions);
   });
 
@@ -358,19 +358,19 @@ describe("fetchRepos", () => {
     const expectedActions = [
       {
         type: getType(repoActions.requestRepos),
-        payload: "other-ns",
-      },
-      {
-        type: getType(repoActions.receiveReposSecrets),
-        payload: [],
+        payload: kubeappsNamespace,
       },
       {
         type: getType(repoActions.receiveRepos),
         payload: [{ name: "repo1", metadata: { uid: "123" } }],
       },
+      {
+        type: getType(repoActions.receiveReposSecrets),
+        payload: [],
+      },
     ];
 
-    await store.dispatch(repoActions.fetchRepos("other-ns", "other-ns"));
+    await store.dispatch(repoActions.fetchRepos(kubeappsNamespace, true));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -42,7 +42,7 @@ afterEach(() => {
 
 it("fetches repos and imagePullSecrets", () => {
   mountWrapper(defaultStore, <AppRepoList />);
-  expect(actions.repos.fetchRepos).toHaveBeenCalledWith(namespace, kubeappsNamespace);
+  expect(actions.repos.fetchRepos).toHaveBeenCalledWith(namespace, true);
   expect(actions.repos.fetchImagePullSecrets).toHaveBeenCalledWith(namespace);
 });
 

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -55,7 +55,7 @@ function AppRepoList() {
       return;
     }
     // In other case, fetch global and namespace repos
-    dispatch(actions.repos.fetchRepos(namespace, kubeappsNamespace));
+    dispatch(actions.repos.fetchRepos(namespace, true));
   }, [dispatch, supportedCluster, namespace, kubeappsNamespace]);
 
   useEffect(() => {

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.test.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.test.tsx
@@ -43,7 +43,7 @@ it("should fetch repositories", () => {
   const fetch = jest.fn();
   actions.repos = { ...actions.repos, fetchRepos: fetch };
   mountWrapper(defaultStore, <SelectRepoForm {...defaultProps} />);
-  expect(fetch).toHaveBeenCalledWith(defaultProps.namespace, initialState.config.kubeappsNamespace);
+  expect(fetch).toHaveBeenCalledWith(defaultProps.namespace, true);
 });
 
 it("should render a loading page if fetching", () => {

--- a/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
+++ b/dashboard/src/components/SelectRepoForm/SelectRepoForm.tsx
@@ -36,7 +36,7 @@ function SelectRepoForm({ cluster, namespace, chartName }: ISelectRepoFormProps)
   useEffect(() => {
     if (namespace !== kubeappsNamespace) {
       // Normal namespace, show local and global repos
-      dispatch(actions.repos.fetchRepos(namespace, kubeappsNamespace));
+      dispatch(actions.repos.fetchRepos(namespace, true));
     } else {
       // Global namespace, show global repos only
       dispatch(actions.repos.fetchRepos(kubeappsNamespace));


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of https://github.com/kubeapps/kubeapps/pull/2245#discussion_r557286054

When `fetchRepos` is called for more than one namespace (any namespace + global namespace), the secrets from the global namespace are not needed so they should not be fetched. That's the current behavior but this PR ensures that, making it a boolean the parameter to fetch global repos or not.
