### PR TITLE
Refactor: Move asset-syncer methods to an interface

### DIFF
--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -581,7 +581,7 @@ func apprepoSyncJobArgs(apprepo *apprepov1alpha1.AppRepository, config Config) [
 		args = append(args, "--user-agent-comment="+config.UserAgentComment)
 	}
 
-	return append(args, "--namespace="+apprepo.GetNamespace(), apprepo.GetName(), apprepo.Spec.URL)
+	return append(args, "--namespace="+apprepo.GetNamespace(), apprepo.GetName(), apprepo.Spec.URL, apprepo.Spec.Type)
 }
 
 // apprepoSyncJobEnvVars returns a list of env variables for the sync container

--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
@@ -581,7 +582,13 @@ func apprepoSyncJobArgs(apprepo *apprepov1alpha1.AppRepository, config Config) [
 		args = append(args, "--user-agent-comment="+config.UserAgentComment)
 	}
 
-	return append(args, "--namespace="+apprepo.GetNamespace(), apprepo.GetName(), apprepo.Spec.URL, apprepo.Spec.Type)
+	args = append(args, "--namespace="+apprepo.GetNamespace(), apprepo.GetName(), apprepo.Spec.URL, apprepo.Spec.Type)
+
+	if len(apprepo.Spec.OCIRepositories) > 0 {
+		args = append(args, "--oci-repositories", strings.Join(apprepo.Spec.OCIRepositories, ","))
+	}
+
+	return args
 }
 
 // apprepoSyncJobEnvVars returns a list of env variables for the sync container

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -89,6 +89,7 @@ func Test_newCronJob(t *testing.T) {
 												"--namespace=kubeapps",
 												"my-charts",
 												"https://charts.acme.com/my-charts",
+												"helm",
 											},
 											Env: []corev1.EnvVar{
 												{
@@ -180,6 +181,7 @@ func Test_newCronJob(t *testing.T) {
 												"--namespace=kubeapps",
 												"my-charts",
 												"https://charts.acme.com/my-charts",
+												"helm",
 											},
 											Env: []corev1.EnvVar{
 												{
@@ -267,6 +269,7 @@ func Test_newCronJob(t *testing.T) {
 												"--namespace=otherns",
 												"my-charts-in-otherns",
 												"https://charts.acme.com/my-charts",
+												"helm",
 											},
 											Env: []corev1.EnvVar{
 												{
@@ -373,6 +376,7 @@ func Test_newSyncJob(t *testing.T) {
 										"--namespace=kubeapps",
 										"my-charts",
 										"https://charts.acme.com/my-charts",
+										"helm",
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -439,6 +443,7 @@ func Test_newSyncJob(t *testing.T) {
 										"--namespace=my-other-namespace",
 										"my-charts",
 										"https://charts.acme.com/my-charts",
+										"helm",
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -520,6 +525,7 @@ func Test_newSyncJob(t *testing.T) {
 										"--namespace=kubeapps",
 										"my-charts",
 										"https://charts.acme.com/my-charts",
+										"helm",
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -606,6 +612,7 @@ func Test_newSyncJob(t *testing.T) {
 										"--namespace=kubeapps",
 										"my-charts",
 										"https://charts.acme.com/my-charts",
+										"helm",
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -704,6 +711,7 @@ func Test_newSyncJob(t *testing.T) {
 										"--namespace=kubeapps",
 										"my-charts",
 										"https://charts.acme.com/my-charts",
+										"helm",
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -820,6 +828,7 @@ func Test_newSyncJob(t *testing.T) {
 										"--namespace=kubeapps",
 										"my-charts",
 										"https://charts.acme.com/my-charts",
+										"helm",
 									},
 									Env: []corev1.EnvVar{
 										{Name: "FOO", Value: "BAR"},

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -847,6 +847,86 @@ func Test_newSyncJob(t *testing.T) {
 				},
 			},
 		},
+		{
+			"OCI registry with repositories",
+			"",
+			&apprepov1alpha1.AppRepository{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AppRepository",
+					APIVersion: "kubeapps.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-charts",
+					Namespace: "kubeapps",
+					Labels: map[string]string{
+						"name":       "my-charts",
+						"created-by": "kubeapps",
+					},
+				},
+				Spec: apprepov1alpha1.AppRepositorySpec{
+					Type:            "oci",
+					URL:             "https://charts.acme.com/my-charts",
+					OCIRepositories: []string{"apache", "jenkins"},
+				},
+			},
+			batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "apprepo-kubeapps-sync-my-charts-",
+					OwnerReferences: []metav1.OwnerReference{
+						*metav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
+							schema.GroupVersionKind{
+								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
+								Version: apprepov1alpha1.SchemeGroupVersion.Version,
+								Kind:    "AppRepository",
+							},
+						),
+					},
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								LabelRepoName:      "my-charts",
+								LabelRepoNamespace: "kubeapps",
+							},
+						},
+						Spec: corev1.PodSpec{
+							RestartPolicy: "OnFailure",
+							Containers: []corev1.Container{
+								{
+									Name:            "sync",
+									Image:           repoSyncImage,
+									ImagePullPolicy: "IfNotPresent",
+									Command:         []string{"/chart-repo"},
+									Args: []string{
+										"sync",
+										"--database-url=postgresql.kubeapps",
+										"--database-user=admin",
+										"--database-name=assets",
+										"--namespace=kubeapps",
+										"my-charts",
+										"https://charts.acme.com/my-charts",
+										"oci",
+										"--oci-repositories",
+										"apache,jenkins",
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: "DB_PASSWORD",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+										},
+									},
+									VolumeMounts: nil,
+								},
+							},
+							Volumes: nil,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/asset-syncer/main.go
+++ b/cmd/asset-syncer/main.go
@@ -29,6 +29,7 @@ var (
 	databasePassword string
 	debug            bool
 	namespace        string
+	ociRepositories  []string
 )
 
 var rootCmd = &cobra.Command{
@@ -57,6 +58,7 @@ func init() {
 
 	databasePassword = os.Getenv("DB_PASSWORD")
 
+	syncCmd.Flags().StringSliceVar(&ociRepositories, "oci-repositories", []string{}, "List of OCI Repositories in case the type is OCI")
 	cmds := []*cobra.Command{syncCmd, deleteCmd, invalidateCacheCmd}
 	for _, cmd := range cmds {
 		rootCmd.AddCommand(cmd)

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -53,7 +53,12 @@ var syncCmd = &cobra.Command{
 		defer manager.Close()
 
 		authorizationHeader := os.Getenv("AUTHORIZATION_HEADER")
-		repoIface, err := getRepo(namespace, args[0], args[1], args[2], authorizationHeader)
+		var repoIface Repo
+		if args[2] == "helm" {
+			repoIface, err = getHelmRepo(namespace, args[0], args[1], authorizationHeader)
+		} else {
+			repoIface, err = getOCIRepo(namespace, args[0], args[1], authorizationHeader, ociRepositories)
+		}
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -216,8 +216,41 @@ func (r *HelmRepo) FetchFiles(name string, cv models.ChartVersion) (map[string]s
 	}, nil
 }
 
-func getRepo(namespace, name, repoURL, repoType, authorizationHeader string) (Repo, error) {
-	// TODO(andresmgot): Handle type: oci
+// OCIRegistry implements the Repo interface for OCI repositories
+type OCIRegistry struct {
+	repositories []string
+	*models.RepoInternal
+}
+
+// Checksum returns the sha256 of the repo
+func (r *OCIRegistry) Checksum() (string, error) {
+	// TBD
+	return "", nil
+}
+
+// Repo returns the repo information
+func (r *OCIRegistry) Repo() *models.RepoInternal {
+	// TBD
+	return r.RepoInternal
+}
+
+// Charts retrieve the list of charts exposed in the repo
+func (r *OCIRegistry) Charts() ([]models.Chart, error) {
+	// TBD
+	return []models.Chart{}, nil
+}
+
+// FetchFiles retrieves the important files of a chart and version from the repo
+func (r *OCIRegistry) FetchFiles(name string, cv models.ChartVersion) (map[string]string, error) {
+	// TBD
+	return map[string]string{
+		values: "",
+		readme: "",
+		schema: "",
+	}, nil
+}
+
+func getHelmRepo(namespace, name, repoURL, authorizationHeader string) (Repo, error) {
 	url, err := parseRepoURL(repoURL)
 	if err != nil {
 		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
@@ -230,6 +263,15 @@ func getRepo(namespace, name, repoURL, repoType, authorizationHeader string) (Re
 	}
 
 	return &HelmRepo{content: repoBytes, RepoInternal: &models.RepoInternal{Namespace: namespace, Name: name, URL: url.String(), AuthorizationHeader: authorizationHeader}}, nil
+}
+
+func getOCIRepo(namespace, name, repoURL, authorizationHeader string, ociRepos []string) (Repo, error) {
+	url, err := parseRepoURL(repoURL)
+	if err != nil {
+		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
+		return nil, err
+	}
+	return &OCIRegistry{repositories: ociRepos, RepoInternal: &models.RepoInternal{Namespace: namespace, Name: name, URL: url.String(), AuthorizationHeader: authorizationHeader}}, nil
 }
 
 func fetchRepoIndex(url, authHeader string) ([]byte, error) {

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -104,24 +104,132 @@ func getSha256(src []byte) (string, error) {
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
-func getRepo(namespace, name, repoURL, authorizationHeader string) (*models.RepoInternal, []byte, error) {
+// Repo defines the methods to retrive information from the given repository
+type Repo interface {
+	Checksum() (string, error)
+	Repo() *models.RepoInternal
+	Charts() ([]models.Chart, error)
+	FetchFiles(name string, cv models.ChartVersion) (map[string]string, error)
+}
+
+// HelmRepo implements the Repo interface for chartmuseum-like repositories
+type HelmRepo struct {
+	content []byte
+	*models.RepoInternal
+}
+
+// Checksum returns the sha256 of the repo
+func (r *HelmRepo) Checksum() (string, error) {
+	return getSha256(r.content)
+}
+
+// Repo returns the repo information
+func (r *HelmRepo) Repo() *models.RepoInternal {
+	return r.RepoInternal
+}
+
+// Charts retrieve the list of charts exposed in the repo
+func (r *HelmRepo) Charts() ([]models.Chart, error) {
+	index, err := parseRepoIndex(r.content)
+	if err != nil {
+		return []models.Chart{}, err
+	}
+
+	repo := &models.Repo{
+		Namespace: r.Namespace,
+		Name:      r.Name,
+		URL:       r.URL,
+		Type:      r.Type,
+	}
+	charts := chartsFromIndex(index, repo)
+	if len(charts) == 0 {
+		return []models.Chart{}, fmt.Errorf("no charts in repository index")
+	}
+
+	return charts, nil
+}
+
+const (
+	readme = "readme"
+	values = "values"
+	schema = "schema"
+)
+
+// FetchFiles retrieves the important files of a chart and version from the repo
+func (r *HelmRepo) FetchFiles(name string, cv models.ChartVersion) (map[string]string, error) {
+	chartTarballURL := chartTarballURL(r.RepoInternal, cv)
+	req, err := http.NewRequest("GET", chartTarballURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent())
+	if len(r.AuthorizationHeader) > 0 {
+		req.Header.Set("Authorization", r.AuthorizationHeader)
+	}
+
+	res, err := netClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	// We read the whole chart into memory, this should be okay since the chart
+	// tarball needs to be small enough to fit into a GRPC call (Tiller
+	// requirement)
+	gzf, err := gzip.NewReader(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer gzf.Close()
+
+	tarf := tar.NewReader(gzf)
+
+	// decode escaped characters
+	// ie., "foo%2Fbar" should return "foo/bar"
+	decodedName, err := url.PathUnescape(name)
+	if err != nil {
+		log.Errorf("Cannot decode %s", name)
+		return nil, err
+	}
+
+	// get last part of the name
+	// ie., "foo/bar" should return "bar"
+	fixedName := path.Base(decodedName)
+	readmeFileName := fixedName + "/README.md"
+	valuesFileName := fixedName + "/values.yaml"
+	schemaFileName := fixedName + "/values.schema.json"
+	filenames := map[string]string{
+		values: valuesFileName,
+		readme: readmeFileName,
+		schema: schemaFileName,
+	}
+
+	files, err := extractFilesFromTarball(filenames, tarf)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{
+		values: files[values],
+		readme: files[readme],
+		schema: files[schema],
+	}, nil
+}
+
+func getRepo(namespace, name, repoURL, repoType, authorizationHeader string) (Repo, error) {
+	// TODO(andresmgot): Handle type: oci
 	url, err := parseRepoURL(repoURL)
 	if err != nil {
 		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
-		return nil, []byte{}, err
+		return nil, err
 	}
 
 	repoBytes, err := fetchRepoIndex(url.String(), authorizationHeader)
 	if err != nil {
-		return nil, []byte{}, err
+		return nil, err
 	}
 
-	repoChecksum, err := getSha256(repoBytes)
-	if err != nil {
-		return nil, []byte{}, err
-	}
-
-	return &models.RepoInternal{Namespace: namespace, Name: name, URL: url.String(), Checksum: repoChecksum, AuthorizationHeader: authorizationHeader}, repoBytes, nil
+	return &HelmRepo{content: repoBytes, RepoInternal: &models.RepoInternal{Namespace: namespace, Name: name, URL: url.String(), AuthorizationHeader: authorizationHeader}}, nil
 }
 
 func fetchRepoIndex(url, authHeader string) ([]byte, error) {
@@ -199,7 +307,7 @@ func newChart(entry helmrepo.ChartVersions, r *models.Repo) models.Chart {
 	return c
 }
 
-func extractFilesFromTarball(filenames []string, tarf *tar.Reader) (map[string]string, error) {
+func extractFilesFromTarball(filenames map[string]string, tarf *tar.Reader) (map[string]string, error) {
 	ret := make(map[string]string)
 	for {
 		header, err := tarf.Next()
@@ -210,11 +318,11 @@ func extractFilesFromTarball(filenames []string, tarf *tar.Reader) (map[string]s
 			return ret, err
 		}
 
-		for _, f := range filenames {
+		for id, f := range filenames {
 			if strings.EqualFold(header.Name, f) {
 				var b bytes.Buffer
 				io.Copy(&b, tarf)
-				ret[f] = string(b.Bytes())
+				ret[id] = string(b.Bytes())
 				break
 			}
 		}
@@ -271,7 +379,7 @@ type fileImporter struct {
 	manager assetManager
 }
 
-func (f *fileImporter) fetchFiles(charts []models.Chart, r *models.RepoInternal) {
+func (f *fileImporter) fetchFiles(charts []models.Chart, repo Repo) {
 	// Process 10 charts at a time
 	numWorkers := 10
 	iconJobs := make(chan models.Chart, numWorkers)
@@ -281,7 +389,7 @@ func (f *fileImporter) fetchFiles(charts []models.Chart, r *models.RepoInternal)
 	log.Debugf("starting %d workers", numWorkers)
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)
-		go f.importWorker(&wg, iconJobs, chartFilesJobs, r)
+		go f.importWorker(&wg, iconJobs, chartFilesJobs, repo)
 	}
 
 	// Enqueue jobs to process chart icons
@@ -315,17 +423,17 @@ func (f *fileImporter) fetchFiles(charts []models.Chart, r *models.RepoInternal)
 	wg.Wait()
 }
 
-func (f *fileImporter) importWorker(wg *sync.WaitGroup, icons <-chan models.Chart, chartFiles <-chan importChartFilesJob, r *models.RepoInternal) {
+func (f *fileImporter) importWorker(wg *sync.WaitGroup, icons <-chan models.Chart, chartFiles <-chan importChartFilesJob, repo Repo) {
 	defer wg.Done()
 	for c := range icons {
 		log.WithFields(log.Fields{"name": c.Name}).Debug("importing icon")
-		if err := f.fetchAndImportIcon(c, r); err != nil {
+		if err := f.fetchAndImportIcon(c, repo.Repo()); err != nil {
 			log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to import icon")
 		}
 	}
 	for j := range chartFiles {
 		log.WithFields(log.Fields{"name": j.Name, "version": j.ChartVersion.Version}).Debug("importing readme and values")
-		if err := f.fetchAndImportFiles(j.Name, r, j.ChartVersion); err != nil {
+		if err := f.fetchAndImportFiles(j.Name, repo, j.ChartVersion); err != nil {
 			log.WithFields(log.Fields{"name": j.Name, "version": j.ChartVersion.Version}).WithError(err).Error("failed to import files")
 		}
 	}
@@ -392,7 +500,8 @@ func (f *fileImporter) fetchAndImportIcon(c models.Chart, r *models.RepoInternal
 	return f.manager.updateIcon(models.Repo{Namespace: r.Namespace, Name: r.Name}, b, contentType, c.ID)
 }
 
-func (f *fileImporter) fetchAndImportFiles(name string, r *models.RepoInternal, cv models.ChartVersion) error {
+func (f *fileImporter) fetchAndImportFiles(name string, repo Repo, cv models.ChartVersion) error {
+	r := repo.Repo()
 	chartID := fmt.Sprintf("%s/%s", r.Name, name)
 	chartFilesID := fmt.Sprintf("%s-%s", chartID, cv.Version)
 
@@ -403,67 +512,23 @@ func (f *fileImporter) fetchAndImportFiles(name string, r *models.RepoInternal, 
 	}
 	log.WithFields(log.Fields{"name": name, "version": cv.Version}).Debug("fetching files")
 
-	chartTarballURL := chartTarballURL(r, cv)
-	req, err := http.NewRequest("GET", chartTarballURL, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("User-Agent", userAgent())
-	if len(r.AuthorizationHeader) > 0 {
-		req.Header.Set("Authorization", r.AuthorizationHeader)
-	}
-
-	res, err := netClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	// We read the whole chart into memory, this should be okay since the chart
-	// tarball needs to be small enough to fit into a GRPC call (Tiller
-	// requirement)
-	gzf, err := gzip.NewReader(res.Body)
-	if err != nil {
-		return err
-	}
-	defer gzf.Close()
-
-	tarf := tar.NewReader(gzf)
-
-	// decode escaped characters
-	// ie., "foo%2Fbar" should return "foo/bar"
-	decodedName, err := url.PathUnescape(name)
-	if err != nil {
-		log.Errorf("Cannot decode %s", name)
-		return err
-	}
-
-	// get last part of the name
-	// ie., "foo/bar" should return "bar"
-	fixedName := path.Base(decodedName)
-
-	readmeFileName := fixedName + "/README.md"
-	valuesFileName := fixedName + "/values.yaml"
-	schemaFileName := fixedName + "/values.schema.json"
-	filenames := []string{valuesFileName, readmeFileName, schemaFileName}
-
-	files, err := extractFilesFromTarball(filenames, tarf)
+	files, err := repo.FetchFiles(name, cv)
 	if err != nil {
 		return err
 	}
 
 	chartFiles := models.ChartFiles{ID: chartFilesID, Repo: &models.Repo{Name: r.Name, Namespace: r.Namespace, URL: r.URL}, Digest: cv.Digest}
-	if v, ok := files[readmeFileName]; ok {
+	if v, ok := files[readme]; ok {
 		chartFiles.Readme = v
 	} else {
 		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("README.md not found")
 	}
-	if v, ok := files[valuesFileName]; ok {
+	if v, ok := files[values]; ok {
 		chartFiles.Values = v
 	} else {
 		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.yaml not found")
 	}
-	if v, ok := files[schemaFileName]; ok {
+	if v, ok := files[schema]; ok {
 		chartFiles.Schema = v
 	} else {
 		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.schema.json not found")

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -184,7 +184,7 @@ func Test_syncURLInvalidity(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := getRepo("namespace", "test", tt.repoURL, "helm", "")
+			_, err := getHelmRepo("namespace", "test", tt.repoURL, "")
 			assert.ExistsErr(t, err, tt.name)
 		})
 	}

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -184,7 +184,7 @@ func Test_syncURLInvalidity(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := getRepo("namespace", "test", tt.repoURL, "")
+			_, err := getRepo("namespace", "test", tt.repoURL, "helm", "")
 			assert.ExistsErr(t, err, tt.name)
 		})
 	}
@@ -347,7 +347,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 			createTestTarball(&b, tt.files)
 			r := bytes.NewReader(b.Bytes())
 			tarf := tar.NewReader(r)
-			files, err := extractFilesFromTarball([]string{tt.filename}, tarf)
+			files, err := extractFilesFromTarball(map[string]string{tt.filename: tt.filename}, tarf)
 			assert.NoErr(t, err)
 			assert.Equal(t, files[tt.filename], tt.want, "file body")
 		})
@@ -359,7 +359,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 		createTestTarball(&b, tFiles)
 		r := bytes.NewReader(b.Bytes())
 		tarf := tar.NewReader(r)
-		files, err := extractFilesFromTarball([]string{tFiles[0].Name, tFiles[1].Name}, tarf)
+		files, err := extractFilesFromTarball(map[string]string{tFiles[0].Name: tFiles[0].Name, tFiles[1].Name: tFiles[1].Name}, tarf)
 		assert.NoErr(t, err)
 		assert.Equal(t, len(files), 2, "matches")
 		for _, f := range tFiles {
@@ -373,7 +373,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 		r := bytes.NewReader(b.Bytes())
 		tarf := tar.NewReader(r)
 		name := "file2.txt"
-		files, err := extractFilesFromTarball([]string{name}, tarf)
+		files, err := extractFilesFromTarball(map[string]string{name: name}, tarf)
 		assert.NoErr(t, err)
 		assert.Equal(t, files[name], "", "file body")
 	})
@@ -383,7 +383,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 		rand.Read(b)
 		r := bytes.NewReader(b)
 		tarf := tar.NewReader(r)
-		files, err := extractFilesFromTarball([]string{"file2.txt"}, tarf)
+		files, err := extractFilesFromTarball(map[string]string{values: "file2.txt"}, tarf)
 		assert.Err(t, io.ErrUnexpectedEOF, err)
 		assert.Equal(t, len(files), 0, "file body")
 	})
@@ -556,6 +556,32 @@ func Test_fetchAndImportIcon(t *testing.T) {
 	})
 }
 
+type fakeRepo struct {
+	*models.RepoInternal
+	charts     []models.Chart
+	chartFiles models.ChartFiles
+}
+
+func (r *fakeRepo) Checksum() (string, error) {
+	return "checksum", nil
+}
+
+func (r *fakeRepo) Repo() *models.RepoInternal {
+	return r.RepoInternal
+}
+
+func (r *fakeRepo) Charts() ([]models.Chart, error) {
+	return r.charts, nil
+}
+
+func (r *fakeRepo) FetchFiles(name string, cv models.ChartVersion) (map[string]string, error) {
+	return map[string]string{
+		values: r.chartFiles.Values,
+		readme: r.chartFiles.Readme,
+		schema: r.chartFiles.Schema,
+	}, nil
+}
+
 func Test_fetchAndImportFiles(t *testing.T) {
 	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
 	repo := &models.RepoInternal{Name: "test", Namespace: "repo-namespace", URL: "http://testrepo.com"}
@@ -571,6 +597,11 @@ func Test_fetchAndImportFiles(t *testing.T) {
 		Repo:   charts[0].Repo,
 		Digest: chartVersion.Digest,
 	}
+	fRepo := &fakeRepo{
+		RepoInternal: repo,
+		charts:       charts,
+		chartFiles:   chartFiles,
+	}
 
 	t.Run("http error", func(t *testing.T) {
 		pgManager, mock, cleanup := getMockManager(t)
@@ -581,7 +612,11 @@ func Test_fetchAndImportFiles(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
 		netClient = &badHTTPClient{}
 		fImporter := fileImporter{pgManager}
-		assert.Err(t, io.EOF, fImporter.fetchAndImportFiles(charts[0].Name, repo, chartVersion))
+		helmRepo := &HelmRepo{
+			content:      []byte{},
+			RepoInternal: repo,
+		}
+		assert.Err(t, io.EOF, fImporter.fetchAndImportFiles(charts[0].Name, helmRepo, chartVersion))
 	})
 
 	t.Run("file not found", func(t *testing.T) {
@@ -608,7 +643,11 @@ func Test_fetchAndImportFiles(t *testing.T) {
 		netClient = &goodTarballClient{c: charts[0], skipValues: true, skipReadme: true, skipSchema: true}
 
 		fImporter := fileImporter{pgManager}
-		err := fImporter.fetchAndImportFiles(charts[0].Name, repo, chartVersion)
+		helmRepo := &HelmRepo{
+			content:      []byte{},
+			RepoInternal: repo,
+		}
+		err := fImporter.fetchAndImportFiles(charts[0].Name, helmRepo, chartVersion)
 		assert.NoErr(t, err)
 	})
 
@@ -629,7 +668,11 @@ func Test_fetchAndImportFiles(t *testing.T) {
 		fImporter := fileImporter{pgManager}
 
 		r := &models.RepoInternal{Name: repo.Name, Namespace: repo.Namespace, URL: repo.URL, AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient"}
-		err := fImporter.fetchAndImportFiles(charts[0].Name, r, chartVersion)
+		repo := &HelmRepo{
+			RepoInternal: r,
+			content:      []byte{},
+		}
+		err := fImporter.fetchAndImportFiles(charts[0].Name, repo, chartVersion)
 		assert.NoErr(t, err)
 	})
 
@@ -647,7 +690,7 @@ func Test_fetchAndImportFiles(t *testing.T) {
 		netClient = &goodTarballClient{c: charts[0]}
 		fImporter := fileImporter{pgManager}
 
-		err := fImporter.fetchAndImportFiles(charts[0].Name, repo, chartVersion)
+		err := fImporter.fetchAndImportFiles(charts[0].Name, fRepo, chartVersion)
 		assert.NoErr(t, err)
 	})
 
@@ -660,7 +703,7 @@ func Test_fetchAndImportFiles(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"info"}).AddRow(`true`))
 
 		fImporter := fileImporter{pgManager}
-		err := fImporter.fetchAndImportFiles(charts[0].Name, repo, chartVersion)
+		err := fImporter.fetchAndImportFiles(charts[0].Name, fRepo, chartVersion)
 		assert.NoErr(t, err)
 	})
 }

--- a/pkg/chart/models/chart.go
+++ b/pkg/chart/models/chart.go
@@ -30,6 +30,7 @@ type Repo struct {
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
 	URL       string `json:"url"`
+	Type      string `json:"type"`
 }
 
 // RepoInternal holds the App repository details including auth and checksum
@@ -37,8 +38,8 @@ type RepoInternal struct {
 	Namespace           string `json:"namespace"`
 	Name                string `json:"name"`
 	URL                 string `json:"url"`
+	Type                string `json:"type"`
 	AuthorizationHeader string `bson:"-"`
-	Checksum            string
 }
 
 // Chart is a higher-level representation of a chart package

--- a/pkg/chart/models/chart.go
+++ b/pkg/chart/models/chart.go
@@ -33,7 +33,7 @@ type Repo struct {
 	Type      string `json:"type"`
 }
 
-// RepoInternal holds the App repository details including auth and checksum
+// RepoInternal holds the App repository details including auth
 type RepoInternal struct {
 	Namespace           string `json:"namespace"`
 	Name                string `json:"name"`


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This PR doesn't include any functional change, two changes have been included:

 - The AppRepository `type` is now passed as an argument to the asset-syncer (but currently it's being ignored)
 - Methods depending on the `type` has been moved to an interface (`Repo`) so I can implement those for the OCI repository type in the next PR.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2232
