### PR TITLE
Add small padding bottom to the OperatorList

### DIFF
--- a/dashboard/src/components/OperatorList/OperatorList.scss
+++ b/dashboard/src/components/OperatorList/OperatorList.scss
@@ -1,0 +1,3 @@
+.operatorListContainer {
+  padding-bottom: 5vh;
+}

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -26,6 +26,7 @@ import PageHeader from "../PageHeader/PageHeader";
 import SearchFilter from "../SearchFilter/SearchFilter";
 import OLMNotFound from "./OLMNotFound";
 import OperatorItems from "./OperatorItems";
+import "./OperatorList.css";
 
 export interface IOperatorListProps {
   cluster: string;
@@ -307,16 +308,20 @@ export default function OperatorList({
                     </div>
                     {installedOperators.length > 0 && (
                       <>
-                        <h3>Installed</h3>
-                        <Row>
-                          <OperatorItems operators={installedOperators} cluster={cluster} />
-                        </Row>
+                        <div className="operatorListContainer">
+                          <h3>Installed</h3>
+                          <Row>
+                            <OperatorItems operators={installedOperators} cluster={cluster} />
+                          </Row>
+                        </div>
                       </>
                     )}
-                    <h3>Available Operators</h3>
-                    <Row>
-                      <OperatorItems operators={availableOperators} cluster={cluster} />
-                    </Row>
+                    <div className="operatorListContainer">
+                      <h3>Available Operators</h3>
+                      <Row>
+                        <OperatorItems operators={availableOperators} cluster={cluster} />
+                      </Row>
+                    </div>
                   </>
                 </Column>
               </Row>


### PR DESCRIPTION
### Description of the change

This PR simply introduces a small bottom padding to the Operator catalog, so the UI remains more or less consistent with the general chart catalog.

### Benefits

Operator catalog will no longer be like:
![image](https://user-images.githubusercontent.com/11535726/105252571-fbe41300-5b7d-11eb-9a6b-da56fe33c11e.png)

... to be like:

![image](https://user-images.githubusercontent.com/11535726/105252909-afe59e00-5b7e-11eb-90e2-af6a508ecc5f.png)


### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A