### PR TITLE
Clear search filter when deleting text

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -175,7 +175,7 @@ function Catalog(props: ICatalogProps) {
   const setSearchFilter = (searchTerm: string) => {
     const newFilters = {
       ...filters,
-      [filterNames.SEARCH]: [trimStart(searchTerm)],
+      [filterNames.SEARCH]: trimStart(searchTerm) ? [trimStart(searchTerm)] : [],
     };
     setFilters(newFilters);
     pushFilters(newFilters);


### PR DESCRIPTION
### Description of the change

After the changes in #2249, some minor bugs are popping up. This PR is just to force the clear when the text input has been deleted.

The current (master) status is:

Note that "Clear all" and `?Search=` remains despite the user input has been deleted.

![textnox](https://user-images.githubusercontent.com/11535726/105253320-8aa55f80-5b7f-11eb-85e4-2c9cbbf3ec91.gif)

### Benefits

Users won't be shown a "clear all" even if they already cleared the input, that is:

![textok](https://user-images.githubusercontent.com/11535726/105253760-639b5d80-5b80-11eb-9cb3-e47078d85f1d.gif)


### Possible drawbacks

N/A (I hope so)

### Applicable issues

N/A

### Additional information

Sometimes I'm noticing a sync problem between the text at the search filter (the `?Search=xxx` value) and the text input content.  Perhaps we can look into this other issue in another PR.
