### PR TITLE
Fix websocket behavior in Firefox

### DIFF
--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -120,7 +120,7 @@ describe("getAndWatchResource", () => {
         payload: {
           ref,
           handler: expect.any(Function),
-          onError: { onErrorHandler: expect.any(Function) },
+          onError: expect.any(Function),
         },
       },
     ];
@@ -169,7 +169,7 @@ describe("getAndWatchResource", () => {
         payload: {
           ref: r,
           handler: expect.any(Function),
-          onError: { onErrorHandler: expect.any(Function) },
+          onError: expect.any(Function),
         },
       },
     ];
@@ -238,7 +238,7 @@ describe("getAndWatchResource", () => {
         payload: {
           ref: r,
           handler: expect.any(Function),
-          onError: { onErrorHandler: expect.any(Function) },
+          onError: expect.any(Function),
         },
       },
     ];
@@ -256,7 +256,7 @@ describe("getAndWatchResource", () => {
     );
 
     const watchFunction = (testActions[1].payload as any).handler as (e: any) => void;
-    const onErrorFunction = (testActions[1].payload as any).onError.onErrorHandler as () => void;
+    const onErrorFunction = (testActions[1].payload as any).onError as () => void;
     onErrorFunction();
     watchFunction({ data: `{"object": ${JSON.stringify(svc)}}` });
     const newActions = [

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -120,7 +120,7 @@ describe("getAndWatchResource", () => {
         payload: {
           ref,
           handler: expect.any(Function),
-          onError: { onErrorHandler: expect.any(Function), closeTimer: expect.any(Function) },
+          onError: { onErrorHandler: expect.any(Function) },
         },
       },
     ];
@@ -169,7 +169,7 @@ describe("getAndWatchResource", () => {
         payload: {
           ref: r,
           handler: expect.any(Function),
-          onError: { onErrorHandler: expect.any(Function), closeTimer: expect.any(Function) },
+          onError: { onErrorHandler: expect.any(Function) },
         },
       },
     ];
@@ -188,14 +188,98 @@ describe("getAndWatchResource", () => {
 
     const watchFunction = (testActions[1].payload as any).handler as (e: any) => void;
     watchFunction({ data: `{"object": ${JSON.stringify(svc)}}` });
-    const newAction = {
-      type: getType(actions.kube.receiveResourceFromList),
-      payload: {
-        key: `api/clusters/${clusterName}/api/v1/namespaces/default/services`,
-        resource: svc,
+    const newActions = [
+      {
+        type: getType(actions.kube.removeTimer),
+        payload: `api/clusters/${clusterName}/api/v1/namespaces/default/services`,
       },
-    };
-    const expectedUpdatedActions = expectedActions.concat(newAction as any);
+      {
+        type: getType(actions.kube.receiveResourceFromList),
+        payload: {
+          key: `api/clusters/${clusterName}/api/v1/namespaces/default/services`,
+          resource: svc,
+        },
+      },
+    ];
+    const expectedUpdatedActions = expectedActions.concat(newActions as any);
+    const updatedActions = store.getActions();
+    expect(updatedActions).toEqual(expectedUpdatedActions);
+  });
+
+  it("adds a timer and removes it if a new event is received", () => {
+    const ref = {
+      kind: "Service",
+      name: "",
+      version: "v1",
+    } as IClusterServiceVersionCRD;
+    const svc = {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        name: "foo",
+        namespace: "default",
+      },
+    } as IResource;
+
+    const r = fromCRD(
+      ref,
+      { apiVersion: "v1", plural: "services", namespaced: true },
+      clusterName,
+      "default",
+      {},
+    );
+    const expectedActions = [
+      {
+        type: getType(actions.kube.requestResource),
+        payload: `api/clusters/${clusterName}/api/v1/namespaces/default/services`,
+      },
+      {
+        type: getType(actions.kube.openWatchResource),
+        payload: {
+          ref: r,
+          handler: expect.any(Function),
+          onError: { onErrorHandler: expect.any(Function) },
+        },
+      },
+    ];
+
+    store.dispatch(actions.kube.getAndWatchResource(r));
+    const testActions = store.getActions();
+    expect(testActions).toEqual(expectedActions);
+    expect(getResourceMock).toHaveBeenCalledWith(
+      clusterName,
+      "v1",
+      "services",
+      true,
+      "default",
+      undefined,
+    );
+
+    const watchFunction = (testActions[1].payload as any).handler as (e: any) => void;
+    const onErrorFunction = (testActions[1].payload as any).onError.onErrorHandler as () => void;
+    onErrorFunction();
+    watchFunction({ data: `{"object": ${JSON.stringify(svc)}}` });
+    const newActions = [
+      {
+        type: getType(actions.kube.addTimer),
+        payload: {
+          id: `api/clusters/${clusterName}/api/v1/namespaces/default/services`,
+          timer: expect.any(Function),
+        },
+      },
+      {
+        type: getType(actions.kube.removeTimer),
+        payload: `api/clusters/${clusterName}/api/v1/namespaces/default/services`,
+      },
+      {
+        type: getType(actions.kube.receiveResourceFromList),
+        payload: {
+          key: `api/clusters/${clusterName}/api/v1/namespaces/default/services`,
+          resource: svc,
+        },
+      },
+    ];
+    const expectedUpdatedActions = expectedActions.concat(newActions as any);
     const updatedActions = store.getActions();
     expect(updatedActions).toEqual(expectedUpdatedActions);
   });

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -34,11 +34,8 @@ export const receiveResourceError = createAction("RECEIVE_RESOURCE_ERROR", resol
 // Takes a ResourceRef to open a WebSocket for and a handler to process messages
 // from the socket.
 export const openWatchResource = createAction("OPEN_WATCH_RESOURCE", resolve => {
-  return (
-    ref: ResourceRef,
-    handler: (e: MessageEvent) => void,
-    onError: { onErrorHandler: (e: Event) => void },
-  ) => resolve({ ref, handler, onError });
+  return (ref: ResourceRef, handler: (e: MessageEvent) => void, onError: (e: Event) => void) =>
+    resolve({ ref, handler, onError });
 });
 
 export const closeWatchResource = createAction("CLOSE_WATCH_RESOURCE", resolve => {
@@ -137,13 +134,11 @@ export function getAndWatchResource(
             dispatch(receiveResource({ key, resource }));
           }
         },
-        {
-          onErrorHandler: (e: Event) => {
-            // If the Socket fails, create an interval to re-request the resource
-            // every 5 seconds. This interval needs to be closed calling closeTimer
-            const timer = () => dispatch(getResource(ref, true));
-            dispatch(addTimer(ref.getResourceURL(), timer));
-          },
+        () => {
+          // If the Socket fails, create an interval to re-request the resource
+          // every 5 seconds. This interval needs to be closed calling closeTimer
+          const timer = () => dispatch(getResource(ref, true));
+          dispatch(addTimer(ref.getResourceURL(), timer));
         },
       ),
     );

--- a/dashboard/src/components/ApplicationStatus/ApplicationStatus.tsx
+++ b/dashboard/src/components/ApplicationStatus/ApplicationStatus.tsx
@@ -74,6 +74,9 @@ export default function ApplicationStatus({
 
   useEffect(() => {
     watchWorkloads();
+    // TODO: Closing websockets before the connection is established
+    // causes a warning. More info at:
+    // https://github.com/kubeapps/kubeapps/issues/2276
     return function cleanup() {
       closeWatches();
     };

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
@@ -17,6 +17,7 @@ const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
     items: resources,
     kinds: initialKinds,
     sockets: {},
+    timers: {},
   };
   return mockStore({ kube: state, config: { featureFlags: {} } });
 };

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
@@ -17,6 +17,7 @@ const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
     items: resources,
     kinds: initialKinds,
     sockets: {},
+    timers: {},
   };
   return mockStore({ kube: state, config: { featureFlags: {} } });
 };

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -255,7 +255,7 @@ describe("kubeReducer", () => {
       });
     });
 
-    describe("addTimer", () => {
+    describe("removeTimer", () => {
       it("remove a timer", () => {
         jest.useFakeTimers();
         const f1 = jest.fn();

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -114,7 +114,7 @@ describe("kubeReducer", () => {
           payload: {
             ref,
             handler: jest.fn(),
-            onError: { onErrorHandler: jest.fn() },
+            onError: jest.fn(),
           },
         });
         const socket = newState.sockets[ref.watchResourceURL()];
@@ -123,7 +123,7 @@ describe("kubeReducer", () => {
 
       it("does not open a new socket if one exists in the state", () => {
         const existingSocket = ref.watchResource();
-        const socket = { socket: existingSocket };
+        const socket = { socket: existingSocket, onError: jest.fn() };
         const state = {
           ...initialState,
           sockets: {
@@ -135,7 +135,7 @@ describe("kubeReducer", () => {
           payload: {
             ref,
             handler: jest.fn(),
-            onError: { onErrorHandler: jest.fn() },
+            onError: jest.fn(),
           },
         });
         expect(newState).toBe(state);
@@ -149,7 +149,7 @@ describe("kubeReducer", () => {
           payload: {
             ref,
             handler: mock,
-            onError: { onErrorHandler: jest.fn() },
+            onError: jest.fn(),
           },
         });
         const socket = newState.sockets[ref.watchResourceURL()].socket;
@@ -168,7 +168,7 @@ describe("kubeReducer", () => {
           payload: {
             ref,
             handler: jest.fn(),
-            onError: { onErrorHandler: mock },
+            onError: mock,
           },
         });
         const socket = newState.sockets[ref.watchResourceURL()].socket;
@@ -185,10 +185,11 @@ describe("kubeReducer", () => {
       it("closes the WebSocket and the timer for the requested resource and removes it from the state", () => {
         const socket = ref.watchResource();
         const spy = jest.spyOn(socket, "close");
+        socket.removeEventListener = jest.fn();
         const state = {
           ...initialState,
           sockets: {
-            [ref.watchResourceURL()]: { socket },
+            [ref.watchResourceURL()]: { socket, onError: jest.fn() },
           },
           timers: {
             [ref.getResourceURL()]: {} as NodeJS.Timer,
@@ -206,7 +207,7 @@ describe("kubeReducer", () => {
       it("does nothing if the socket doesn't exist", () => {
         const state = {
           ...initialState,
-          sockets: { dontdeleteme: { socket: {} as WebSocket } },
+          sockets: { dontdeleteme: { socket: {} as WebSocket, onError: jest.fn() } },
         };
         const newState = kubeReducer(state, {
           type: actionTypes.closeWatchResource,

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -19,6 +19,8 @@ describe("kubeReducer", () => {
     receiveResourceKinds: getType(actions.kube.receiveResourceKinds),
     requestResourceKinds: getType(actions.kube.requestResourceKinds),
     receiveKindsError: getType(actions.kube.receiveKindsError),
+    addTimer: getType(actions.kube.addTimer),
+    removeTimer: getType(actions.kube.removeTimer),
   };
 
   const ref = new ResourceRef(
@@ -40,6 +42,7 @@ describe("kubeReducer", () => {
       items: {},
       sockets: {},
       kinds: initialKinds,
+      timers: {},
     };
   });
 
@@ -111,7 +114,7 @@ describe("kubeReducer", () => {
           payload: {
             ref,
             handler: jest.fn(),
-            onError: { onErrorHandler: jest.fn(), closeTimer: jest.fn() },
+            onError: { onErrorHandler: jest.fn() },
           },
         });
         const socket = newState.sockets[ref.watchResourceURL()];
@@ -120,7 +123,7 @@ describe("kubeReducer", () => {
 
       it("does not open a new socket if one exists in the state", () => {
         const existingSocket = ref.watchResource();
-        const socket = { socket: existingSocket, closeTimer: jest.fn() };
+        const socket = { socket: existingSocket };
         const state = {
           ...initialState,
           sockets: {
@@ -132,7 +135,7 @@ describe("kubeReducer", () => {
           payload: {
             ref,
             handler: jest.fn(),
-            onError: { onErrorHandler: jest.fn(), closeTimer: jest.fn() },
+            onError: { onErrorHandler: jest.fn() },
           },
         });
         expect(newState).toBe(state);
@@ -146,7 +149,7 @@ describe("kubeReducer", () => {
           payload: {
             ref,
             handler: mock,
-            onError: { onErrorHandler: jest.fn(), closeTimer: jest.fn() },
+            onError: { onErrorHandler: jest.fn() },
           },
         });
         const socket = newState.sockets[ref.watchResourceURL()].socket;
@@ -165,7 +168,7 @@ describe("kubeReducer", () => {
           payload: {
             ref,
             handler: jest.fn(),
-            onError: { onErrorHandler: mock, closeTimer: jest.fn() },
+            onError: { onErrorHandler: mock },
           },
         });
         const socket = newState.sockets[ref.watchResourceURL()].socket;
@@ -181,12 +184,14 @@ describe("kubeReducer", () => {
     describe("closeWatchResource", () => {
       it("closes the WebSocket and the timer for the requested resource and removes it from the state", () => {
         const socket = ref.watchResource();
-        const timerMock = jest.fn();
         const spy = jest.spyOn(socket, "close");
         const state = {
           ...initialState,
           sockets: {
-            [ref.watchResourceURL()]: { socket, closeTimer: timerMock },
+            [ref.watchResourceURL()]: { socket },
+          },
+          timers: {
+            [ref.getResourceURL()]: {} as NodeJS.Timer,
           },
         };
         const newState = kubeReducer(state, {
@@ -195,22 +200,83 @@ describe("kubeReducer", () => {
         });
         expect(spy).toHaveBeenCalled();
         expect(newState.sockets).toEqual({});
-        expect(timerMock).toHaveBeenCalled();
+        expect(newState.timers).toEqual({ [ref.getResourceURL()]: undefined });
+      });
+
+      it("does nothing if the socket doesn't exist", () => {
+        const state = {
+          ...initialState,
+          sockets: { dontdeleteme: { socket: {} as WebSocket } },
+        };
+        const newState = kubeReducer(state, {
+          type: actionTypes.closeWatchResource,
+          payload: ref,
+        });
+        expect(newState).toEqual(state);
+        // check that dontdeleteme is not modified
+        expect(newState.sockets.dontdeleteme).toBe(state.sockets.dontdeleteme);
       });
     });
 
-    it("does nothing if the socket doesn't exist", () => {
-      const state = {
-        ...initialState,
-        sockets: { dontdeleteme: { socket: {} as WebSocket, closeTimer: jest.fn() } },
-      };
-      const newState = kubeReducer(state, {
-        type: actionTypes.closeWatchResource,
-        payload: ref,
+    describe("addTimer", () => {
+      it("should add a timer", () => {
+        const newState = kubeReducer(initialState, {
+          type: actionTypes.addTimer,
+          payload: { id: "foo", timer: jest.fn() },
+        });
+        expect(newState).toEqual({
+          ...initialState,
+          timers: { foo: expect.any(Number) },
+        });
       });
-      expect(newState).toEqual(state);
-      // check that dontdeleteme is not modified
-      expect(newState.sockets.dontdeleteme).toBe(state.sockets.dontdeleteme);
+
+      it("should not add a timer if there is already one", () => {
+        jest.useFakeTimers();
+        const f1 = jest.fn();
+        const f2 = jest.fn();
+        const timer = setTimeout(f1, 1);
+        const newState = kubeReducer(
+          {
+            ...initialState,
+            timers: { foo: timer },
+          },
+          {
+            type: actionTypes.addTimer,
+            payload: { id: "foo", timer: f2 },
+          },
+        );
+        expect(newState).toEqual({
+          ...initialState,
+          timers: { foo: timer },
+        });
+        jest.runAllTimers();
+        expect(f1).toHaveBeenCalled();
+        expect(f2).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("addTimer", () => {
+      it("remove a timer", () => {
+        jest.useFakeTimers();
+        const f1 = jest.fn();
+        const timer = setTimeout(f1, 1);
+        const newState = kubeReducer(
+          {
+            ...initialState,
+            timers: { foo: timer },
+          },
+          {
+            type: actionTypes.removeTimer,
+            payload: "foo",
+          },
+        );
+        expect(newState).toEqual({
+          ...initialState,
+          timers: { foo: undefined },
+        });
+        jest.runAllTimers();
+        expect(f1).not.toHaveBeenCalled();
+      });
     });
 
     describe("receiveResourceKinds", () => {

--- a/dashboard/src/reducers/kube.ts
+++ b/dashboard/src/reducers/kube.ts
@@ -188,13 +188,12 @@ const kubeReducer = (
       }
       const socket = ref.watchResource();
       socket.addEventListener("message", handler);
-      const { onErrorHandler } = onError;
-      socket.addEventListener("error", onErrorHandler);
+      socket.addEventListener("error", onError);
       return {
         ...state,
         sockets: {
           ...state.sockets,
-          [key]: { socket },
+          [key]: { socket, onError },
         },
       };
     // TODO(adnan): this won't handle cases where one component closes a socket
@@ -208,6 +207,7 @@ const kubeReducer = (
       const timer = state.timers[timerID];
       // close the socket if it exists
       if (foundSocket !== undefined) {
+        foundSocket.socket.removeEventListener("error", foundSocket.onError);
         foundSocket.socket.close();
       }
       if (timer) {

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -552,9 +552,10 @@ export interface IKind {
 
 export interface IKubeState {
   items: { [s: string]: IKubeItem<IResource | IK8sList<IResource, {}>> };
-  sockets: { [s: string]: { socket: WebSocket; closeTimer: () => void } };
+  sockets: { [s: string]: { socket: WebSocket } };
   kinds: { [kind: string]: IKind };
   kindsError?: Error;
+  timers: { [id: string]: NodeJS.Timer | undefined };
 }
 
 export interface IBasicFormParam {

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -552,7 +552,7 @@ export interface IKind {
 
 export interface IKubeState {
   items: { [s: string]: IKubeItem<IResource | IK8sList<IResource, {}>> };
-  sockets: { [s: string]: { socket: WebSocket } };
+  sockets: { [s: string]: { socket: WebSocket; onError: (e: Event) => void } };
   kinds: { [kind: string]: IKind };
   kindsError?: Error;
   timers: { [id: string]: NodeJS.Timer | undefined };


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

In Firefox, there is an issue that a warning is thrown when opening a websocket: https://github.com/socketio/socket.io/issues/2016

This causes Kubeapps to fallback to the periodic polling mechanism but it's still receiving events from the websocket. It's also losing the reference to the "timer" that needs to be cleaned when the component is unmounted.

This PR includes two fixes:

 - If the websocket receives an event, remove the timer so the fallback method is not executed.
 - The timer is stored in the Kube state, identified uniquely by the resource is polling so it's not possible to create two timers for the same resource.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2258
