### PR TITLE
Helm with pinniped

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -171,24 +171,6 @@ func NewActionConfig(storageForDriver StorageForDriver, config *rest.Config, cli
 	return actionConfig, nil
 }
 
-// configForCluster implements the RESTClientGetter interface
-// and ensures that it returns the config it was given, rather
-// than re-creating a config as if the CLI options were passed in as the
-// genericclioptions.ConfigFlags implementation strips the bearer token
-// if the host is not https (helpful for the CLI).
-// TODO(mnelson) Update pinniped-proxy to support a TLS(-only) configuration
-// as even though its for internal traffic it will be required in many circumstances.
-// https://github.com/kubeapps/kubeapps/issues/2268
-type configForCluster struct {
-	config *rest.Config
-	*genericclioptions.ConfigFlags
-}
-
-// Override the default implementation to return the original config.
-func (c *configForCluster) ToRESTConfig() (*rest.Config, error) {
-	return c.config, nil
-}
-
 // NewConfigFlagsFromCluster returns ConfigFlags with default values set from within cluster.
 func NewConfigFlagsFromCluster(namespace string, clusterConfig *rest.Config) genericclioptions.RESTClientGetter {
 	impersonateGroup := []string{}
@@ -204,8 +186,9 @@ func NewConfigFlagsFromCluster(namespace string, clusterConfig *rest.Config) gen
 		ImpersonateGroup: &impersonateGroup,
 	}
 	return &configForCluster{
-		config:      clusterConfig,
-		ConfigFlags: configFlags,
+		config:         clusterConfig,
+		discoveryBurst: 100,
+		ConfigFlags:    configFlags,
 	}
 }
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -171,12 +171,30 @@ func NewActionConfig(storageForDriver StorageForDriver, config *rest.Config, cli
 	return actionConfig, nil
 }
 
+// configForCluster implements the RESTClientGetter interface
+// and ensures that it returns the config it was given, rather
+// than re-creating a config as if the CLI options were passed in as the
+// genericclioptions.ConfigFlags implementation strips the bearer token
+// if the host is not https (helpful for the CLI).
+// TODO(mnelson) Update pinniped-proxy to support a TLS(-only) configuration
+// as even though its for internal traffic it will be required in many circumstances.
+// https://github.com/kubeapps/kubeapps/issues/2268
+type configForCluster struct {
+	config *rest.Config
+	*genericclioptions.ConfigFlags
+}
+
+// Override the default implementation to return the original config.
+func (c *configForCluster) ToRESTConfig() (*rest.Config, error) {
+	return c.config, nil
+}
+
 // NewConfigFlagsFromCluster returns ConfigFlags with default values set from within cluster.
 func NewConfigFlagsFromCluster(namespace string, clusterConfig *rest.Config) genericclioptions.RESTClientGetter {
 	impersonateGroup := []string{}
 
 	// CertFile and KeyFile must be nil for the BearerToken to be used for authentication and authorization instead of the pod's service account.
-	return &genericclioptions.ConfigFlags{
+	configFlags := &genericclioptions.ConfigFlags{
 		Insecure:         &clusterConfig.TLSClientConfig.Insecure,
 		Timeout:          stringptr("0"),
 		Namespace:        stringptr(namespace),
@@ -184,6 +202,10 @@ func NewConfigFlagsFromCluster(namespace string, clusterConfig *rest.Config) gen
 		CAFile:           stringptr(clusterConfig.CAFile),
 		BearerToken:      stringptr(clusterConfig.BearerToken),
 		ImpersonateGroup: &impersonateGroup,
+	}
+	return &configForCluster{
+		config:      clusterConfig,
+		ConfigFlags: configFlags,
 	}
 }
 

--- a/pkg/agent/httpConfigForCluster.go
+++ b/pkg/agent/httpConfigForCluster.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/log"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	diskcached "k8s.io/client-go/discovery/cached/disk"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+// configForCluster implements the genericclioptions.RESTClientGetter interface
+// while ensuring that it returns the config it was given, rather
+// than re-creating a config as if the CLI options were passed in as the
+// genericclioptions.ConfigFlags implementation, which strips the bearer token
+// if the host is not https (helpful for the CLI).
+//
+// TODO(mnelson) The better short-term option is to update pinniped-proxy to support TLS
+// even though it's for internal traffic only, as it will be required in many circumstances.
+// https://github.com/kubeapps/kubeapps/issues/2268
+// This implementation can be completely removed once TLS is used by pinniped-proxy.
+type configForCluster struct {
+	config         *rest.Config
+	discoveryBurst int
+	*genericclioptions.ConfigFlags
+}
+
+// ToRESTConfig has the main difference from the original implementation,
+// returning the config as is.
+func (f *configForCluster) ToRESTConfig() (*rest.Config, error) {
+	log.Debug("configForCluster.ToRESTConfig called")
+	return f.config, nil
+}
+
+// ToDiscoveryClient requires an implementation on the embedding struct because
+// the implementation calls ToRESTConfig(). Painfully, this then requires copying
+// the complete function.
+func (f *configForCluster) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	log.Debug("configForCluster.ToDiscoveryClient called")
+	config, err := f.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// The more groups you have, the more discovery requests you need to make.
+	// given 25 groups (our groups + a few custom resources) with one-ish version each, discovery needs to make 50 requests
+	// double it just so we don't end up here again for a while.  This config is only used for discovery.
+	config.Burst = f.discoveryBurst
+
+	cacheDir := filepath.Join(homedir.HomeDir(), ".kube", "cache")
+
+	// retrieve a user-provided value for the "cache-dir"
+	// override httpCacheDir and discoveryCacheDir if user-value is given.
+	if f.CacheDir != nil {
+		cacheDir = *f.CacheDir
+	}
+	httpCacheDir := filepath.Join(cacheDir, "http")
+	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, "discovery"), config.Host)
+
+	return diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, time.Duration(10*time.Minute))
+}
+
+// ToRESTMapper requires an implementation on the embedding struct because
+// it calls ToDiscoveryClient.
+func (f *configForCluster) ToRESTMapper() (meta.RESTMapper, error) {
+	log.Debug("configForCluster.ToRESTMapper called")
+	discoveryClient, err := f.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+	expander := restmapper.NewShortcutExpander(mapper, discoveryClient)
+	return expander, nil
+}
+
+// ToRawKubeConfigLoader may need to be replicated here, but from limited
+// testing it works just to call the embedded implementation.
+func (f *configForCluster) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	log.Debug("configForCluster.ToRawKubeConfigLoader called")
+	return f.ConfigFlags.ToRawKubeConfigLoader()
+}
+
+// WithDiscoveryBurst is required because it sets the private var used by
+// ToDiscoveryClient.
+func (f *configForCluster) WithDiscoveryBurst(discoveryBurst int) *configForCluster {
+	f.discoveryBurst = discoveryBurst
+	return f
+}
+
+// The following var and func are only required here because computeDiscoverCacheDir
+// is used in ToDiscoveryClient above.
+
+// overlyCautiousIllegalFileCharacters matches characters that *might* not be supported.  Windows is really restrictive, so this is really restrictive
+var overlyCautiousIllegalFileCharacters = regexp.MustCompile(`[^(\w/\.)]`)
+
+// computeDiscoverCacheDir takes the parentDir and the host and comes up with a "usually non-colliding" name.
+func computeDiscoverCacheDir(parentDir, host string) string {
+	// strip the optional scheme from host if its there:
+	schemelessHost := strings.Replace(strings.Replace(host, "https://", "", 1), "http://", "", 1)
+	// now do a simple collapse of non-AZ09 characters.  Collisions are possible but unlikely.  Even if we do collide the problem is short lived
+	safeHost := overlyCautiousIllegalFileCharacters.ReplaceAllString(schemelessHost, "_")
+	return filepath.Join(parentDir, safeHost)
+}

--- a/pkg/agent/httpConfigForCluster.go
+++ b/pkg/agent/httpConfigForCluster.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/common/log"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
@@ -36,7 +35,6 @@ type configForCluster struct {
 // ToRESTConfig has the main difference from the original implementation,
 // returning the config as is.
 func (f *configForCluster) ToRESTConfig() (*rest.Config, error) {
-	log.Debug("configForCluster.ToRESTConfig called")
 	return f.config, nil
 }
 
@@ -44,7 +42,6 @@ func (f *configForCluster) ToRESTConfig() (*rest.Config, error) {
 // the implementation calls ToRESTConfig(). Painfully, this then requires copying
 // the complete function.
 func (f *configForCluster) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
-	log.Debug("configForCluster.ToDiscoveryClient called")
 	config, err := f.ToRESTConfig()
 	if err != nil {
 		return nil, err
@@ -71,7 +68,6 @@ func (f *configForCluster) ToDiscoveryClient() (discovery.CachedDiscoveryInterfa
 // ToRESTMapper requires an implementation on the embedding struct because
 // it calls ToDiscoveryClient.
 func (f *configForCluster) ToRESTMapper() (meta.RESTMapper, error) {
-	log.Debug("configForCluster.ToRESTMapper called")
 	discoveryClient, err := f.ToDiscoveryClient()
 	if err != nil {
 		return nil, err
@@ -85,7 +81,6 @@ func (f *configForCluster) ToRESTMapper() (meta.RESTMapper, error) {
 // ToRawKubeConfigLoader may need to be replicated here, but from limited
 // testing it works just to call the embedded implementation.
 func (f *configForCluster) ToRawKubeConfigLoader() clientcmd.ClientConfig {
-	log.Debug("configForCluster.ToRawKubeConfigLoader called")
 	return f.ConfigFlags.ToRawKubeConfigLoader()
 }
 


### PR DESCRIPTION
### Description of the change

While testing and demoing Kubeapps on a non-oidc cluster using pinniped, I've found that although helm releases are fetched correctly, I was not able to create a new release (deploy an app). Instead I'd get the cryptic message: Release "..." failed and has been uninstalled: unable to build kubernetes objects from release manifest: unknown

![deploy-error](https://user-images.githubusercontent.com/497518/105444485-05769380-5cc2-11eb-99fc-89c9ecf3b5df.png)

I assumed the issue was in pinniped-proxy, so began debugging there only to find that certain requests were hitting pinniped-proxy without the `Authorization` header with the bearer token. Confused, I then looked to kubeops where we create the requests via the helm API. After a lot of hunting around, the issue was pinpointed in that *something* in the internals of `genericclioptions.ConfigFlags.ToRestConfig()` was stripping off the bearer token if the API host was not secure, which makes sense for general (and external) interaction with an API server. This was only happening in requests from helm that use the discovery client on the API server. Everything else just works with the existing config. See the unit-tests which fail without this change.

Currently the internal pinniped-proxy service isn't (yet) running with TLS (though I'd like to make that happen separately - see #2268 ), so the only way I found to ensure the correct config (with the bearer token) is used for these specific helm requests to the discovery endpoints, was to implement parts of the `genericclioptions.RESTClientGetter` interface with a version that returns the original config.
 
### Benefits

I can install apps in Kubeapps on a non-oidc cluster.

### Possible drawbacks

It's not specific to this change (as we were already using http for traffic to the internal pinniped-proxy service) but we should update that to tls-only.

### Applicable issues

  - Ref #2181 

### Additional information

I got sick of looking for the actual code which is removing or not including the token, but I'm really keen to find it. If you're keen to get lost in the depths of client-go and join the hunt, I won't stop you :P 
