### PR TITLE
Implement checksum method for OCI registries

### DIFF
--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -249,7 +249,6 @@ func doReq(url, authHeader string) ([]byte, error) {
 
 // Checksum returns the sha256 of the repo
 func (r *OCIRegistry) Checksum() (string, error) {
-	// repositoryAPIurl := fmt.Sprintf("%s://%s/v2%s", url.Scheme, url.Host, url.Path)
 	content := []byte{}
 	for _, appName := range r.repositories {
 		url, err := parseRepoURL(r.RepoInternal.URL)

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -247,7 +247,8 @@ func doReq(url, authHeader string) ([]byte, error) {
 	return ioutil.ReadAll(res.Body)
 }
 
-// Checksum returns the sha256 of the repo
+// Checksum returns the sha256 of the repo by concatenating tags for
+// all repositories within the registry and returning the sha256.
 func (r *OCIRegistry) Checksum() (string, error) {
 	content := []byte{}
 	for _, appName := range r.repositories {
@@ -257,7 +258,7 @@ func (r *OCIRegistry) Checksum() (string, error) {
 		}
 		// Retrieve the list of tags to add it to the list
 		// Caveat: Mutated image tags won't be detected as new
-		url.Path = path.Join("v2", url.Path, appName, "tags/list")
+		url.Path = path.Join("v2", url.Path, appName, "tags", "list")
 		data, err := doReq(url.String(), r.RepoInternal.AuthorizationHeader)
 		if err != nil {
 			return "", err

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -707,3 +707,70 @@ func Test_fetchAndImportFiles(t *testing.T) {
 		assert.NoErr(t, err)
 	})
 }
+
+type goodChecksumHTTPClient struct{}
+
+const tags = `{"name":"test/apache","tags":["7.5.1","8.1.1"]}`
+
+func (h *goodChecksumHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	w := httptest.NewRecorder()
+	// Don't accept trailing slashes
+	if strings.HasPrefix(req.URL.Path, "//") {
+		w.WriteHeader(500)
+	}
+
+	w.Write([]byte(tags))
+	return w.Result(), nil
+}
+
+type authenticatedChecksumHTTPClient struct{}
+
+func (h *authenticatedChecksumHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	w := httptest.NewRecorder()
+
+	// Ensure we're sending the right Authorization header
+	if !strings.Contains(req.Header.Get("Authorization"), "Bearer ThisSecretAccessTokenAuthenticatesTheClient") {
+		w.WriteHeader(500)
+	}
+	w.Write([]byte(tags))
+	return w.Result(), nil
+}
+
+func Test_OCIRegistry(t *testing.T) {
+	repo := OCIRegistry{
+		repositories: []string{"apache", "jenkins"},
+		RepoInternal: &models.RepoInternal{
+			URL: "http://oci-test",
+		},
+	}
+
+	t.Run("Checksum - failed request", func(t *testing.T) {
+		netClient = &badHTTPClient{}
+		_, err := repo.Checksum()
+		assert.Err(t, fmt.Errorf("request failed: %v", nil), err)
+	})
+
+	t.Run("Checksum - success", func(t *testing.T) {
+		netClient = &goodChecksumHTTPClient{}
+		checksum, err := repo.Checksum()
+		assert.NoErr(t, err)
+		expectedChecksum, _ := getSha256([]byte(fmt.Sprintf("%s%s", tags, tags)))
+		assert.Equal(t, checksum, expectedChecksum, "expected checksum")
+	})
+
+	t.Run("Checksum with auth - success", func(t *testing.T) {
+		authRepo := OCIRegistry{
+			repositories: []string{"apache", "jenkins"},
+			RepoInternal: &models.RepoInternal{
+				URL:                 "http://oci-test",
+				AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient",
+			},
+		}
+
+		netClient = &authenticatedChecksumHTTPClient{}
+		checksum, err := authRepo.Checksum()
+		assert.NoErr(t, err)
+		expectedChecksum, _ := getSha256([]byte(fmt.Sprintf("%s%s", tags, tags)))
+		assert.Equal(t, checksum, expectedChecksum, "expected checksum")
+	})
+}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Add the method to get the "checksum" of an OCI registry. To achieve this, the method retrieves the list of tags for each repository (app) and calculates the checksum of the aggregated list.

### Possible drawbacks

For large registries, a request will be made per repository which might bloat the registry API.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2232

