### PR TITLE
Remove the '$' character from the error message

### DIFF
--- a/dashboard/src/components/Layout/Layout.tsx
+++ b/dashboard/src/components/Layout/Layout.tsx
@@ -38,7 +38,7 @@ function Layout({ children }: any) {
               {kindsError && (
                 <div className="margin-t-sm">
                   <AlertGroup status="warning" closable={true} size="sm">
-                    Unable to retrieve API info: ${kindsError.message}
+                    Unable to retrieve API info: {kindsError.message}
                   </AlertGroup>
                 </div>
               )}


### PR DESCRIPTION
### Description of the change

Warning messages generated by the `AlertGroup` wrongly include a  `$`. This PR is to get rid of this char.

### Benefits

Browsers will save some computation time by not rendering the `$`, I guess :stuck_out_tongue: 

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
