### PR TITLE
feat(auth): enable implicit cookie-based SSO authentication

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -52,6 +52,7 @@ data:
       "kubeappsNamespace": "{{ .Release.Namespace }}",
       "appVersion": "v{{ .Chart.AppVersion }}",
       "authProxyEnabled": {{ .Values.authProxy.enabled }},
+      "cookieName": {{ .Values.authProxy.cookieName }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},
       "authProxySkipLoginPage": {{ .Values.authProxy.skipKubeappsLoginPage }},

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -552,6 +552,10 @@ testImage:
 # Auth Proxy configuration for OIDC support
 # ref: https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md
 authProxy:
+  ## Set to the name of your auth cookie. Enables implicit session-based SSO.
+  # TODO: Default to "" as this should be an opt-in feature.
+  cookieName: "sessionid"
+
   ## Set to true if Kubeapps should configure the OAuth login/logout URIs defined below.
   #
   enabled: false

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -3,6 +3,7 @@
   "kubeappsNamespace": "kubeapps",
   "appVersion": "DEVEL",
   "authProxyEnabled": false,
+  "cookieName": "sessionid",
   "authProxySkipLoginPage": false,
   "oauthLoginURI": "/oauth2/start",
   "oauthLogoutURI": "/oauth2/sign_out",

--- a/dashboard/src/reducers/auth.ts
+++ b/dashboard/src/reducers/auth.ts
@@ -13,10 +13,17 @@ export interface IAuthState {
 }
 
 const getInitialState: () => IAuthState = (): IAuthState => {
-  const token = Auth.getAuthToken() || "";
+  // let authenticated = await Auth.isAuthenticatedWithCookie("default");
+  let authenticated = false;
+  if (!authenticated) {
+    const token = Auth.getAuthToken() || "";
+    if (token !== "") {
+      authenticated = true;
+    }
+  }
   return {
     sessionExpired: false,
-    authenticated: token !== "",
+    authenticated,
     authenticating: false,
     oidcAuthenticated: Auth.usingOIDCToken(),
   };

--- a/pkg/auth/authgate.go
+++ b/pkg/auth/authgate.go
@@ -22,7 +22,13 @@ type CheckerForRequest func(clustersConfig kube.ClustersConfig, req *http.Reques
 func AuthCheckerForRequest(clustersConfig kube.ClustersConfig, req *http.Request) (Checker, error) {
 	token := ExtractToken(req.Header.Get("Authorization"))
 	if token == "" {
-		return nil, fmt.Errorf("Authorization token missing")
+		// TODO: Get `sessionid` cookie name from Helm config `authProxy.cookieName`
+		cookie, err := req.Cookie("sessionid")
+		if err != nil {
+			return nil, fmt.Errorf("Authorization token missing")
+		} else {
+			token = cookie.Value
+		}
 	}
 	clusterName := mux.Vars(req)["cluster"]
 	return NewAuth(token, clusterName, clustersConfig)


### PR DESCRIPTION
## Description

The purpose of this PR is to enable cookie SSO authentication configuration. (What a mouthful!)

More specifically, the idea is to facilitate a use-case where:

1. k8s API is configured to do custom webhook token auth
2. A user visiting kubeapps has already signed in with this hypothetical "cloud provider" - imagine kubeapps is hosted at `apps.company.com` and the user signed in already at `cloud.company.com`
3. `cloud.company.com` has written an `HttpOnly` cookie to `.company.dom` domain
4. This cookie can then be presented to the k8s API and bearer token auth performed against it

To facilitate such a flow, I see ~4 issues/things that need changed or configured:

1. The dashboard `/login` page currently relies on [local storage](https://github.com/mecampbellsoup/kubeapps/blob/9a7b52c6911e8d97f470677722043b3ae765037e/dashboard/src/shared/Auth.ts#L6-L19) to store tokens. It has been explained to me by @absoludity that this is [development-only behavior](https://github.com/kubeapps/kubeapps/issues/2253#issuecomment-761953949). For my proposed flow we would need the dashboard to simply try to make a request to e.g. `http://localhost:3000/api/clusters/default` to determine if the user is authenticated by the existing cookie stored in the browser. I [tried](https://github.com/mecampbellsoup/kubeapps/blob/375df7bb616812f0fe164ee1b0d91dd6870b57bd/dashboard/src/reducers/auth.ts#L16) to use [`Auth.isAuthenticatedWithCookie`](https://github.com/mecampbellsoup/kubeapps/blob/9a7b52c6911e8d97f470677722043b3ae765037e/dashboard/src/shared/Auth.ts#L110) but didn't want to spend hours messing around with async/await issues in the event this proposal is immediately shot down.
2. The name of the cookie to be read would need to be [configurable in the Helm chart](https://github.com/mecampbellsoup/kubeapps/blob/375df7bb616812f0fe164ee1b0d91dd6870b57bd/chart/kubeapps/values.yaml#L555-L557).
3. The kubeapps backend auth logic I believe should try to auth _its_ requests to k8s using the cookie if configured. I took a stab at that change [here](https://github.com/mecampbellsoup/kubeapps/blob/375df7bb616812f0fe164ee1b0d91dd6870b57bd/pkg/auth/authgate.go#L24-L32). 
3. I have to edit the frontend NGINX conf (code snippet of this below) to add `proxy_set_header Authorization "Bearer $cookie_sessionid";`. I can do this manually but would also be nice if it were configurable I think.

Here is how I amended my kubeapps frontend NGINX config (stored in the ConfigMap). Note the additions of `proxy_set_header`:

```
      # Helm returns a nil pointer error when accessing foo.bar if foo doesn't
      # exist, even with the `default` function.
      # See https://github.com/helm/helm/issues/8026#issuecomment-756538254
        # Otherwise we route directly through to the clusters with existing credentials.
        proxy_set_header Authorization "Bearer $cookie_sessionid";
        proxy_pass https://kubernetes.default;
        include "./server_blocks/k8s-api-proxy.conf";
      }

      # TODO: The following location is left for backwards compat but will no longer
      # be needed once clients are sending the cluster name.
      # Using regexp match instead of prefix one because the application can be
      # deployed under a specific path i.e /kubeapps
      location ~* /api/kube {
        rewrite /api/kube/(.*) /$1 break;
        rewrite /api/kube / break;
        proxy_set_header Authorization "Bearer $cookie_sessionid";
        proxy_pass https://kubernetes.default;
        include "./server_blocks/k8s-api-proxy.conf";
      }
```

## Alternative Solution

As an alternative, it would be simpler if we just put an auth gateway in front of our kubeapps deployment. This gateway could be the step at which the `sessionid` cookie is authenticated, and set as a header `Authorization: Bearer my-cookie-value`. However, issue number 1 in my list above still exists - i.e. the kubeapps frontend simply does not think you are logged in unless you (1) submit an auth token manually (local storage route, supposed to be non-production deployment), or (2) configure an OAuth proxy via Helm chart `.Values.authProxy`.

## Valediction

As I said, the purpose of this PR is to clarify the conversation I've been having with @absoludity in https://github.com/kubeapps/kubeapps/issues/2253.

I hope to generate some discussion and wanted to have pseudo-code to illustrate my intentions.

Thanks for taking the time to take a look!