### PR TITLE
Change comma by pipe to concat filters in the catalog

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.test.tsx
+++ b/dashboard/src/components/Catalog/Catalog.test.tsx
@@ -424,7 +424,7 @@ describe("filters by category", () => {
       <Catalog
         {...defaultProps}
         csvs={[csv, csvWithCat]}
-        filter={{ [filterNames.CATEGORY]: "Developer Tools,Infrastructure" }}
+        filter={{ [filterNames.CATEGORY]: "Developer Tools|Infrastructure" }}
       />,
     );
     expect(wrapper.find(InfoCard)).toHaveLength(1);

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -69,7 +69,7 @@ export function filtersToQuery(filters: any) {
   const activeFilters = Object.keys(filters).filter(f => filters[f].length);
   if (activeFilters.length) {
     const filterQueries = activeFilters.map(
-      filter => `${filter}=${filters[filter].map((f: string) => encodeURIComponent(f)).join(",")}`,
+      filter => `${filter}=${filters[filter].map((f: string) => encodeURIComponent(f)).join("|")}`,
     );
     query = "?" + filterQueries.join("&");
   }
@@ -107,7 +107,7 @@ function Catalog(props: ICatalogProps) {
   useEffect(() => {
     const newFilters = {};
     Object.keys(propsFilter).forEach(filter => {
-      newFilters[filter] = propsFilter[filter]?.toString().split(",");
+      newFilters[filter] = propsFilter[filter]?.toString().split("|");
     });
     setFilters({
       ...initialFilterState(),
@@ -167,7 +167,7 @@ function Catalog(props: ICatalogProps) {
 
   // Only one search filter can be set
   const searchFilter = propsFilter[filterNames.SEARCH]?.toString() || "";
-  const reposFilter = filters[filterNames.REPO]?.join(",") || "";
+  const reposFilter = filters[filterNames.REPO]?.join("|") || "";
   useEffect(() => {
     fetchCharts(cluster, namespace, reposFilter, page, size, searchFilter);
   }, [fetchCharts, cluster, namespace, reposFilter, page, size, searchFilter]);

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -64,6 +64,10 @@ export function initialFilterState() {
   return result;
 }
 
+const tmpStrRegex = /__/g;
+const tmpStr = "__";
+const commaRegex = /,/g;
+
 export function filtersToQuery(filters: any) {
   let query = "";
   const activeFilters = Object.keys(filters).filter(f => filters[f].length);
@@ -75,7 +79,7 @@ export function filtersToQuery(filters: any) {
     const filterQueries = activeFilters.map(
       filter =>
         `${filter}=${filters[filter]
-          .map((f: string) => encodeURIComponent(f.replace(/,/g, "__")))
+          .map((f: string) => encodeURIComponent(f.replace(commaRegex, tmpStr)))
           .join(",")}`,
     );
     query = "?" + filterQueries.join("&");
@@ -115,7 +119,7 @@ function Catalog(props: ICatalogProps) {
     const newFilters = {};
     Object.keys(propsFilter).forEach(filter => {
       const filterValue = propsFilter[filter]?.toString() || "";
-      newFilters[filter] = filterValue.split(",").map(a => a.replace(/__/g, ","));
+      newFilters[filter] = filterValue.split(",").map(a => a.replace(tmpStrRegex, ","));
     });
     setFilters({
       ...initialFilterState(),
@@ -174,7 +178,7 @@ function Catalog(props: ICatalogProps) {
   }, [getCSVs, fetchChartCategories, cluster, namespace]);
 
   // Only one search filter can be set
-  const searchFilter = propsFilter[filterNames.SEARCH]?.toString().replace(/__/g, ",") || "";
+  const searchFilter = propsFilter[filterNames.SEARCH]?.toString().replace(tmpStrRegex, ",") || "";
   const reposFilter = filters[filterNames.REPO]?.join(",") || "";
   useEffect(() => {
     fetchCharts(cluster, namespace, reposFilter, page, size, searchFilter);

--- a/dashboard/src/components/OperatorList/OperatorList.test.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.test.tsx
@@ -202,6 +202,16 @@ describe("filter operators", () => {
     expect(operator.prop("title")).toBe(sampleOperator.metadata.name);
   });
 
+  it("transforms the received '__' in query params into a ','", () => {
+    const wrapper = mountWrapper(
+      getStore({
+        operators: { isOLMInstalled: true, operators: [sampleOperator, sampleOperator2] },
+      }),
+      <OperatorList {...defaultProps} filter={{ [filterNames.PROVIDER]: "kubeapps__%20inc" }} />,
+    );
+    expect(wrapper.find(".label-info").text()).toBe("Provider: kubeapps,%20inc ");
+  });
+
   it("show a message if the filter doesn't match any operator", () => {
     const wrapper = mountWrapper(
       getStore({

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -78,17 +78,18 @@ export default function OperatorList({
   const dispatch = useDispatch();
   const [filters, setFilters] = useState(initialFilterState());
 
+  const tmpStrRegex = /__/g;
   useEffect(() => {
     const newFilters = {};
     Object.keys(propsFilter).forEach(filter => {
       const filterValue = propsFilter[filter]?.toString() || "";
-      newFilters[filter] = filterValue.split(",").map(a => a.replace(/__/g, ","));
+      newFilters[filter] = filterValue.split(",").map(a => a.replace(tmpStrRegex, ","));
     });
     setFilters({
       ...initialFilterState(),
       ...newFilters,
     });
-  }, [propsFilter]);
+  }, [propsFilter, tmpStrRegex]);
 
   const pushFilters = (newFilters: any) => {
     dispatch(push(app.operators.list(cluster, namespace) + filtersToQuery(newFilters)));

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -81,7 +81,7 @@ export default function OperatorList({
   useEffect(() => {
     const newFilters = {};
     Object.keys(propsFilter).forEach(filter => {
-      newFilters[filter] = propsFilter[filter]?.toString().split(",");
+      newFilters[filter] = propsFilter[filter]?.toString().split("|");
     });
     setFilters({
       ...initialFilterState(),

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -78,8 +78,8 @@ export default function OperatorList({
   const dispatch = useDispatch();
   const [filters, setFilters] = useState(initialFilterState());
 
-  const tmpStrRegex = /__/g;
   useEffect(() => {
+    const tmpStrRegex = /__/g;
     const newFilters = {};
     Object.keys(propsFilter).forEach(filter => {
       const filterValue = propsFilter[filter]?.toString() || "";
@@ -89,7 +89,7 @@ export default function OperatorList({
       ...initialFilterState(),
       ...newFilters,
     });
-  }, [propsFilter, tmpStrRegex]);
+  }, [propsFilter]);
 
   const pushFilters = (newFilters: any) => {
     dispatch(push(app.operators.list(cluster, namespace) + filtersToQuery(newFilters)));

--- a/dashboard/src/components/OperatorList/OperatorList.tsx
+++ b/dashboard/src/components/OperatorList/OperatorList.tsx
@@ -81,7 +81,8 @@ export default function OperatorList({
   useEffect(() => {
     const newFilters = {};
     Object.keys(propsFilter).forEach(filter => {
-      newFilters[filter] = propsFilter[filter]?.toString().split("|");
+      const filterValue = propsFilter[filter]?.toString() || "";
+      newFilters[filter] = filterValue.split(",").map(a => a.replace(/__/g, ","));
     });
     setFilters({
       ...initialFilterState(),


### PR DESCRIPTION
### Description of the change

Following up https://github.com/kubeapps/kubeapps/pull/2221#issuecomment-760943588 and https://github.com/kubeapps/kubeapps/pull/2264#pullrequestreview-575212694.

This PR is to workaround this bug by simply change the default character for splitting and joining, the comma `,`, to another less frequent but also meaningful, the pipe `|`.

### Benefits

Filters values having a comma as part of their names won't break the UI anymore: 

![image](https://user-images.githubusercontent.com/11535726/105752382-82ff0580-5f47-11eb-9cf7-06a1ce35450c.png)


### Possible drawbacks

I don't think so, but I'm not fully aware whether or not this "comma"-split way to generate the URL is being used anywhere else. 

### Applicable issues

N/A

### Additional information

N/A
