### PR TITLE
pinniped api server cert must be encoded when sent as header.

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -70,7 +70,7 @@ data:
         # If pinniped proxy is enabled *and* the current cluster is configured
         # to exchange credentials then we route via pinnipedProxy to exchange
         # credentials for client certificates.
-        {{- if .apiServiceUrl }}
+        {{- if .apiServiceURL }}
         proxy_set_header PINNIPED_PROXY_API_SERVER_URL {{ .apiServiceURL }};
         {{- end }}
         {{- if .certificateAuthorityData }}

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -222,7 +222,7 @@ func parseClusterConfig(configPath, caFilesPrefix string) (kube.ClustersConfig, 
 			if err != nil {
 				return kube.ClustersConfig{}, deferFn, err
 			}
-			c.CertificateAuthorityData = string(decodedCAData)
+			c.CertificateAuthorityDataDecoded = string(decodedCAData)
 
 			// We also need a CAFile field because Helm uses the genericclioptions.ConfigFlags
 			// struct which does not support CAData.

--- a/cmd/kubeops/main_test.go
+++ b/cmd/kubeops/main_test.go
@@ -23,10 +23,11 @@ func TestParseClusterConfig(t *testing.T) {
 			expectedConfig: kube.ClustersConfig{
 				Clusters: map[string]kube.ClusterConfig{
 					"cluster-2": {
-						Name:                     "cluster-2",
-						APIServiceURL:            "https://example.com",
-						CertificateAuthorityData: "ca-cert-data\n",
-						ServiceToken:             "abcd",
+						Name:                            "cluster-2",
+						APIServiceURL:                   "https://example.com",
+						CertificateAuthorityData:        "Y2EtY2VydC1kYXRhCg==",
+						CertificateAuthorityDataDecoded: "ca-cert-data\n",
+						ServiceToken:                    "abcd",
 					},
 				},
 				PinnipedProxyURL: "http://kubeapps-internal-pinniped-proxy.kubeapps:3333",
@@ -41,14 +42,16 @@ func TestParseClusterConfig(t *testing.T) {
 			expectedConfig: kube.ClustersConfig{
 				Clusters: map[string]kube.ClusterConfig{
 					"cluster-2": {
-						Name:                     "cluster-2",
-						APIServiceURL:            "https://example.com/cluster-2",
-						CertificateAuthorityData: "ca-cert-data\n",
+						Name:                            "cluster-2",
+						APIServiceURL:                   "https://example.com/cluster-2",
+						CertificateAuthorityData:        "Y2EtY2VydC1kYXRhCg==",
+						CertificateAuthorityDataDecoded: "ca-cert-data\n",
 					},
 					"cluster-3": {
-						Name:                     "cluster-3",
-						APIServiceURL:            "https://example.com/cluster-3",
-						CertificateAuthorityData: "ca-cert-data-additional\n",
+						Name:                            "cluster-3",
+						APIServiceURL:                   "https://example.com/cluster-3",
+						CertificateAuthorityData:        "Y2EtY2VydC1kYXRhLWFkZGl0aW9uYWwK",
+						CertificateAuthorityDataDecoded: "ca-cert-data-additional\n",
 					},
 				},
 				PinnipedProxyURL: "http://kubeapps-internal-pinniped-proxy.kubeapps:3333",
@@ -68,14 +71,16 @@ func TestParseClusterConfig(t *testing.T) {
 						Name: "cluster-1",
 					},
 					"cluster-2": {
-						Name:                     "cluster-2",
-						APIServiceURL:            "https://example.com/cluster-2",
-						CertificateAuthorityData: "ca-cert-data\n",
+						Name:                            "cluster-2",
+						APIServiceURL:                   "https://example.com/cluster-2",
+						CertificateAuthorityData:        "Y2EtY2VydC1kYXRhCg==",
+						CertificateAuthorityDataDecoded: "ca-cert-data\n",
 					},
 					"cluster-3": {
-						Name:                     "cluster-3",
-						APIServiceURL:            "https://example.com/cluster-3",
-						CertificateAuthorityData: "ca-cert-data-additional\n",
+						Name:                            "cluster-3",
+						APIServiceURL:                   "https://example.com/cluster-3",
+						CertificateAuthorityData:        "Y2EtY2VydC1kYXRhLWFkZGl0aW9uYWwK",
+						CertificateAuthorityDataDecoded: "ca-cert-data-additional\n",
 					},
 				},
 				PinnipedProxyURL: "http://kubeapps-internal-pinniped-proxy.kubeapps:3333",
@@ -87,10 +92,11 @@ func TestParseClusterConfig(t *testing.T) {
 			expectedConfig: kube.ClustersConfig{
 				Clusters: map[string]kube.ClusterConfig{
 					"cluster-2": {
-						Name:                     "cluster-2",
-						APIServiceURL:            "https://example.com",
-						CertificateAuthorityData: "ca-cert-data\n",
-						ServiceToken:             "abcd",
+						Name:                            "cluster-2",
+						APIServiceURL:                   "https://example.com",
+						CertificateAuthorityData:        "Y2EtY2VydC1kYXRhCg==",
+						CertificateAuthorityDataDecoded: "ca-cert-data\n",
+						ServiceToken:                    "abcd",
 						PinnipedConfig: kube.PinnipedConciergeConfig{
 							Enable: true,
 						},
@@ -139,12 +145,12 @@ func TestParseClusterConfig(t *testing.T) {
 			}
 
 			for clusterName, clusterConfig := range tc.expectedConfig.Clusters {
-				if clusterConfig.CertificateAuthorityData != "" {
+				if clusterConfig.CertificateAuthorityDataDecoded != "" {
 					fileCAData, err := ioutil.ReadFile(config.Clusters[clusterName].CAFile)
 					if err != nil {
 						t.Fatalf("error opening %s: %+v", config.Clusters[clusterName].CAFile, err)
 					}
-					if got, want := string(fileCAData), clusterConfig.CertificateAuthorityData; got != want {
+					if got, want := string(fileCAData), clusterConfig.CertificateAuthorityDataDecoded; got != want {
 						t.Errorf("got: %q, want: %q", got, want)
 					}
 				}

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -46,6 +46,9 @@ type ClusterConfig struct {
 	Name                     string `json:"name"`
 	APIServiceURL            string `json:"apiServiceURL"`
 	CertificateAuthorityData string `json:"certificateAuthorityData,omitempty"`
+	// When parsing config we decode the cert auth data to ensure it is valid
+	// and store it since it's required when using the data.
+	CertificateAuthorityDataDecoded string
 	// The genericclioptions.ConfigFlags struct includes only a CAFile field, not
 	// a CAData field.
 	// https://github.com/kubernetes/cli-runtime/issues/8
@@ -134,8 +137,8 @@ func NewClusterConfig(inClusterConfig *rest.Config, userToken string, cluster st
 	config.Host = clusterConfig.APIServiceURL
 	config.TLSClientConfig = rest.TLSClientConfig{}
 	config.TLSClientConfig.Insecure = clusterConfig.Insecure
-	if clusterConfig.CertificateAuthorityData != "" {
-		config.TLSClientConfig.CAData = []byte(clusterConfig.CertificateAuthorityData)
+	if clusterConfig.CertificateAuthorityDataDecoded != "" {
+		config.TLSClientConfig.CAData = []byte(clusterConfig.CertificateAuthorityDataDecoded)
 		config.CAFile = clusterConfig.CAFile
 	}
 	return config, nil

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -1094,9 +1094,10 @@ func TestNewClusterConfig(t *testing.T) {
 				Clusters: map[string]ClusterConfig{
 					"default": {},
 					"cluster-1": {
-						APIServiceURL:            "https://cluster-1.example.com:7890",
-						CertificateAuthorityData: "ca-file-data",
-						CAFile:                   "/tmp/ca-file-data",
+						APIServiceURL:                   "https://cluster-1.example.com:7890",
+						CertificateAuthorityData:        "Y2EtZmlsZS1kYXRhCg==",
+						CertificateAuthorityDataDecoded: "ca-file-data",
+						CAFile:                          "/tmp/ca-file-data",
 					},
 				},
 			},


### PR DESCRIPTION
### Description of the change

This PR has two small changes which I found necessary while testing a setup of multiple clusters without OIDC configuration (but using pinniped instead).

The first is just a typo in the frontend config which resulted in the api server URL not being set for the requests to a configured second cluster.

The second was that in Kubeops we were attempting to send the certificate authority data for a second cluster unencoded.

### Benefits

With these changes we can now use pinniped in a multi-cluster scenario.

### Possible drawbacks

Not aware of any.

### Applicable issues

  - Ref: #2181

### Other info

I noticed while testing this that the context selector does not seem to be updating the current cluster after changing context. I'll check separately whether this is related or unrelated. (I had to manually update the URL after changing the context).
