### PR TITLE
Fix context selector when changing clusters.

### DIFF
--- a/dashboard/src/components/Header/ContextSelector.test.tsx
+++ b/dashboard/src/components/Header/ContextSelector.test.tsx
@@ -170,7 +170,7 @@ it("changes the location with the new namespace", () => {
   const push = jest.fn();
   spyOnUseHistory = jest.spyOn(ReactRouter, "useHistory").mockReturnValue({ push } as any);
   spyOnUseLocation = jest.spyOn(ReactRouter, "useLocation").mockReturnValue({
-    pathname: "/c/cluster-foo/ns/ns-bar/catalog",
+    pathname: "/c/default-cluster/ns/ns-bar/catalog",
     search: "",
     state: "",
   } as any);
@@ -185,7 +185,33 @@ it("changes the location with the new namespace", () => {
       .filterWhere(b => b.text() === "Change Context")
       .prop("onClick") as any)();
   });
-  expect(push).toHaveBeenCalledWith("/c/cluster-foo/ns/other/catalog");
+  expect(push).toHaveBeenCalledWith("/c/default-cluster/ns/other/catalog");
+});
+
+it("changes the location with the new cluster and namespace", () => {
+  const push = jest.fn();
+  spyOnUseHistory = jest.spyOn(ReactRouter, "useHistory").mockReturnValue({ push } as any);
+  spyOnUseLocation = jest.spyOn(ReactRouter, "useLocation").mockReturnValue({
+    pathname: "/c/default-cluster/ns/ns-bar/catalog",
+    search: "",
+    state: "",
+  } as any);
+  const wrapper = mountWrapper(defaultStore, <ContextSelector />);
+  wrapper
+    .find("select")
+    .findWhere(s => s.prop("name") === "clusters")
+    .simulate("change", { target: { value: "second-cluster" } });
+  wrapper
+    .find("select")
+    .findWhere(s => s.prop("name") === "namespaces")
+    .simulate("change", { target: { value: "other" } });
+  act(() => {
+    (wrapper
+      .find(CdsButton)
+      .filterWhere(b => b.text() === "Change Context")
+      .prop("onClick") as any)();
+  });
+  expect(push).toHaveBeenCalledWith("/c/second-cluster/ns/other/catalog");
 });
 
 it("don't call push if the pathname is not recognized", () => {

--- a/dashboard/src/components/Header/ContextSelector.tsx
+++ b/dashboard/src/components/Header/ContextSelector.tsx
@@ -64,7 +64,7 @@ function ContextSelector() {
     if (nsRegex.test(location.pathname)) {
       // Change the namespace in the route
       history.push(
-        location.pathname.replace(nsRegex, `/c/$1/ns/${namespace}/`).concat(location.search),
+        location.pathname.replace(nsRegex, `/c/${cluster}/ns/${namespace}/`).concat(location.search),
       );
     }
     setOpen(false);

--- a/dashboard/src/components/Header/ContextSelector.tsx
+++ b/dashboard/src/components/Header/ContextSelector.tsx
@@ -64,7 +64,9 @@ function ContextSelector() {
     if (nsRegex.test(location.pathname)) {
       // Change the namespace in the route
       history.push(
-        location.pathname.replace(nsRegex, `/c/${cluster}/ns/${namespace}/`).concat(location.search),
+        location.pathname
+          .replace(nsRegex, `/c/${cluster}/ns/${namespace}/`)
+          .concat(location.search),
       );
     }
     setOpen(false);

--- a/dashboard/src/shared/specs/mountWrapper.tsx
+++ b/dashboard/src/shared/specs/mountWrapper.tsx
@@ -38,6 +38,11 @@ export const initialState = {
         namespaces: ["default", "other"],
         canCreateNS: true,
       },
+      "second-cluster": {
+        currentNamespace: "default",
+        namespaces: ["default", "other"],
+        canCreateNS: true,
+      },
     },
   },
   repos: cloneDeep(reposInitialState),


### PR DESCRIPTION
### Description of the change

While testing the multicluster setup with pinniped, I noticed that when selecting a different cluster, the current cluster didn't appear to change. See comment on #2281.

Looking more closely here using the redux debugger, I could see that SET_NAMESPACES was called when changing context which correctly updated `currentCluster` in the state, but it was immediately followed by a LOCATION_CHANGE which set it back to its previous value.

Checking the code, it appeared to be related to a change in #2187 where we'd updated the location when changing context, directly after calling `setNamespace`, but had done so without using the new cluster in the location.

### Benefits

You can change clusters again :)

### Possible drawbacks

Not aware of any.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref #2018, Ref #2181

