### PR TITLE
Update pinniped-proxy runtime to bitnami/minideb. Add to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,15 @@ workflows:
           <<: *build_always
       - test_dashboard:
           <<: *build_always
+      - test_pinniped_proxy:
+          <<: *build_always
       - test_chart_render:
           <<: *build_always
       - build_go_images:
           <<: *build_always
       - build_dashboard:
+          <<: *build_always
+      - build_pinniped_proxy:
           <<: *build_always
       - local_e2e_tests:
           <<: *build_always
@@ -270,6 +274,12 @@ jobs:
       - run: yarn install --cwd=dashboard --frozen-lockfile
       - run: yarn --cwd=dashboard run lint
       - run: yarn --cwd=dashboard run test --maxWorkers=4 --coverage
+  test_pinniped_proxy:
+    docker:
+      - image: circleci/rust
+    steps:
+      - checkout
+      - run: cargo test --manifest-path ./cmd/pinniped-proxy/Cargo.toml
   test_chart_render:
     environment:
       HELM_VERSION: "v3.0.2"
@@ -293,6 +303,13 @@ jobs:
       - image: circleci/golang:1.13
     environment:
       IMAGES: "dashboard"
+    <<: *build_images
+  build_pinniped_proxy:
+    docker:
+      - image: circleci/rust
+    working_directory: /go/src/github.com/kubeapps/kubeapps
+    environment:
+      IMAGES: "pinniped-proxy"
     <<: *build_images
   release:
     docker:
@@ -360,7 +377,7 @@ jobs:
       - run: |
           if [[ -z "$CIRCLE_PULL_REQUEST" && -n "$DOCKER_USERNAME" && -n "$DOCKER_PASSWORD" ]]; then
             docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-            for IMAGE in kubeapps/apprepository-controller kubeapps/dashboard kubeapps/asset-syncer kubeapps/assetsvc kubeapps/kubeops; do
+            for IMAGE in kubeapps/apprepository-controller kubeapps/dashboard kubeapps/asset-syncer kubeapps/assetsvc kubeapps/kubeops kubeapps/pinniped-proxy; do
               docker pull ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
               docker tag ${IMAGE}${IMG_MODIFIER}:${DEV_TAG} ${IMAGE}:${PROD_TAG}
               docker push ${IMAGE}:${PROD_TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,6 @@ jobs:
   build_pinniped_proxy:
     docker:
       - image: circleci/rust
-    working_directory: /go/src/github.com/kubeapps/kubeapps
     environment:
       IMAGES: "pinniped-proxy"
     <<: *build_images

--- a/cmd/pinniped-proxy/Dockerfile
+++ b/cmd/pinniped-proxy/Dockerfile
@@ -1,7 +1,8 @@
-FROM rust:1.47 as builder
+FROM rust:1.49 as builder
 
 # Create a new project and build pinniped-proxy dependencies only, so that they
-# are built as a layer on their own.
+# are built as a layer on their own, to reduce build times when only our code
+# changes.
 RUN USER=root cargo new --bin pinniped-proxy
 WORKDIR /pinniped-proxy
 COPY ./cmd/pinniped-proxy/Cargo.* ./
@@ -12,12 +13,7 @@ ADD ./cmd/pinniped-proxy ./
 RUN rm ./target/release/deps/pinniped_proxy*
 RUN cargo build --release
 
-# Put it all together on a scratch image.
-# TODO: Turns out we'll need to include libssl on the scratch image, perhaps compiling libssl or copying dyn libs listed by ldd.
-# FROM scratch
-# COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-# FROM bitnami/minideb:buster-snapshot-20201121T213529Z
-FROM debian:10.6-slim
+FROM bitnami/minideb:buster-snapshot-20210126T024633Z
 RUN apt-get update && apt-get install -y ca-certificates libssl1.1 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /pinniped-proxy/target/release/pinniped-proxy /pinniped-proxy
 

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -9,8 +9,8 @@ The [values.yaml](../../chart/kubeapps/values.yaml) uses the following Bitnami i
 * [bitnami/nginx](https://hub.docker.com/r/bitnami/nginx/tags)
 * [bitnami/kubectl](https://hub.docker.com/r/bitnami/kubectl/tags)
 * [bitnami/oauth2-proxy](https://hub.docker.com/r/bitnami/oauth2-proxy/tags)
-
-while the [dashboard/Dockerfile](../../dashboard/Dockerfile) uses bitnami/nginx and [bitnami/node](https://hub.docker.com/r/bitnami/node/tags) also (though the latter is a rolling tag since it's a build-only image).
+* the [dashboard/Dockerfile](../../dashboard/Dockerfile) uses bitnami/nginx and [bitnami/node](https://hub.docker.com/r/bitnami/node/tags) also (though the latter is a rolling tag since it's a build-only image).
+* the [pinniped-proxy/Dockerfile](../../cmd/pinniped-proxy/Dockerfile) uses the [bitnami/minideb](https://hub.docker.com/r/bitnami/minideb/tags) image.
 
 All tags for these images should be updated to their latest compatible versions and security patches.
 
@@ -48,7 +48,7 @@ git push origin ${VERSION_NAME}
 ```
 
 This will trigger a build, test and **release** [workflow in our CI](https://circleci.com/gh/kubeapps/workflows).
- 
+
 ## 2 - Complete the GitHub release notes
 
 Once the release job is finished, you will have a GitHub release draft pre-populated. You still must **add a high level description with the release highlights**. Save the draft and **do not publish it yet**.


### PR DESCRIPTION
### Description of the change

Cleans up the Dockerfile used to build pinniped-proxy, updating to use bitnami/minideb for the runtime base.

Also adds the testing and building of pinniped-proxy to circleci, but does not depend on it for any other images/tests.

### Benefits

Start building the pinniped-proxy image.

### Possible drawbacks

I'll check with @carrodher about landing this and whether we need to wait for equivalent config in the bitnami pipeline.

### Applicable issues

  - fixes #2181

### Additional information

@andresmgot You mentioned recently that the build image might be an issue since it's not part of the bitnami catalog, but I'm not sure how that's different to the golang images which use a dockerhub image for building - ah, unless during the bitnami release it's switched for a specific bitnami go image in that case?
