### PR TITLE
Create pinnipedProxyURL based on existing params.

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -76,7 +76,7 @@ data:
         {{- if .certificateAuthorityData }}
         proxy_set_header PINNIPED_PROXY_API_SERVER_CERT {{ .certificateAuthorityData }};
         {{- end }}
-        proxy_pass http://localhost:3333;
+        proxy_pass http://kubeapps-internal-pinniped-proxy.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
       {{- else }}
         # Otherwise we route directly through to the clusters with existing credentials.
         proxy_pass {{ default "https://kubernetes.default" .apiServiceURL }};

--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -49,6 +49,9 @@ spec:
             {{- if .Values.clusters }}
             - --clusters-config-path=/config/clusters.conf
             {{- end }}
+            {{- if .Values.pinnipedProxy.enabled }}
+            - --pinniped-proxy-url=http://kubeapps-internal-pinniped-proxy.{{ .Release.Namespace }}:{{ .Values.pinnipedProxy.service.port }}
+            {{- end }}
           {{- if .Values.clusters }}
           volumeMounts:
             - name: kubeops-config


### PR DESCRIPTION
### Description of the change

Without this change the pinniped-proxy-url used by kubeops was relying on a default value (kubeapps namespace).

This updates the location for pinniped-proxy in both the kubeops and frontend deployments, based on existing values.

### Benefits

Pinniped-proxy will work when using a namespace other than kubeapps for the kubeapps deployment.

### Possible drawbacks

None.

### Applicable issues

  - Ref #2181
