### PR TITLE
Several fixes to the pull process

### DIFF
--- a/cmd/asset-syncer/helm.go
+++ b/cmd/asset-syncer/helm.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/remotes"
 	"github.com/deislabs/oras/pkg/content"
 	orascontext "github.com/deislabs/oras/pkg/context"
 	"github.com/deislabs/oras/pkg/oras"
@@ -53,15 +53,15 @@ type chartPuller interface {
 	pullOCIChart(ociFullName string) (*bytes.Buffer, string, error)
 }
 
-type ociPuller struct{}
+type ociPuller struct {
+	resolver remotes.Resolver
+}
 
 // Code from: https://github.com/helm/helm/blob/fee2257e3493e9d06ca6caa4be7ef7660842cbdb/internal/experimental/registry/client.go
 func (p *ociPuller) pullOCIChart(ociFullName string) (*bytes.Buffer, string, error) {
-	// TODO: Implement auth
-	resolver := docker.NewResolver(docker.ResolverOptions{})
 	store := content.NewMemoryStore()
 
-	desc, layerDescriptors, err := oras.Pull(ctx(os.Stdout, log.GetLevel() == log.DebugLevel), resolver, ociFullName, store,
+	desc, layerDescriptors, err := oras.Pull(ctx(os.Stdout, log.GetLevel() == log.DebugLevel), p.resolver, ociFullName, store,
 		oras.WithPullEmptyNameAllowed(),
 		oras.WithAllowedMediaTypes(KnownMediaTypes()))
 	if err != nil {

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -37,6 +37,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containerd/containerd/remotes/docker"
 	"github.com/disintegration/imaging"
 	"github.com/ghodss/yaml"
 	"github.com/jinzhu/copier"
@@ -254,7 +255,11 @@ func doReq(url string, headers map[string]string) ([]byte, error) {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request failed: %v", err)
+		errC, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error content: %v", err)
+		}
+		return nil, fmt.Errorf("request failed: %v", string(errC))
 	}
 
 	return ioutil.ReadAll(res.Body)
@@ -528,10 +533,16 @@ func getOCIRepo(namespace, name, repoURL, authorizationHeader string, ociRepos [
 		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
 		return nil, err
 	}
+	headers := http.Header{}
+	if authorizationHeader != "" {
+		headers["Authorization"] = []string{authorizationHeader}
+	}
+	ociResolver := docker.NewResolver(docker.ResolverOptions{Headers: headers})
+
 	return &OCIRegistry{
 		repositories: ociRepos,
 		RepoInternal: &models.RepoInternal{Namespace: namespace, Name: name, URL: url.String(), AuthorizationHeader: authorizationHeader},
-		puller:       &ociPuller{},
+		puller:       &ociPuller{resolver: ociResolver},
 		ociCli:       &ociAPICli{authHeader: authorizationHeader, url: url},
 	}, nil
 }

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -31,6 +31,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -49,11 +50,16 @@ var validRepoIndexYAML = string(validRepoIndexYAMLBytes)
 
 var invalidRepoIndexYAML = "invalid"
 
-type badHTTPClient struct{}
+type badHTTPClient struct {
+	errMsg string
+}
 
 func (h *badHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	w := httptest.NewRecorder()
 	w.WriteHeader(500)
+	if len(h.errMsg) > 0 {
+		w.Write([]byte(h.errMsg))
+	}
 	return w.Result(), nil
 }
 
@@ -190,6 +196,19 @@ func Test_syncURLInvalidity(t *testing.T) {
 			assert.ExistsErr(t, err, tt.name)
 		})
 	}
+}
+
+func Test_getOCIRepo(t *testing.T) {
+	t.Run("it should add the auth header to the resolver", func(t *testing.T) {
+		repo, _ := getOCIRepo("namespace", "test", "https://test", "Basic auth", []string{})
+		// The header property is private so we need to use reflect to get its value
+		resolver := repo.(*OCIRegistry).puller.(*ociPuller).resolver
+		resolverValue := reflect.ValueOf(resolver)
+		headerValue := reflect.Indirect(resolverValue).FieldByName("header")
+		if !strings.Contains(fmt.Sprintf("%v", headerValue), "Authorization:[Basic auth]") {
+			t.Error("Missing authorization header")
+		}
+	})
 }
 
 func Test_fetchRepoIndex(t *testing.T) {
@@ -752,9 +771,11 @@ func Test_ociAPICli(t *testing.T) {
 	}
 
 	t.Run("TagList - failed request", func(t *testing.T) {
-		netClient = &badHTTPClient{}
+		netClient = &badHTTPClient{
+			errMsg: "forbidden",
+		}
 		_, err := apiCli.TagList("apache")
-		assert.Err(t, fmt.Errorf("request failed: %v", nil), err)
+		assert.Err(t, fmt.Errorf("request failed: forbidden"), err)
 	})
 
 	t.Run("TagList - successful request", func(t *testing.T) {
@@ -776,7 +797,7 @@ func Test_ociAPICli(t *testing.T) {
 		}
 		netClient = &authenticatedOCIAPIHTTPClient{}
 		_, err := apiCli.TagList("apache")
-		assert.Err(t, fmt.Errorf("request failed: %v", nil), err)
+		assert.Err(t, fmt.Errorf("request failed: "), err)
 	})
 
 	t.Run("TagList with auth - success", func(t *testing.T) {
@@ -798,7 +819,7 @@ func Test_ociAPICli(t *testing.T) {
 	t.Run("FilterChartTags - failed request", func(t *testing.T) {
 		netClient = &badHTTPClient{}
 		err := apiCli.FilterChartTags(&TagList{Name: "test/apache", Tags: []string{"7.5.1", "8.1.1"}})
-		assert.Err(t, fmt.Errorf("request failed: %v", nil), err)
+		assert.Err(t, fmt.Errorf("request failed: "), err)
 	})
 
 	t.Run("FilterChartTags - successful request", func(t *testing.T) {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

After testing the code related to OCI registries IRL, I noticed the three issues fixed here (the first one is the bigger):

 - An OCI endpoint can contain any kind of artifact (docker images or helm charts). We need to filter only the Helm charts, if not it will fail trying to pull a docker image as a chart. For simplicity, I have moved the methods related to the OCI API to an interface (`ociAPICli`).
 - If a chart contained several READMEs, the last one read was the one stored (e.g. `apache/vhosts/README.md`). Fixed to only take into account files in the root directory.
 - For "large" text files (e.g. Jenkins README), `tarReader.Read` lost a bunch of bytes at the end, filling those with "0"s (TBH, not sure why). Using `ioutil.ReadAll` fixes the issue.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2232 
