### PR TITLE
Delete unused API endpoints

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -88,17 +88,6 @@ data:
       }
       {{- end }}
 
-      # TODO: The following location is left for backwards compat but will no longer
-      # be needed once clients are sending the cluster name.
-      # Using regexp match instead of prefix one because the application can be
-      # deployed under a specific path i.e /kubeapps
-      location ~* /api/kube {
-        rewrite /api/kube/(.*) /$1 break;
-        rewrite /api/kube / break;
-        proxy_pass https://kubernetes.default;
-        include "./server_blocks/k8s-api-proxy.conf";
-      }
-
       # Forward '/api/assetsvc' to '/assetsvc'
       # but preserving the encoding (eg. '%2F' is not converted to '/')
       # see https://serverfault.com/a/906479
@@ -117,12 +106,12 @@ data:
         proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
       }
 
-      location ~* /api/tiller-deploy {
+      location ~* /api/kubeops {
         # Keep the connection open with the API server even if idle (the default is 60 seconds)
         # Setting it to 10 minutes which should be enough for our current use case of deploying/upgrading/deleting apps
         proxy_read_timeout 10m;
-        rewrite /api/tiller-deploy/(.*) /$1 break;
-        rewrite /api/tiller-deploy / break;
+        rewrite /api/kubeops/(.*) /$1 break;
+        rewrite /api/kubeops / break;
         proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
 
         {{- if .Values.frontend.proxypassAccessTokenAsBearer }}

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -107,13 +107,6 @@ func main() {
 	// Routes
 	// Auth not necessary here with Helm 3 because it's done by Kubernetes.
 	addRoute := handler.AddRouteWith(r.PathPrefix("/v1").Subrouter(), withHandlerConfig)
-	// Deprecate non-cluster-aware URIs.
-	addRoute("GET", "/releases", handler.ListAllReleases)
-	addRoute("GET", "/namespaces/{namespace}/releases", handler.ListReleases)
-	addRoute("POST", "/namespaces/{namespace}/releases", handler.CreateRelease)
-	addRoute("GET", "/namespaces/{namespace}/releases/{releaseName}", handler.GetRelease)
-	addRoute("PUT", "/namespaces/{namespace}/releases/{releaseName}", handler.OperateRelease)
-	addRoute("DELETE", "/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
 	addRoute("GET", "/clusters/{cluster}/releases", handler.ListAllReleases)
 	addRoute("GET", "/clusters/{cluster}/namespaces/{namespace}/releases", handler.ListReleases)
 	addRoute("POST", "/clusters/{cluster}/namespaces/{namespace}/releases", handler.CreateRelease)

--- a/dashboard/src/shared/App.test.ts
+++ b/dashboard/src/shared/App.test.ts
@@ -150,7 +150,7 @@ describe("App", () => {
       axiosWithAuth.put = jest.fn().mockReturnValue({ data: "ok" });
       expect(await App.rollback("default-c", "default-ns", "foo", 1)).toBe("ok");
       expect(axiosWithAuth.put).toBeCalledWith(
-        "api/tiller-deploy/v1/clusters/default-c/namespaces/default-ns/releases/foo",
+        "api/kubeops/v1/clusters/default-c/namespaces/default-ns/releases/foo",
         {},
         { params: { action: "rollback", revision: 1 } },
       );

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -3,7 +3,7 @@ import { axiosWithAuth } from "./AxiosInstance";
 import { hapi } from "./hapi/release";
 import { IAppOverview, IChartVersion } from "./types";
 
-export const KUBEOPS_ROOT_URL = "api/tiller-deploy/v1";
+export const KUBEOPS_ROOT_URL = "api/kubeops/v1";
 
 export class App {
   public static async create(

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -102,8 +102,8 @@ export const backend = {
 export const kubeops = {
   releases: {
     list: (cluster: string, namespace: string) =>
-      `api/tiller-deploy/v1/clusters/${cluster}/namespaces/${namespace}/releases`,
-    listAll: (cluster: string) => `api/tiller-deploy/v1/clusters/${cluster}/releases`,
+      `api/kubeops/v1/clusters/${cluster}/namespaces/${namespace}/releases`,
+    listAll: (cluster: string) => `api/kubeops/v1/clusters/${cluster}/releases`,
     get: (cluster: string, namespace: string, name: string) =>
       `${kubeops.releases.list(cluster, namespace)}/${name}`,
   },

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -337,15 +337,6 @@ func SetupDefaultRoutes(r *mux.Router, clustersConfig kube.ClustersConfig) error
 	if err != nil {
 		return err
 	}
-	// Deprecate non-cluster-aware URIs.
-	r.Methods("GET").Path("/namespaces").Handler(http.HandlerFunc(GetNamespaces(backendHandler)))
-	r.Methods("GET").Path("/namespaces/{namespace}/apprepositories").Handler(http.HandlerFunc(ListAppRepositories(backendHandler)))
-	r.Methods("POST").Path("/namespaces/{namespace}/apprepositories").Handler(http.HandlerFunc(CreateAppRepository(backendHandler)))
-	r.Methods("POST").Path("/namespaces/{namespace}/apprepositories/validate").Handler(http.HandlerFunc(ValidateAppRepository(backendHandler)))
-	r.Methods("PUT").Path("/namespaces/{namespace}/apprepositories/{name}").Handler(http.HandlerFunc(UpdateAppRepository(backendHandler)))
-	r.Methods("DELETE").Path("/namespaces/{namespace}/apprepositories/{name}").Handler(http.HandlerFunc(DeleteAppRepository(backendHandler)))
-	r.Methods("GET").Path("/namespaces/{namespace}/operator/{name}/logo").Handler(http.HandlerFunc(GetOperatorLogo(backendHandler)))
-
 	r.Methods("POST").Path("/clusters/{cluster}/can-i").Handler(http.HandlerFunc(CanI(backendHandler)))
 	r.Methods("GET").Path("/clusters/{cluster}/namespaces").Handler(http.HandlerFunc(GetNamespaces(backendHandler)))
 	r.Methods("GET").Path("/clusters/{cluster}/apprepositories").Handler(http.HandlerFunc(ListAppRepositories(backendHandler)))


### PR DESCRIPTION
### Description of the change

This PR is just to delete a bunch of old endpoints that are no longer used by any part of the code.

### Benefits

We finally will: 1) get rid of the non-cluster aware docs; 2) replace the reference to tiller by kubeops; 3) remove the old non-cluster aware `/kube/` proxypass.

### Possible drawbacks

Can't think of any, but I'm opening this draft PR to see if CI complains

### Applicable issues

  - fixes #2298

### Additional information

Related to  #2291. If this PR becomes merged, `tiller-deploy` should be also renamed there.
