### PR TITLE
Add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,6 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 2
 
-  - package-ecosystem: "npm"
-    directory: "/integration"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 2
-
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Basic dependabot.yml file
+# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/dashboard"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/integration"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "cargo"
+    directory: "/cmd/pinniped-proxy"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
### Description of the change

This PR is to simply add the config file for Dependabot. This is just a proposal, feel free to customize any parameter.

Dependabot will be watching 1) dashboard npm deps; 2) integration npm deps; 3) go deps; 4) pinniped proxy cargo deps
For each category, a maximum of 2 concurrent PR is set (so we don't have tons of PR to review) with a daily frequency.

This process can also be set to `weekly` during a certain day/time. I'm ok if you rather go for this periodicity.

### Benefits

Our deps will be finally up to date  :)

### Possible drawbacks

We'll have more work to review the generated PRs, but it's a good practice to keep ours deps up to date as much as possible.

### Applicable issues

  - related  #2237

### Additional information

After merging, perhaps we should disable the snyk feature to do the same (but it's just click a toggle button, let's see how it's work for a couple of days).
Also, I'll try to update these docs to reference we're using this automatic system: https://github.com/kubeapps/kubeapps/blob/master/docs/developer/release-process.md
