### PR TITLE
Fix unhandled rejection in actions/apps

### DIFF
--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -44,6 +44,17 @@ describe("fetches applications", () => {
     expect(store.getActions()).toEqual(expectedActions);
     expect(listAppsMock.mock.calls[0]).toEqual(["default-cluster", "default"]);
   });
+  it("fetches applications, ignore when no data", async () => {
+    App.listApps = jest.fn();
+    const expectedActions = [
+      { type: getType(actions.apps.listApps) },
+      { type: getType(actions.apps.receiveAppList), payload: undefined },
+    ];
+    await store.dispatch(actions.apps.fetchAppsWithUpdateInfo("default-cluster", "default"));
+    App.listApps = listAppsMock;
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(listAppsMock.mock.calls[0]).toBeUndefined();
+  });
 
   describe("fetches chart updates", () => {
     it("gets a chart latest version", async () => {

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -232,19 +232,23 @@ export function fetchAppsWithUpdateInfo(
   namespaceOrAll: string,
 ): ThunkAction<Promise<void>, IStoreState, null, AppsAction> {
   return async dispatch => {
-    const apps = await dispatch(fetchApps(cluster, namespaceOrAll));
-    apps.forEach(app =>
-      dispatch(
-        getAppUpdateInfo(
-          cluster,
-          app.namespace,
-          app.releaseName,
-          app.chartMetadata.name,
-          app.chartMetadata.version,
-          app.chartMetadata.appVersion,
+    try {
+      const apps = await dispatch(fetchApps(cluster, namespaceOrAll));
+      apps?.forEach(app =>
+        dispatch(
+          getAppUpdateInfo(
+            cluster,
+            app.namespace,
+            app.releaseName,
+            app.chartMetadata.name,
+            app.chartMetadata.version,
+            app.chartMetadata.appVersion,
+          ),
         ),
-      ),
-    );
+      );
+    } catch (e) {
+      dispatch(errorApp(new FetchError(e.message)));
+    }
   };
 }
 


### PR DESCRIPTION
### Description of the change

Fix an unhandled rejection that shouldn't really occur. While developing the UI the URLs are pointing to `/kubeops/` and not to `/tiller-proxy/`. There is a temporary inconsistency just when telepresencing just the UI pod.

However, it always good to remove these rejections :)

### Benefits

Avoid annoying rejection when developing the UI until we release the next version.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A