### PR TITLE
Allow to create OCI apprepos

### DIFF
--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -463,6 +463,30 @@ describe("fetchChartVersionsAndSelectVersion", () => {
       `api/assetsvc/v1/clusters/${cluster}/namespaces/${namespace}/charts/foo/versions`,
     );
   });
+
+  it("selects the latest version by default", async () => {
+    response = {
+      data: [
+        { id: "foo", attributes: { version: "1.0.0" } },
+        { id: "foo", attributes: { version: "1.0.0" } },
+      ],
+    };
+    const expectedActions = [
+      { type: getType(actions.charts.requestCharts) },
+      { type: getType(actions.charts.receiveChartVersions), payload: response.data },
+      {
+        type: getType(actions.charts.selectChartVersion),
+        payload: { chartVersion: response.data[1] },
+      },
+    ];
+    await store.dispatch(
+      actions.charts.fetchChartVersionsAndSelectVersion(cluster, namespace, "foo", ""),
+    );
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(axiosGetMock.mock.calls[0][0]).toBe(
+      `api/assetsvc/v1/clusters/${cluster}/namespaces/${namespace}/charts/foo/versions`,
+    );
+  });
 });
 
 describe("getDeployedChartVersion", () => {

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -1,5 +1,6 @@
 import { JSONSchema4 } from "json-schema";
 import { ThunkAction } from "redux-thunk";
+import * as semver from "semver";
 import { ActionType, createAction } from "typesafe-actions";
 
 import Chart from "../shared/Chart";
@@ -215,7 +216,9 @@ export function fetchChartVersionsAndSelectVersion(
       fetchChartVersions(cluster, namespace, id),
     )) as IChartVersion[];
     if (versions.length > 0) {
-      let cv: IChartVersion = versions[0];
+      let cv: IChartVersion = versions.sort((a, b) =>
+        semver.compare(b.attributes.version, a.attributes.version),
+      )[0];
       if (version) {
         const found = versions.find(v => v.attributes.version === version);
         if (!found) {

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -517,6 +517,34 @@ describe("installRepo", () => {
       );
     });
 
+    it("calls AppRepository create including ociRepositories", async () => {
+      await store.dispatch(
+        repoActions.installRepo(
+          "my-repo",
+          "my-namespace",
+          "http://foo.bar",
+          "oci",
+          "",
+          "",
+          "",
+          [],
+          ["apache", "jenkins"],
+        ),
+      );
+      expect(AppRepository.create).toHaveBeenCalledWith(
+        "default",
+        "my-repo",
+        "my-namespace",
+        "http://foo.bar",
+        "oci",
+        "",
+        "",
+        {},
+        [],
+        ["apache", "jenkins"],
+      );
+    });
+
     it("returns true", async () => {
       const res = await store.dispatch(installRepoCMDAuth);
       expect(res).toBe(true);
@@ -842,6 +870,37 @@ describe("updateRepo", () => {
     );
     expect(store.getActions()).toEqual(expectedActions);
   });
+
+  it("updates a repo with ociRepositories", async () => {
+    AppRepository.update = jest.fn().mockReturnValue({
+      appRepository: {},
+    });
+    await store.dispatch(
+      repoActions.updateRepo(
+        "my-repo",
+        "my-namespace",
+        "http://foo.bar",
+        "oci",
+        "",
+        "",
+        "",
+        [],
+        ["apache", "jenkins"],
+      ),
+    );
+    expect(AppRepository.update).toHaveBeenCalledWith(
+      "default",
+      "my-repo",
+      "my-namespace",
+      "http://foo.bar",
+      "oci",
+      "",
+      "",
+      {},
+      [],
+      ["apache", "jenkins"],
+    );
+  });
 });
 
 describe("checkChart", () => {
@@ -955,6 +1014,20 @@ describe("validateRepo", () => {
     const res = await store.dispatch(repoActions.validateRepo("url", "helm", "auth", "cert", []));
     expect(store.getActions()).toEqual(expectedActions);
     expect(res).toBe(false);
+  });
+
+  it("validates repo with ociRepositories", async () => {
+    AppRepository.validate = jest.fn().mockReturnValue({
+      code: 200,
+    });
+    const res = await store.dispatch(
+      repoActions.validateRepo("url", "oci", "", "", ["apache", "jenkins"]),
+    );
+    expect(res).toBe(true);
+    expect(AppRepository.validate).toHaveBeenCalledWith("default", "url", "oci", "", "", [
+      "apache",
+      "jenkins",
+    ]);
   });
 });
 

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -480,9 +480,11 @@ describe("installRepo", () => {
     "my-repo",
     "my-namespace",
     "http://foo.bar",
+    "helm",
     "",
     "",
     "",
+    [],
     [],
   );
 
@@ -491,9 +493,11 @@ describe("installRepo", () => {
       "my-repo",
       "my-namespace",
       "http://foo.bar",
+      "helm",
       "Bearer: abc",
       "",
       "",
+      [],
       [],
     );
 
@@ -504,9 +508,11 @@ describe("installRepo", () => {
         "my-repo",
         "my-namespace",
         "http://foo.bar",
+        "helm",
         "Bearer: abc",
         "",
         {},
+        [],
         [],
       );
     });
@@ -522,9 +528,11 @@ describe("installRepo", () => {
       "my-repo",
       "my-namespace",
       "http://foo.bar",
+      "helm",
       "",
       "This is a cert!",
       "",
+      [],
       [],
     );
 
@@ -535,9 +543,11 @@ describe("installRepo", () => {
         "my-repo",
         "my-namespace",
         "http://foo.bar",
+        "helm",
         "",
         "This is a cert!",
         {},
+        [],
         [],
       );
     });
@@ -554,9 +564,11 @@ describe("installRepo", () => {
             "my-repo",
             "my-namespace",
             "http://foo.bar",
+            "helm",
             "",
             "",
             safeYAMLTemplate,
+            [],
             [],
           ),
         );
@@ -566,11 +578,13 @@ describe("installRepo", () => {
           "my-repo",
           "my-namespace",
           "http://foo.bar",
+          "helm",
           "",
           "",
           {
             spec: { containers: [{ env: [{ name: "FOO", value: "BAR" }] }] },
           },
+          [],
           [],
         );
       });
@@ -585,9 +599,11 @@ describe("installRepo", () => {
             "my-repo",
             "my-namespace",
             "http://foo.bar",
+            "helm",
             "",
             "",
             unsafeYAMLTemplate,
+            [],
             [],
           ),
         );
@@ -604,9 +620,11 @@ describe("installRepo", () => {
         "my-repo",
         "my-namespace",
         "http://foo.bar",
+        "helm",
         "",
         "",
         {},
+        [],
         [],
       );
     });
@@ -662,7 +680,17 @@ describe("installRepo", () => {
 
   it("includes registry secrets if given", async () => {
     await store.dispatch(
-      repoActions.installRepo("my-repo", "foo", "http://foo.bar", "", "", "", ["repo-1"]),
+      repoActions.installRepo(
+        "my-repo",
+        "foo",
+        "http://foo.bar",
+        "helm",
+        "",
+        "",
+        "",
+        ["repo-1"],
+        [],
+      ),
     );
 
     expect(AppRepository.create).toHaveBeenCalledWith(
@@ -670,10 +698,12 @@ describe("installRepo", () => {
       "my-repo",
       "foo",
       "http://foo.bar",
+      "helm",
       "",
       "",
       {},
       ["repo-1"],
+      [],
     );
   });
 });
@@ -708,10 +738,12 @@ describe("updateRepo", () => {
         "my-repo",
         "my-namespace",
         "http://foo.bar",
+        "helm",
         "foo",
         "bar",
         safeYAMLTemplate,
         ["repo-1"],
+        [],
       ),
     );
     expect(store.getActions()).toEqual(expectedActions);
@@ -720,10 +752,12 @@ describe("updateRepo", () => {
       "my-repo",
       "my-namespace",
       "http://foo.bar",
+      "helm",
       "foo",
       "bar",
       { spec: { containers: [{ env: [{ name: "FOO", value: "BAR" }] }] } },
       ["repo-1"],
+      [],
     );
   });
 
@@ -756,10 +790,12 @@ describe("updateRepo", () => {
         "my-repo",
         "my-namespace",
         "http://foo.bar",
+        "helm",
         "foo",
         "bar",
         safeYAMLTemplate,
         ["repo-1"],
+        [],
       ),
     );
     expect(store.getActions()).toEqual(expectedActions);
@@ -768,10 +804,12 @@ describe("updateRepo", () => {
       "my-repo",
       "my-namespace",
       "http://foo.bar",
+      "helm",
       "foo",
       "bar",
       { spec: { containers: [{ env: [{ name: "FOO", value: "BAR" }] }] } },
       ["repo-1"],
+      [],
     );
   });
 
@@ -794,9 +832,11 @@ describe("updateRepo", () => {
         "my-repo",
         "my-namespace",
         "http://foo.bar",
+        "helm",
         "foo",
         "bar",
         safeYAMLTemplate,
+        [],
         [],
       ),
     );
@@ -871,7 +911,7 @@ describe("validateRepo", () => {
       },
     ];
 
-    const res = await store.dispatch(repoActions.validateRepo("url", "auth", "cert"));
+    const res = await store.dispatch(repoActions.validateRepo("url", "helm", "auth", "cert", []));
     expect(store.getActions()).toEqual(expectedActions);
     expect(res).toBe(true);
   });
@@ -890,7 +930,7 @@ describe("validateRepo", () => {
         payload: { err: error, op: "validate" },
       },
     ];
-    const res = await store.dispatch(repoActions.validateRepo("url", "auth", "cert"));
+    const res = await store.dispatch(repoActions.validateRepo("url", "helm", "auth", "cert", []));
     expect(store.getActions()).toEqual(expectedActions);
     expect(res).toBe(false);
   });
@@ -912,7 +952,7 @@ describe("validateRepo", () => {
         },
       },
     ];
-    const res = await store.dispatch(repoActions.validateRepo("url", "auth", "cert"));
+    const res = await store.dispatch(repoActions.validateRepo("url", "helm", "auth", "cert", []));
     expect(store.getActions()).toEqual(expectedActions);
     expect(res).toBe(false);
   });

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -236,10 +236,12 @@ export const installRepo = (
   name: string,
   namespace: string,
   repoURL: string,
+  type: string,
   authHeader: string,
   customCA: string,
   syncJobPodTemplate: string,
   registrySecrets: string[],
+  ociRepositories: string[],
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     const {
@@ -253,10 +255,12 @@ export const installRepo = (
         name,
         namespace,
         repoURL,
+        type,
         authHeader,
         customCA,
         syncJobPodTemplateObj,
         registrySecrets,
+        ociRepositories,
       );
       dispatch(addedRepo(data.appRepository));
 
@@ -272,10 +276,12 @@ export const updateRepo = (
   name: string,
   namespace: string,
   repoURL: string,
+  type: string,
   authHeader: string,
   customCA: string,
   syncJobPodTemplate: string,
   registrySecrets: string[],
+  ociRepositories: string[],
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     const {
@@ -289,10 +295,12 @@ export const updateRepo = (
         name,
         namespace,
         repoURL,
+        type,
         authHeader,
         customCA,
         syncJobPodTemplateObj,
         registrySecrets,
+        ociRepositories,
       );
       dispatch(repoUpdated(data.appRepository));
       // Re-fetch the helm repo secret that could have been modified with the updated headers
@@ -321,8 +329,10 @@ export const updateRepo = (
 
 export const validateRepo = (
   repoURL: string,
+  type: string,
   authHeader: string,
   customCA: string,
+  ociRepositories: string[],
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     const {
@@ -330,7 +340,14 @@ export const validateRepo = (
     } = getState();
     try {
       dispatch(repoValidating());
-      const data = await AppRepository.validate(currentCluster, repoURL, authHeader, customCA);
+      const data = await AppRepository.validate(
+        currentCluster,
+        repoURL,
+        type,
+        authHeader,
+        customCA,
+        ociRepositories,
+      );
       if (data.code === 200) {
         dispatch(repoValidated(data));
         return true;

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -39,10 +39,12 @@ export function AppRepoAddButton({
   const onSubmit = (
     name: string,
     url: string,
+    type: string,
     authHeader: string,
     customCA: string,
     syncJobPodTemplate: string,
     registrySecrets: string[],
+    ociRepositories: string[],
   ) => {
     if (repo) {
       return dispatch(
@@ -50,10 +52,12 @@ export function AppRepoAddButton({
           name,
           namespace,
           url,
+          type,
           authHeader,
           customCA,
           syncJobPodTemplate,
           registrySecrets,
+          ociRepositories,
         ),
       );
     } else {
@@ -62,10 +66,12 @@ export function AppRepoAddButton({
           name,
           namespace,
           url,
+          type,
           authHeader,
           customCA,
           syncJobPodTemplate,
           registrySecrets,
+          ociRepositories,
         ),
       );
     }

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -152,7 +152,7 @@ it("should call the install method with the selected docker credentials", async 
       preventDefault: jest.fn(),
     });
   });
-  expect(install).toHaveBeenCalledWith("", "", "", "", "", ["repo-1"]);
+  expect(install).toHaveBeenCalledWith("", "", "helm", "", "", "", ["repo-1"], []);
 });
 
 describe("when the repository info is already populated", () => {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -108,6 +108,26 @@ it("should not call the install method when the validation fails unless forced",
   expect(install).toHaveBeenCalled();
 });
 
+it("should call the install method with OCI information", async () => {
+  const validateRepo = jest.fn().mockReturnValue(true);
+  const install = jest.fn().mockReturnValue(true);
+  actions.repos = {
+    ...actions.repos,
+    validateRepo,
+  };
+  const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} onSubmit={install} />);
+  wrapper.find("#kubeapps-repo-type-oci").simulate("change");
+  wrapper
+    .find("#kubeapps-oci-repositories")
+    .simulate("change", { target: { value: "apache, jenkins" } });
+  const form = wrapper.find("form");
+  await act(async () => {
+    await (form.prop("onSubmit") as (e: any) => Promise<any>)({ preventDefault: jest.fn() });
+  });
+  wrapper.update();
+  expect(install).toHaveBeenCalledWith("", "", "oci", "", "", "", [], ["apache", "jenkins"]);
+});
+
 it("should not show the docker registry credentials section if the namespace is the global one", () => {
   const wrapper = mountWrapper(
     defaultStore,
@@ -153,6 +173,23 @@ it("should call the install method with the selected docker credentials", async 
     });
   });
   expect(install).toHaveBeenCalledWith("", "", "helm", "", "", "", ["repo-1"], []);
+});
+
+it("should not show the custom CA field if using an OCI registry", () => {
+  const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} />);
+  wrapper.find("#kubeapps-repo-type-oci").simulate("change");
+  const section = wrapper
+    .find(".clr-form-control")
+    .filterWhere(c => c.text().includes("Custom CA Certificate"));
+  expect(section.prop("hidden")).toBeTruthy();
+});
+
+it("should not show the list of OCI repositories if using a Helm repo (default)", () => {
+  const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} />);
+  const section = wrapper
+    .find(".clr-control-container")
+    .filterWhere(c => c.text().includes("List of Repositories"));
+  expect(section.prop("hidden")).toBeTruthy();
 });
 
 describe("when the repository info is already populated", () => {
@@ -206,6 +243,12 @@ describe("when the repository info is already populated", () => {
       );
       expect(wrapper.find("#kubeapps-repo-username").prop("value")).toBe("foo");
       expect(wrapper.find("#kubeapps-repo-password").prop("value")).toBe("bar");
+    });
+
+    it("should parse the existing type", () => {
+      const repo = { metadata: { name: "foo" }, spec: { type: "oci" } } as any;
+      const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
+      expect(wrapper.find("#kubeapps-repo-type-oci")).toBeChecked();
     });
 
     it("should parse a bearer token", () => {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -116,6 +116,7 @@ it("should call the install method with OCI information", async () => {
     validateRepo,
   };
   const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} onSubmit={install} />);
+  wrapper.find("#kubeapps-repo-url").simulate("change", { target: { value: "oci.repo" } });
   wrapper.find("#kubeapps-repo-type-oci").simulate("change");
   wrapper
     .find("#kubeapps-oci-repositories")
@@ -125,7 +126,16 @@ it("should call the install method with OCI information", async () => {
     await (form.prop("onSubmit") as (e: any) => Promise<any>)({ preventDefault: jest.fn() });
   });
   wrapper.update();
-  expect(install).toHaveBeenCalledWith("", "", "oci", "", "", "", [], ["apache", "jenkins"]);
+  expect(install).toHaveBeenCalledWith(
+    "",
+    "https://oci.repo",
+    "oci",
+    "",
+    "",
+    "",
+    [],
+    ["apache", "jenkins"],
+  );
 });
 
 it("should not show the docker registry credentials section if the namespace is the global one", () => {
@@ -165,6 +175,7 @@ it("should call the install method with the selected docker credentials", async 
   act(() => {
     label.simulate("change");
   });
+  wrapper.find("#kubeapps-repo-url").simulate("change", { target: { value: "http://test" } });
   wrapper.update();
 
   await act(async () => {
@@ -172,7 +183,7 @@ it("should call the install method with the selected docker credentials", async 
       preventDefault: jest.fn(),
     });
   });
-  expect(install).toHaveBeenCalledWith("", "", "helm", "", "", "", ["repo-1"], []);
+  expect(install).toHaveBeenCalledWith("", "http://test", "helm", "", "", "", ["repo-1"], []);
 });
 
 it("should not show the custom CA field if using an OCI registry", () => {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -436,21 +436,25 @@ export function AppRepoForm(props: IAppRepoFormProps) {
               </label>
             </Column>
             <Column span={9}>
-              <div className="column-valing-center clr-control-container">
-                <div hidden={type !== TYPE_OCI}>
-                  <label className="clr-control-label" htmlFor="kubeapps-repo-username">
-                    List of Repositories
-                  </label>
-                  <div className="clr-textarea-wrapper">
-                    <textarea
-                      id="kubeapps-oci-repositories"
-                      rows={4}
-                      className="clr-textarea"
-                      placeholder={"nginx, jenkins"}
-                      value={ociRepositories}
-                      onChange={handleOCIRepositoriesChange}
-                    />
-                  </div>
+              <div
+                className="column-valing-center clr-control-container"
+                hidden={type !== TYPE_OCI}
+              >
+                <label className="clr-control-label" htmlFor="kubeapps-repo-username">
+                  List of Repositories
+                </label>
+                <span className="clr-form-description">
+                  Include a list of comma-separated repositories that will be available in Kubeapps.
+                </span>
+                <div className="clr-textarea-wrapper">
+                  <textarea
+                    id="kubeapps-oci-repositories"
+                    rows={4}
+                    className="clr-textarea"
+                    placeholder={"nginx, jenkins"}
+                    value={ociRepositories}
+                    onChange={handleOCIRepositoriesChange}
+                  />
                 </div>
               </div>
             </Column>
@@ -467,7 +471,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
           </label>
           <span className="clr-form-description">
             Select existing secret(s) to access a private Docker registry and pull images from it.
-            Note that this functionality is supported for Kubeapps with Helm3 only, more info{" "}
+            More info{" "}
             <a
               href={`https://github.com/kubeapps/kubeapps/blob/${appVersion}/docs/user/private-app-repository.md`}
               target="_blank"
@@ -487,7 +491,8 @@ export function AppRepoForm(props: IAppRepoFormProps) {
           </div>
         </div>
       )}
-      <div className="clr-form-control">
+      <div className="clr-form-control" hidden={type === TYPE_OCI}>
+        {/* hidden for OCI registries since it's not possible to use a Custom CA Certificate for that */}
         <label className="clr-control-label" htmlFor="kubeapps-repo-custom-ca">
           Custom CA Certificate (optional)
         </label>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -134,13 +134,15 @@ export function AppRepoForm(props: IAppRepoFormProps) {
         break;
     }
     const ociRepoList = ociRepositories.length ? ociRepositories.split(",").map(r => r.trim()) : [];
+    // If the scheme is not specified, assume HTTPS. This is common for OCI registries
+    const finalURL = url.startsWith("http") ? url : `https://${url}`;
     // If the validation already failed and we try to reinstall,
     // skip validation and force install
     const force = validated === false;
     let currentlyValidated = validated;
     if (!validated && !force) {
       currentlyValidated = await dispatch(
-        actions.repos.validateRepo(url, type, finalHeader, customCA, ociRepoList),
+        actions.repos.validateRepo(finalURL, type, finalHeader, customCA, ociRepoList),
       );
       setValidated(currentlyValidated);
     }
@@ -150,7 +152,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
       );
       const success = await onSubmit(
         name,
-        url,
+        finalURL,
         type,
         finalHeader,
         customCA,

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -16,10 +16,12 @@ interface IAppRepoFormProps {
   onSubmit: (
     name: string,
     url: string,
+    type: string,
     authHeader: string,
     customCA: string,
     syncJobPodTemplate: string,
     registrySecrets: string[],
+    ociRepositories: string[],
   ) => Promise<boolean>;
   onAfterInstall?: () => void;
   namespace: string;
@@ -32,6 +34,9 @@ const AUTH_METHOD_NONE = "none";
 const AUTH_METHOD_BASIC = "basic";
 const AUTH_METHOD_BEARER = "bearer";
 const AUTH_METHOD_CUSTOM = "custom";
+
+const TYPE_HELM = "helm";
+const TYPE_OCI = "oci";
 
 export function AppRepoForm(props: IAppRepoFormProps) {
   const { onSubmit, onAfterInstall, namespace, kubeappsNamespace, repo, secret } = props;
@@ -46,6 +51,9 @@ export function AppRepoForm(props: IAppRepoFormProps) {
   const [url, setURL] = useState("");
   const [customCA, setCustomCA] = useState("");
   const [syncJobPodTemplate, setSyncJobTemplate] = useState("");
+  const [type, setType] = useState(TYPE_HELM);
+  const [ociRepositories, setOCIRepositories] = useState("");
+
   const [selectedImagePullSecrets, setSelectedImagePullSecrets] = useState(
     {} as { [key: string]: boolean },
   );
@@ -80,9 +88,11 @@ export function AppRepoForm(props: IAppRepoFormProps) {
     if (repo) {
       setName(repo.metadata.name);
       setURL(repo.spec?.url || "");
+      setType(repo.spec?.type || "");
       setSyncJobTemplate(
         repo.spec?.syncJobPodTemplate ? yaml.dump(repo.spec?.syncJobPodTemplate) : "",
       );
+      setOCIRepositories(repo.spec?.ociRepositories?.join(", ") || "");
       if (secret) {
         if (secret.data["ca.crt"]) {
           setCustomCA(atob(secret.data["ca.crt"]));
@@ -123,12 +133,15 @@ export function AppRepoForm(props: IAppRepoFormProps) {
         finalHeader = `Bearer ${token}`;
         break;
     }
+    const ociRepoList = ociRepositories.length ? ociRepositories.split(",").map(r => r.trim()) : [];
     // If the validation already failed and we try to reinstall,
     // skip validation and force install
     const force = validated === false;
     let currentlyValidated = validated;
     if (!validated && !force) {
-      currentlyValidated = await dispatch(actions.repos.validateRepo(url, finalHeader, customCA));
+      currentlyValidated = await dispatch(
+        actions.repos.validateRepo(url, type, finalHeader, customCA, ociRepoList),
+      );
       setValidated(currentlyValidated);
     }
     if (currentlyValidated || force) {
@@ -138,10 +151,12 @@ export function AppRepoForm(props: IAppRepoFormProps) {
       const success = await onSubmit(
         name,
         url,
+        type,
         finalHeader,
         customCA,
         syncJobPodTemplate,
         imagePullSecretsNames,
+        ociRepoList,
       );
       if (success && onAfterInstall) {
         onAfterInstall();
@@ -170,6 +185,10 @@ export function AppRepoForm(props: IAppRepoFormProps) {
     setAuthMethod(e.target.value);
     setValidated(undefined);
   };
+  const handleTypeRadioButtonChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setType(e.target.value);
+    setValidated(undefined);
+  };
   const handleUserChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUser(e.target.value);
     setValidated(undefined);
@@ -180,6 +199,10 @@ export function AppRepoForm(props: IAppRepoFormProps) {
   };
   const handleSyncJobPodTemplateChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setSyncJobTemplate(e.target.value);
+    setValidated(undefined);
+  };
+  const handleOCIRepositoriesChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setOCIRepositories(e.target.value);
     setValidated(undefined);
   };
 
@@ -366,6 +389,68 @@ export function AppRepoForm(props: IAppRepoFormProps) {
                     value={authHeader}
                     onChange={handleAuthHeaderChange}
                   />
+                </div>
+              </div>
+            </Column>
+          </Row>
+        </div>
+      </div>
+      <div className="clr-form-control">
+        <label className="clr-control-label">Repository Type</label>
+        <span className="clr-form-description">
+          Charts can be stored either in a Helm repository (e.g. ChartMuseum) or in a OCI Registry.
+          Select the one that applies.
+        </span>
+        <div className="clr-form-columns">
+          <Row>
+            <Column span={3}>
+              <label
+                htmlFor="kubeapps-repo-type-helm"
+                className="clr-control-label clr-control-label-radio"
+              >
+                <input
+                  type="radio"
+                  id="kubeapps-repo-type-helm"
+                  name="type"
+                  value={TYPE_HELM}
+                  checked={type === TYPE_HELM}
+                  onChange={handleTypeRadioButtonChange}
+                />
+                Helm Repository
+                <br />
+              </label>
+              <label
+                htmlFor="kubeapps-repo-type-oci"
+                className="clr-control-label clr-control-label-radio"
+              >
+                <input
+                  type="radio"
+                  id="kubeapps-repo-type-oci"
+                  name="type"
+                  value={TYPE_OCI}
+                  checked={type === TYPE_OCI}
+                  onChange={handleTypeRadioButtonChange}
+                />
+                OCI Registry
+                <br />
+              </label>
+            </Column>
+            <Column span={9}>
+              <div className="column-valing-center clr-control-container">
+                <div hidden={type !== TYPE_OCI}>
+                  <label className="clr-control-label" htmlFor="kubeapps-repo-username">
+                    List of Repositories
+                  </label>
+                  <div className="clr-textarea-wrapper">
+                    <textarea
+                      id="kubeapps-oci-repositories"
+                      rows={4}
+                      className="clr-textarea"
+                      placeholder={"nginx, jenkins"}
+                      value={ociRepositories}
+                      onChange={handleOCIRepositoriesChange}
+                    />
+                  </div>
                 </div>
               </div>
             </Column>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -397,10 +397,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
       </div>
       <div className="clr-form-control">
         <label className="clr-control-label">Repository Type</label>
-        <span className="clr-form-description">
-          Charts can be stored either in a Helm repository (e.g. ChartMuseum) or in a OCI Registry.
-          Select the one that applies.
-        </span>
+        <span className="clr-form-description">Select the chart storage type.</span>
         <div className="clr-form-columns">
           <Row>
             <Column span={3}>

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -29,15 +29,26 @@ export class AppRepository {
     name: string,
     namespace: string,
     repoURL: string,
+    type: string,
     authHeader: string,
     customCA: string,
     syncJobPodTemplate: any,
     registrySecrets: string[],
+    ociRepositories: string[],
   ) {
     const { data } = await axiosWithAuth.put<ICreateAppRepositoryResponse>(
       url.backend.apprepositories.update(cluster, namespace, name),
       {
-        appRepository: { name, repoURL, authHeader, customCA, syncJobPodTemplate, registrySecrets },
+        appRepository: {
+          name,
+          repoURL,
+          type,
+          authHeader,
+          customCA,
+          syncJobPodTemplate,
+          registrySecrets,
+          ociRepositories,
+        },
       },
     );
     return data;
@@ -58,15 +69,26 @@ export class AppRepository {
     name: string,
     namespace: string,
     repoURL: string,
+    type: string,
     authHeader: string,
     customCA: string,
     syncJobPodTemplate: any,
     registrySecrets: string[],
+    ociRepositories: string[],
   ) {
     const { data } = await axiosWithAuth.post<ICreateAppRepositoryResponse>(
       url.backend.apprepositories.create(cluster, namespace),
       {
-        appRepository: { name, repoURL, authHeader, customCA, syncJobPodTemplate, registrySecrets },
+        appRepository: {
+          name,
+          repoURL,
+          authHeader,
+          type,
+          customCA,
+          syncJobPodTemplate,
+          registrySecrets,
+          ociRepositories,
+        },
       },
     );
     return data;
@@ -75,11 +97,13 @@ export class AppRepository {
   public static async validate(
     cluster: string,
     repoURL: string,
+    type: string,
     authHeader: string,
     customCA: string,
+    ociRepositories: string[],
   ) {
     const { data } = await axiosWithAuth.post<any>(url.backend.apprepositories.validate(cluster), {
-      appRepository: { repoURL, authHeader, customCA },
+      appRepository: { repoURL, type, authHeader, customCA, ociRepositories },
     });
     return data;
   }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -453,6 +453,7 @@ export interface IAppRepository
       resyncRequests: number;
       syncJobPodTemplate?: object;
       dockerRegistrySecrets?: string[];
+      ociRepositories?: string[];
     },
     undefined
   > {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Enable the usage of OCI registries for AppRepositories: 

![Screenshot from 2021-02-08 14-00-11](https://user-images.githubusercontent.com/4025665/107223191-29520d00-6a16-11eb-984c-e26158344bcb.png)

Note that using a CA cert is not supported as explained here: https://github.com/kubeapps/kubeapps/pull/2323#issuecomment-775029689

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2232 

