### PR TITLE
Allow apiServiceURLs to include subpath in NGINX location

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -6,13 +6,6 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "kubeapps.parseAPIServiceURL" -}}
-{{- $parsed := urlParse . }}
-{{- $baseURL := (printf "%s://%s" (get $parsed "scheme") (get $parsed "host")) }}
-{{- $path := get $parsed "path" }}
-{{ dict "baseURL" $baseURL "path" $path | toYaml }}
-{{- end -}}
-
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "kubeapps.parseAPIServiceURL" -}}
+{{- $parsed := urlParse . }}
+{{- $baseURL := (printf "%s://%s" (get $parsed "scheme") (get $parsed "host")) }}
+{{- $path := get $parsed "path" }}
+{{ dict "baseURL" $baseURL "path" $path | toYaml }}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -62,9 +62,9 @@ data:
     {{/* We need to split the API service URL(s) into the base url and the path segment so
            those configurations using a path can be appropriately rewritten below while
            ensuring the proxy_pass statement is given the base URL only. */}}
-    {{- $parsed := urlParse (default "" .apiServiceURL) }}
-    {{- $apiServiceBaseURL := ternary "" (printf "%s://%s" (get $parsed "scheme") (get $parsed "host")) (empty .apiServiceURL)}}
-    {{- $apiServiceURLPath := get $parsed "path" }}
+    {{- $parsed := urlParse (default "https://kubernetes.default" .apiServiceURL) }}
+    {{- $apiServiceBaseURL := urlJoin (pick $parsed "scheme" "host") }}
+    {{- $apiServiceURLPath := $parsed.path }}
         rewrite /api/clusters/{{ .name }}/(.*) {{ $apiServiceURLPath }}/$1 break;
         rewrite /api/clusters/{{ .name }} {{ $apiServiceURLPath }}/ break;
 
@@ -85,7 +85,7 @@ data:
         proxy_pass http://kubeapps-internal-pinniped-proxy.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
     {{- else }}
         # Otherwise we route directly through to the clusters with existing credentials.
-        proxy_pass {{ default "https://kubernetes.default" $apiServiceBaseURL }};
+        proxy_pass {{ $apiServiceBaseURL }};
     {{- if .certificateAuthorityData }}
         proxy_ssl_trusted_certificate "./server_blocks/{{ .name }}-ca.pem";
     {{- end }}

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -103,6 +103,9 @@ data:
         proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
         {{- end }}
 
+        {{- if .Values.frontend.proxypassExtraSetHeader }}
+        proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
+        {{- end }}
         proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
       }
 
@@ -112,6 +115,9 @@ data:
         proxy_read_timeout 10m;
         rewrite /api/kubeops/(.*) /$1 break;
         rewrite /api/kubeops / break;
+        {{- if .Values.frontend.proxypassExtraSetHeader }}
+        proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
+        {{- end }}
         proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
 
         {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
@@ -130,6 +136,9 @@ data:
         proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
         {{- end }}
 
+        {{- if .Values.frontend.proxypassExtraSetHeader }}
+        proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
+        {{- end }}
         proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
       }
 

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -59,8 +59,12 @@ data:
       # the cluster). See clusters option.
       {{- range .Values.clusters }}
       location ~* /api/clusters/{{ .name }} {
-        rewrite /api/clusters/{{ .name }}/(.*) /$1 break;
-        rewrite /api/clusters/{{ .name }} / break;
+        {{- $apiServiceURL := default "https://kubernetes.default" .apiServiceURL }}
+        {{- $parsed := urlParse $apiServiceURL }}
+        {{- $baseURL := (printf "%s://%s" (get $parsed "scheme") (get $parsed "host")) }}
+        {{- $path := get $parsed "path" }}
+        rewrite /api/clusters/{{ .name }}/(.*) {{ $path }}/$1 break;
+        rewrite /api/clusters/{{ .name }} {{ $path }}/ break;
 
       {{/* Helm returns a nil pointer error when accessing foo.bar if foo doesn't
            exist, even with the `default` function.
@@ -79,7 +83,7 @@ data:
         proxy_pass http://kubeapps-internal-pinniped-proxy.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
       {{- else }}
         # Otherwise we route directly through to the clusters with existing credentials.
-        proxy_pass {{ default "https://kubernetes.default" .apiServiceURL }};
+        proxy_pass {{ $baseURL }};
         {{- if .certificateAuthorityData }}
         proxy_ssl_trusted_certificate "./server_blocks/{{ .name }}-ca.pem";
         {{- end }}

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kubeapps.frontend-config.fullname" . }}
-  labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}
+  labels: {{ include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "kubeapps.frontend-config.fullname" . }}
 data:
   k8s-api-proxy.conf: |-
@@ -22,10 +22,10 @@ data:
     # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
     proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
     {{- end }}
-  {{- range .Values.clusters }}
+    {{- range .Values.clusters }}
   {{- if .certificateAuthorityData }}
   {{ .name }}-ca.pem: {{ .certificateAuthorityData }}
-   {{- end }}
+  {{- end }}
   {{- end}}
   vhost.conf: |-
     # Retain the default nginx handling of requests without a "Connection" header
@@ -40,12 +40,12 @@ data:
 
     server {
       listen 8080;
-  {{- if .Values.frontend.largeClientHeaderBuffers }}
+    {{- if .Values.frontend.largeClientHeaderBuffers }}
       large_client_header_buffers {{ .Values.frontend.largeClientHeaderBuffers }};
-  {{- end }}
-  {{- if .Values.enableIPv6 }}
+    {{- end }}
+    {{- if .Values.enableIPv6 }}
       listen [::]:8080;
-  {{- end}}
+    {{- end}}
       server_name _;
 
       location /healthz {
@@ -57,40 +57,40 @@ data:
       # Ensure each cluster can be reached (should only be
       # used with an auth-proxy where k8s credentials never leave
       # the cluster). See clusters option.
-      {{- range .Values.clusters }}
+    {{- range .Values.clusters }}
       location ~* /api/clusters/{{ .name }} {
-        {{- $apiServiceURL := default "https://kubernetes.default" .apiServiceURL }}
-        {{- $parsed := urlParse $apiServiceURL }}
-        {{- $baseURL := (printf "%s://%s" (get $parsed "scheme") (get $parsed "host")) }}
-        {{- $path := get $parsed "path" }}
+    {{- $apiServiceURL := default "https://kubernetes.default" .apiServiceURL }}
+    {{- $parsed := urlParse $apiServiceURL }}
+    {{- $baseURL := (printf "%s://%s" (get $parsed "scheme") (get $parsed "host")) }}
+    {{- $path := get $parsed "path" }}
         rewrite /api/clusters/{{ .name }}/(.*) {{ $path }}/$1 break;
         rewrite /api/clusters/{{ .name }} {{ $path }}/ break;
 
-      {{/* Helm returns a nil pointer error when accessing foo.bar if foo doesn't
+    {{/* Helm returns a nil pointer error when accessing foo.bar if foo doesn't
            exist, even with the `default` function.
            See https://github.com/helm/helm/issues/8026#issuecomment-756538254 */}}
-      {{- $pinnipedConfig := .pinnipedConfig | default dict }}
-      {{- if and $.Values.pinnipedProxy.enabled $pinnipedConfig.enable }}
+    {{- $pinnipedConfig := .pinnipedConfig | default dict }}
+    {{- if and $.Values.pinnipedProxy.enabled $pinnipedConfig.enable }}
         # If pinniped proxy is enabled *and* the current cluster is configured
         # to exchange credentials then we route via pinnipedProxy to exchange
         # credentials for client certificates.
-        {{- if .apiServiceURL }}
+    {{- if .apiServiceURL }}
         proxy_set_header PINNIPED_PROXY_API_SERVER_URL {{ .apiServiceURL }};
-        {{- end }}
-        {{- if .certificateAuthorityData }}
+    {{- end }}
+    {{- if .certificateAuthorityData }}
         proxy_set_header PINNIPED_PROXY_API_SERVER_CERT {{ .certificateAuthorityData }};
-        {{- end }}
+    {{- end }}
         proxy_pass http://kubeapps-internal-pinniped-proxy.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
-      {{- else }}
+    {{- else }}
         # Otherwise we route directly through to the clusters with existing credentials.
         proxy_pass {{ $baseURL }};
-        {{- if .certificateAuthorityData }}
+    {{- if .certificateAuthorityData }}
         proxy_ssl_trusted_certificate "./server_blocks/{{ .name }}-ca.pem";
-        {{- end }}
-      {{- end }}
+    {{- end }}
+    {{- end }}
         include "./server_blocks/k8s-api-proxy.conf";
       }
-      {{- end }}
+    {{- end }}
 
       # Forward '/api/assetsvc' to '/assetsvc'
       # but preserving the encoding (eg. '%2F' is not converted to '/')
@@ -102,14 +102,14 @@ data:
         rewrite ^ $request_uri; # pass the encoded url downstream as is,
         rewrite /api/assetsvc([^?]*) /assetsvc$1?$args break;
 
-        {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
+    {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
         # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
         proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
-        {{- end }}
+    {{- end }}
 
-        {{- if .Values.frontend.proxypassExtraSetHeader }}
+    {{- if .Values.frontend.proxypassExtraSetHeader }}
         proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
-        {{- end }}
+    {{- end }}
         proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
       }
 
@@ -119,15 +119,15 @@ data:
         proxy_read_timeout 10m;
         rewrite /api/kubeops/(.*) /$1 break;
         rewrite /api/kubeops / break;
-        {{- if .Values.frontend.proxypassExtraSetHeader }}
+    {{- if .Values.frontend.proxypassExtraSetHeader }}
         proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
-        {{- end }}
+    {{- end }}
         proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
 
-        {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
+    {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
         # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
         proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
-        {{- end }}
+    {{- end }}
       }
 
       # The route for the Kubeapps backend API is not prefixed.
@@ -135,14 +135,14 @@ data:
         rewrite /api/(.*) /backend/$1 break;
         rewrite /api/ /backend break;
 
-        {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
+    {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
         # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
         proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
-        {{- end }}
+    {{- end }}
 
-        {{- if .Values.frontend.proxypassExtraSetHeader }}
+    {{- if .Values.frontend.proxypassExtraSetHeader }}
         proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
-        {{- end }}
+    {{- end }}
         proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
       }
 

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -62,9 +62,11 @@ data:
     {{/* We need to split the API service URL(s) into the base url and the path segment so
            those configurations using a path can be appropriately rewritten below while
            ensuring the proxy_pass statement is given the base URL only. */}}
-    {{- $apiServiceURLMap := include "kubeapps.parseAPIServiceURL" .apiServiceURL | fromYaml }}
-        rewrite /api/clusters/{{ .name }}/(.*) {{ $apiServiceURLMap.path }}/$1 break;
-        rewrite /api/clusters/{{ .name }} {{ $apiServiceURLMap.path }}/ break;
+    {{- $parsed := urlParse (default "" .apiServiceURL) }}
+    {{- $apiServiceBaseURL := ternary "" (printf "%s://%s" (get $parsed "scheme") (get $parsed "host")) (empty .apiServiceURL)}}
+    {{- $apiServiceURLPath := get $parsed "path" }}
+        rewrite /api/clusters/{{ .name }}/(.*) {{ $apiServiceURLPath }}/$1 break;
+        rewrite /api/clusters/{{ .name }} {{ $apiServiceURLPath }}/ break;
 
     {{/* Helm returns a nil pointer error when accessing foo.bar if foo doesn't
            exist, even with the `default` function.
@@ -83,7 +85,7 @@ data:
         proxy_pass http://kubeapps-internal-pinniped-proxy.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
     {{- else }}
         # Otherwise we route directly through to the clusters with existing credentials.
-        proxy_pass {{ $apiServiceURLMap.baseURL }};
+        proxy_pass {{ default "https://kubernetes.default" $apiServiceBaseURL }};
     {{- if .certificateAuthorityData }}
         proxy_ssl_trusted_certificate "./server_blocks/{{ .name }}-ca.pem";
     {{- end }}

--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -59,12 +59,12 @@ data:
       # the cluster). See clusters option.
     {{- range .Values.clusters }}
       location ~* /api/clusters/{{ .name }} {
-    {{- $apiServiceURL := default "https://kubernetes.default" .apiServiceURL }}
-    {{- $parsed := urlParse $apiServiceURL }}
-    {{- $baseURL := (printf "%s://%s" (get $parsed "scheme") (get $parsed "host")) }}
-    {{- $path := get $parsed "path" }}
-        rewrite /api/clusters/{{ .name }}/(.*) {{ $path }}/$1 break;
-        rewrite /api/clusters/{{ .name }} {{ $path }}/ break;
+    {{/* We need to split the API service URL(s) into the base url and the path segment so
+           those configurations using a path can be appropriately rewritten below while
+           ensuring the proxy_pass statement is given the base URL only. */}}
+    {{- $apiServiceURLMap := include "kubeapps.parseAPIServiceURL" .apiServiceURL | fromYaml }}
+        rewrite /api/clusters/{{ .name }}/(.*) {{ $apiServiceURLMap.path }}/$1 break;
+        rewrite /api/clusters/{{ .name }} {{ $apiServiceURLMap.path }}/ break;
 
     {{/* Helm returns a nil pointer error when accessing foo.bar if foo doesn't
            exist, even with the `default` function.
@@ -83,7 +83,7 @@ data:
         proxy_pass http://kubeapps-internal-pinniped-proxy.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
     {{- else }}
         # Otherwise we route directly through to the clusters with existing credentials.
-        proxy_pass {{ $baseURL }};
+        proxy_pass {{ $apiServiceURLMap.baseURL }};
     {{- if .certificateAuthorityData }}
         proxy_ssl_trusted_certificate "./server_blocks/{{ .name }}-ca.pem";
     {{- end }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -198,6 +198,10 @@ frontend:
   ## Some K8s distributions such as GKE requires it
   ##
   proxypassAccessTokenAsBearer: false
+
+  ## Set an additional proxy header for or all requests proxied via NGINX to the kubeops backend.
+  # proxypassExtraSetHeader: Authorization "Bearer $cookie_sessionid";
+
   ## Set large_client_header_buffers in nginx config
   ## Can be required when using OIDC or LDAP due to large cookies
   #

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -199,7 +199,10 @@ frontend:
   ##
   proxypassAccessTokenAsBearer: false
 
-  ## Set an additional proxy header for or all requests proxied via NGINX to the kubeops backend.
+  ## Set an additional proxy header for all requests proxied via NGINX to the kubeops backend.
+  ## Authorization header(s) set in this way will be included with the request from kubeops to the
+  ## k8s service API URL.
+  ## Ref: https://github.com/kubeapps/kubeapps/blob/7e31d0e7241f826aa365856c134cf901d40890e7/pkg/http-handler/http-handler.go#L247
   # proxypassExtraSetHeader: Authorization "Bearer $cookie_sessionid";
 
   ## Set large_client_header_buffers in nginx config


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

More context in Slack can be found [here](https://kubernetes.slack.com/archives/C9D3TSUG4/p1612546656047300?thread_ts=1612465715.011500&cid=C9D3TSUG4).

In order to use kubeapps with our API gateway (authenticating proxy), I need to be able to configure an optional k8s API URL _path_ (in addition to the base service URL).

This way I can write an ingress rule that matches that path, and set the base k8s service URL to my ingress service. Voila - kubeapps sits behind our API gateway, like all our other upstream services!

One additional change is needed: In the kubeops NGINX locations (i.e. those that proxy via `proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};`), I need to be able to set an additional proxy header so as to include an `Authorization: Bearer some-token` that kubeops will [in turn](https://github.com/kubeapps/kubeapps/blob/e49b5ee672018e2293b66af1c1e4be11f32782ee/pkg/auth/authgate.go#L23) use when making its request to the k8s backend.


### Benefits

kubeapps charts will now be compatible with [k8s authenticating proxy](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authenticating-proxy) auth strategies like ours!

### Possible drawbacks

As these values would be strictly opt-in there should be no drawbacks.

### Applicable issues

Resolves https://github.com/kubeapps/kubeapps/issues/2253.

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
