### PR TITLE
Some OCI repo form fixes

### DIFF
--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -463,6 +463,30 @@ describe("fetchChartVersionsAndSelectVersion", () => {
       `api/assetsvc/v1/clusters/${cluster}/namespaces/${namespace}/charts/foo/versions`,
     );
   });
+
+  it("selects the latest version by default", async () => {
+    response = {
+      data: [
+        { id: "foo", attributes: { version: "1.0.0" } },
+        { id: "foo", attributes: { version: "1.0.0" } },
+      ],
+    };
+    const expectedActions = [
+      { type: getType(actions.charts.requestCharts) },
+      { type: getType(actions.charts.receiveChartVersions), payload: response.data },
+      {
+        type: getType(actions.charts.selectChartVersion),
+        payload: { chartVersion: response.data[1] },
+      },
+    ];
+    await store.dispatch(
+      actions.charts.fetchChartVersionsAndSelectVersion(cluster, namespace, "foo", ""),
+    );
+    expect(store.getActions()).toEqual(expectedActions);
+    expect(axiosGetMock.mock.calls[0][0]).toBe(
+      `api/assetsvc/v1/clusters/${cluster}/namespaces/${namespace}/charts/foo/versions`,
+    );
+  });
 });
 
 describe("getDeployedChartVersion", () => {

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -1,5 +1,6 @@
 import { JSONSchema4 } from "json-schema";
 import { ThunkAction } from "redux-thunk";
+import * as semver from "semver";
 import { ActionType, createAction } from "typesafe-actions";
 
 import Chart from "../shared/Chart";
@@ -215,7 +216,9 @@ export function fetchChartVersionsAndSelectVersion(
       fetchChartVersions(cluster, namespace, id),
     )) as IChartVersion[];
     if (versions.length > 0) {
-      let cv: IChartVersion = versions[0];
+      let cv: IChartVersion = versions.sort((a, b) =>
+        semver.compare(b.attributes.version, a.attributes.version),
+      )[0];
       if (version) {
         const found = versions.find(v => v.attributes.version === version);
         if (!found) {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -116,6 +116,7 @@ it("should call the install method with OCI information", async () => {
     validateRepo,
   };
   const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} onSubmit={install} />);
+  wrapper.find("#kubeapps-repo-url").simulate("change", { target: { value: "oci.repo" } });
   wrapper.find("#kubeapps-repo-type-oci").simulate("change");
   wrapper
     .find("#kubeapps-oci-repositories")
@@ -125,7 +126,16 @@ it("should call the install method with OCI information", async () => {
     await (form.prop("onSubmit") as (e: any) => Promise<any>)({ preventDefault: jest.fn() });
   });
   wrapper.update();
-  expect(install).toHaveBeenCalledWith("", "", "oci", "", "", "", [], ["apache", "jenkins"]);
+  expect(install).toHaveBeenCalledWith(
+    "",
+    "https://oci.repo",
+    "oci",
+    "",
+    "",
+    "",
+    [],
+    ["apache", "jenkins"],
+  );
 });
 
 it("should not show the docker registry credentials section if the namespace is the global one", () => {
@@ -165,6 +175,7 @@ it("should call the install method with the selected docker credentials", async 
   act(() => {
     label.simulate("change");
   });
+  wrapper.find("#kubeapps-repo-url").simulate("change", { target: { value: "http://test" } });
   wrapper.update();
 
   await act(async () => {
@@ -172,7 +183,7 @@ it("should call the install method with the selected docker credentials", async 
       preventDefault: jest.fn(),
     });
   });
-  expect(install).toHaveBeenCalledWith("", "", "helm", "", "", "", ["repo-1"], []);
+  expect(install).toHaveBeenCalledWith("", "http://test", "helm", "", "", "", ["repo-1"], []);
 });
 
 it("should not show the custom CA field if using an OCI registry", () => {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -134,13 +134,15 @@ export function AppRepoForm(props: IAppRepoFormProps) {
         break;
     }
     const ociRepoList = ociRepositories.length ? ociRepositories.split(",").map(r => r.trim()) : [];
+    // If the scheme is not specified, assume HTTPS. This is common for OCI registries
+    const finalURL = url.startsWith("http") ? url : `https://${url}`;
     // If the validation already failed and we try to reinstall,
     // skip validation and force install
     const force = validated === false;
     let currentlyValidated = validated;
     if (!validated && !force) {
       currentlyValidated = await dispatch(
-        actions.repos.validateRepo(url, type, finalHeader, customCA, ociRepoList),
+        actions.repos.validateRepo(finalURL, type, finalHeader, customCA, ociRepoList),
       );
       setValidated(currentlyValidated);
     }
@@ -150,7 +152,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
       );
       const success = await onSubmit(
         name,
-        url,
+        finalURL,
         type,
         finalHeader,
         customCA,


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

A couple of fixes I noticed when testing the OCI repo sync (on top of #2336):
 - When loading a chart, use the latest version available (using semver).
 - When not using a scheme in the repo form (`http://` or `https://`), assume https://. This is fairly common when using OCI registries.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2232

