### PR TITLE
Use yaml to define customLocale

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -51,7 +51,7 @@ data:
   custom_style.css: |-
 {{- .Values.dashboard.customStyle | nindent 4 }}
   custom_locale.json: |-
-{{- .Values.dashboard.customLocale | nindent 4 }}
+{{- .Values.dashboard.customLocale | toJson | nindent 4 }}
   config.json: |-
     {
       "kubeappsCluster": "{{ template "kubeapps.kubeappsCluster" . -}}",

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -499,10 +499,9 @@ dashboard:
   ## Custom translations injected to the Dashboard to customize the strings used in Kubeapps
   ## Ref: https://github.com/kubeapps/kubeapps/blob/master/docs/developer/translate-kubeapps.md
   ## e.g:
-  ## customLocale: |-
-  ##   {
-  ##     "Kubeapps": "My dashboard",
-  ##   }
+  ## customLocale:
+  ##   "Kubeapps": "My Dashboard"
+  ##   "login-oidc": "Login with my company SSO"
   customLocale: ""
 
 ## PostgreSQL chart configuration


### PR DESCRIPTION
### Description of the change

Autoconvert from yaml to json for easing the process of writing a custom locale

### Benefits

Users will write yaml instead of json

### Possible drawbacks

N/A

### Applicable issues

  - related #2346 

### Additional information

N/A
