### PR TITLE
Add custom_style and custom_locale to the skip-auth

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -68,6 +68,8 @@ spec:
             - --pass-access-token=true
             - --pass-authorization-header=true
             - --skip-auth-regex=^\/config\.json$
+            - --skip-auth-regex=^\/custom_style\.css$
+            - --skip-auth-regex=^\/custom_locale\.json$
             - --skip-auth-regex=^\/favicon.*\.png$
             - --skip-auth-regex=^\/static\/
             - --skip-auth-regex=^\/$


### PR DESCRIPTION
### Description of the change

When testing the translation feature in an OIDC scenario, requests to the custom style and locale were 403-blocked. This PR just add both files to the skip flags of the authProxy.

### Benefits

Custom styles and locales can be used in the OIDC login page

### Possible drawbacks

N/A

### Applicable issues

  - related #2346 

### Additional information

N/A
