### PR TITLE
Pull charts in parallel

### DIFF
--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -533,12 +533,14 @@ func (r *OCIRegistry) Charts() ([]models.Chart, error) {
 	}()
 
 	log.Debugf("starting %d workers", numWorkers)
-	for _, appName := range r.repositories {
-		for _, tag := range r.tags[appName].Tags {
-			chartJobs <- pullChartJob{AppName: appName, Tag: tag}
+	go func() {
+		for _, appName := range r.repositories {
+			for _, tag := range r.tags[appName].Tags {
+				chartJobs <- pullChartJob{AppName: appName, Tag: tag}
+			}
 		}
-	}
-	close(chartJobs)
+		close(chartJobs)
+	}()
 
 	// Start receiving charts
 	for res := range chartResults {

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -811,13 +811,13 @@ func Test_ociAPICli(t *testing.T) {
 		}
 	})
 
-	t.Run("FilterChartTags - failed request", func(t *testing.T) {
+	t.Run("IsHelmChart - failed request", func(t *testing.T) {
 		netClient = &badHTTPClient{}
-		err := apiCli.FilterChartTags(&TagList{Name: "test/apache", Tags: []string{"7.5.1", "8.1.1"}})
+		_, err := apiCli.IsHelmChart("apache", "7.5.1")
 		assert.Err(t, fmt.Errorf("request failed: "), err)
 	})
 
-	t.Run("FilterChartTags - successful request", func(t *testing.T) {
+	t.Run("IsHelmChart - successful request", func(t *testing.T) {
 		netClient = &goodOCIAPIHTTPClient{
 			responseByPath: map[string]string{
 				// 7.5.1 is not a chart
@@ -825,12 +825,15 @@ func Test_ociAPICli(t *testing.T) {
 				"/v2/test/apache/manifests/8.1.1": `{"schemaVersion":2,"config":{"mediaType":"application/vnd.cncf.helm.config.v1+json","digest":"sha256:123","size":665}}`,
 			},
 		}
-		tagList := &TagList{Name: "test/apache", Tags: []string{"7.5.1", "8.1.1"}}
-		err := apiCli.FilterChartTags(tagList)
+		is751, err := apiCli.IsHelmChart("test/apache", "7.5.1")
 		assert.NoErr(t, err)
-		expectedTagList := &TagList{Name: "test/apache", Tags: []string{"8.1.1"}}
-		if !cmp.Equal(tagList, expectedTagList) {
-			t.Errorf("Unexpected result %v", cmp.Diff(tagList, expectedTagList))
+		if is751 {
+			t.Errorf("Tag 7.5.1 should not be a helm chart")
+		}
+		is811, err := apiCli.IsHelmChart("test/apache", "8.1.1")
+		assert.NoErr(t, err)
+		if !is811 {
+			t.Errorf("Tag 8.1.1 should be a helm chart")
 		}
 	})
 }
@@ -844,8 +847,8 @@ func (o *fakeOCIAPICli) TagList(appName string) (*TagList, error) {
 	return o.tagList, o.err
 }
 
-func (o *fakeOCIAPICli) FilterChartTags(tagList *TagList) error {
-	return o.err
+func (o *fakeOCIAPICli) IsHelmChart(appName, tag string) (bool, error) {
+	return true, o.err
 }
 
 func Test_OCIRegistry(t *testing.T) {

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -841,7 +841,6 @@ type fakeOCIAPICli struct {
 }
 
 func (o *fakeOCIAPICli) TagList(appName string) (*TagList, error) {
-	fmt.Printf("Returning ! %v", o.err)
 	return o.tagList, o.err
 }
 
@@ -967,6 +966,7 @@ version: 1.0.0
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
+			log.SetLevel(log.DebugLevel)
 			w := httptest.NewRecorder()
 			gzw := gzip.NewWriter(w)
 			createTestTarball(gzw, tt.ociArtifactFiles)

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -810,7 +810,7 @@ func TestOCIClient(t *testing.T) {
 		cli := NewOCIClient("foo")
 		cli.(*OCIClient).puller = &helmfake.OCIPuller{}
 		_, err := cli.GetChart(nil, "foo")
-		assert.Equal(t, "parse foo: invalid URI for request", err.Error(), "error")
+		assert.Equal(t, "parse \"foo\": invalid URI for request", err.Error(), "error")
 	})
 
 	t.Run("GetChart - Returns a chart", func(t *testing.T) {

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -810,7 +811,9 @@ func TestOCIClient(t *testing.T) {
 		cli := NewOCIClient("foo")
 		cli.(*OCIClient).puller = &helmfake.OCIPuller{}
 		_, err := cli.GetChart(nil, "foo")
-		assert.Equal(t, "parse \"foo\": invalid URI for request", err.Error(), "error")
+		if !strings.Contains(err.Error(), "invalid URI for request") {
+			t.Errorf("Unexpected error %v", err)
+		}
 	})
 
 	t.Run("GetChart - Returns a chart", func(t *testing.T) {

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -63,7 +63,7 @@ type OCIPuller struct {
 func (p *OCIPuller) PullOCIChart(ociFullName string) (*bytes.Buffer, string, error) {
 	store := content.NewMemoryStore()
 
-	desc, layerDescriptors, err := oras.Pull(ctx(os.Stdout, log.GetLevel() == log.DebugLevel), p.Resolver, ociFullName, store,
+	desc, layerDescriptors, err := oras.Pull(ctx(os.Stdout, log.GetLevel() == log.TraceLevel), p.Resolver, ociFullName, store,
 		oras.WithPullEmptyNameAllowed(),
 		oras.WithAllowedMediaTypes(KnownMediaTypes()))
 	if err != nil {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Right now, there is a mechanism to download files (tarballs) in parallel for the Helm repository case but not for OCI charts. This PR implements this.

### Benefits

The sync process is quite faster (the pulling process is now 5x faster in the test I've done).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2232 

### Additional information

I noticed that the process of getting the list of tags is almost as slow as the process of pulling charts so I will do another PR to query that in parallel as well.