### PR TITLE
Request tags in parallel

### DIFF
--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -74,6 +74,17 @@ type pullChartResult struct {
 	Error error
 }
 
+type checkTagJob struct {
+	AppName string
+	Tag     string
+}
+
+type checkTagResult struct {
+	checkTagJob
+	isHelmChart bool
+	Error       error
+}
+
 type httpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -293,7 +304,7 @@ type OCIManifest struct {
 
 type ociAPI interface {
 	TagList(appName string) (*TagList, error)
-	FilterChartTags(tagList *TagList) error
+	IsHelmChart(appName, tag string) (bool, error)
 }
 
 type ociAPICli struct {
@@ -318,57 +329,89 @@ func (o *ociAPICli) TagList(appName string) (*TagList, error) {
 	return &appTags, nil
 }
 
-// FilterChartTags modifies tagList and remove artifacts in other formats (e.g. Docker images)
-func (o *ociAPICli) FilterChartTags(tagList *TagList) error {
-	url := *o.url
-	chartTags := []string{}
-	for _, tag := range tagList.Tags {
-		url.Path = path.Join("v2", tagList.Name, "manifests", tag)
-		log.Debugf("getting tag %s", url.String())
-		manifestData, err := doReq(
-			url.String(),
-			map[string]string{
-				"Authorization": o.authHeader,
-				"Accept":        "application/vnd.oci.image.manifest.v1+json",
-			})
-		if err != nil {
-			return err
-		}
-		var manifest OCIManifest
-		err = json.Unmarshal(manifestData, &manifest)
-		if err != nil {
-			return err
-		}
-		if manifest.Config.MediaType == helm.HelmChartConfigMediaType {
-			chartTags = append(chartTags, tag)
-		}
+func (o *ociAPICli) IsHelmChart(appName, tag string) (bool, error) {
+	repoURL := *o.url
+	repoURL.Path = path.Join("v2", repoURL.Path, appName, "manifests", tag)
+	log.Debugf("getting tag %s", repoURL.String())
+	manifestData, err := doReq(
+		repoURL.String(),
+		map[string]string{
+			"Authorization": o.authHeader,
+			"Accept":        "application/vnd.oci.image.manifest.v1+json",
+		})
+	if err != nil {
+		return false, err
 	}
-	tagList.Tags = chartTags
-	return nil
+	var manifest OCIManifest
+	err = json.Unmarshal(manifestData, &manifest)
+	if err != nil {
+		return false, err
+	}
+	return manifest.Config.MediaType == helm.HelmChartConfigMediaType, nil
+}
+
+func tagCheckerWorker(o ociAPI, tagJobs <-chan checkTagJob, resultChan chan checkTagResult) {
+	for j := range tagJobs {
+		isHelmChart, err := o.IsHelmChart(j.AppName, j.Tag)
+		resultChan <- checkTagResult{j, isHelmChart, err}
+	}
 }
 
 // Checksum returns the sha256 of the repo by concatenating tags for
 // all repositories within the registry and returning the sha256.
 // Caveat: Mutated image tags won't be detected as new
 func (r *OCIRegistry) Checksum() (string, error) {
-	tagList := map[string]TagList{}
+	r.tags = map[string]TagList{}
+	checktagJobs := make(chan checkTagJob, numWorkers)
+	tagcheckRes := make(chan checkTagResult)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	totalTags := 0
+
+	// Process 10 tags at a time
+	for i := 0; i < numWorkers; i++ {
+		go tagCheckerWorker(r.ociCli, checktagJobs, tagcheckRes)
+	}
+
+	// Start receiving charts
+	processedTags := 0
+	go func() {
+		for res := range tagcheckRes {
+			if res.Error == nil {
+				if res.isHelmChart {
+					r.tags[res.AppName] = TagList{
+						Name: r.tags[res.AppName].Name,
+						Tags: append(r.tags[res.AppName].Tags, res.Tag),
+					}
+				}
+			} else {
+				log.Errorf("failed to pull chart. Got %v", res.Error)
+			}
+			processedTags++
+			if processedTags == totalTags {
+				wg.Done()
+			}
+		}
+	}()
+
 	for _, appName := range r.repositories {
 		log.Debugf("Getting tags from %s", appName)
 		tags, err := r.ociCli.TagList(appName)
 		if err != nil {
 			return "", err
 		}
-		log.Debugf("Filtering tags from %s", appName)
-		err = r.ociCli.FilterChartTags(tags)
-		if err != nil {
-			return "", err
+		totalTags += len(tags.Tags)
+		r.tags[appName] = TagList{Name: tags.Name, Tags: []string{}}
+		for _, tag := range tags.Tags {
+			checktagJobs <- checkTagJob{AppName: appName, Tag: tag}
 		}
-
-		tagList[appName] = *tags
 	}
-	r.tags = tagList
+	close(checktagJobs)
+	// Wait for the worker pools to finish processing
+	wg.Wait()
 
-	content, err := json.Marshal(tagList)
+	log.Debugf("Final list of tags: %v", r.tags)
+	content, err := json.Marshal(r.tags)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -811,13 +811,13 @@ func Test_ociAPICli(t *testing.T) {
 		}
 	})
 
-	t.Run("FilterChartTags - failed request", func(t *testing.T) {
+	t.Run("IsHelmChart - failed request", func(t *testing.T) {
 		netClient = &badHTTPClient{}
-		err := apiCli.FilterChartTags(&TagList{Name: "test/apache", Tags: []string{"7.5.1", "8.1.1"}})
+		_, err := apiCli.IsHelmChart("apache", "7.5.1")
 		assert.Err(t, fmt.Errorf("request failed: "), err)
 	})
 
-	t.Run("FilterChartTags - successful request", func(t *testing.T) {
+	t.Run("IsHelmChart - successful request", func(t *testing.T) {
 		netClient = &goodOCIAPIHTTPClient{
 			responseByPath: map[string]string{
 				// 7.5.1 is not a chart
@@ -825,12 +825,15 @@ func Test_ociAPICli(t *testing.T) {
 				"/v2/test/apache/manifests/8.1.1": `{"schemaVersion":2,"config":{"mediaType":"application/vnd.cncf.helm.config.v1+json","digest":"sha256:123","size":665}}`,
 			},
 		}
-		tagList := &TagList{Name: "test/apache", Tags: []string{"7.5.1", "8.1.1"}}
-		err := apiCli.FilterChartTags(tagList)
+		is751, err := apiCli.IsHelmChart("test/apache", "7.5.1")
 		assert.NoErr(t, err)
-		expectedTagList := &TagList{Name: "test/apache", Tags: []string{"8.1.1"}}
-		if !cmp.Equal(tagList, expectedTagList) {
-			t.Errorf("Unexpected result %v", cmp.Diff(tagList, expectedTagList))
+		if is751 {
+			t.Errorf("Tag 7.5.1 should not be a helm chart")
+		}
+		is811, err := apiCli.IsHelmChart("test/apache", "8.1.1")
+		assert.NoErr(t, err)
+		if !is811 {
+			t.Errorf("Tag 8.1.1 should be a helm chart")
 		}
 	})
 }
@@ -844,8 +847,8 @@ func (o *fakeOCIAPICli) TagList(appName string) (*TagList, error) {
 	return o.tagList, o.err
 }
 
-func (o *fakeOCIAPICli) FilterChartTags(tagList *TagList) error {
-	return o.err
+func (o *fakeOCIAPICli) IsHelmChart(appName, tag string) (bool, error) {
+	return true, o.err
 }
 
 func Test_OCIRegistry(t *testing.T) {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Similar to #2373 but this time for getting tags. As mentioned in that issue, checking tag per tag is a bit slow (since it requires an API request per tag) so doing it in parallel improves a lot the total time took.

### Benefits

From the test run, I got a 10x faster sync in the part of the sync that checks the tags.

In total (this PR plus the previous one), my test sync went from ~25 to 4 minutes.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2232
