### PR TITLE
fix deploy other clusters

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -175,7 +175,7 @@ func CreateRelease(cfg Config, w http.ResponseWriter, req *http.Request, params 
 		returnErrMessage(err, w)
 		return
 	}
-	appRepo, caCertSecret, authSecret, err := chart.GetAppRepoAndRelatedSecrets(chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, cfg.KubeHandler, cfg.Token, cfg.Cluster, cfg.Options.KubeappsNamespace)
+	appRepo, caCertSecret, authSecret, err := chart.GetAppRepoAndRelatedSecrets(chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, cfg.KubeHandler, cfg.Token, cfg.Options.ClustersConfig.KubeappsClusterName, cfg.Options.KubeappsNamespace)
 	if err != nil {
 		returnErrMessage(fmt.Errorf("unable to get app repository %q: %v", chartDetails.AppRepositoryResourceName, err), w)
 		return

--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -175,6 +175,7 @@ func CreateRelease(cfg Config, w http.ResponseWriter, req *http.Request, params 
 		returnErrMessage(err, w)
 		return
 	}
+	// TODO: currently app repositories are only supported on the cluster on which Kubeapps is installed. #1982
 	appRepo, caCertSecret, authSecret, err := chart.GetAppRepoAndRelatedSecrets(chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, cfg.KubeHandler, cfg.Token, cfg.Options.ClustersConfig.KubeappsClusterName, cfg.Options.KubeappsNamespace)
 	if err != nil {
 		returnErrMessage(fmt.Errorf("unable to get app repository %q: %v", chartDetails.AppRepositoryResourceName, err), w)

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -31,15 +31,14 @@ import (
 const clustersCAFilesPrefix = "/etc/additional-clusters-cafiles"
 
 var (
-	additionalClustersConfigPath string
-	clustersConfigPath           string
-	assetsvcURL                  string
-	helmDriverArg                string
-	listLimit                    int
-	pinnipedProxyURL             string
-	settings                     environment.EnvSettings
-	timeout                      int64
-	userAgentComment             string
+	clustersConfigPath string
+	assetsvcURL        string
+	helmDriverArg      string
+	listLimit          int
+	pinnipedProxyURL   string
+	settings           environment.EnvSettings
+	timeout            int64
+	userAgentComment   string
 )
 
 func init() {
@@ -51,7 +50,6 @@ func init() {
 	// Default timeout from https://github.com/helm/helm/blob/b0b0accdfc84e154b3d48ec334cd5b4f9b345667/cmd/helm/install.go#L216
 	pflag.Int64Var(&timeout, "timeout", 300, "Timeout to perform release operations (install, upgrade, rollback, delete)")
 	pflag.StringVar(&clustersConfigPath, "clusters-config-path", "", "Configuration for clusters")
-	pflag.StringVar(&additionalClustersConfigPath, "additional-clusters-config-path", "", "Configuration for clusters")
 	pflag.StringVar(&pinnipedProxyURL, "pinniped-proxy-url", "http://kubeapps-internal-pinniped-proxy.kubeapps:3333", "internal url to be used for requests to clusters configured for credential proxying via pinniped")
 }
 
@@ -66,10 +64,6 @@ func main() {
 
 	// If there is no clusters config, we default to the previous behaviour of a "default" cluster.
 	clustersConfig := kube.ClustersConfig{KubeappsClusterName: "default"}
-	// TODO(absoludity): remove support for --additional-clusters-config-path once we're +2 releases away.
-	if clustersConfigPath == "" && additionalClustersConfigPath != "" {
-		clustersConfigPath = additionalClustersConfigPath
-	}
 	if clustersConfigPath != "" {
 		var err error
 		var cleanupCAFiles func()


### PR DESCRIPTION
### Description of the change

Currently deploying to an additional cluster fails due to a recent change (see [comment](https://github.com/kubeapps/kubeapps/pull/2310/files#r574249840)) which switched from fetching an AppRepository only ever from the Kubeapps cluster to instead trying to fetch the AppRepository from the *current* cluster.

### Benefits

You can once again deploy to other clusters.

### Possible drawbacks

Not as a result of this, but we currently don't test deploying to other clusters in CI. We should (#2367).

