### PR TITLE
Display scrollbar in the catalog to prevent blinking

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.scss
+++ b/dashboard/src/components/Catalog/Catalog.scss
@@ -33,3 +33,7 @@
   margin-top: 2rem;
   text-align: center;
 }
+
+.kubeapps-main-container .content-area {
+  overflow-y: scroll;
+}


### PR DESCRIPTION
### Description of the change

This PR just forces the vertical scrollbar to appear to prevent it to blink while fetching filtered and paginated charts in the catalog.

The issue is caused by:

```jsx
{!hasFinishedFetching && !isFetching && (
  <div className="scrollHandler" ref={observeBorder} />
)}
```

This `scrollHandler` has an overflow of about 50% vertical viewport to allow scrolling down to fetch more when in a natural way.
I've also tried hiding (`visitbility: hidden`) instead of not rendering it, but the interactionObserver API doesn't trigger as expected (no UI shaking, but tons of messed up HTTP requests...)

Since the scroll is, now, an inherent feature of the catalog, a possible workaround is just to force the scrollbar to always appear.


### Benefits

The bug described in #2290 won't happen anymore if we always display the vertical scrollbar.
### Possible drawbacks

The scrollbar will always appear, regardless of the number of charts loaded. Example:

![image](https://user-images.githubusercontent.com/11535726/108050965-997e1580-704a-11eb-9546-5c24d387e1df.png)


### Applicable issues

  - fixes #2290 

### Additional information

N/A