### PR TITLE
Allow to skip TLS verification and use a custom CA

### DIFF
--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -603,6 +603,10 @@ func apprepoSyncJobArgs(apprepo *apprepov1alpha1.AppRepository, config Config) [
 		args = append(args, "--oci-repositories", strings.Join(apprepo.Spec.OCIRepositories, ","))
 	}
 
+	if apprepo.Spec.TLSInsecureSkipVerify {
+		args = append(args, "--tls-insecure-skip-verify")
+	}
+
 	return args
 }
 

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -939,6 +939,89 @@ func Test_newSyncJob(t *testing.T) {
 				},
 			},
 		},
+		{
+			"Skip TLS verification",
+			"",
+			&apprepov1alpha1.AppRepository{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AppRepository",
+					APIVersion: "kubeapps.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-charts",
+					Namespace: "kubeapps",
+					Labels: map[string]string{
+						"name":       "my-charts",
+						"created-by": "kubeapps",
+					},
+				},
+				Spec: apprepov1alpha1.AppRepositorySpec{
+					Type:                  "oci",
+					URL:                   "https://charts.acme.com/my-charts",
+					OCIRepositories:       []string{"apache", "jenkins"},
+					TLSInsecureSkipVerify: true,
+				},
+			},
+			batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "apprepo-kubeapps-sync-my-charts-",
+					OwnerReferences: []metav1.OwnerReference{
+						*metav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
+							schema.GroupVersionKind{
+								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
+								Version: apprepov1alpha1.SchemeGroupVersion.Version,
+								Kind:    "AppRepository",
+							},
+						),
+					},
+				},
+				Spec: batchv1.JobSpec{
+					TTLSecondsAfterFinished: &defaultTTL,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								LabelRepoName:      "my-charts",
+								LabelRepoNamespace: "kubeapps",
+							},
+						},
+						Spec: corev1.PodSpec{
+							RestartPolicy: "OnFailure",
+							Containers: []corev1.Container{
+								{
+									Name:            "sync",
+									Image:           repoSyncImage,
+									ImagePullPolicy: "IfNotPresent",
+									Command:         []string{"/chart-repo"},
+									Args: []string{
+										"sync",
+										"--database-url=postgresql.kubeapps",
+										"--database-user=admin",
+										"--database-name=assets",
+										"--namespace=kubeapps",
+										"my-charts",
+										"https://charts.acme.com/my-charts",
+										"oci",
+										"--oci-repositories",
+										"apache,jenkins",
+										"--tls-insecure-skip-verify",
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: "DB_PASSWORD",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+										},
+									},
+									VolumeMounts: nil,
+								},
+							},
+							Volumes: nil,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
@@ -48,6 +48,8 @@ type AppRepositorySpec struct {
 	// In case of an OCI type, the list of repositories is needed
 	// as there is no API for the index
 	OCIRepositories []string `json:"ociRepositories,omitempty"`
+	// TLSInsecureSkipVerify skips TLS verification
+	TLSInsecureSkipVerify bool `json:"tlsInsecureSkipVerify,omitempty"`
 }
 
 // AppRepositoryAuth is the auth for an AppRepository resource

--- a/cmd/asset-syncer/main.go
+++ b/cmd/asset-syncer/main.go
@@ -23,13 +23,14 @@ import (
 )
 
 var (
-	databaseURL      string
-	databaseName     string
-	databaseUser     string
-	databasePassword string
-	debug            bool
-	namespace        string
-	ociRepositories  []string
+	databaseURL           string
+	databaseName          string
+	databaseUser          string
+	databasePassword      string
+	debug                 bool
+	namespace             string
+	ociRepositories       []string
+	tlsInsecureSkipVerify bool
 )
 
 var rootCmd = &cobra.Command{
@@ -55,6 +56,7 @@ func init() {
 	// User agent configuration can be found in version.go. Check that file for more details
 	rootCmd.PersistentFlags().StringVar(&userAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "verbose logging")
+	rootCmd.PersistentFlags().BoolVar(&tlsInsecureSkipVerify, "tls-insecure-skip-verify", false, "Skip TLS verification")
 
 	databasePassword = os.Getenv("DB_PASSWORD")
 

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -52,12 +52,17 @@ var syncCmd = &cobra.Command{
 		}
 		defer manager.Close()
 
+		netClient, err := initNetClient(additionalCAFile)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		authorizationHeader := os.Getenv("AUTHORIZATION_HEADER")
 		var repoIface Repo
 		if args[2] == "helm" {
-			repoIface, err = getHelmRepo(namespace, args[0], args[1], authorizationHeader)
+			repoIface, err = getHelmRepo(namespace, args[0], args[1], authorizationHeader, netClient)
 		} else {
-			repoIface, err = getOCIRepo(namespace, args[0], args[1], authorizationHeader, ociRepositories)
+			repoIface, err = getOCIRepo(namespace, args[0], args[1], authorizationHeader, ociRepositories, netClient)
 		}
 		if err != nil {
 			logrus.Fatal(err)
@@ -84,7 +89,7 @@ var syncCmd = &cobra.Command{
 		}
 
 		// Fetch and store chart icons
-		fImporter := fileImporter{manager}
+		fImporter := fileImporter{manager, netClient}
 		fImporter.fetchFiles(charts, repoIface)
 
 		// Update cache in the database

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -52,7 +52,7 @@ var syncCmd = &cobra.Command{
 		}
 		defer manager.Close()
 
-		netClient, err := initNetClient(additionalCAFile)
+		netClient, err := initNetClient(additionalCAFile, tlsInsecureSkipVerify)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -89,20 +89,20 @@ type httpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-var netClient httpClient = &http.Client{}
+// var netClient httpClient = &http.Client{}
 
 func parseRepoURL(repoURL string) (*url.URL, error) {
 	repoURL = strings.TrimSpace(repoURL)
 	return url.ParseRequestURI(repoURL)
 }
 
-func init() {
-	var err error
-	netClient, err = initNetClient(additionalCAFile)
-	if err != nil {
-		log.Fatal(err)
-	}
-}
+// func init() {
+// 	var err error
+// 	netClient, err = initNetClient(additionalCAFile)
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
+// }
 
 type assetManager interface {
 	Delete(repo models.Repo) error
@@ -142,6 +142,7 @@ type Repo interface {
 type HelmRepo struct {
 	content []byte
 	*models.RepoInternal
+	netClient httpClient
 }
 
 // Checksum returns the sha256 of the repo
@@ -193,7 +194,7 @@ func (r *HelmRepo) FetchFiles(name string, cv models.ChartVersion) (map[string]s
 		req.Header.Set("Authorization", r.AuthorizationHeader)
 	}
 
-	res, err := netClient.Do(req)
+	res, err := r.netClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +259,7 @@ type OCIRegistry struct {
 	ociCli ociAPI
 }
 
-func doReq(url string, headers map[string]string) ([]byte, error) {
+func doReq(url string, cli httpClient, headers map[string]string) ([]byte, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -269,7 +270,7 @@ func doReq(url string, headers map[string]string) ([]byte, error) {
 		req.Header.Set(header, content)
 	}
 
-	res, err := netClient.Do(req)
+	res, err := cli.Do(req)
 	if res != nil {
 		defer res.Body.Close()
 	}
@@ -310,13 +311,14 @@ type ociAPI interface {
 type ociAPICli struct {
 	authHeader string
 	url        *url.URL
+	netClient  httpClient
 }
 
 // TagList retrieves the list of tags for an asset
 func (o *ociAPICli) TagList(appName string) (*TagList, error) {
 	url := *o.url
 	url.Path = path.Join("v2", url.Path, appName, "tags", "list")
-	data, err := doReq(url.String(), map[string]string{"Authorization": o.authHeader})
+	data, err := doReq(url.String(), o.netClient, map[string]string{"Authorization": o.authHeader})
 	if err != nil {
 		return nil, err
 	}
@@ -335,6 +337,7 @@ func (o *ociAPICli) IsHelmChart(appName, tag string) (bool, error) {
 	log.Debugf("getting tag %s", repoURL.String())
 	manifestData, err := doReq(
 		repoURL.String(),
+		o.netClient,
 		map[string]string{
 			"Authorization": o.authHeader,
 			"Accept":        "application/vnd.oci.image.manifest.v1+json",
@@ -618,22 +621,31 @@ func (r *OCIRegistry) FetchFiles(name string, cv models.ChartVersion) (map[strin
 	}, nil
 }
 
-func getHelmRepo(namespace, name, repoURL, authorizationHeader string) (Repo, error) {
+func getHelmRepo(namespace, name, repoURL, authorizationHeader string, netClient httpClient) (Repo, error) {
 	url, err := parseRepoURL(repoURL)
 	if err != nil {
 		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
 		return nil, err
 	}
 
-	repoBytes, err := fetchRepoIndex(url.String(), authorizationHeader)
+	repoBytes, err := fetchRepoIndex(url.String(), authorizationHeader, netClient)
 	if err != nil {
 		return nil, err
 	}
 
-	return &HelmRepo{content: repoBytes, RepoInternal: &models.RepoInternal{Namespace: namespace, Name: name, URL: url.String(), AuthorizationHeader: authorizationHeader}}, nil
+	return &HelmRepo{
+		content: repoBytes,
+		RepoInternal: &models.RepoInternal{
+			Namespace:           namespace,
+			Name:                name,
+			URL:                 url.String(),
+			AuthorizationHeader: authorizationHeader,
+		},
+		netClient: netClient,
+	}, nil
 }
 
-func getOCIRepo(namespace, name, repoURL, authorizationHeader string, ociRepos []string) (Repo, error) {
+func getOCIRepo(namespace, name, repoURL, authorizationHeader string, ociRepos []string, netClient httpClient) (Repo, error) {
 	url, err := parseRepoURL(repoURL)
 	if err != nil {
 		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
@@ -649,18 +661,18 @@ func getOCIRepo(namespace, name, repoURL, authorizationHeader string, ociRepos [
 		repositories: ociRepos,
 		RepoInternal: &models.RepoInternal{Namespace: namespace, Name: name, URL: url.String(), AuthorizationHeader: authorizationHeader},
 		puller:       &helm.OCIPuller{Resolver: ociResolver},
-		ociCli:       &ociAPICli{authHeader: authorizationHeader, url: url},
+		ociCli:       &ociAPICli{authHeader: authorizationHeader, url: url, netClient: netClient},
 	}, nil
 }
 
-func fetchRepoIndex(url, authHeader string) ([]byte, error) {
+func fetchRepoIndex(url, authHeader string, cli httpClient) ([]byte, error) {
 	indexURL, err := parseRepoURL(url)
 	if err != nil {
 		log.WithFields(log.Fields{"url": url}).WithError(err).Error("failed to parse URL")
 		return nil, err
 	}
 	indexURL.Path = path.Join(indexURL.Path, "index.yaml")
-	return doReq(indexURL.String(), map[string]string{"Authorization": authHeader})
+	return doReq(indexURL.String(), cli, map[string]string{"Authorization": authHeader})
 }
 
 func parseRepoIndex(body []byte) (*helmrepo.IndexFile, error) {
@@ -768,7 +780,8 @@ func initNetClient(additionalCA string) (*http.Client, error) {
 }
 
 type fileImporter struct {
-	manager assetManager
+	manager   assetManager
+	netClient httpClient
 }
 
 func (f *fileImporter) fetchFiles(charts []models.Chart, repo Repo) {
@@ -844,7 +857,7 @@ func (f *fileImporter) fetchAndImportIcon(c models.Chart, r *models.RepoInternal
 		req.Header.Set("Authorization", r.AuthorizationHeader)
 	}
 
-	res, err := netClient.Do(req)
+	res, err := f.netClient.Do(req)
 	if res != nil {
 		defer res.Body.Close()
 	}

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -201,7 +201,7 @@ func Test_syncURLInvalidity(t *testing.T) {
 
 func Test_getOCIRepo(t *testing.T) {
 	t.Run("it should add the auth header to the resolver", func(t *testing.T) {
-		repo, _ := getOCIRepo("namespace", "test", "https://test", "Basic auth", []string{}, &goodHTTPClient{})
+		repo, _ := getOCIRepo("namespace", "test", "https://test", "Basic auth", []string{}, &http.Client{})
 		helmtest.CheckHeader(t, repo.(*OCIRegistry).puller, "Authorization", "Basic auth")
 	})
 }
@@ -466,7 +466,7 @@ h251U/Daz6NiQBM9AxyAw6EHm8XAZBvCuebfzyrT
 		t.Error(err)
 	}
 
-	_, err = initNetClient(otherCA)
+	_, err = initNetClient(otherCA, false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -19,7 +19,6 @@ package chart
 import (
 	"bytes"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -384,14 +383,9 @@ func (c *OCIClient) InitClient(appRepo *appRepov1.AppRepository, caCertSecret *c
 	headers := http.Header{
 		"User-Agent": []string{c.userAgent},
 	}
-	// TODO: Use a CA certificate when https://github.com/deislabs/oras/issues/217 is fixed
-	netClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: appRepo.Spec.TLSInsecureSkipVerify,
-			},
-			Proxy: http.ProxyFromEnvironment,
-		},
+	netClient, err := kube.InitHTTPClient(appRepo, caCertSecret)
+	if err != nil {
+		return err
 	}
 	if authSecret != nil && appRepo.Spec.Auth.Header != nil {
 		var auth string

--- a/pkg/kube/http_utils.go
+++ b/pkg/kube/http_utils.go
@@ -71,9 +71,8 @@ func GetData(key string, s *corev1.Secret) (string, error) {
 	return auth, nil
 }
 
-// InitNetClient returns an HTTP client based on the chart details loading a
-// custom CA if provided (as a secret)
-func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *corev1.Secret, defaultHeaders http.Header) (HTTPClient, error) {
+// InitHTTPClient returns a HTTP client using the configuration from the apprepo and CA secret given.
+func InitHTTPClient(appRepo *v1alpha1.AppRepository, caCertSecret *corev1.Secret) (*http.Client, error) {
 	// Require the SystemCertPool unless the env var is explicitly set.
 	caCertPool, err := x509.SystemCertPool()
 	if err != nil {
@@ -98,6 +97,28 @@ func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *co
 			return nil, fmt.Errorf("Failed to append %s to RootCAs", appRepo.Spec.Auth.CustomCA.SecretKeyRef.Name)
 		}
 	}
+	proxyConfig := getProxyConfig(appRepo)
+	proxyFunc := func(r *http.Request) (*url.URL, error) { return proxyConfig.ProxyFunc()(r.URL) }
+
+	return &http.Client{
+		Timeout: time.Second * defaultTimeoutSeconds,
+		Transport: &http.Transport{
+			Proxy: proxyFunc,
+			TLSClientConfig: &tls.Config{
+				RootCAs:            caCertPool,
+				InsecureSkipVerify: appRepo.Spec.TLSInsecureSkipVerify,
+			},
+		},
+	}, nil
+}
+
+// InitNetClient returns an HTTP client based on the chart details loading a
+// custom CA if provided (as a secret)
+func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *corev1.Secret, defaultHeaders http.Header) (HTTPClient, error) {
+	netClient, err := InitHTTPClient(appRepo, caCertSecret)
+	if err != nil {
+		return nil, err
+	}
 
 	if defaultHeaders == nil {
 		defaultHeaders = http.Header{}
@@ -110,20 +131,8 @@ func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *co
 		defaultHeaders.Set("Authorization", string(auth))
 	}
 
-	proxyConfig := getProxyConfig(appRepo)
-	proxyFunc := func(r *http.Request) (*url.URL, error) { return proxyConfig.ProxyFunc()(r.URL) }
-
 	return &clientWithDefaultHeaders{
-		client: &http.Client{
-			Timeout: time.Second * defaultTimeoutSeconds,
-			Transport: &http.Transport{
-				Proxy: proxyFunc,
-				TLSClientConfig: &tls.Config{
-					RootCAs:            caCertPool,
-					InsecureSkipVerify: appRepo.Spec.TLSInsecureSkipVerify,
-				},
-			},
-		},
+		client:         netClient,
 		defaultHeaders: defaultHeaders,
 	}, nil
 }

--- a/pkg/kube/http_utils.go
+++ b/pkg/kube/http_utils.go
@@ -119,7 +119,8 @@ func InitNetClient(appRepo *v1alpha1.AppRepository, caCertSecret, authSecret *co
 			Transport: &http.Transport{
 				Proxy: proxyFunc,
 				TLSClientConfig: &tls.Config{
-					RootCAs: caCertPool,
+					RootCAs:            caCertPool,
+					InsecureSkipVerify: appRepo.Spec.TLSInsecureSkipVerify,
 				},
 			},
 		},

--- a/pkg/kube/http_utils_test.go
+++ b/pkg/kube/http_utils_test.go
@@ -75,6 +75,7 @@ func TestInitNetClient(t *testing.T) {
 		numCertsExpected int
 		expectedHeaders  http.Header
 		expectProxied    bool
+		expectSkipTLS    bool
 	}{
 		{
 			name:             "default cert pool without auth",
@@ -161,6 +162,14 @@ func TestInitNetClient(t *testing.T) {
 			expectProxied:    true,
 			numCertsExpected: len(systemCertPool.Subjects()),
 		},
+		{
+			name: "skip tls config",
+			appRepoSpec: v1alpha1.AppRepositorySpec{
+				TLSInsecureSkipVerify: true,
+			},
+			expectSkipTLS:    true,
+			numCertsExpected: len(systemCertPool.Subjects()),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -224,6 +233,9 @@ func TestInitNetClient(t *testing.T) {
 			transport, ok := client.Transport.(*http.Transport)
 			if !ok {
 				t.Fatalf("unable to assert expected type")
+			}
+			if tc.expectSkipTLS && !transport.TLSClientConfig.InsecureSkipVerify {
+				t.Error("expecting to skip TLS verification")
 			}
 			certPool := transport.TLSClientConfig.RootCAs
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Allow to use HTTPS for Helm repositories/registries but skip the TLS verification for self-signed certificates.

### Benefits

Since the `Resolver` is now using a custom HTTP client, we can additionally use a custom CA

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2232

### Additional information

As an extra, the `netClient` variable is no longer global but part of the repository `struct`.

Reviewing per commit may be easier.