### PR TITLE
Revert last chart version bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,13 +54,14 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_15_LATEST_RELEASE:
-          <<: *build_on_master
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
+      # TODO(andresmgot): Re-enable when releasing 2.2
+      # - GKE_1_15_LATEST_RELEASE:
+      #     <<: *build_on_master
+      #     requires:
+      #       - test_go
+      #       - test_dashboard
+      #       - build_go_images
+      #       - build_dashboard
       - GKE_1_16_MASTER:
           <<: *build_on_master
           requires:
@@ -68,37 +69,37 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - GKE_1_16_LATEST_RELEASE:
-          <<: *build_on_master
-          requires:
-            - test_go
-            - test_dashboard
-            - build_go_images
-            - build_dashboard
+      # - GKE_1_16_LATEST_RELEASE:
+      #     <<: *build_on_master
+      #     requires:
+      #       - test_go
+      #       - test_dashboard
+      #       - build_go_images
+      #       - build_dashboard
       - sync_chart:
           <<: *build_on_master
           requires:
             - local_e2e_tests
             - GKE_1_15_MASTER
-            - GKE_1_15_LATEST_RELEASE
+            # - GKE_1_15_LATEST_RELEASE
             - GKE_1_16_MASTER
-            - GKE_1_16_LATEST_RELEASE
+            # - GKE_1_16_LATEST_RELEASE
       - push_images:
           <<: *build_on_master
           requires:
             - local_e2e_tests
             - GKE_1_15_MASTER
-            - GKE_1_15_LATEST_RELEASE
+            # - GKE_1_15_LATEST_RELEASE
             - GKE_1_16_MASTER
-            - GKE_1_16_LATEST_RELEASE
+            # - GKE_1_16_LATEST_RELEASE
       - release:
           <<: *build_on_tag
           requires:
             - local_e2e_tests
             - GKE_1_15_MASTER
-            - GKE_1_15_LATEST_RELEASE
+            # - GKE_1_15_LATEST_RELEASE
             - GKE_1_16_MASTER
-            - GKE_1_16_LATEST_RELEASE
+            # - GKE_1_16_LATEST_RELEASE
 
 ## Definitions
 install_gcloud_sdk: &install_gcloud_sdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,14 +54,13 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      # TODO(andresmgot): Re-enable when releasing 2.2
-      # - GKE_1_15_LATEST_RELEASE:
-      #     <<: *build_on_master
-      #     requires:
-      #       - test_go
-      #       - test_dashboard
-      #       - build_go_images
-      #       - build_dashboard
+      - GKE_1_15_LATEST_RELEASE:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
       - GKE_1_16_MASTER:
           <<: *build_on_master
           requires:
@@ -69,37 +68,37 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      # - GKE_1_16_LATEST_RELEASE:
-      #     <<: *build_on_master
-      #     requires:
-      #       - test_go
-      #       - test_dashboard
-      #       - build_go_images
-      #       - build_dashboard
+      - GKE_1_16_LATEST_RELEASE:
+          <<: *build_on_master
+          requires:
+            - test_go
+            - test_dashboard
+            - build_go_images
+            - build_dashboard
       - sync_chart:
           <<: *build_on_master
           requires:
             - local_e2e_tests
             - GKE_1_15_MASTER
-            # - GKE_1_15_LATEST_RELEASE
+            - GKE_1_15_LATEST_RELEASE
             - GKE_1_16_MASTER
-            # - GKE_1_16_LATEST_RELEASE
+            - GKE_1_16_LATEST_RELEASE
       - push_images:
           <<: *build_on_master
           requires:
             - local_e2e_tests
             - GKE_1_15_MASTER
-            # - GKE_1_15_LATEST_RELEASE
+            - GKE_1_15_LATEST_RELEASE
             - GKE_1_16_MASTER
-            # - GKE_1_16_LATEST_RELEASE
+            - GKE_1_16_LATEST_RELEASE
       - release:
           <<: *build_on_tag
           requires:
             - local_e2e_tests
             - GKE_1_15_MASTER
-            # - GKE_1_15_LATEST_RELEASE
+            - GKE_1_15_LATEST_RELEASE
             - GKE_1_16_MASTER
-            # - GKE_1_16_LATEST_RELEASE
+            - GKE_1_16_LATEST_RELEASE
 
 ## Definitions
 install_gcloud_sdk: &install_gcloud_sdk

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -20,4 +20,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 5.1.1
+version: 5.1.0


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

At the moment, `master` builds are broken because we have changed some routes (https://github.com/kubeapps/kubeapps/pull/2300). The last version `v2.1.0` uses `tiller-proxy` URLs while the current NGINX config in the latest chart configures `kubeops`. We have two options: either add backward-compatible config and routes or disable the "latest release" builds knowing that **we cannot release a new version of the chart until we release a new version of Kubeapps**.

I am going for the second option since we plan to release a new version soon anyway. Note that we are only testing the combination of the current chart + the latest release when releasing a new chart version. Because of that, I am reverting the change at #2359 for the version bump.

### Benefits

Fix master

### Possible drawbacks

Block chart releases
