### PR TITLE
Encode OCI repository names before storing them

### DIFF
--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -522,7 +522,7 @@ func pullAndExtract(repoURL *url.URL, appName, tag string, puller helm.ChartPull
 	}
 
 	// Encode repository names to store them in the database.
-	encodedAppName := url.QueryEscape(appName)
+	encodedAppName := url.PathEscape(appName)
 
 	return &models.Chart{
 		ID:            path.Join(r.Name, encodedAppName),

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -521,9 +521,12 @@ func pullAndExtract(repoURL *url.URL, appName, tag string, puller helm.ChartPull
 		})
 	}
 
+	// Encode repository names to store them in the database.
+	encodedAppName := url.QueryEscape(appName)
+
 	return &models.Chart{
-		ID:            path.Join(r.Name, appName),
-		Name:          appName,
+		ID:            path.Join(r.Name, encodedAppName),
+		Name:          encodedAppName,
 		Repo:          &models.Repo{Namespace: r.Namespace, Name: r.Name, URL: r.URL, Type: r.Type},
 		Description:   chartMetadata.Description,
 		Home:          chartMetadata.Home,


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

When using an OCI repository, there two options:
1. Use the registry URL with the repo and the app name without the repository (e.g. `registry: docker.io/bitnami, app: wordpress`).
2. Use the registry URL without the repo and include that in the app name (e.g. `registry: docker.io, app: bitnami/wordpress`).

The second was not working because the app was stored with `/` while the request to the asset service the name is URL-encoded.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2232 
