### PR TITLE
Use command for pinniped-proxy to overwrite entrypoint.

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -91,7 +91,7 @@ spec:
         {{- end }}
         {{- if and .Values.pinnipedProxy.enabled }}
         - name: pinniped-proxy
-          args:
+          command:
             - /pinniped-proxy
           env:
             - name: DEFAULT_PINNIPED_NAMESPACE


### PR DESCRIPTION
### Description of the change

The devel Dockerfile doesn't specify an entrypoint (similar to all Kubeapps devel Dockerfiles) so our deployment worked fine, but since the bitnami Dockerfile for pinniped-proxy *does* define an ENTRYPOINT, our deployment effectively tried to do `./pinniped-proxy pinniped-proxy`.

This change ensures that our deployment specifies the command (which is therefore used instead of the entrypoint).

### Benefits

Our deployment works with the bitnami pinniped-proxy image.

### Possible drawbacks

None.

