### PR TITLE
Don't use absolute ref to pinniped-proxy command in container.

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -92,7 +92,7 @@ spec:
         {{- if and .Values.pinnipedProxy.enabled }}
         - name: pinniped-proxy
           command:
-            - /pinniped-proxy
+            - pinniped-proxy
           env:
             - name: DEFAULT_PINNIPED_NAMESPACE
               value: {{ .Values.pinnipedProxy.defaultPinnipedNamespace }}

--- a/cmd/pinniped-proxy/Dockerfile
+++ b/cmd/pinniped-proxy/Dockerfile
@@ -16,6 +16,7 @@ RUN cargo build --release
 FROM bitnami/minideb:buster
 RUN apt-get update && apt-get install -y ca-certificates libssl1.1 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /pinniped-proxy/target/release/pinniped-proxy /pinniped-proxy
+ENV PATH="/:$PATH"
 
 EXPOSE 3333
 USER 1001

--- a/cmd/pinniped-proxy/Dockerfile
+++ b/cmd/pinniped-proxy/Dockerfile
@@ -20,4 +20,5 @@ ENV PATH="/:$PATH"
 
 EXPOSE 3333
 USER 1001
-CMD ["/pinniped-proxy"]
+ENTRYPOINT [ "pinniped-proxy" ]
+CMD [ "--help" ]


### PR DESCRIPTION
### Description of the change

Yesterday I saw that we needed to explicitly specify the command for pinniped-proxy deployment rather than just using args, as the [bitnami image](https://github.com/bitnami/bitnami-docker-kubeapps-pinniped-proxy/blob/2.2.0-debian-10-r0/2/debian-10/Dockerfile) specifies an entrypoint.

What I failed to notice is that the bitnami image is not putting the executable in the root directory, but rather is relying on the path.

This change updates the chart deployment config to similarly rely on the path to find the executable. This change is required for the release (sorry).
The second change to our devel dockerfile just matches the bitnami Dockerfile in terms of the executable and is not required for the release (ie. we don't need new images).

### Benefits

Our devel Dockerfile is more inline with the bitnami one and will avoid these discrepancies in the future. Right now it means our deployment will succeed with the bitnami image.
