### PR TITLE
[chart] Use bitnami/common function + provide compatibilty with different K8s versions

### DIFF
--- a/chart/kubeapps/Chart.lock
+++ b/chart/kubeapps/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.4.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.3.2
-digest: sha256:435f16eb455af98c4871c3cd92f6958fbdae18d947810bfe24242001e730d69b
-generated: "2021-02-18T11:50:16.90772045+01:00"
+  version: 10.3.4
+digest: sha256:1d6763b61d72184e436c2eee054dd5fe2a49a4f42f5332512900233ce10d51e9
+generated: "2021-02-22T17:04:09.668543+01:00"

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -3,6 +3,11 @@ annotations:
 apiVersion: v2
 appVersion: DEVEL
 dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
     version: '10.X.X'
@@ -20,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 5.2.2
+version: 5.3.0

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -110,11 +110,39 @@ For annotations, please see [this document](https://github.com/kubeapps/kubeapps
 
 ##### TLS
 
-To enable TLS, please set `ingress.tls` to `true`. When enabling this parameter, the TLS certificates will be retrieved from a TLS secret with name *INGRESS_HOSTNAME-tls* (where *INGRESS_HOSTNAME* is a placeholder to be replaced with the hostname you set using the `ingress.hostname` parameter).
+This chart will facilitate the creation of TLS secrets for use with the ingress controller, however, this is not required. There are four common use cases:
 
-You can use the `ingress.extraTls` to provide the TLS configuration for the extra hosts you set using the `ingress.extraHosts` array. Please see [this example](https://kubernetes.github.io/ingress-nginx/examples/tls-termination/) for more information.
+- Helm generates/manages certificate secrets based on the parameters.
+- User generates/manages certificates separately.
+- Helm creates self-signed certificates and generates/manages certificate secrets.
+- An additional tool (like [cert-manager](https://github.com/jetstack/cert-manager/)) manages the secrets for the application.
 
-You can provide your own certificates using the `ingress.secrets` object. If your cluster has a [cert-manager](https://github.com/jetstack/cert-manager) add-on to automate the management and issuance of TLS certificates, set `ingress.certManager` boolean to true to enable the corresponding annotations for cert-manager. For a full list of configuration parameters related to configuring TLS can see the [values.yaml](values.yaml) file.
+In the first two cases, it's needed a certificate and a key. We would expect them to look like this:
+
+- certificate files should look like (and there can be more than one certificate if there is a certificate chain)
+
+  ```console
+  -----BEGIN CERTIFICATE-----
+  MIID6TCCAtGgAwIBAgIJAIaCwivkeB5EMA0GCSqGSIb3DQEBCwUAMFYxCzAJBgNV
+  ...
+  jScrvkiBO65F46KioCL9h5tDvomdU1aqpI/CBzhvZn1c0ZTf87tGQR8NK7v7
+  -----END CERTIFICATE-----
+  ```
+
+- keys should look like:
+
+  ```console
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIEogIBAAKCAQEAvLYcyu8f3skuRyUgeeNpeDvYBCDcgq+LsWap6zbX5f8oLqp4
+  ...
+  wrj2wDbCDCFmfqnSJ+dKI3vFLlEz44sAV8jX/kd4Y6ZTQhlLbYc=
+  -----END RSA PRIVATE KEY-----
+  ```
+
+- If you are going to use Helm to manage the certificates based on the parameters, please copy these values into the `certificate` and `key` values for a given `ingress.secrets` entry.
+- In case you are going to manage TLS secrects separately, please know that you can must a TLS secret with name *INGRESS_HOSTNAME-tls* (where *INGRESS_HOSTNAME* is a placeholder to be replaced with the hostname you set using the `ingress.hostname` parameter).
+- To use self-signed certificates created by Helm, set `ingress.tls` to `true` and `ingress.certManager` to `false`.
+- If your cluster has a [cert-manager](https://github.com/jetstack/cert-manager) add-on to automate the management and issuance of TLS certificates, set `ingress.certManager` boolean to true to enable the corresponding annotations for cert-manager.
 
 ## Upgrading Kubeapps
 

--- a/chart/kubeapps/crds/apprepository-crd.yaml
+++ b/chart/kubeapps/crds/apprepository-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ include "common.capabilities.crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: apprepositories.kubeapps.com
@@ -10,4 +10,9 @@ spec:
     plural: apprepositories
     shortNames:
       - apprepos
+  {{- if semverCompare "<1.19-0" (include "common.capabilities.kubeVersion" .) -}}
   version: v1alpha1
+  {{- else }}
+  versions:
+    - name: v1alpha1
+  {{- end }}

--- a/chart/kubeapps/crds/apprepository-crd.yaml
+++ b/chart/kubeapps/crds/apprepository-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ include "common.capabilities.crd.apiVersion" . }}
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: apprepositories.kubeapps.com
@@ -10,9 +10,4 @@ spec:
     plural: apprepositories
     shortNames:
       - apprepos
-  {{- if semverCompare "<1.19-0" (include "common.capabilities.kubeVersion" .) -}}
   version: v1alpha1
-  {{- else }}
-  versions:
-    - name: v1alpha1
-  {{- end }}

--- a/chart/kubeapps/templates/NOTES.txt
+++ b/chart/kubeapps/templates/NOTES.txt
@@ -6,7 +6,7 @@ Tip:
 
 Kubeapps can be accessed via port {{ .Values.frontend.service.port }} on the following DNS name from within your cluster:
 
-   {{ template "kubeapps.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+   {{ template "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 {{- $reposWithOrphanSecrets := include "kubeapps.repos-with-orphan-secrets" . }}
 {{- if ne $reposWithOrphanSecrets "" }}
@@ -35,22 +35,22 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
 {{- if contains "NodePort" .Values.frontend.service.type }}
 
    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kubeapps.fullname" . }})
+   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
    echo "Kubeapps URL: http://$NODE_IP:$NODE_PORT"
 
 {{- else if contains "LoadBalancer" .Values.frontend.service.type }}
 
  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-       Watch the status by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "kubeapps.fullname" . }}'
+       Watch the status by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
 
-   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kubeapps.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
    echo "Kubeapps URL: http://$SERVICE_IP:{{ .Values.frontend.service.port }}"
 
 {{- else if contains "ClusterIP" .Values.frontend.service.type }}
 
 {{- $portNumber := include "kubeapps.frontend-port-number" . }}
    echo "Kubeapps URL: http://127.0.0.1:{{ $portNumber }}"
-   kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ template "kubeapps.fullname" . }} {{ $portNumber }}:{{ .Values.frontend.service.port }}
+   kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ template "common.names.fullname" . }} {{ $portNumber }}:{{ .Values.frontend.service.port }}
 
 {{- end }}
 {{- end }}

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -1,28 +1,4 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "kubeapps.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "kubeapps.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
@@ -39,40 +15,25 @@ from kubeapps
 chart: {{ include "kubeapps.chart" . }}
 release: {{ .Release.Name }}
 heritage: {{ .Release.Service }}
-helm.sh/chart: {{ template "kubeapps.chart" . }}
+helm.sh/chart: {{ include "kubeapps.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/name: {{ include "kubeapps.name" . }}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
 {{- define "kubeapps.labels" -}}
-app: {{ include "kubeapps.name" . }}
+app: {{ include "common.names.name" . }}
 {{ template "kubeapps.extraAppLabels" . }}
 {{- end -}}
 
 {{/*
-Render image reference
+Return the proper Docker Image Registry Secret Names
 */}}
-{{- define "kubeapps.image" -}}
-{{- $image := index . 0 -}}
-{{- $global := index . 1 -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if $global -}}
-    {{- if $global.imageRegistry -}}
-        {{ $global.imageRegistry }}/{{ $image.repository }}:{{ $image.tag }}
-    {{- else -}}
-        {{ $image.registry }}/{{ $image.repository }}:{{ $image.tag }}
-    {{- end -}}
-{{- else -}}
-    {{ $image.registry }}/{{ $image.repository }}:{{ $image.tag }}
-{{- end -}}
+{{- define "kubeapps.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.frontend.image .Values.dashboard.image .Values.apprepository.image .Values.apprepository.syncImage .Values.assetsvc.image .Values.kubeops.image .Values.authProxy.image .Values.pinnipedProxy.image .Values.hooks.image .Values.testImage) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -88,63 +49,63 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create name for the apprepository-controller based on the fullname
 */}}
 {{- define "kubeapps.apprepository.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-apprepository-controller
+{{ include "common.names.fullname" . }}-internal-apprepository-controller
 {{- end -}}
 
 {{/*
 Create name for the apprepository pre-upgrade job
 */}}
 {{- define "kubeapps.apprepository-job-postupgrade.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-apprepository-job-postupgrade
+{{ include "common.names.fullname" . }}-internal-apprepository-job-postupgrade
 {{- end -}}
 
 {{/*
 Create name for the apprepository cleanup job
 */}}
 {{- define "kubeapps.apprepository-jobs-cleanup.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-apprepository-jobs-cleanup
+{{ include "common.names.fullname" . }}-internal-apprepository-jobs-cleanup
 {{- end -}}
 
 {{/*
 Create name for the db-secret secret bootstrap job
 */}}
 {{- define "kubeapps.db-secret-jobs-cleanup.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-db-secret-jobs-cleanup
+{{ include "common.names.fullname" . }}-internal-db-secret-jobs-cleanup
 {{- end -}}
 
 {{/*
 Create name for the kubeapps upgrade job
 */}}
 {{- define "kubeapps.kubeapps-jobs-upgrade.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-kubeapps-jobs-upgrade
+{{ include "common.names.fullname" . }}-internal-kubeapps-jobs-upgrade
 {{- end -}}
 
 {{/*
 Create name for the assetsvc based on the fullname
 */}}
 {{- define "kubeapps.assetsvc.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-assetsvc
+{{ include "common.names.fullname" . }}-internal-assetsvc
 {{- end -}}
 
 {{/*
 Create name for the dashboard based on the fullname
 */}}
 {{- define "kubeapps.dashboard.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-dashboard
+{{ include "common.names.fullname" . }}-internal-dashboard
 {{- end -}}
 
 {{/*
 Create name for the dashboard config based on the fullname
 */}}
 {{- define "kubeapps.dashboard-config.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-dashboard-config
+{{ include "common.names.fullname" . }}-internal-dashboard-config
 {{- end -}}
 
 {{/*
 Create name for the frontend config based on the fullname
 */}}
 {{- define "kubeapps.frontend-config.fullname" -}}
-{{ template "kubeapps.fullname" . }}-frontend-config
+{{ include "common.names.fullname" . }}-frontend-config
 {{- end -}}
 
 {{/*
@@ -158,14 +119,14 @@ http://{{ template "kubeapps.kubeops.fullname" . }}:{{ .Values.kubeops.service.p
 Create name for kubeops based on the fullname
 */}}
 {{- define "kubeapps.kubeops.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-kubeops
+{{ include "common.names.fullname" . }}-internal-kubeops
 {{- end -}}
 
 {{/*
 Create name for the kubeops config based on the fullname
 */}}
 {{- define "kubeapps.kubeops-config.fullname" -}}
-{{ template "kubeapps.fullname" . }}-kubeops-config
+{{ include "common.names.fullname" . }}-kubeops-config
 {{- end -}}
 
 {{/*
@@ -187,7 +148,7 @@ Create name for pinniped-proxy based on the fullname.
 Currently used for a service name only.
 */}}
 {{- define "kubeapps.pinniped-proxy.fullname" -}}
-{{ template "kubeapps.fullname" . }}-internal-pinniped-proxy
+{{ include "common.names.fullname" . }}-internal-pinniped-proxy
 {{- end -}}
 
 {{/*
@@ -210,36 +171,6 @@ Frontend service port number
 {{- else -}}
 8080
 {{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Docker Image Registry Secret Names
-*/}}
-{{- define "kubeapps.imagePullSecrets" -}}
-{{/*
-We can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "kubeapps.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "kubeapps.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
 {{- end -}}
 
 {{/*

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "kubeapps.apprepository.fullname" . }}
@@ -16,18 +16,18 @@ spec:
         app: {{ template "kubeapps.apprepository.fullname" . }}
         release: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/name: {{ template "kubeapps.name" . }}
+        app.kubernetes.io/name: {{ template "common.names.name" . }}
     spec:
       serviceAccountName: {{ template "kubeapps.apprepository.fullname" . }}
 {{- include "kubeapps.imagePullSecrets" . | indent 6 }}
       {{- if .Values.apprepository.affinity }}
-      affinity: {{- include "kubeapps.tplValue" (dict "value" .Values.apprepository.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.apprepository.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.apprepository.nodeSelector }}
-      nodeSelector: {{- include "kubeapps.tplValue" (dict "value" .Values.apprepository.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.apprepository.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.apprepository.tolerations }}
-      tolerations: {{- include "kubeapps.tplValue" (dict "value" .Values.apprepository.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.apprepository.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -36,13 +36,13 @@ spec:
       {{- end }}
       containers:
         - name: controller
-          image: {{ template "kubeapps.image" (list .Values.apprepository.image .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.apprepository.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.apprepository.image.pullPolicy | quote }}
           command:
             - /apprepository-controller
           args:
             - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
-            - --repo-sync-image={{ template "kubeapps.image" (list .Values.apprepository.syncImage .Values.global) }}
+            - --repo-sync-image={{ include "common.images.image" (dict "imageRoot" .Values.apprepository.syncImage "global" .Values.global) }}
            {{- if .Values.global }}
              {{- if.Values.global.imagePullSecrets }}
                {{- range $key, $value := .Values.global.imagePullSecrets }}

--- a/chart/kubeapps/templates/apprepository-jobs-cleanup-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-cleanup-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "kubeapps.apprepository-jobs-cleanup.fullname" . }}
@@ -25,7 +25,7 @@ rules:
       - list
       - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.apprepository-jobs-cleanup.fullname" . }}

--- a/chart/kubeapps/templates/apprepository-jobs-cleanup.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-cleanup.yaml
@@ -13,19 +13,19 @@ spec:
     metadata:
       labels:
         app: {{ template "kubeapps.apprepository-jobs-cleanup.fullname" . }}
-        app.kubernetes.io/name: {{ template "kubeapps.name" . }}
+        app.kubernetes.io/name: {{ template "common.names.name" . }}
         release: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
 {{- include "kubeapps.imagePullSecrets" . | indent 6 }}
       {{- if .Values.hooks.affinity }}
-      affinity: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.hooks.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.hooks.nodeSelector }}
-      nodeSelector: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.hooks.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.hooks.tolerations }}
-      tolerations: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.hooks.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: {{ template "kubeapps.apprepository-jobs-cleanup.fullname" . }}
       containers:
         - name: kubectl
-          image: {{ template "kubeapps.image" (list .Values.hooks.image .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.hooks.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.hooks.image.pullPolicy | quote }}
           command:
             - /bin/sh
@@ -44,4 +44,4 @@ spec:
             - -ec
             - |
               kubectl delete apprepositories.kubeapps.com -n {{ .Release.Namespace }} --all
-              kubectl delete secrets -n {{ .Release.Namespace }} -l app={{ template "kubeapps.name" $ }},release={{ $.Release.Name }}
+              kubectl delete secrets -n {{ .Release.Namespace }} -l app={{ template "common.names.name" $ }},release={{ $.Release.Name }}

--- a/chart/kubeapps/templates/apprepository-jobs-postupgrade-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-postupgrade-rbac.yaml
@@ -2,7 +2,7 @@
 # Helm 3.1 supports a lookup template tag to create a secret if it does not exist
 # but we can't yet restrict to helm 3.1, hence manually doing this with an initContainer.
 # in the post upgrade job.
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "kubeapps.apprepository-job-postupgrade.fullname" . }}
@@ -17,7 +17,7 @@ rules:
       - get
       - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.apprepository-job-postupgrade.fullname" . }}

--- a/chart/kubeapps/templates/apprepository-jobs-postupgrade.yaml
+++ b/chart/kubeapps/templates/apprepository-jobs-postupgrade.yaml
@@ -15,19 +15,19 @@ spec:
     metadata:
       labels:
         app: {{ template "kubeapps.apprepository-job-postupgrade.fullname" . }}
-        app.kubernetes.io/name: {{ template "kubeapps.name" . }}
+        app.kubernetes.io/name: {{ template "common.names.name" . }}
         release: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
 {{- include "kubeapps.imagePullSecrets" . | indent 6 }}
       {{- if .Values.hooks.affinity }}
-      affinity: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.hooks.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.hooks.nodeSelector }}
-      nodeSelector: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.hooks.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.hooks.tolerations }}
-      tolerations: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.hooks.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: {{ template "kubeapps.apprepository-job-postupgrade.fullname" . }}
       containers:
         - name: invalidate-cache
-          image: {{ template "kubeapps.image" (list .Values.apprepository.syncImage .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.apprepository.syncImage "global" .Values.global) }}
           imagePullPolicy: {{ .Values.apprepository.syncImage.pullPolicy | quote }}
           command:
             - /asset-syncer
@@ -58,7 +58,7 @@ spec:
         # Helm 3.1 supports a lookup template tag to create a secret if it does not exist
         # but we can't yet restrict to helm 3.1, hence manually doing this with an initContainer.
         - name: ensure-postgres-password
-          image: {{ template "kubeapps.image" (list .Values.hooks.image .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.hooks.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.hooks.image.pullPolicy | quote }}
           command:
             - /bin/bash

--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "kubeapps.apprepository.fullname" . }}
@@ -40,7 +40,7 @@ rules:
       - update
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.apprepository.fullname" . }}
@@ -56,7 +56,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 # Define role, but no binding, so users can be bound to this role
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ .Release.Name }}-repositories-read
@@ -70,7 +70,7 @@ rules:
       - get
 ---
 # Define role, but no binding, so users can be bound to this role
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ .Release.Name }}-repositories-write
@@ -91,8 +91,7 @@ rules:
 # The Kubeapps app repository controller can read and watch its own
 # AppRepository resources cluster-wide. The read and write cluster-roles can
 # also be bound to users in specific namespaces as required.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: "kubeapps:{{ .Release.Namespace }}:apprepositories-read"
   labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}
@@ -108,7 +107,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: "kubeapps:controller:{{ .Release.Namespace }}:apprepositories-read"
@@ -123,7 +122,7 @@ subjects:
     name: {{ template "kubeapps.apprepository.fullname" . }}
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: "kubeapps:{{ .Release.Namespace }}:apprepositories-write"
@@ -143,7 +142,7 @@ rules:
     verbs:
       - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: "kubeapps:{{ .Release.Namespace }}:apprepositories-refresh"

--- a/chart/kubeapps/templates/apprepository-rbac.yaml
+++ b/chart/kubeapps/templates/apprepository-rbac.yaml
@@ -92,6 +92,7 @@ rules:
 # AppRepository resources cluster-wide. The read and write cluster-roles can
 # also be bound to users in specific namespaces as required.
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
 metadata:
   name: "kubeapps:{{ .Release.Namespace }}:apprepositories-read"
   labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}

--- a/chart/kubeapps/templates/assetsvc-deployment.yaml
+++ b/chart/kubeapps/templates/assetsvc-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "kubeapps.assetsvc.fullname" . }}
@@ -14,19 +14,19 @@ spec:
     metadata:
       labels:
         app: {{ template "kubeapps.assetsvc.fullname" . }}
-        app.kubernetes.io/name: {{ template "kubeapps.name" . }}
+        app.kubernetes.io/name: {{ template "common.names.name" . }}
         release: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
 {{- include "kubeapps.imagePullSecrets" . | indent 6 }}
       {{- if .Values.assetsvc.affinity }}
-      affinity: {{- include "kubeapps.tplValue" (dict "value" .Values.assetsvc.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.assetsvc.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.assetsvc.nodeSelector }}
-      nodeSelector: {{- include "kubeapps.tplValue" (dict "value" .Values.assetsvc.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.assetsvc.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.assetsvc.tolerations }}
-      tolerations: {{- include "kubeapps.tplValue" (dict "value" .Values.assetsvc.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.assetsvc.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       containers:
         - name: assetsvc
-          image: {{ template "kubeapps.image" (list .Values.assetsvc.image .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.assetsvc.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.assetsvc.image.pullPolicy | quote }}
           command:
             - /assetsvc

--- a/chart/kubeapps/templates/assetsvc-service.yaml
+++ b/chart/kubeapps/templates/assetsvc-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "kubeapps.assetsvc.fullname" . }}
   labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}
-    app: {{ template "kubeapps.name" . }}
+    app: {{ template "common.names.name" . }}
 spec:
   type: ClusterIP
   ports:

--- a/chart/kubeapps/templates/dashboard-deployment.yaml
+++ b/chart/kubeapps/templates/dashboard-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "kubeapps.dashboard.fullname" . }}
@@ -16,7 +16,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/dashboard-config.yaml") . | sha256sum }}
       labels:
         app: {{ template "kubeapps.dashboard.fullname" . }}
-        app.kubernetes.io/name: {{ template "kubeapps.name" . }}
+        app.kubernetes.io/name: {{ template "common.names.name" . }}
         release: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         chart: {{ template "kubeapps.chart" . }}
@@ -24,13 +24,13 @@ spec:
     spec:
 {{- include "kubeapps.imagePullSecrets" . | indent 6 }}
       {{- if .Values.dashboard.affinity }}
-      affinity: {{- include "kubeapps.tplValue" (dict "value" .Values.dashboard.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.dashboard.nodeSelector }}
-      nodeSelector: {{- include "kubeapps.tplValue" (dict "value" .Values.dashboard.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.dashboard.tolerations }}
-      tolerations: {{- include "kubeapps.tplValue" (dict "value" .Values.dashboard.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers:
         - name: dashboard
-          image: {{ template "kubeapps.image" (list .Values.dashboard.image .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.dashboard.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.dashboard.image.pullPolicy | quote }}
           {{- if .Values.dashboard.livenessProbe }}
           livenessProbe: {{- toYaml .Values.dashboard.livenessProbe | nindent 12 }}

--- a/chart/kubeapps/templates/db-secret-cleanup-rbac.yaml
+++ b/chart/kubeapps/templates/db-secret-cleanup-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "kubeapps.db-secret-jobs-cleanup.fullname" . }}
@@ -17,7 +17,7 @@ rules:
     verbs:
       - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.db-secret-jobs-cleanup.fullname" . }}

--- a/chart/kubeapps/templates/db-secret-jobs-cleanup.yaml
+++ b/chart/kubeapps/templates/db-secret-jobs-cleanup.yaml
@@ -12,19 +12,19 @@ spec:
     metadata:
       labels:
         app: {{ template "kubeapps.db-secret-jobs-cleanup.fullname" . }}
-        app.kubernetes.io/name: {{ template "kubeapps.name" . }}
+        app.kubernetes.io/name: {{ template "common.names.name" . }}
         release: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
 {{- include "kubeapps.imagePullSecrets" . | indent 6 }}
       {{- if .Values.hooks.affinity }}
-      affinity: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.hooks.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.hooks.nodeSelector }}
-      nodeSelector: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.hooks.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.hooks.tolerations }}
-      tolerations: {{- include "kubeapps.tplValue" (dict "value" .Values.hooks.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.hooks.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: {{ template "kubeapps.db-secret-jobs-cleanup.fullname" . }}
       containers:
         - name: kubectl
-          image: {{ template "kubeapps.image" (list .Values.hooks.image .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.hooks.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.hooks.image.pullPolicy | quote }}
           command:
             - /bin/sh

--- a/chart/kubeapps/templates/ingress.yaml
+++ b/chart/kubeapps/templates/ingress.yaml
@@ -1,12 +1,8 @@
 {{- if .Values.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
-apiVersion: networking.k8s.io/v1beta1
-{{ else }}
-apiVersion: extensions/v1beta1
-{{ end -}}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ template "kubeapps.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   labels: {{ include "kubeapps.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.certManager }}
@@ -23,7 +19,7 @@ spec:
         paths:
         - path: /
           backend:
-            serviceName: {{ template "kubeapps.fullname" . }}
+            serviceName: {{ template "common.names.fullname" . }}
             servicePort: http
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -32,7 +28,7 @@ spec:
         paths:
         - path: {{ default "/" .path }}
           backend:
-            serviceName: {{ template "kubeapps.fullname" $ }}
+            serviceName: {{ template "common.names.fullname" $ }}
             servicePort: http
     {{- end }}
     ## The block below is deprecated and must removed on 3.0.0
@@ -42,7 +38,7 @@ spec:
         paths:
         - path: {{ default "/" .path }}
           backend:
-            serviceName: {{ template "kubeapps.fullname" $ }}
+            serviceName: {{ template "common.names.fullname" $ }}
             servicePort: http
     {{- end }}
     ## end of block

--- a/chart/kubeapps/templates/ingress.yaml
+++ b/chart/kubeapps/templates/ingress.yaml
@@ -8,8 +8,8 @@ metadata:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
   rules:
@@ -17,49 +17,31 @@ spec:
     - host: {{ .Values.ingress.hostname }}
       http:
         paths:
-        - path: /
-          backend:
-            serviceName: {{ template "common.names.fullname" . }}
-            servicePort: http
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
-        - path: {{ default "/" .path }}
-          backend:
-            serviceName: {{ template "common.names.fullname" $ }}
-            servicePort: http
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
-    ## The block below is deprecated and must removed on 3.0.0
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .name }}
-      http:
-        paths:
-        - path: {{ default "/" .path }}
-          backend:
-            serviceName: {{ template "common.names.fullname" $ }}
-            servicePort: http
-    {{- end }}
-    ## end of block
-  {{- if or .Values.ingress.tls .Values.ingress.extraTls .Values.ingress.hosts }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:
-    ## The block below is deprecated and must removed on 3.0.0
-    {{- range .Values.ingress.hosts }}
-    {{- if .tls }}
-    - hosts:
-        - {{ .name }}
-      secretName: {{ .tlsSecret }}
-    {{- end }}
-    {{- end }}
-    ## end of block
     {{- if .Values.ingress.tls }}
     - hosts:
         - {{ .Values.ingress.hostname }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
-    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -1,34 +1,34 @@
-apiVersion: apps/v1
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ template "kubeapps.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}
-    app: {{ template "kubeapps.fullname" . }}
+    app: {{ template "common.names.fullname" . }}
 spec:
   replicas: {{ .Values.frontend.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "kubeapps.fullname" . }}
+      app: {{ template "common.names.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/kubeapps-frontend-config.yaml") . | sha256sum }}
       labels:
-        app: {{ template "kubeapps.fullname" . }}
-        app.kubernetes.io/name: {{ template "kubeapps.name" . }}
+        app: {{ template "common.names.fullname" . }}
+        app.kubernetes.io/name: {{ template "common.names.name" . }}
         release: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
 {{- include "kubeapps.imagePullSecrets" . | indent 6 }}
       {{- if .Values.frontend.affinity }}
-      affinity: {{- include "kubeapps.tplValue" (dict "value" .Values.frontend.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.frontend.nodeSelector }}
-      nodeSelector: {{- include "kubeapps.tplValue" (dict "value" .Values.frontend.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.frontend.tolerations }}
-      tolerations: {{- include "kubeapps.tplValue" (dict "value" .Values.frontend.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: nginx
-          image: {{ template "kubeapps.image" (list .Values.frontend.image .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.frontend.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy | quote }}
           {{- if .Values.frontend.livenessProbe }}
           livenessProbe: {{- toYaml .Values.frontend.livenessProbe | nindent 12 }}
@@ -74,7 +74,7 @@ spec:
             {{- range .Values.authProxy.additionalFlags }}
             - {{ . }}
             {{- end }}
-          image: {{ template "kubeapps.image" (list .Values.authProxy.image .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.authProxy.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.authProxy.image.pullPolicy | quote }}
           env:
             - name: OAUTH2_PROXY_CLIENT_ID
@@ -115,7 +115,7 @@ spec:
               value: {{ .Values.pinnipedProxy.defaultAuthenticatorName }}
             - name: RUST_LOG
               value: info
-          image: {{ template "kubeapps.image" (list .Values.pinnipedProxy.image .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.pinnipedProxy.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.pinnipedProxy.image.pullPolicy | quote }}
           ports:
             - name: pinniped-proxy

--- a/chart/kubeapps/templates/kubeapps-frontend-service.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kubeapps.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   labels:{{ include "kubeapps.labels" . | nindent 4 }}
   {{- if .Values.frontend.service.annotations }}
-  annotations: {{- include "kubeapps.tplValue" (dict "value" .Values.frontend.service.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.frontend.service.type }}
@@ -24,7 +24,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ template "kubeapps.fullname" . }}
+    app: {{ template "common.names.fullname" . }}
     release: {{ .Release.Name }}
 {{- if .Values.pinnipedProxy.enabled }}
 ---
@@ -43,6 +43,6 @@ spec:
       protocol: TCP
       name: pinniped-proxy
   selector:
-    app: {{ template "kubeapps.fullname" . }}
+    app: {{ template "common.names.fullname" . }}
     release: {{ .Release.Name }}
 {{- end }}

--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "kubeapps.kubeops.fullname" . }}
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ template "kubeapps.kubeops.fullname" . }}
-        app.kubernetes.io/name: {{ template "kubeapps.name" . }}
+        app.kubernetes.io/name: {{ template "common.names.name" . }}
         release: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
@@ -24,13 +24,13 @@ spec:
       # This is because new releases/upgrades/deletions are synchronous operations
       terminationGracePeriodSeconds: 300
       {{- if .Values.kubeops.affinity }}
-      affinity: {{- include "kubeapps.tplValue" (dict "value" .Values.kubeops.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.kubeops.nodeSelector }}
-      nodeSelector: {{- include "kubeapps.tplValue" (dict "value" .Values.kubeops.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.kubeops.tolerations }}
-      tolerations: {{- include "kubeapps.tplValue" (dict "value" .Values.kubeops.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers:
         - name: kubeops
-          image: {{ template "kubeapps.image" (list .Values.kubeops.image .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.kubeops.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.kubeops.image.pullPolicy | quote }}
           command:
             - /kubeops

--- a/chart/kubeapps/templates/kubeops-rbac.yaml
+++ b/chart/kubeapps/templates/kubeops-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "kubeapps.kubeops.fullname" . }}
@@ -22,7 +22,7 @@ rules:
       - get
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "kubeapps.kubeops.fullname" . }}
@@ -38,7 +38,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- if .Values.allowNamespaceDiscovery }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: "kubeapps:controller:kubeops-ns-discovery-{{ .Release.Namespace }}"
@@ -52,7 +52,7 @@ rules:
     verbs:
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: "kubeapps:controller:kubeops-ns-discovery-{{ .Release.Namespace }}"
@@ -68,7 +68,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: "kubeapps:controller:kubeops-operators-{{ .Release.Namespace }}"
@@ -82,7 +82,7 @@ rules:
     verbs:
       - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: "kubeapps:controller:kubeops-operators-{{ .Release.Namespace }}"

--- a/chart/kubeapps/templates/tests/test-assetsvc.yaml
+++ b/chart/kubeapps/templates/tests/test-assetsvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: {{ .Release.Name }}-assetsvc-test
-      image: {{ template "kubeapps.image" (list .Values.testImage .Values.global) }}
+      image: {{ include "common.images.image" (dict "imageRoot" .Values.testImage "global" .Values.global) }}
       env:
         - name: ASSETSVC_HOST
           value: {{ template "kubeapps.assetsvc.fullname" . }}.{{ .Release.Namespace }}

--- a/chart/kubeapps/templates/tests/test-dashboard.yaml
+++ b/chart/kubeapps/templates/tests/test-dashboard.yaml
@@ -7,10 +7,10 @@ metadata:
 spec:
   containers:
     - name: {{ .Release.Name }}-dashboard-test
-      image: {{ template "kubeapps.image" (list .Values.testImage .Values.global) }}
+      image: {{ include "common.images.image" (dict "imageRoot" .Values.testImage "global" .Values.global) }}
       env:
         - name: DASHBOARD_HOST
-          value: {{ template "kubeapps.fullname" . }}.{{ .Release.Namespace }}
+          value: {{ template "common.names.fullname" . }}.{{ .Release.Namespace }}
       command:
         - sh
         - -c

--- a/chart/kubeapps/templates/tls-secrets.yaml
+++ b/chart/kubeapps/templates/tls-secrets.yaml
@@ -1,13 +1,32 @@
 {{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
 {{- range .Values.ingress.secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
   labels: {{ include "kubeapps.labels" $ | nindent 4 }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}
   tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- $ca := genCA "kubeapps-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "kubeapps.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -38,6 +38,10 @@ enableIPv6: false
 clusters:
   - name: default
 
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion: ""
+
 ## The frontend service is the main reverse proxy used to access the Kubeapps UI
 ## To expose Kubeapps externally either configure the ingress object below or
 ## set frontend.service.type=LoadBalancer in the frontend configuration.
@@ -48,6 +52,14 @@ ingress:
   ##
   enabled: false
 
+  ## Override API Version (automatically detected if not set)
+  ##
+  apiVersion: ""
+
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
+
   ## Set this to true in order to add the corresponding annotations for cert-manager
   ##
   certManager: false
@@ -56,9 +68,15 @@ ingress:
   ##
   hostname: kubeapps.local
 
+  ## The Path to Kubeapps Dashboard. You may need to set this to '/*' in order to use this
+  ## with ALB ingress controllers.
+  ##
+  path: /
+
   ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
   ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
-  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
+  ## You can use the ingress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
+  ## let the chart create self-signed certificates for you
   ##
   tls: false
 
@@ -77,16 +95,22 @@ ingress:
 
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## e.g:
   ## extraHosts:
-  ## - name: kubeapps.local
-  ##   path: /
+  ##   - name: kubeapps.local
+  ##     path: /
+  ##
+  extraHosts: []
 
   ## The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## e.g:
   ## extraTls:
-  ## - hosts:
-  ##     - kubeapps.local
-  ##   secretName: kubeapps.local-tls
+  ##   - hosts:
+  ##       - kubeapps.local
+  ##     secretName: kubeapps.local-tls
+  ##
+  extraTls: []
 
   ## If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or
@@ -94,28 +118,15 @@ ingress:
   ##
   ## name should line up with a tlsSecret set further up
   ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
+  ## e.g:
+  ## secrets:
+  ##   - name: kubeapps.local-tls
+  ##     key:
+  ##     certificate:
   ##
   secrets: []
-  ## - name: kubeapps.local-tls
-  ##   key:
-  ##   certificate:
-
-  ## DEPRECATED: to be removed on 3.0.0
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  ##
-  # hosts:
-  #   - name: kubeapps.local
-  #     path: /
-  #     ## Set this to true in order to enable TLS on the ingress record
-  #     ##
-  #     tls: false
-  #     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-  #     ##
-  #     tlsSecret: kubeapps.local-tls
 
 ## Frontend paramters
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

### Description of the change

This PR adapts the Kubeapps chart to use the `bitnami/common` library so several common macros are reused. This is important to standardize this chart with the rest of the Bitnami Catalog.

On the other hand, it ensures the `apiVersion` of several objects (e.g. Ingress, RBAC, CRDs, etc.) is compatible with different K8s versions.

### Benefits

- Standardization
- Compatibility with multiple K8s versions.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

None