### PR TITLE
Fix behavior for multiple chart versions for OCI registries

### DIFF
--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -550,7 +550,7 @@ func chartImportWorker(repoURL *url.URL, r *OCIRegistry, chartJobs <-chan pullCh
 
 // Charts retrieve the list of charts exposed in the repo
 func (r *OCIRegistry) Charts() ([]models.Chart, error) {
-	result := map[string]models.Chart{}
+	result := map[string]*models.Chart{}
 	url, err := parseRepoURL(r.RepoInternal.URL)
 	if err != nil {
 		return nil, err
@@ -592,7 +592,7 @@ func (r *OCIRegistry) Charts() ([]models.Chart, error) {
 				// Chart already exists, append version
 				r.ChartVersions = append(result[ch.ID].ChartVersions, ch.ChartVersions...)
 			} else {
-				result[ch.ID] = *ch
+				result[ch.ID] = ch
 			}
 		} else {
 			log.Errorf("failed to pull chart. Got %v", res.Error)
@@ -601,7 +601,7 @@ func (r *OCIRegistry) Charts() ([]models.Chart, error) {
 
 	charts := []models.Chart{}
 	for _, c := range result {
-		charts = append(charts, c)
+		charts = append(charts, *c)
 	}
 	return charts, nil
 }

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -822,7 +822,7 @@ func TestOCIClient(t *testing.T) {
 		assert.NoErr(t, err)
 		cli.(*OCIClient).puller = &helmfake.OCIPuller{
 			ExpectedName: "foo/bar/nginx:5.1.1",
-			Content:      bytes.NewBuffer(data),
+			Content:      map[string]*bytes.Buffer{"5.1.1": bytes.NewBuffer(data)},
 		}
 		ch, err := cli.GetChart(&Details{ChartName: "nginx", Version: "5.1.1"}, "http://foo/bar")
 		if ch.Name() != "nginx" || ch.Metadata.Version != "5.1.1" {

--- a/pkg/helm/fake/helm.go
+++ b/pkg/helm/fake/helm.go
@@ -3,20 +3,22 @@ package fake
 import (
 	"bytes"
 	"fmt"
+	"strings"
 )
 
 // OCIPuller implements the ChartPuller interface
 type OCIPuller struct {
 	ExpectedName string
-	Content      *bytes.Buffer
+	Content      map[string]*bytes.Buffer
 	Checksum     string
 	Err          error
 }
 
 // PullOCIChart returns some fake content
 func (f *OCIPuller) PullOCIChart(ociFullName string) (*bytes.Buffer, string, error) {
+	tag := strings.Split(ociFullName, ":")[1]
 	if f.ExpectedName != "" && f.ExpectedName != ociFullName {
 		return nil, "", fmt.Errorf("expecting %s got %s", f.ExpectedName, ociFullName)
 	}
-	return f.Content, f.Checksum, f.Err
+	return f.Content[tag], f.Checksum, f.Err
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

I introduced a bug after https://github.com/kubeapps/kubeapps/pull/2373

The variable for the chart versions was scoped to goroutine so only the first one was stored (causing the app to just store the first version received of the chart).

### Additional information

Will need to release a patch version after this :/