### PR TITLE
Fix for Operators without owned CRDs

### DIFF
--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -348,7 +348,7 @@ export function getResource(
     dispatch(requestCustomResource());
     const csv = await dispatch(getCSV(cluster, namespace, csvName));
     if (csv) {
-      const crd = csv.spec.customresourcedefinitions.owned.find(c => c.name === crdName);
+      const crd = csv.spec.customresourcedefinitions.owned?.find(c => c.name === crdName);
       if (crd) {
         const { plural, group } = parseCRD(crd.name);
         try {

--- a/dashboard/src/components/AppList/AppListGrid.tsx
+++ b/dashboard/src/components/AppList/AppListGrid.tsx
@@ -56,7 +56,7 @@ function AppListGrid(props: IAppListProps) {
         })}
         {filteredCRs.map(r => {
           const csv = props.csvs.find(c =>
-            c.spec.customresourcedefinitions.owned.some(crd => crd.kind === r.kind),
+            c.spec.customresourcedefinitions.owned?.some(crd => crd.kind === r.kind),
           );
           return (
             <CustomResourceListItem

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -240,7 +240,7 @@ function Catalog(props: ICatalogProps) {
       const regex = new RegExp(escapeRegExp(searchFilter), "i");
       return (
         regex.test(c.metadata.name) ||
-        c?.spec?.customresourcedefinitions?.owned.find(crd => regex.test(crd.displayName))
+        c?.spec?.customresourcedefinitions?.owned?.find(crd => regex.test(crd.displayName))
       );
     })
     .filter(

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -333,7 +333,7 @@ export interface IClusterServiceVersionCRD {
 export interface IClusterServiceVersionSpec {
   apiservicedefinitions: any;
   customresourcedefinitions: {
-    owned: IClusterServiceVersionCRD[];
+    owned?: IClusterServiceVersionCRD[];
   };
   description: string;
   displayName: string;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

If an Operator doesn't contain CRDs, the dashboard fails with: `cannot read owned of undefined`. Adapted the typescript definition to avoid this issue.
