### PR TITLE
Update oauth2-proxy version to 7.x

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -598,7 +598,7 @@ authProxy:
   image:
     registry: docker.io
     repository: bitnami/oauth2-proxy
-    tag: 6.1.1-debian-10-r154
+    tag: 7.0.1-debian-10-r5
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##


### PR DESCRIPTION
### Description of the change

Verified locally that oidc setup works fine with the new version.

I've not updated the chart versions since #2436 hasn't yet landed which also updates the chart version. If you land this first it will be included, otherwise I'll add an update before landing?

### Benefits

Use the current oauth2-proxy with update support.

