### PR TITLE
Minor css fixes and tweaks for the dark mode

### DIFF
--- a/dashboard/src/components/ApiDocs/ApiDocs.scss
+++ b/dashboard/src/components/ApiDocs/ApiDocs.scss
@@ -5,3 +5,151 @@
 .swagger-ui .info {
   margin: 0.5em 0;
 }
+
+.swagger-ui .info .title {
+  font-family: var(
+    --cds-global-typography-header-font-family,
+    "Clarity City",
+    "Avenir Next",
+    "sans-serif"
+  );
+  font-size: var(--cds-global-typography-font-size-6, 0.55rem);
+  color: var(--cds-global-typography-color-400, #333);
+}
+
+.swagger-ui a.nostyle,
+.swagger-ui .info h1,
+.swagger-ui .info h2,
+.swagger-ui .info h3,
+.swagger-ui .info h4,
+.swagger-ui .info h5 {
+  font-family: var(
+    --cds-global-typography-header-font-family,
+    "Clarity City",
+    "Avenir Next",
+    "sans-serif"
+  );
+  font-size: var(--cds-global-typography-font-size-5, 0.55rem);
+  color: var(--cds-global-typography-color-400, #333);
+}
+
+.swagger-ui,
+.swagger-ui .info li,
+.swagger-ui .info p,
+.swagger-ui .info table,
+.swagger-ui .opblock .opblock-summary-description,
+.swagger-ui .btn,
+.swagger-ui table thead tr td,
+.swagger-ui table thead tr th,
+.swagger-ui .parameter__name,
+.swagger-ui .parameter__type,
+.swagger-ui .response-col_status,
+.swagger-ui .response-col_links,
+.swagger-ui .tab li,
+.swagger-ui .opblock-description-wrapper p,
+.swagger-ui .opblock-external-docs-wrapper p,
+.swagger-ui .opblock-title_normal p,
+.swagger-ui label,
+.swagger-ui .responses-inner h4,
+.swagger-ui .opblock .opblock-section-header h4,
+.swagger-ui .responses-inner h5,
+.swagger-ui .model-title,
+.swagger-ui section.models h4 span,
+.swagger-ui .model {
+  font-family: var(
+    --cds-global-typography-header-font-family,
+    "Clarity City",
+    "Avenir Next",
+    "sans-serif"
+  );
+  font-size: var(--cds-global-typography-font-size-4, 0.55rem);
+  color: var(--cds-global-typography-color-400, #333);
+}
+
+.swagger-ui select {
+  font-family: var(
+    --cds-global-typography-header-font-family,
+    "Clarity City",
+    "Avenir Next",
+    "sans-serif"
+  );
+  font-size: var(--cds-global-typography-font-size-4, 0.55rem);
+}
+
+.swagger-ui .info a {
+  font-family: var(
+    --cds-global-typography-header-font-family,
+    "Clarity City",
+    "Avenir Next",
+    "sans-serif"
+  );
+  font-size: var(--cds-global-typography-font-size-4, 0.55rem);
+  color: var(--cds-global-typography-link-color, #0072a3);
+}
+
+.swagger-ui .scheme-container {
+  background-color: var(--cds-alias-object-overlay-background, #fff);
+}
+
+.swagger-ui .btn {
+  border-color: var(--cds-alias-object-app-border-color, #fff);
+  color: var(--cds-global-typography-color-400, #000);
+  background-color: var(--cds-alias-object-overlay-background, #fff);
+}
+
+.swagger-ui input,
+.swagger-ui textarea {
+  color: var(--cds-global-typography-color-100, #000);
+}
+
+.swagger-ui input[disabled],
+.swagger-ui select[disabled],
+.swagger-ui textarea[disabled] {
+  color: var(--cds-global-typography-color-200, #454545);
+}
+
+.swagger-ui input[disabled]::placeholder,
+.swagger-ui select[disabled]::placeholder,
+.swagger-ui textarea[disabled]::placeholder {
+  color: var(--cds-global-typography-color-200, #454545);
+}
+
+.swagger-ui .response-control-media-type__accept-message {
+  color: var(--cds-alias-status-success, green);
+}
+
+.swagger-ui .opblock .opblock-section-header {
+  background: none;
+}
+
+.modal-ux-inner {
+  background-color: var(--cds-alias-object-app-background);
+  color: var(--cds-global-typography-color-200, #454545);
+}
+
+.swagger-ui .code,
+.swagger-ui code,
+.swagger-ui .dialog-ux .modal-ux-header h3,
+.swagger-ui .dialog-ux .modal-ux-content h4 {
+  color: var(--cds-global-typography-color-400, #333);
+}
+
+.swagger-ui .authorization__btn.unlocked,
+.swagger-ui .dialog-ux .modal-ux-header .close-modal,
+.swagger-ui .expand-methods svg,
+.swagger-ui .expand-operation svg,
+.swagger-ui .models svg,
+.swagger-ui .model-toggle:after,
+.swagger-ui .loading-container {
+  filter: invert(1) brightness(80%) saturate(0%);
+}
+
+.swagger-ui .opblock-body pre.microlight {
+  background-color: var(--cds-global-typography-color-100, #333) !important;
+  color: var(--cds-global-typography-color-400, #fff) !important;
+}
+
+.swagger-ui .opblock-tag,
+.swagger-ui section.models {
+  border-color: var(--cds-alias-object-interaction-border-color);
+}

--- a/dashboard/src/components/AppView/AppSecrets/AppSecrets.scss
+++ b/dashboard/src/components/AppView/AppSecrets/AppSecrets.scss
@@ -5,5 +5,4 @@
 
 .app-secrets-section {
   max-height: 10rem;
-  overflow-y: auto;
 }

--- a/dashboard/src/components/Header/ContextSelector.scss
+++ b/dashboard/src/components/Header/ContextSelector.scss
@@ -28,10 +28,6 @@
   font-size: small;
 }
 
-.kubeapps-dropdown-items {
-  margin-block-start: 0.5em;
-}
-
 .kubeapps-dropdown-text {
   margin-left: 0.2rem;
   margin-right: 0.7rem;

--- a/dashboard/src/components/Header/Menu.scss
+++ b/dashboard/src/components/Header/Menu.scss
@@ -67,6 +67,7 @@
 
 .dropdown-divider {
   opacity: 0.2;
+  border-bottom-color: var(--cds-global-color-gray-50, #fafafa) !important;
 }
 
 .dropdown-menu-item {

--- a/dashboard/src/components/Header/Menu.scss
+++ b/dashboard/src/components/Header/Menu.scss
@@ -65,9 +65,9 @@
   }
 }
 
-.dropdown-divider {
+div .dropdown-menu .dropdown-divider {
   opacity: 0.2;
-  border-bottom-color: var(--cds-global-color-gray-50, #fafafa) !important;
+  border-bottom-color: var(--cds-global-color-gray-50, #fafafa);
 }
 
 .dropdown-menu-item {

--- a/dashboard/src/components/Header/Menu.tsx
+++ b/dashboard/src/components/Header/Menu.tsx
@@ -110,7 +110,7 @@ function Menu({ clusters, appVersion, logout }: IContextSelectorProps) {
                 {appVersion}
                 <br />
                 <Link to={"/docs"}>
-                  Kubeapps API docs{" "}
+                  API documentation portal{" "}
                   <CdsIcon size="sm" shape="network-globe" inverse={true} solid={true} />
                 </Link>
                 <CdsToggle className="dropdown-theme-toggle" control-align="right">

--- a/dashboard/src/components/Layout/Layout.scss
+++ b/dashboard/src/components/Layout/Layout.scss
@@ -115,10 +115,6 @@
   }
   img {
     max-width: 400px;
-    // Invert colors of the logo for the dark mode
-    @media (prefers-color-scheme: dark) {
-      filter: invert(1);
-    }
   }
 }
 

--- a/dashboard/src/components/PageHeader/PageHeader.scss
+++ b/dashboard/src/components/PageHeader/PageHeader.scss
@@ -66,4 +66,7 @@
     font-weight: 500;
     margin-right: 0.6rem;
   }
+  & button {
+    color: var(--cds-global-typography-color-400, #333);
+  }
 }

--- a/dashboard/src/index.scss
+++ b/dashboard/src/index.scss
@@ -3,10 +3,32 @@
 @import "~@cds/core/styles/theme.dark.css"; // clarity core dark theme
 @import "~@cds/core/styles/module.shims.css"; // non-evergreen browser shims
 @import "~@cds/city/css/bundles/default.css"; // load base font
-// clarity UI light/dark themes should be conditionalled loaded since they don't support dynamic theming
+// clarity UI light/dark themes are loaded by changing <link href=...>, since they aren't prepared for theming
 
 svg.icon {
   /* Fix positioning */
   position: relative;
   bottom: -0.125em;
+}
+
+// CSS tweaks the dark mode theme theme
+[cds-theme~="dark"] {
+  %convert-to-white {
+    filter: invert(1) brightness(100%) saturate(0%);
+  }
+
+  .section-not-found img {
+    // White 404 logo
+    @extend %convert-to-white;
+  }
+
+  .kubeapps-header-subtitle img {
+    // White header subtitle Helm logo
+    @extend %convert-to-white;
+  }
+
+  .bg-img img {
+    // White Helm logo in card overlay
+    @extend %convert-to-white;
+  }
 }


### PR DESCRIPTION
_Depends on #2450_ 


### Description of the change

This PR introduces some tweaks for the dark mode (rendered when loading the dark clr theme), mainly converts some svg to white for improving the contrast.
It also fixes an issue with the scrollbars in the secret view and a wrong color in a cds-icon.


### Benefits

It adds these changes:

![image](https://user-images.githubusercontent.com/11535726/109039218-d42c2180-76cc-11eb-8d70-2f10bd88a865.png)

![image](https://user-images.githubusercontent.com/11535726/109039228-d7271200-76cc-11eb-848f-855dba74ff46.png)

![image](https://user-images.githubusercontent.com/11535726/109039236-d9896c00-76cc-11eb-94e7-4d154f42c132.png)

![image](https://user-images.githubusercontent.com/11535726/109039245-dbebc600-76cc-11eb-9be5-5024504c50bc.png)

![image](https://user-images.githubusercontent.com/11535726/109703970-5ff2f180-7b96-11eb-9b36-5b09ff7df9b7.png)


### Possible drawbacks

N/A

### Applicable issues

  - fixes #2462 
  -  related #2372
  -  related #2371 

### Additional information

N/A