### PR TITLE
feat(form): Add custom form component integration

### DIFF
--- a/chart/kubeapps/templates/dashboard-config.yaml
+++ b/chart/kubeapps/templates/dashboard-config.yaml
@@ -27,6 +27,10 @@ data:
         root /app/custom-locale/;
       }
 
+      location /custom_components.js {
+        root /app/custom-components/;
+      }
+
       location / {
         # Redirects are required to be relative otherwise the internal hostname will be exposed
         absolute_redirect off;
@@ -50,6 +54,8 @@ data:
     }
   custom_style.css: |-
 {{- .Values.dashboard.customStyle | nindent 4 }}
+  custom_components.js: |-
+{{- .Values.dashboard.customComponents | nindent 4 }}
   custom_locale.json: |-
 {{- .Values.dashboard.customLocale | toJson | nindent 4 }}
   config.json: |-

--- a/chart/kubeapps/templates/dashboard-deployment.yaml
+++ b/chart/kubeapps/templates/dashboard-deployment.yaml
@@ -57,6 +57,8 @@ spec:
               name: custom-css
             - mountPath: /app/custom-locale
               name: custom-locale
+            - mountPath: /app/custom-components
+              name: custom-components
           ports:
             - name: http
               containerPort: 8080
@@ -88,3 +90,9 @@ spec:
             items:
               - key: custom_locale.json
                 path: custom_locale.json
+        - name: custom-components
+          configMap:
+            name: {{ template "kubeapps.dashboard-config.fullname" . }}
+            items:
+              - key: custom_components.js
+                path: custom_components.js

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -508,6 +508,10 @@ dashboard:
   ##      background-color: #991700;
   ##    }
   customStyle: ""
+  ## Custom Form components injected into the BasicDeploymentForm
+  ## Read the reference below for a step-by-step integration
+  ## https://github.com/kubeapps/kubeapps/blob/master/docs/developer/custom-form-component-support.md
+  customComponents: ""
   ## Custom translations injected to the Dashboard to customize the strings used in Kubeapps
   ## Ref: https://github.com/kubeapps/kubeapps/blob/master/docs/developer/translate-kubeapps.md
   ## e.g:

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,6 +8,7 @@
     "@cds/core": "^5.0.3",
     "@cds/react": "^5.0.3",
     "@clr/ui": "^5.0.3",
+    "@paciolan/remote-component": "^2.11.0",
     "@types/diff": "^5.0.0",
     "@types/js-yaml": "^4.0.0",
     "@types/json-schema": "^7.0.7",

--- a/dashboard/src/RemoteComponent.js
+++ b/dashboard/src/RemoteComponent.js
@@ -1,0 +1,6 @@
+import { createRemoteComponent, createRequires } from "@paciolan/remote-component";
+import { resolve } from "./remote-component.config.js";
+
+const requires = createRequires(resolve);
+
+export const CustomComponent = createRemoteComponent({ requires });

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
@@ -1,0 +1,42 @@
+import { mount } from "enzyme";
+import { IBasicFormParam } from "shared/types";
+import { CustomComponent } from "../../../RemoteComponent";
+import CustomFormComponentLoader from "./CustomFormParam";
+
+const param = {
+  path: "enableMetrics",
+  value: true,
+  type: "boolean",
+  customComponent: {
+    className: "test",
+  },
+} as IBasicFormParam;
+
+const defaultProps = {
+  param,
+  handleBasicFormParamChange: jest.fn(),
+};
+
+// Mocking the window so that the injected components are imported correctly
+const { location } = window;
+beforeAll((): void => {
+  // @ts-ignore
+  delete window.location;
+  // @ts-ignore
+  window.location = {
+    origin: "../../../../../docs/developer/examples/CustomComponent.min.js",
+  };
+});
+afterAll((): void => {
+  window.location = location;
+});
+
+it("should render a custom form component", () => {
+  const wrapper = mount(<CustomFormComponentLoader {...defaultProps} />);
+  expect(wrapper.find(CustomFormComponentLoader)).toExist();
+});
+
+it("should render the remote component", () => {
+  const wrapper = mount(<CustomFormComponentLoader {...defaultProps} />);
+  expect(wrapper.find(CustomComponent)).toExist();
+});

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.tsx
@@ -1,0 +1,29 @@
+import React, { useMemo } from "react";
+import { IBasicFormParam } from "shared/types";
+import { CustomComponent } from "../../../RemoteComponent";
+
+export interface ICustomParamProps {
+  param: IBasicFormParam;
+  handleBasicFormParamChange: (
+    p: IBasicFormParam,
+  ) => (e: React.FormEvent<HTMLInputElement>) => void;
+}
+
+export default function CustomFormComponentLoader({
+  param,
+  handleBasicFormParamChange,
+}: ICustomParamProps) {
+  // Fetches the custom-component bundle served by the dashboard nginx
+  const url = `${window.location.origin}/custom_components.js`;
+
+  return useMemo(
+    () => (
+      <CustomComponent
+        url={url}
+        param={param}
+        handleBasicFormParamChange={handleBasicFormParamChange}
+      />
+    ),
+    [handleBasicFormParamChange, param, url],
+  );
+}

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Param.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Param.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { getValue } from "shared/schema";
 import { DeploymentEvent, IBasicFormParam, IBasicFormSliderParam } from "shared/types";
 import BooleanParam from "./BooleanParam";
+import CustomFormComponentLoader from "./CustomFormParam";
 import SliderParam from "./SliderParam";
 import Subsection from "./Subsection";
 import TextParam from "./TextParam";
@@ -99,6 +100,18 @@ export default function Param({
       return paramDeploymentEvent === deploymentEvent;
     }
   };
+
+  // Return early for custom components
+  if (param.customComponent) {
+    return (
+      <div key={id} hidden={isHidden()}>
+        <CustomFormComponentLoader
+          param={param}
+          handleBasicFormParamChange={handleBasicFormParamChange}
+        />
+      </div>
+    );
+  }
 
   // If the type of the param is an array, represent it as its first type
   const type = isArray(param.type) ? param.type[0] : param.type;

--- a/dashboard/src/remote-component.config.js
+++ b/dashboard/src/remote-component.config.js
@@ -1,0 +1,8 @@
+/**
+ * Dependencies for Remote Components
+ */
+module.exports = {
+  resolve: {
+    react: require("react"),
+  },
+};

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -579,6 +579,7 @@ export interface IBasicFormParam {
   maximum?: number;
   render?: string;
   description?: string;
+  customComponent?: object;
   enum?: string[];
   hidden?:
     | {

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -1639,6 +1639,18 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@paciolan/remote-component@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@paciolan/remote-component/-/remote-component-2.11.0.tgz#fc3c2a45fcba21e98d66ceaf894144906bcb4fed"
+  integrity sha512-ujQxfJa0Cp0q+uCiTFpscYD7q14f2rVuUl934HgVXBW/CBChfzLwZGYjtF59IAsbwVGMpgpUlMdD0B26p/hxTg==
+  dependencies:
+    "@paciolan/remote-module-loader" "^2.6.0"
+
+"@paciolan/remote-module-loader@^2.6.0":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@paciolan/remote-module-loader/-/remote-module-loader-2.6.2.tgz#27177a73810ab78d1cbc4ed8ba7f0389af80d5ef"
+  integrity sha512-A49c4kX70zNpjFNuLwa53+xMlGf1W/DXMqBFR1JOMGTIpfZ6KJLpfonRG+2eA1c3CFZNvn+j99QWFEd6lgKSMA==
+
 "@pmmmwh/react-refresh-webpack-plugin@0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"

--- a/docs/developer/basic-form-support.md
+++ b/docs/developer/basic-form-support.md
@@ -9,7 +9,7 @@ Since Kubeapps 1.6.0, it's possible to include a JSON schema with a chart that d
 
 The goal of this feature is to present the user with the most common parameters which are typically modified before deploying a chart (like username and password) in a more user-friendly form.
 
-This document specifies what's needed to be defined in order to present this basic form to the users of a chart.
+This document specifies what's needed to be defined in order to present this basic form to the users of a chart. If the basic form components do not fit your needs we also offer the ability for developers to inject their own custom components, the integration docs can be found [here](https://github.com/kubeapps/kubeapps/blob/master/docs/developer/custom-form-component-support.md).
 
 ## Create a values.schema.json
 

--- a/docs/developer/custom-form-component-support.md
+++ b/docs/developer/custom-form-component-support.md
@@ -1,0 +1,48 @@
+# Custom Form Component Support
+This is an extension to the [basic form support](https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md#basic-form-support)
+
+## Possible use cases
+- Custom UI component that are not yet supported by the basic components (e.g: radio selectors)
+- Consuming third party APIs for component values and validation
+
+## Step-by-step integration process
+1. First you will need a react component to render instead of the default Kubeapps form components. You're React components must be compiled into a JS file so that they can be interpreted by the browser since they cannot natively parse `.jsx` or `.tsx` files. You can compile `jsx` or `tsx` into js with tools like webpack, create-react-app, babel, etc. If you just want to try this feature out and you don't have a component yet we provide some test files you can try (Do not try to load the `jsx` file since browsers cannot parse it! We simply include it so that you can see the pre-compiled version of the `.js` files).
+2. The easiest way to add inject the file in is via the command line. You can do it via the following command:
+    ```
+    helm install  bitnami/kubeapps --set-file dashboard.customComponents=*path to file* <other_flags>
+    ```
+    Note: The file can be located anywhere on your file system or even a remote source!
+
+3. Once the deployment is complete you will need a values json that will signal to Kubeapps that we want to render a custom component and not one fo the provided ones. To do that you will need a `values.json.schema` that has a `customComponent` key, more info [here](https://github.com/kubeapps/kubeapps/blob/master/docs/developer/custom-form-component-support.md#render-a-custom-component).
+
+## Render a custom component
+Signaling to the Kubeapps dashboard that you want to render a custom component is pretty straight forward.  Simply add a `customComponent` field to any form parameter defined in the  `values.json.schema` and that will tell the react application to fetch the component from the custom js bundle. An example parameter could look like:
+```
+    "databaseType": {
+      "type": "string",
+      "form": true,
+      "enum": ["mariadb", "postgresql"],
+      "title": "Database Type",
+      "description": "Allowed values: \"mariadb\" and \"postgresql\"",
+      "customComponent": {
+          "type": "radio",
+          "className": "primary-radio"
+      }
+    }
+```
+Note: The `customComponent` field **MUST BE AN OBJECT**. This design decision was made so that developers can pass extra values/properties into their custom components should they require them.
+
+## Updating Helm values with custom components
+Custom form components would be useless without the ability to interact with the YAML state. To do this your custom components should be set up to receive 2 props: `handleBasicFormParamChange` and `param`. `param` is the current json object this is being rendered (denoted by the `customComponent` field) and `handleBasicFormParamChange` which is a function that updates the YAML file. An example of how you use this function can be found in any of the BasicDeploymentForm components such as the [SliderParam](https://github.com/kubeapps/kubeapps/blob/master/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/SliderParam.tsx#L47-L53).
+```
+  const handleParamChange = (newValue: number) => {
+    handleBasicFormParamChange(param)({
+      currentTarget: {
+        value: newValue,
+      },
+    } as React.FormEvent<HTMLInputElement>);
+  };
+```
+
+## Tips
+To help you get started we provide some examples that you can try [here](https://github.com/kubeapps/kubeapps/blob/master/docs/developer/examples). The three files should give you a good idea about how to start developing and building your own custom components. `CustomComponent.jsx` is a super simple react component that takes the `handleBasicFormParamChange` and `param` props and renders a button that changes the value to 'test'. `CustomComponent.js` is the JavaScript variant of `CustomComponent.jsx` and `CustomComponent.min.js` is a minified js bundle created using [remote-component-starter](https://github.com/Paciolan/remote-component-starter), which is specifically made to help build components that you want to load remotely with the [remote-component](https://github.com/Paciolan/remote-component) tool used by Kubeapps.

--- a/docs/developer/examples/CustomComponent.js
+++ b/docs/developer/examples/CustomComponent.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from "react"; //This is a super simple react component to demo how a custom component could look
+
+export default function Test(props) {
+  const {
+    param,
+    handleBasicFormParamChange
+  } = props;
+  const [value, setValue] = useState(props.value || "");
+  useEffect(() => {
+    setValue(props.param.value);
+  }, [props.param.value]);
+
+  const handleChange = newValue => {
+    handleBasicFormParamChange(props.param)({
+      currentTarget: {
+        value: "test"
+      }
+    });
+    setValue(newValue);
+  };
+
+  const selectedStyle = {
+    backgroundColor: "rgba(0, 140, 255, 0.19)"
+  };
+  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("button", {
+    key: `test`,
+    type: "button",
+    onClick: () => handleChange("test"),
+    style: "test" === value ? selectedStyle : null
+  }, "Test"));
+}

--- a/docs/developer/examples/CustomComponent.jsx
+++ b/docs/developer/examples/CustomComponent.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+
+//This is a super simple react component to demo how a custom component could look
+export default function Test(props) {
+  const { param, handleBasicFormParamChange } = props;
+
+  const [value, setValue] = useState(props.value || "");
+
+  useEffect(() => {
+    setValue(props.param.value);
+  }, [props.param.value]);
+
+  const handleChange = newValue => {
+    handleBasicFormParamChange(props.param)({
+      currentTarget: {
+        value: "test"
+      }
+    });
+    setValue(newValue);
+  };
+
+  const selectedStyle = {
+    backgroundColor: "rgba(0, 140, 255, 0.19)"
+  };
+
+  return (
+    <>
+      <button
+        key={`test`}
+        type="button"
+        onClick={() => handleChange("test")}
+        style={"test" === value ? selectedStyle : null}
+      >
+        Test
+      </button>
+    </>
+  );
+}

--- a/docs/developer/examples/CustomComponent.min.js
+++ b/docs/developer/examples/CustomComponent.min.js
@@ -1,0 +1,181 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-sequences */
+/* eslint-disable strict */
+(function(e, a) { for(var i in a) e[i] = a[i]; }(exports, /******/ (function(modules) { // webpackBootstrap
+    /******/ 	// The module cache
+    /******/ 	var installedModules = {};
+    /******/
+    /******/ 	// The require function
+    /******/ 	function __webpack_require__(moduleId) {
+    /******/
+    /******/ 		// Check if module is in cache
+    /******/ 		if(installedModules[moduleId]) {
+    /******/ 			return installedModules[moduleId].exports;
+    /******/ 		}
+    /******/ 		// Create a new module (and put it into the cache)
+    /******/ 		var module = installedModules[moduleId] = {
+    /******/ 			i: moduleId,
+    /******/ 			l: false,
+    /******/ 			exports: {}
+    /******/ 		};
+    /******/
+    /******/ 		// Execute the module function
+    /******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+    /******/
+    /******/ 		// Flag the module as loaded
+    /******/ 		module.l = true;
+    /******/
+    /******/ 		// Return the exports of the module
+    /******/ 		return module.exports;
+    /******/ 	}
+    /******/
+    /******/
+    /******/ 	// expose the modules object (__webpack_modules__)
+    /******/ 	__webpack_require__.m = modules;
+    /******/
+    /******/ 	// expose the module cache
+    /******/ 	__webpack_require__.c = installedModules;
+    /******/
+    /******/ 	// define getter function for harmony exports
+    /******/ 	__webpack_require__.d = function(exports, name, getter) {
+    /******/ 		if(!__webpack_require__.o(exports, name)) {
+    /******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+    /******/ 		}
+    /******/ 	};
+    /******/
+    /******/ 	// define __esModule on exports
+    /******/ 	__webpack_require__.r = function(exports) {
+    /******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+    /******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+    /******/ 		}
+    /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+    /******/ 	};
+    /******/
+    /******/ 	// create a fake namespace object
+    /******/ 	// mode & 1: value is a module id, require it
+    /******/ 	// mode & 2: merge all properties of value into the ns
+    /******/ 	// mode & 4: return value when already ns object
+    /******/ 	// mode & 8|1: behave like require
+    /******/ 	__webpack_require__.t = function(value, mode) {
+    /******/ 		if(mode & 1) value = __webpack_require__(value);
+    /******/ 		if(mode & 8) return value;
+    /******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+    /******/ 		var ns = Object.create(null);
+    /******/ 		__webpack_require__.r(ns);
+    /******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+    /******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+    /******/ 		return ns;
+    /******/ 	};
+    /******/
+    /******/ 	// getDefaultExport function for compatibility with non-harmony modules
+    /******/ 	__webpack_require__.n = function(module) {
+    /******/ 		var getter = module && module.__esModule ?
+    /******/ 			function getDefault() { return module['default']; } :
+    /******/ 			function getModuleExports() { return module; };
+    /******/ 		__webpack_require__.d(getter, 'a', getter);
+    /******/ 		return getter;
+    /******/ 	};
+    /******/
+    /******/ 	// Object.prototype.hasOwnProperty.call
+    /******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+    /******/
+    /******/ 	// __webpack_public_path__
+    /******/ 	__webpack_require__.p = "";
+    /******/
+    /******/
+    /******/ 	// Load entry module and return exports
+    /******/ 	return __webpack_require__(__webpack_require__.s = "./src/index.js");
+    /******/ })
+    /************************************************************************/
+    /******/ ({
+    
+    /***/ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js":
+    /*!*****************************************************************!*\
+      !*** ./node_modules/@babel/runtime/helpers/arrayLikeToArray.js ***!
+      \*****************************************************************/
+    /*! no static exports found */
+    /***/ (function(module, exports) {
+    
+    eval("function _arrayLikeToArray(arr, len) {\n  if (len == null || len > arr.length) len = arr.length;\n\n  for (var i = 0, arr2 = new Array(len); i < len; i++) {\n    arr2[i] = arr[i];\n  }\n\n  return arr2;\n}\n\nmodule.exports = _arrayLikeToArray;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/arrayLikeToArray.js?");
+    
+    /***/ }),
+    
+    /***/ "./node_modules/@babel/runtime/helpers/arrayWithHoles.js":
+    /*!***************************************************************!*\
+      !*** ./node_modules/@babel/runtime/helpers/arrayWithHoles.js ***!
+      \***************************************************************/
+    /*! no static exports found */
+    /***/ (function(module, exports) {
+    
+    eval("function _arrayWithHoles(arr) {\n  if (Array.isArray(arr)) return arr;\n}\n\nmodule.exports = _arrayWithHoles;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/arrayWithHoles.js?");
+    
+    /***/ }),
+    
+    /***/ "./node_modules/@babel/runtime/helpers/iterableToArrayLimit.js":
+    /*!*********************************************************************!*\
+      !*** ./node_modules/@babel/runtime/helpers/iterableToArrayLimit.js ***!
+      \*********************************************************************/
+    /*! no static exports found */
+    /***/ (function(module, exports) {
+    
+    eval("function _iterableToArrayLimit(arr, i) {\n  if (typeof Symbol === \"undefined\" || !(Symbol.iterator in Object(arr))) return;\n  var _arr = [];\n  var _n = true;\n  var _d = false;\n  var _e = undefined;\n\n  try {\n    for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {\n      _arr.push(_s.value);\n\n      if (i && _arr.length === i) break;\n    }\n  } catch (err) {\n    _d = true;\n    _e = err;\n  } finally {\n    try {\n      if (!_n && _i[\"return\"] != null) _i[\"return\"]();\n    } finally {\n      if (_d) throw _e;\n    }\n  }\n\n  return _arr;\n}\n\nmodule.exports = _iterableToArrayLimit;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/iterableToArrayLimit.js?");
+    
+    /***/ }),
+    
+    /***/ "./node_modules/@babel/runtime/helpers/nonIterableRest.js":
+    /*!****************************************************************!*\
+      !*** ./node_modules/@babel/runtime/helpers/nonIterableRest.js ***!
+      \****************************************************************/
+    /*! no static exports found */
+    /***/ (function(module, exports) {
+    
+    eval("function _nonIterableRest() {\n  throw new TypeError(\"Invalid attempt to destructure non-iterable instance.\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\");\n}\n\nmodule.exports = _nonIterableRest;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/nonIterableRest.js?");
+    
+    /***/ }),
+    
+    /***/ "./node_modules/@babel/runtime/helpers/slicedToArray.js":
+    /*!**************************************************************!*\
+      !*** ./node_modules/@babel/runtime/helpers/slicedToArray.js ***!
+      \**************************************************************/
+    /*! no static exports found */
+    /***/ (function(module, exports, __webpack_require__) {
+    
+    eval("var arrayWithHoles = __webpack_require__(/*! ./arrayWithHoles */ \"./node_modules/@babel/runtime/helpers/arrayWithHoles.js\");\n\nvar iterableToArrayLimit = __webpack_require__(/*! ./iterableToArrayLimit */ \"./node_modules/@babel/runtime/helpers/iterableToArrayLimit.js\");\n\nvar unsupportedIterableToArray = __webpack_require__(/*! ./unsupportedIterableToArray */ \"./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js\");\n\nvar nonIterableRest = __webpack_require__(/*! ./nonIterableRest */ \"./node_modules/@babel/runtime/helpers/nonIterableRest.js\");\n\nfunction _slicedToArray(arr, i) {\n  return arrayWithHoles(arr) || iterableToArrayLimit(arr, i) || unsupportedIterableToArray(arr, i) || nonIterableRest();\n}\n\nmodule.exports = _slicedToArray;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/slicedToArray.js?");
+    
+    /***/ }),
+    
+    /***/ "./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js":
+    /*!***************************************************************************!*\
+      !*** ./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js ***!
+      \***************************************************************************/
+    /*! no static exports found */
+    /***/ (function(module, exports, __webpack_require__) {
+    
+    eval("var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray */ \"./node_modules/@babel/runtime/helpers/arrayLikeToArray.js\");\n\nfunction _unsupportedIterableToArray(o, minLen) {\n  if (!o) return;\n  if (typeof o === \"string\") return arrayLikeToArray(o, minLen);\n  var n = Object.prototype.toString.call(o).slice(8, -1);\n  if (n === \"Object\" && o.constructor) n = o.constructor.name;\n  if (n === \"Map\" || n === \"Set\") return Array.from(o);\n  if (n === \"Arguments\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return arrayLikeToArray(o, minLen);\n}\n\nmodule.exports = _unsupportedIterableToArray;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js?");
+    
+    /***/ }),
+    
+    /***/ "./src/index.js":
+    /*!**********************!*\
+      !*** ./src/index.js ***!
+      \**********************/
+    /*! exports provided: default */
+    /***/ (function(module, __webpack_exports__, __webpack_require__) {
+    
+    "use strict";
+    eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \"default\", function() { return Test; });\n/* harmony import */ var _babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/slicedToArray */ \"./node_modules/@babel/runtime/helpers/slicedToArray.js\");\n/* harmony import */ var _babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0__);\n/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! react */ \"react\");\n/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_1__);\n\n\n//This is a super simple react component to demo how a custom component could look\nfunction Test(props) {var\n  param = props.param,handleBasicFormParamChange = props.handleBasicFormParamChange;var _useState =\n\n  Object(react__WEBPACK_IMPORTED_MODULE_1__[\"useState\"])(props.value || \"\"),_useState2 = _babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0___default()(_useState, 2),value = _useState2[0],setValue = _useState2[1];\n\n  Object(react__WEBPACK_IMPORTED_MODULE_1__[\"useEffect\"])(function () {\n    setValue(props.param.value);\n  }, [props.param.value]);\n\n  var handleChange = function handleChange(newValue) {\n    handleBasicFormParamChange(props.param)({\n      currentTarget: {\n        value: \"test\" } });\n\n\n    setValue(newValue);\n  };\n\n  var selectedStyle = {\n    backgroundColor: \"rgba(0, 140, 255, 0.19)\" };\n\n\n  return /*#__PURE__*/(\n    react__WEBPACK_IMPORTED_MODULE_1___default.a.createElement(react__WEBPACK_IMPORTED_MODULE_1___default.a.Fragment, null, /*#__PURE__*/\n    react__WEBPACK_IMPORTED_MODULE_1___default.a.createElement(\"button\", {\n      key: \"test\",\n      type: \"button\",\n      onClick: function onClick() {return handleChange(\"test\");},\n      style: \"test\" === value ? selectedStyle : null }, \"Test\")));\n\n\n\n\n\n}\n\n//# sourceURL=webpack:///./src/index.js?");
+    
+    /***/ }),
+    
+    /***/ "react":
+    /*!************************!*\
+      !*** external "react" ***!
+      \************************/
+    /*! no static exports found */
+    /***/ (function(module, exports) {
+    
+    eval("module.exports = require(\"react\");\n\n//# sourceURL=webpack:///external_%22react%22?");
+    
+    /***/ })
+    
+    /******/ })));


### PR DESCRIPTION
Signed-off-by: Anthony Rizzo <36711320+aanthonyrizzo@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR adds the ability to load custom form components from a separate js file by passing the render param and the the handleChange func.

### Benefits

<!-- What benefits will be realized by the code change? -->

- Allow devs to build custom UI components (radios for example)
- Allow devs to consume external APIs inside of components for rendering logic/validation

### Possible drawbacks

<!-- Describe any known limitations with your change -->

- Unfortunately the external components have to be loaded via a separate js file (im imagining this is a js bundle). As you will see I decided to use a pvc to mount the file into the dashboard nginx so that when pods are deleted the js file is remounted. 

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
Fixes #2352 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Example:
![image](https://user-images.githubusercontent.com/36711320/109541481-db1eaf80-7a91-11eb-83ae-a167254d8e4a.png)
Instead of rendering a dropdown it rendered 'Hello world!' from a js bundle file
