### PR TITLE
Avoid endless page requesting if when failing requests + manual retry

### DIFF
--- a/dashboard/src/actions/charts.test.tsx
+++ b/dashboard/src/actions/charts.test.tsx
@@ -225,6 +225,23 @@ describe("fetchCharts", () => {
     );
     expect(store.getActions()).toEqual(expectedActions);
   });
+
+  it("returns a generic error and it is cleared later", async () => {
+    const expectedActions = [
+      { type: getType(actions.charts.requestCharts), payload: 1 },
+      { type: getType(actions.charts.errorChart), payload: new Error("something went wrong") },
+      { type: getType(actions.charts.clearErrorChart) },
+    ];
+    axiosGetMock = jest.fn(() => {
+      throw new Error("something went wrong");
+    });
+    axiosWithAuth.get = axiosGetMock;
+    await store.dispatch(
+      actions.charts.fetchCharts(cluster, namespace, "foo", defaultPage, defaultSize),
+    );
+    await store.dispatch(actions.charts.clearErrorChart());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
 });
 
 describe("fetchChartCategories", () => {

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -39,6 +39,8 @@ export const errorChart = createAction("ERROR_CHART", resolve => {
   return (err: Error) => resolve(err);
 });
 
+export const clearErrorChart = createAction("CLEAR_ERROR_CHART");
+
 export const errorChartCatetories = createAction("ERROR_CHART_CATEGORIES", resolve => {
   return (err: Error) => resolve(err);
 });
@@ -74,6 +76,7 @@ const allActions = [
   requestCharts,
   requestChart,
   errorChart,
+  clearErrorChart,
   errorChartCatetories,
   requestChartsCategories,
   receiveCharts,

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -264,7 +264,7 @@ function Catalog(props: ICatalogProps) {
 
   const forceRetry = () => {
     dispatch(actions.charts.clearErrorChart());
-    increaseRequestedPage();
+    fetchCharts(cluster, namespace, reposFilter, page, size, searchFilter);
   };
 
   const increaseRequestedPage = () => {

--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -1,5 +1,6 @@
 import { CdsButton } from "@cds/react/button";
 import { CdsIcon } from "@cds/react/icon";
+import actions from "actions";
 import FilterGroup from "components/FilterGroup/FilterGroup";
 import Alert from "components/js/Alert";
 import Column from "components/js/Column";
@@ -256,8 +257,20 @@ function Catalog(props: ICatalogProps) {
 
   // Required to have the latest value of page
   const setPageWithContext = () => {
+    if (!error) {
+      increaseRequestedPage();
+    }
+  };
+
+  const forceRetry = () => {
+    dispatch(actions.charts.clearErrorChart());
+    increaseRequestedPage();
+  };
+
+  const increaseRequestedPage = () => {
     setPage(page + 1);
   };
+
   const observeBorder = (node: any) => {
     // Check if the IntersectionAPI is enabled
     if ("IntersectionObserver" in window && "IntersectionObserverEntry" in window) {
@@ -305,7 +318,15 @@ function Catalog(props: ICatalogProps) {
         }
       />
       {error && (
-        <Alert theme="danger">An error occurred while fetching the catalog: {error.message}</Alert>
+        <Alert theme="danger">
+          An error occurred while fetching the catalog: {error.message}.{" "}
+          {!hasFinishedFetching && (
+            <CdsButton size="sm" action="flat" onClick={forceRetry} type="button">
+              {" "}
+              Try again{" "}
+            </CdsButton>
+          )}
+        </Alert>
       )}
       {isEqual(filters, initialFilterState()) &&
       hasFinishedFetching &&
@@ -426,6 +447,12 @@ function Catalog(props: ICatalogProps) {
                         filters[filterNames.TYPE].find((type: string) => type === "Charts")) && (
                         <div className="endPageMessage">
                           <LoadingWrapper medium={true} loaded={false} />
+                          {error && !hasFinishedFetching && (
+                            <CdsButton size="sm" action="flat" onClick={forceRetry} type="button">
+                              {" "}
+                              Try again{" "}
+                            </CdsButton>
+                          )}
                         </div>
                       )}
                     {!hasFinishedFetching && !isFetching && (

--- a/dashboard/src/reducers/charts.test.ts
+++ b/dashboard/src/reducers/charts.test.ts
@@ -299,7 +299,26 @@ describe("chartReducer", () => {
     expect(state3).toEqual({
       ...initialState,
       isFetching: false,
-      items: [],
+      items: [chartItem],
+    });
+  });
+
+  it("clears errors after clearErrorChart", () => {
+    const state1 = chartsReducer(undefined, {
+      type: getType(actions.charts.receiveCharts) as any,
+      payload: { items: [chartItem], page: 1, totalPages: 5 },
+    });
+    const state2 = chartsReducer(state1, {
+      type: getType(actions.charts.errorChart) as any,
+    });
+    const state3 = chartsReducer(state2, {
+      type: getType(actions.charts.clearErrorChart) as any,
+    });
+    expect(state3).toEqual({
+      ...initialState,
+      isFetching: false,
+      items: [chartItem],
+      selected: initialState.selected,
     });
   });
 

--- a/dashboard/src/reducers/charts.ts
+++ b/dashboard/src/reducers/charts.ts
@@ -42,6 +42,8 @@ const chartsSelectedReducer = (
       return { ...state, readme: action.payload, readmeError: undefined };
     case getType(actions.charts.errorChart):
       return { ...state, error: action.payload };
+    case getType(actions.charts.clearErrorChart):
+      return { ...state, error: undefined };
     case getType(actions.charts.errorReadme):
       return { ...state, readmeError: action.payload };
     case getType(actions.charts.resetChartVersion):
@@ -105,7 +107,12 @@ const chartsReducer = (
         ...state,
         isFetching: false,
         hasFinishedFetching: false,
-        items: [],
+        items: state.items,
+        selected: chartsSelectedReducer(state.selected, action),
+      };
+    case getType(actions.charts.clearErrorChart):
+      return {
+        ...state,
         selected: chartsSelectedReducer(state.selected, action),
       };
     case getType(actions.charts.errorChartCatetories):


### PR DESCRIPTION
### Description of the change

This PR aims at solving one of the issues detected in https://github.com/kubeapps/kubeapps/issues/2484#issuecomment-788658490. Currently, the pagination is trying to increase the page regardless of the status code.

In this PR we stop requesting more pages if an error is detected. However, solely adding that has a severe impact on the UX: if request happens to fail, all the previously requested items will be discarded and the only way to retry is by performing a hard reload (f5).
Wherefore this PR also adds a mechanism to trigger: i) an increase of the requested page; 2) clearing the current error.


### Benefits

 A live example is depicted below:

![tryAgainReq](https://user-images.githubusercontent.com/11535726/109838071-1bbf2a00-7c46-11eb-939b-e092dd7e93a5.gif)


### Possible drawbacks

This approach just assumes there is a problem on a given page and we force to request the next one. As a result, the failing page will remain unrequested. 

### Applicable issues

  - related https://github.com/kubeapps/kubeapps/issues/2484

### Additional information

Perhaps 'try again' is not the best message (since we do discard the failing page), see what you think.
