### PR TITLE
Make pinniped-proxy compatible with 0.6.0 and TMC

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -113,6 +113,8 @@ spec:
               value: {{ .Values.pinnipedProxy.defaultAuthenticatorType }}
             - name: DEFAULT_PINNIPED_AUTHENTICATOR_NAME
               value: {{ .Values.pinnipedProxy.defaultAuthenticatorName }}
+            - name: DEFAULT_PINNIPED_API_SUFFIX
+              value: {{ .Values.pinnipedProxy.defaultPinnipedAPISuffix }}
             - name: RUST_LOG
               value: info
           image: {{ include "common.images.image" (dict "imageRoot" .Values.pinnipedProxy.image "global" .Values.global) }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -686,6 +686,9 @@ pinnipedProxy:
   defaultPinnipedNamespace: pinniped-concierge
   defaultAuthenticatorType: JWTAuthenticator
   defaultAuthenticatorName: jwt-authenticator
+  ## The defaultPinnipedAPISuffix flag is not fully supported yet, 
+  ## please use the default value "pinniped.dev"
+  defaultPinnipedAPISuffix: pinniped.dev
 
   ## OAuth2 Proxy containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/cmd/pinniped-proxy/src/pinniped.rs
+++ b/cmd/pinniped-proxy/src/pinniped.rs
@@ -241,6 +241,7 @@ fn get_pinniped_login_api_group() ->  String  {
     return format!("{}.{}", "login.concierge", &api_suffix).to_string();
 }
 
+
 #[macro_use]
 #[cfg(test)]
 mod tests {
@@ -293,6 +294,7 @@ mod tests {
     #[test]
     #[serial(envtest)]
     fn test_get_api_group_getters() -> Result<()> {
+        env::remove_var("DEFAULT_DEFAULT_PINNIPED_API_SUFFIX");
         let authenticator_api_group =  get_pinniped_authenticator_api_group();
         assert_eq!(authenticator_api_group, "authentication.concierge.pinniped.dev");
 
@@ -306,5 +308,23 @@ mod tests {
         let login_api_group = get_pinniped_login_api_group();
         assert_eq!(login_api_group, "login.concierge.foo.bar");
         Ok(())
-}
+    }
+
+    #[test]
+    #[serial(envtest)]
+    fn test_get_is_tmc_environment() -> Result<()> {
+        env::remove_var("DEFAULT_PINNIPED_API_SUFFIX");
+        let is_tmc_environment: bool = env::var(DEFAULT_PINNIPED_API_SUFFIX).unwrap_or(DEFAULT_API_SUFFIX.into()) == TMC_PINNIPED_API_SUFFIX;
+        assert_eq!(is_tmc_environment, false);
+        
+        let is_tmc_environment: bool = env::var(DEFAULT_PINNIPED_API_SUFFIX).unwrap_or(DEFAULT_API_SUFFIX.into()) == TMC_PINNIPED_API_SUFFIX;
+        env::set_var(DEFAULT_PINNIPED_API_SUFFIX, "foo.bar");
+        assert_eq!(is_tmc_environment, false);
+
+        let is_tmc_environment: bool = env::var(DEFAULT_PINNIPED_API_SUFFIX).unwrap_or(DEFAULT_API_SUFFIX.into()) == TMC_PINNIPED_API_SUFFIX;
+        env::set_var(DEFAULT_PINNIPED_API_SUFFIX, "pinniped.tmc.cloud.vmware.com");
+        assert_eq!(is_tmc_environment, false);
+
+        Ok(())
+    }
 }

--- a/cmd/pinniped-proxy/src/pinniped.rs
+++ b/cmd/pinniped-proxy/src/pinniped.rs
@@ -294,7 +294,7 @@ mod tests {
     #[test]
     #[serial(envtest)]
     fn test_get_api_group_getters() -> Result<()> {
-        env::remove_var("DEFAULT_DEFAULT_PINNIPED_API_SUFFIX");
+        env::remove_var("DEFAULT_PINNIPED_API_SUFFIX");
         let authenticator_api_group =  get_pinniped_authenticator_api_group();
         assert_eq!(authenticator_api_group, "authentication.concierge.pinniped.dev");
 

--- a/cmd/pinniped-proxy/src/pinniped.rs
+++ b/cmd/pinniped-proxy/src/pinniped.rs
@@ -4,7 +4,6 @@ use std::convert::TryFrom;
 use anyhow::{Context, Result};
 use k8s_openapi::api::core::v1 as corev1;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
-use k8s_openapi::Metadata;
 use kube::{
     api::{Api, PostParams},
     Client, Config,
@@ -19,9 +18,13 @@ use serde_json;
 use thiserror::Error;
 use url::Url;
 
+const DEFAULT_PINNIPED_API_SUFFIX: &str = "DEFAULT_PINNIPED_API_SUFFIX";
 const DEFAULT_PINNIPED_NAMESPACE: &str = "DEFAULT_PINNIPED_NAMESPACE";
 const DEFAULT_PINNIPED_AUTHENTICATOR_NAME: &str = "DEFAULT_PINNIPED_AUTHENTICATOR_NAME";
 const DEFAULT_PINNIPED_AUTHENTICATOR_TYPE: &str = "DEFAULT_PINNIPED_AUTHENTICATOR_TYPE";
+
+const DEFAULT_API_SUFFIX: &str = "pinniped.dev";
+const TMC_PINNIPED_API_SUFFIX: &str = "pinniped.tmc.cloud.vmware.com";
 
 #[derive(Error, Debug)]
 pub enum PinnipedError {
@@ -33,20 +36,42 @@ pub enum PinnipedError {
 ///
 /// The token is exchanged with pinniped concierge API running on the identified kubernetes api server.
 pub async fn exchange_token_for_identity(authorization: &str, k8s_api_server_url: &str, k8s_api_ca_cert_data: &[u8]) -> Result<Identity> {
-    let credential_request = call_pinniped_exchange(authorization, k8s_api_server_url, k8s_api_ca_cert_data).await.context("Failed to exchange credentials")?;
-    match credential_request.status {
-        Some(s) => {
-            match s.credential {
-                Some(c) => return identity_for_exchange(&c),
-                None => match s.message {
-                    // A returned status without a credential is unsuccessful authentication so
-                    // add context to identify this.
-                    Some(m) => return Err(anyhow::anyhow!(m.clone()).context(PinnipedError::UnsuccessfulAuthentication(m))),
-                    None => return Err(anyhow::anyhow!("response status neither an error msg or a credential: {:#?}", s)),
+    let is_tmc_environment: bool = env::var(DEFAULT_PINNIPED_API_SUFFIX).unwrap_or(DEFAULT_API_SUFFIX.into()) == TMC_PINNIPED_API_SUFFIX;
+        
+    // TODO(agamez): remove this duplicated branch and use a generic dynamic approach when possible.
+    // see PR comments: https://github.com/kubeapps/kubeapps/pull/2515
+    if is_tmc_environment {
+        let credential_request_tmc = call_pinniped_exchange_tmc(authorization, k8s_api_server_url, k8s_api_ca_cert_data).await.context("Failed to exchange credentials")?;
+        match credential_request_tmc.status {
+            Some(s) => {
+                match s.credential {
+                    Some(c) => return identity_for_exchange(&c),
+                    None => match s.message {
+                        // A returned status without a credential is unsuccessful authentication so
+                        // add context to identify this.
+                        Some(m) => return Err(anyhow::anyhow!(m.clone()).context(PinnipedError::UnsuccessfulAuthentication(m))),
+                        None => return Err(anyhow::anyhow!("response status neither an error msg or a credential: {:#?}", s)),
+                    }
                 }
-            }
-        },
-        None => return Err(anyhow::anyhow!("pinniped credential request did not include status: {:#?}", credential_request))
+            },
+            None => return Err(anyhow::anyhow!("pinniped credential request did not include status: {:#?}", credential_request_tmc))
+        }
+    } else {
+        let credential_request = call_pinniped_exchange(authorization, k8s_api_server_url, k8s_api_ca_cert_data).await.context("Failed to exchange credentials")?;
+        match credential_request.status {
+            Some(s) => {
+                match s.credential {
+                    Some(c) => return identity_for_exchange(&c),
+                    None => match s.message {
+                        // A returned status without a credential is unsuccessful authentication so
+                        // add context to identify this.
+                        Some(m) => return Err(anyhow::anyhow!(m.clone()).context(PinnipedError::UnsuccessfulAuthentication(m))),
+                        None => return Err(anyhow::anyhow!("response status neither an error msg or a credential: {:#?}", s)),
+                    }
+                }
+            },
+            None => return Err(anyhow::anyhow!("pinniped credential request did not include status: {:#?}", credential_request))
+        }
     }
 }
 
@@ -79,9 +104,33 @@ fn identity_for_exchange(cred: &ClusterCredential) -> Result<Identity> {
 /// The rust derive macro together with the kube macro creates serializable and deserializable
 /// resources based on the struct. See https://docs.rs/kube/0.43.0/kube/ for more details.
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
-#[kube(group = "login.concierge.pinniped.dev", version = "v1alpha1", kind = "TokenCredentialRequest", namespaced)]
-#[kube(status = "TokenCredentialRequestStatus")]
+#[kube(group = "login.concierge.pinniped.dev", version = "v1alpha1", kind = "TokenCredentialRequest")]
+#[kube(status = "TokenCredentialRequestStatus",struct="TokenCredentialRequest")]
 pub struct TokenCredentialRequestSpec {
+    // Bearer token supplied with the credential request.
+    token: Option<String>,
+
+    // Reference to an authenticator which can verify this credential request.
+    authenticator: corev1::TypedLocalObjectReference,
+}
+
+/// TokenCredentialRequestTMCSpec
+///
+/// TokenCredentialRequestTMCSpec and the Status including the returned cluster credential
+/// are structs based on the corresponding structs in the pinniped code at:
+/// https://github.com/vmware-tanzu/pinniped/blob/main/generated/1.19/apis/concierge/login/v1alpha1/types_token.go#L11
+/// 
+/// This is a custom version for TMC with its own API group suffix
+///
+/// The rust derive macro together with the kube macro creates serializable and deserializable
+/// resources based on the struct. See https://docs.rs/kube/0.43.0/kube/ for more details.
+/// 
+// TODO(agamez): remove this struct and use a generic dynamic approach when possible.
+// see PR comments: https://github.com/kubeapps/kubeapps/pull/2515
+#[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
+#[kube(group = "login.concierge.pinniped.tmc.cloud.vmware.com", version = "v1alpha1", kind = "TokenCredentialRequest")]
+#[kube(status = "TokenCredentialRequestStatus", struct="TokenCredentialRequestTMC")]
+pub struct TokenCredentialRequestTMCSpec {
     // Bearer token supplied with the credential request.
     token: Option<String>,
 
@@ -116,33 +165,33 @@ pub struct ClusterCredential {
     client_key_data: String,
 }
 
-/// call_pinniped_exchange returns the resulting TokenCredentialRequest with Status after requesting a token credential exchange.
-async fn call_pinniped_exchange(authorization: &str, k8s_api_server_url: &str, k8s_api_ca_cert_data: &[u8]) -> Result<TokenCredentialRequest> {
-    let pinniped_namespace = env::var(DEFAULT_PINNIPED_NAMESPACE)?;
-
+fn get_client_config(k8s_api_server_url: &str, k8s_api_ca_cert_data: &[u8], pinniped_namespace: String) -> Result<kube::Client> {
     let mut config = Config::new(Url::parse(k8s_api_server_url).context("Failed parsing url for exchange")?);
     config.default_ns = pinniped_namespace.clone();
     let x509 = X509::from_pem(k8s_api_ca_cert_data).context("error creating x509 from pem")?;
     let der = x509.to_der().context("error creating der from x509")?;
     config.root_cert = Some(vec!(der));
-    let client = Client::new(Service::try_from(config)?);
 
+    Ok(Client::new(Service::try_from(config)?))
+}
+
+/// call_pinniped_exchange returns the resulting TokenCredentialRequest with Status after requesting a token credential exchange.
+async fn call_pinniped_exchange(authorization: &str, k8s_api_server_url: &str, k8s_api_ca_cert_data: &[u8]) -> Result<TokenCredentialRequest> {
+    let pinniped_namespace = env::var(DEFAULT_PINNIPED_NAMESPACE)?;
+    let client = get_client_config(k8s_api_server_url, k8s_api_ca_cert_data, pinniped_namespace.clone())?;
     let auth_token = match authorization.to_string().strip_prefix("Bearer ") {
         Some(a) => a.to_string(),
         None => authorization.to_string(),
     };
-    let token_creds: Api<TokenCredentialRequest> = Api::namespaced(client.clone(), &pinniped_namespace);
-    let mut cred_request = TokenCredentialRequest::new("", TokenCredentialRequestSpec {
+    let token_creds: Api<TokenCredentialRequest> = Api::all(client.clone());
+    let cred_request = TokenCredentialRequest::new("", TokenCredentialRequestSpec {
         token: Some(auth_token),
         authenticator: corev1::TypedLocalObjectReference {
             name: env::var(DEFAULT_PINNIPED_AUTHENTICATOR_NAME).with_context(|| format!("error retrieving {}", DEFAULT_PINNIPED_AUTHENTICATOR_NAME))?,
             kind: env::var(DEFAULT_PINNIPED_AUTHENTICATOR_TYPE).with_context(|| format!("error retrieving {}", DEFAULT_PINNIPED_AUTHENTICATOR_TYPE))?,
-            api_group: Some("authentication.concierge.pinniped.dev".into()),
+            api_group: Some(get_pinniped_authenticator_api_group().into()),
         },
     });
-    // The pinniped authenticator cache requires the namespace of the request to be included
-    // explicitly, even if the client is limited to a specific namespace.
-    cred_request.metadata_mut().namespace = Some(pinniped_namespace);
 
     debug!("{}", serde_json::to_string(&cred_request).unwrap());
     match token_creds.create(&PostParams::default(), &cred_request).await {
@@ -151,6 +200,45 @@ async fn call_pinniped_exchange(authorization: &str, k8s_api_server_url: &str, k
             Err(anyhow::anyhow!("err creating token exchange: {:#?}\n{}", serde_json::to_string(&cred_request).unwrap(), e))
         },
     }
+}
+
+/// call_pinniped_exchange returns the resulting TokenCredentialRequest with Status after requesting a token credential exchange.
+// TODO(agamez): remove this duplicated code and use a generic dynamic approach when possible.
+// see PR comments: https://github.com/kubeapps/kubeapps/pull/2515
+async fn call_pinniped_exchange_tmc(authorization: &str, k8s_api_server_url: &str, k8s_api_ca_cert_data: &[u8]) -> Result<TokenCredentialRequestTMC> {
+    let pinniped_namespace = env::var(DEFAULT_PINNIPED_NAMESPACE)?;
+    let client = get_client_config(k8s_api_server_url, k8s_api_ca_cert_data, pinniped_namespace.clone())?;
+    let auth_token = match authorization.to_string().strip_prefix("Bearer ") {
+        Some(a) => a.to_string(),
+        None => authorization.to_string(),
+    };
+    let token_creds: Api<TokenCredentialRequestTMC> = Api::all(client.clone());
+    let cred_request = TokenCredentialRequestTMC::new("", TokenCredentialRequestTMCSpec {
+        token: Some(auth_token),
+        authenticator: corev1::TypedLocalObjectReference {
+            name: env::var(DEFAULT_PINNIPED_AUTHENTICATOR_NAME).with_context(|| format!("error retrieving {}", DEFAULT_PINNIPED_AUTHENTICATOR_NAME))?,
+            kind: env::var(DEFAULT_PINNIPED_AUTHENTICATOR_TYPE).with_context(|| format!("error retrieving {}", DEFAULT_PINNIPED_AUTHENTICATOR_TYPE))?,
+            api_group: Some(get_pinniped_authenticator_api_group().into()),
+        },
+    });
+
+    debug!("{}", serde_json::to_string(&cred_request).unwrap());
+    match token_creds.create(&PostParams::default(), &cred_request).await {
+        Ok(o) => Ok(o),
+        Err(e) => {
+            Err(anyhow::anyhow!("err creating token exchange: {:#?}\n{}", serde_json::to_string(&cred_request).unwrap(), e))
+        },
+    }
+}
+
+fn get_pinniped_authenticator_api_group() ->  String  {
+    let api_suffix = env::var(DEFAULT_PINNIPED_API_SUFFIX).unwrap_or(DEFAULT_API_SUFFIX.into());
+    return format!("{}.{}", "authentication.concierge", &api_suffix).to_string();
+}
+
+fn get_pinniped_login_api_group() ->  String  {
+    let api_suffix = env::var(DEFAULT_PINNIPED_API_SUFFIX).unwrap_or(DEFAULT_API_SUFFIX.into());
+    return format!("{}.{}", "login.concierge", &api_suffix).to_string();
 }
 
 #[macro_use]
@@ -201,4 +289,22 @@ mod tests {
             },
         }
     }
+
+    #[test]
+    #[serial(envtest)]
+    fn test_get_api_group_getters() -> Result<()> {
+        let authenticator_api_group =  get_pinniped_authenticator_api_group();
+        assert_eq!(authenticator_api_group, "authentication.concierge.pinniped.dev");
+
+        let login_api_group = get_pinniped_login_api_group();
+        assert_eq!(login_api_group, "login.concierge.pinniped.dev");
+
+        env::set_var(DEFAULT_PINNIPED_API_SUFFIX, "foo.bar");
+        let authenticator_api_group =  get_pinniped_authenticator_api_group();
+        assert_eq!(authenticator_api_group, "authentication.concierge.foo.bar");
+
+        let login_api_group = get_pinniped_login_api_group();
+        assert_eq!(login_api_group, "login.concierge.foo.bar");
+        Ok(())
+}
 }

--- a/docs/user/using-an-OIDC-provider-with-pinniped.md
+++ b/docs/user/using-an-OIDC-provider-with-pinniped.md
@@ -4,13 +4,15 @@ The [Pinniped project](https://pinniped.dev/) exists to "Simplify user authentic
 
 ## Installing Pinniped
 
-Install Pinniped 0.5.0 into a `pinniped-concierge` namespace on your cluster with:
+Install Pinniped 0.6.0 into a `pinniped-concierge` namespace on your cluster with:
 
 ```bash
-kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.5.0/install-pinniped-concierge.yaml
+kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.6.0/install-pinniped-concierge.yaml
 ```
 
-**NOTE**: At the time of writing, [0.6.0 of Pinniped](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.6.0) has been released but due to a breaking change noted in the release notes, does not yet work with Kubeapps ([#2426](https://github.com/kubeapps/kubeapps/issues/2426)).
+**NOTE**: Due to a breaking change in [Pinniped 0.6.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.6.0), the minimum version supported by Kubeapps is 0.6.0. Furthermore, [custom API suffixes](https://pinniped.dev/posts/multiple-pinnipeds) (introduced in Pinniped 0.5.0) are not yet fully supported. If your platform uses this feature, please [drop us an issue](https://github.com/kubeapps/kubeapps/issues/new).
+
+
 
 ## Configure Pinniped to trust your OIDC identity provider
 
@@ -21,7 +23,6 @@ kind: JWTAuthenticator
 apiVersion: authentication.concierge.pinniped.dev/v1alpha1
 metadata:
   name: jwt-authenticator
-  namespace: pinniped-concierge
 spec:
   issuer: https://172.18.0.2:32000
   audience: default
@@ -31,6 +32,8 @@ spec:
   tls:
     certificateAuthorityData: <removed-for-clarity>
 ```
+
+> Note that in TMC, `authentication.concierge.pinniped.dev/v1alpha1` will become `authentication.concierge.pinniped.tmc.cloud.vmware.com/v1alpha1`
 
 When the `pinniped-proxy` service of Kubeapps requests to exchange a JWT `id_token` for client certificates, Pinniped will verify the `id_token` is signed by the issuer identified here. Once verified, the claims for `username` and `groups` will be included on the generated client certificate so that the Kubernetes API server knows the username and groups associated with the request.
 


### PR DESCRIPTION
### Description of the change

This PR adds support for Pinniped 0.6.0 (but with a **not-backward-compatible** change). It means Pinniped-proxy will only work in >=0.6.0.

Apart from some very minor refactor, there are two main changes:

1. API calls to `authentication.concierge....` and `login.concierge....` will be global instead of namespaced (this is the breaking change).
2. Shamefully ugly workaround consisting of duplicating code for supporting another API group rather than `pinniped.dev`. Specifically, this PR adds support for the one that will be used in Tanzu Mission Control.

### Benefits

1.  Pinniped >= 0.6.0 will be supported.
2.  Pinniped-proxy can be used in TMC.

### Possible drawbacks

Dropping support for Pinniped < 0.6.0

### Applicable issues

  - fixes #2426 

### Additional information

There is another PR aimed at solving the problem more generically (https://github.com/kubeapps/kubeapps/pull/2515), but it is still in progress.

@absoludity , I'd need your help in setting up the environment. Still not able to get authenticated... see https://github.com/kubeapps/kubeapps/pull/2515#discussion_r592298764, but ping me on Slack if you want.

Edit: thanks a lot!! Now I've been able to deploy the dev scenario for both the default and the TMC API suffixes.
