### PR TITLE
Fix dangling reference to old template helper.

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 5.3.0
+version: 5.3.1

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -140,7 +140,7 @@ apprepo-{{ .name }}-secrets
 Create name for the secrets related to oauth2_proxy
 */}}
 {{- define "kubeapps.oauth2_proxy-secret.name" -}}
-{{ template "kubeapps.fullname" . }}-oauth2
+{{ template "common.names.fullname" . }}-oauth2
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

Looks like the result of merging both the common chart dependency together with the oauth2 sensitive data PR #2436

As a result, templating when using oauth proxy fails:

```
helm template chart/kubeapps --set authProxy.enabled=true
Error: template: kubeapps/templates/_helpers.tpl:143:12: executing "kubeapps.oauth2_proxy-secret.name" at <{{template "kubeapps.fullname" .}}>: template "kubeapps.fullname" not defined
```
