### PR TITLE
Fix test to work with the latest eslint rules

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
@@ -18,16 +18,15 @@ const defaultProps = {
 };
 
 // Mocking the window so that the injected components are imported correctly
-const { location } = window;
 beforeAll((): void => {
-  // @ts-ignore
-  delete window.location;
-  // @ts-ignore
-  window.location = {
-    origin: "../../../../../docs/developer/examples/CustomComponent.min.js",
-  };
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: { origin: "../../../../../docs/developer/examples/CustomComponent.min.js" },
+  });
 });
 afterAll((): void => {
+  // eslint-disable-next-line no-restricted-globals
   window.location = location;
 });
 


### PR DESCRIPTION
### Description of the change

Since one of the latest PR was being developed at the same point as we were migrating to eslit, there is a minor issue preventing our CI to work.
This PR simply tweaks a little bit the failing file, a test using window.location.

### Benefits

No CI errors.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
