### PR TITLE
Add the static manifest.json to the auth-proxy skip-auth-regex

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -65,6 +65,7 @@ spec:
             - --pass-access-token=true
             - --pass-authorization-header=true
             - --skip-auth-regex=^\/config\.json$
+            - --skip-auth-regex=^\/manifest\.json$
             - --skip-auth-regex=^\/custom_style\.css$
             - --skip-auth-regex=^\/custom_locale\.json$
             - --skip-auth-regex=^\/favicon.*\.png$


### PR DESCRIPTION
### Description of the change

This simple PR just adds the manifest.json to the `skip-auth-regex` .

### Benefits

A 403 warning will not be thrown in the login page.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A