### PR TITLE
Parallelize namespace-check requests

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -197,6 +197,7 @@ kubectl delete namespace kubeapps
 - [Is there any API documentation?](#is-there-any-api-documentation)
 - [Why can't I configure global private repositories?](#why-cant-i-configure-global-private-repositories)
 - [Does Kubeapps support Operators?](#does-kubeapps-support-operators)
+- [Slow response when listing namespaces?](#slow-response-when-listing-namespaces)
 - [More questions?](#more-questions)
 
 ### How to install Kubeapps for demo purposes?
@@ -274,6 +275,12 @@ You could alternatively ensure that the `imagePullSecret` is available in all na
 ### Does Kubeapps support Operators?
 
 Yes! You can get started by following the [operators documentation](https://github.com/kubeapps/kubeapps/blob/master/docs/user/operators.md).
+
+### Slow response when listing namespaces
+
+Kubeapps uses the logged user account to retrieve the list of namespaces. If the user doesn't have permission to list namespaces, the fallback mechanism verifies if the user has permissions to get secrets for each namespace (to verify it it should be allowed to use that namespace or not). This can lead to a slow response if the number of namespaces of the cluster is big enough.
+
+To reduce this time, you can increase the number of checks that Kubeapps will perform in parallel setting the value: `kubeops.extraEnvVars[0].name=MAX_REQUESTS` and `kubeops.extraEnvVars[0].value=<desired_number>`. The default value, if not set is 20 concurrent requests.
 
 ### More questions? 
 

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -278,9 +278,9 @@ Yes! You can get started by following the [operators documentation](https://gith
 
 ### Slow response when listing namespaces
 
-Kubeapps uses the logged user account to retrieve the list of namespaces. If the user doesn't have permission to list namespaces, the fallback mechanism verifies if the user has permissions to get secrets for each namespace (to verify it it should be allowed to use that namespace or not). This can lead to a slow response if the number of namespaces of the cluster is big enough.
+Kubeapps uses the currently logged-in user credential to retrieve the list of all namespaces. If the user doesn't have permission to list namespaces, the backend will try again with its own service account to list all namespaces and then iterate through each namespace to check if the user has permissions to get secrets for each namespace (to verify if they should be allowed to use that namespace or not and hence whether it is included in the selector). This can lead to a slow response if the number of namespaces on the cluster is large.
 
-To reduce this time, you can increase the number of checks that Kubeapps will perform in parallel setting the value: `kubeops.extraEnvVars[0].name=MAX_REQUESTS` and `kubeops.extraEnvVars[0].value=<desired_number>`. The default value, if not set is 20 concurrent requests.
+To reduce this time, you can increase the number of checks that Kubeapps will perform in parallel (per connection) setting the value: `kubeops.burst=<desired_number>` and `kubeops.QPS=<desired_number>`. The default value, if not set, is 15 burst requests and 10 QPS afterwards.
 
 ### More questions? 
 

--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -52,6 +52,12 @@ spec:
             {{- if .Values.pinnipedProxy.enabled }}
             - --pinniped-proxy-url=http://kubeapps-internal-pinniped-proxy.{{ .Release.Namespace }}:{{ .Values.pinnipedProxy.service.port }}
             {{- end }}
+            {{- if .Values.kubeops.burst }}
+            - --burst={{ .Values.kubeops.burst }}
+            {{- end }}
+            {{- if .Values.kubeops.QPS }}
+            - --qps={{ .Values.kubeops.QPS }}
+            {{- end }}
           {{- if .Values.clusters }}
           volumeMounts:
             - name: kubeops-config

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -391,6 +391,10 @@ kubeops:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  ## Kubeops QPS and Burst configuration (per user request)
+  ## Used when requesting namespaces
+  # QPS: 10
+  # burst: 15
 
 ## Assetsvc is used to serve assets metadata over a REST API.
 ##

--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -43,6 +43,8 @@ type Options struct {
 	UserAgent         string
 	KubeappsNamespace string
 	ClustersConfig    kube.ClustersConfig
+	Burst             int
+	QPS               float32
 }
 
 // Config represents data needed by each handler to be able to create Helm 3 actions.
@@ -97,7 +99,7 @@ func WithHandlerConfig(storageForDriver agent.StorageForDriver, options Options)
 				return
 			}
 
-			kubeHandler, err := kube.NewHandler(options.KubeappsNamespace, options.ClustersConfig)
+			kubeHandler, err := kube.NewHandler(options.KubeappsNamespace, options.Burst, options.QPS, options.ClustersConfig)
 			if err != nil {
 				log.Errorf("Failed to create handler: %v", err)
 				response.NewErrorResponse(http.StatusInternalServerError, authUserError).Write(w)

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -332,8 +332,8 @@ func CanI(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, req *http.Re
 }
 
 // SetupDefaultRoutes enables call-sites to use the backend api's default routes with minimal setup.
-func SetupDefaultRoutes(r *mux.Router, clustersConfig kube.ClustersConfig) error {
-	backendHandler, err := kube.NewHandler(os.Getenv("POD_NAMESPACE"), clustersConfig)
+func SetupDefaultRoutes(r *mux.Router, burst int, qps float32, clustersConfig kube.ClustersConfig) error {
+	backendHandler, err := kube.NewHandler(os.Getenv("POD_NAMESPACE"), burst, qps, clustersConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -367,12 +367,8 @@ func NewHandler(kubeappsNamespace string, burst int, qps float32, clustersConfig
 	// This is useful to handle a large number of namespaces which are check in parallel
 	// Burst is the initial number of request made in parallel
 	// Then further requests are performed following the QPS rate
-	if burst != 0 {
-		config.Burst = burst
-	}
-	if qps != 0 {
-		config.QPS = qps
-	}
+	config.Burst = burst
+	config.QPS = qps
 
 	svcRestConfig, err := rest.InClusterConfig()
 	if err != nil {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Run namespace checks in parallel (the check that verifies if a user can access a namespace). Also, if the user has permissions to list namespaces, this check is skipped.

I did the following tests to verify the new performance:

1. 200 namespaces, without this PR: 39s
~~2. 200 namespaces, 20 parallel workers (the new default): 8.6s~~
2. 200 namespaces, 10 QPS, 15 Burst requests: 19.8s
3. 200 namespaces, 100 QPS, 200 Burst requests: 0.5s

### Possible drawbacks

Using too many workers might saturate the k8s API.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2506

### Additional information

cc/ @mecampbellsoup 