### PR TITLE
Add ability to set annotations to each individual deployment

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 5.4.0
+version: 5.5.0

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -2,8 +2,13 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "kubeapps.apprepository.fullname" . }}
-  labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}
+  labels:
+    {{- include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "kubeapps.apprepository.fullname" . }}
+  {{- with .Values.apprepository.annotations }}
+  annotations:
+    {{ toYaml . }}
+  {{- end }}
 spec:
   replicas: {{ .Values.apprepository.replicaCount }}
   selector:

--- a/chart/kubeapps/templates/apprepository-deployment.yaml
+++ b/chart/kubeapps/templates/apprepository-deployment.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     {{- include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "kubeapps.apprepository.fullname" . }}
-  {{- with .Values.apprepository.annotations }}
-  annotations:
-    {{ toYaml . }}
-  {{- end }}
 spec:
   replicas: {{ .Values.apprepository.replicaCount }}
   selector:
@@ -17,6 +13,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      {{- with .Values.apprepository.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ template "kubeapps.apprepository.fullname" . }}
         release: {{ .Release.Name }}

--- a/chart/kubeapps/templates/assetsvc-deployment.yaml
+++ b/chart/kubeapps/templates/assetsvc-deployment.yaml
@@ -2,8 +2,13 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "kubeapps.assetsvc.fullname" . }}
-  labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}
+  labels:
+    {{- include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "kubeapps.assetsvc.fullname" . }}
+  {{- with .Values.assetsvc.annotations }}
+  annotations:
+    {{ toYaml . }}
+  {{- end }}
 spec:
   replicas: {{ .Values.assetsvc.replicaCount }}
   selector:

--- a/chart/kubeapps/templates/assetsvc-deployment.yaml
+++ b/chart/kubeapps/templates/assetsvc-deployment.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     {{- include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "kubeapps.assetsvc.fullname" . }}
-  {{- with .Values.assetsvc.annotations }}
-  annotations:
-    {{ toYaml . }}
-  {{- end }}
 spec:
   replicas: {{ .Values.assetsvc.replicaCount }}
   selector:
@@ -17,6 +13,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      {{- with .Values.assetsvc.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8}}
+      {{- end }}
       labels:
         app: {{ template "kubeapps.assetsvc.fullname" . }}
         app.kubernetes.io/name: {{ template "common.names.name" . }}

--- a/chart/kubeapps/templates/dashboard-deployment.yaml
+++ b/chart/kubeapps/templates/dashboard-deployment.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     {{- include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "kubeapps.dashboard.fullname" . }}
-  {{- with .Values.dashboard.annotations }}
-  annotations:
-    {{ toYaml . }}
-  {{- end }}
 spec:
   replicas: {{ .Values.dashboard.replicaCount }}
   selector:
@@ -19,6 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/dashboard-config.yaml") . | sha256sum }}
+        {{- with .Values.dashboard.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ template "kubeapps.dashboard.fullname" . }}
         app.kubernetes.io/name: {{ template "common.names.name" . }}

--- a/chart/kubeapps/templates/dashboard-deployment.yaml
+++ b/chart/kubeapps/templates/dashboard-deployment.yaml
@@ -2,8 +2,13 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "kubeapps.dashboard.fullname" . }}
-  labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}
+  labels:
+    {{- include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "kubeapps.dashboard.fullname" . }}
+  {{- with .Values.dashboard.annotations }}
+  annotations:
+    {{ toYaml . }}
+  {{- end }}
 spec:
   replicas: {{ .Values.dashboard.replicaCount }}
   selector:

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     {{- include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "common.names.fullname" . }}
-  {{- with .Values.frontend.annotations }}
-  annotations:
-    {{ toYaml . }}
-  {{- end }}
 spec:
   replicas: {{ .Values.frontend.replicaCount }}
   selector:
@@ -19,6 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/kubeapps-frontend-config.yaml") . | sha256sum }}
+        {{- with .Values.frontend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ template "common.names.fullname" . }}
         app.kubernetes.io/name: {{ template "common.names.name" . }}

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -2,8 +2,13 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "common.names.fullname" . }}
-  labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}
+  labels:
+    {{- include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "common.names.fullname" . }}
+  {{- with .Values.frontend.annotations }}
+  annotations:
+    {{ toYaml . }}
+  {{- end }}
 spec:
   replicas: {{ .Values.frontend.replicaCount }}
   selector:

--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -2,8 +2,13 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "kubeapps.kubeops.fullname" . }}
-  labels:{{ include "kubeapps.extraAppLabels" . | nindent 4 }}
+  labels:
+    {{- include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "kubeapps.kubeops.fullname" . }}
+  {{- with .Values.kubeops.annotations }}
+  annotations:
+    {{ toYaml . }}
+  {{- end }}
 spec:
   replicas: {{ .Values.kubeops.replicaCount }}
   selector:

--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     {{- include "kubeapps.extraAppLabels" . | nindent 4 }}
     app: {{ template "kubeapps.kubeops.fullname" . }}
-  {{- with .Values.kubeops.annotations }}
-  annotations:
-    {{ toYaml . }}
-  {{- end }}
 spec:
   replicas: {{ .Values.kubeops.replicaCount }}
   selector:
@@ -17,6 +13,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      {{- with .Values.kubeops.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ template "kubeapps.kubeops.fullname" . }}
         app.kubernetes.io/name: {{ template "common.names.name" . }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -132,6 +132,9 @@ ingress:
 ##
 frontend:
   replicaCount: 2
+  ## Add additional annotations to the frontend deployment
+  ##
+  annotations: {}
   ## Bitnami Nginx image
   ## ref: https://hub.docker.com/r/bitnami/nginx/tags/
   ##
@@ -229,6 +232,9 @@ apprepository:
   ## Running a single controller replica to avoid sync job duplication
   ##
   replicaCount: 1
+  ## Add additional annotations to the controllers deployment
+  ##
+  annotations: {}
   ## Schedule for syncing apprepositories. Every ten minutes by default
   # crontab: "*/10 * * * *"
   ## Bitnami Kubeapps AppRepository Controller image
@@ -348,6 +354,9 @@ hooks:
 # Kubeops is an interface between the Kubeapps Dashboard and Helm 3/Kubernetes.
 kubeops:
   replicaCount: 2
+  ## Add additional annotations to the kubeops deployment
+  ##
+  annotations: {}
   image:
     registry: docker.io
     repository: kubeapps/kubeops
@@ -396,6 +405,9 @@ kubeops:
 ##
 assetsvc:
   replicaCount: 2
+  ## Add additional annotations to the assetsvc deployment
+  ##
+  annotations: {}
   ## Bitnami Kubeapps Assetsvc image
   ## ref: https://hub.docker.com/r/bitnami/kubeapps-assetsvc/tags/
   ##
@@ -461,6 +473,9 @@ assetsvc:
 ##
 dashboard:
   replicaCount: 2
+  ## Add additional annotations to the dashboard deployment
+  ##
+  annotations: {}
   ## Bitnami Kubeapps Dashboard image
   ## ref: https://hub.docker.com/r/bitnami/kubeapps-dashboard/tags/
   ##

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -132,9 +132,9 @@ ingress:
 ##
 frontend:
   replicaCount: 2
-  ## Add additional annotations to the frontend deployment
+  ## Add additional annotations to the frontend pods
   ##
-  annotations: {}
+  podAnnotations: {}
   ## Bitnami Nginx image
   ## ref: https://hub.docker.com/r/bitnami/nginx/tags/
   ##
@@ -232,9 +232,9 @@ apprepository:
   ## Running a single controller replica to avoid sync job duplication
   ##
   replicaCount: 1
-  ## Add additional annotations to the controllers deployment
+  ## Add additional annotations to the controllers pods
   ##
-  annotations: {}
+  podAnnotations: {}
   ## Schedule for syncing apprepositories. Every ten minutes by default
   # crontab: "*/10 * * * *"
   ## Bitnami Kubeapps AppRepository Controller image
@@ -354,9 +354,9 @@ hooks:
 # Kubeops is an interface between the Kubeapps Dashboard and Helm 3/Kubernetes.
 kubeops:
   replicaCount: 2
-  ## Add additional annotations to the kubeops deployment
+  ## Add additional annotations to the kubeops pods
   ##
-  annotations: {}
+  podAnnotations: {}
   image:
     registry: docker.io
     repository: kubeapps/kubeops
@@ -405,9 +405,9 @@ kubeops:
 ##
 assetsvc:
   replicaCount: 2
-  ## Add additional annotations to the assetsvc deployment
+  ## Add additional annotations to the assetsvc pods
   ##
-  annotations: {}
+  podAnnotations: {}
   ## Bitnami Kubeapps Assetsvc image
   ## ref: https://hub.docker.com/r/bitnami/kubeapps-assetsvc/tags/
   ##
@@ -473,9 +473,9 @@ assetsvc:
 ##
 dashboard:
   replicaCount: 2
-  ## Add additional annotations to the dashboard deployment
+  ## Add additional annotations to the dashboard pods
   ##
-  annotations: {}
+  podAnnotations: {}
   ## Bitnami Kubeapps Dashboard image
   ## ref: https://hub.docker.com/r/bitnami/kubeapps-dashboard/tags/
   ##


### PR DESCRIPTION
### Description of the change

The reason I want this supported is so that I can add these deployments
to my service mesh. Most service mesh decide on which deployments/pods
should be part of the mesh using annotations. I would like to be able to
control this via the Helm chart.

Service meshes can also allow you to add a whole namespace to the
service mesh. The reason this doesn't work well is that the sync jobs
created by kubeapps will never complete if they have a sidecar
container, which is what's done to add a pod to a service mesh.

This only adds support for adding annotations to the deployments, not
the pods created by those deployments. If we want to support that as
well, we could add another field called podAnnotations to each of these
components.

### Additional information

I also changed how the labels were added to the deployments, using the
"-" to trim the whitespace.