### PR TITLE
Fail when proxing ws in pinniped proxy

### DIFF
--- a/cmd/pinniped-proxy/src/service.rs
+++ b/cmd/pinniped-proxy/src/service.rs
@@ -83,7 +83,12 @@ pub async fn proxy(mut req: Request<Body>, default_ca_data: Vec<u8>) -> Result<R
     match client.request(req).await {
         Ok(r) => {
             info!("{}", logging::response_log_data(&r, log_data));
-            Ok(r)
+            if r.status() == StatusCode::SWITCHING_PROTOCOLS {
+                // TODO(agamez): implement ws proxing here; see https://github.com/kubeapps/kubeapps/issues/2328
+                Ok(Response::builder().status(StatusCode::NOT_IMPLEMENTED).body(Body::from("pinniped-proxy does not support websockets yet")).unwrap())
+            } else {
+                Ok(r)
+            }
         },
         Err(e) => return handle_error(anyhow::anyhow!(e), StatusCode::INTERNAL_SERVER_ERROR, log_data),
     }


### PR DESCRIPTION
### Description of the change

As per the discussion in https://github.com/kubeapps/kubeapps/issues/2328#issuecomment-803984871, this PR simply adds an explicit 5xx-error when proxying a websocket connection attempt (aka 101 HTTP status code).

### Benefits

The polling fallback mechanism now will be triggered.

### Possible drawbacks

An error msg will be thrown in the js console.

### Applicable issues

  - rel #2328

### Additional information

N/A
