### PR TITLE
Update image versions

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -141,7 +141,7 @@ frontend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.19.7-debian-10-r1
+    tag: 1.19.8-debian-10-r14
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -332,7 +332,7 @@ hooks:
   image:
     registry: docker.io
     repository: bitnami/kubectl
-    tag: 1.18.16-debian-10-r0
+    tag: 1.19.9-debian-10-r7
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -607,7 +607,7 @@ securityContext:
 testImage:
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.19.7-debian-10-r1
+  tag: 1.19.8-debian-10-r14
 
 # Auth Proxy configuration for OIDC support
 # ref: https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md
@@ -639,7 +639,7 @@ authProxy:
   image:
     registry: docker.io
     repository: bitnami/oauth2-proxy
-    tag: 7.0.1-debian-10-r5
+    tag: 7.1.0-debian-10-r0
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##


### PR DESCRIPTION
### Description of the change

This PRs simply performs an upgrade of the external image versions that Kubeapps uses, particularly:

[bitnami/nginx](https://github.com/bitnami/bitnami-docker-nginx)
[bitnami/kubectl](https://github.com/bitnami/bitnami-docker-kubectl)
[bitnami/oauth2-proxy](https://github.com/bitnami/bitnami-docker-oauth2-proxy)

### Benefits

Since the oauth2proxy has been bumped up to 7.1.0, it includes the changes required by #2118 to be solved.
Furthermore, these latest versions of nginx/kubectl will include as well the latest release of the openssl dep.

### Possible drawbacks

N/A

### Applicable issues

  - closes #2118

### Additional information

If you may prefer, we can just update the oauth2proxy version for addressing the #2118 issue and leave the other unchanged.
