### PR TITLE
Use common environment variables in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ parameters:
   POSTGRESQL_VERSION:
     type: "string"
     default: "11.11.0-debian-10-r45"
+  IMAGES_TO_PUSH:
+    type: "string"
+    default: "kubeapps/apprepository-controller kubeapps/dashboard kubeapps/asset-syncer kubeapps/assetsvc kubeapps/kubeops kubeapps/pinniped-proxy"
 
 ## Build conditions
 # Build in any branch or tag
@@ -140,6 +143,19 @@ workflows:
             - GKE_1_16_LATEST_RELEASE
 
 ## Definitions
+common_envars: &common_envars
+  DOCKER_VERSION: << pipeline.parameters.DOCKER_VERSION >>
+  GOLANG_VERSION: << pipeline.parameters.GOLANG_VERSION >>
+  HELM_VERSION: << pipeline.parameters.HELM_VERSION >>
+  K8S_KIND_VERSION: << pipeline.parameters.K8S_KIND_VERSION >>
+  KIND_VERSION: << pipeline.parameters.KIND_VERSION >>
+  KUBECTL_VERSION: << pipeline.parameters.KUBECTL_VERSION >>
+  MKCERT_VERSION: << pipeline.parameters.MKCERT_VERSION >>
+  NODE_VERSION: << pipeline.parameters.NODE_VERSION >>
+  OLM_VERSION: << pipeline.parameters.OLM_VERSION >>
+  POSTGRESQL_VERSION: << pipeline.parameters.POSTGRESQL_VERSION >>
+  RUST_VERSION: << pipeline.parameters.RUST_VERSION >>
+
 install_gcloud_sdk: &install_gcloud_sdk
   run:
     name: "Install gcloud sdk"
@@ -277,7 +293,7 @@ gke_test: &gke_test
         command: | 
           source ./script/chart_sync_utils.sh
 
-          # In case of GKE we will only want to build if it is
+          # In the case of GKE we will only want to build if it is
           # a build of a branch in the kubeapps repository
           if [[ -z "$GKE_ADMIN" ]]; then
             echo "Step aborted, we are not in the Kubeapps repository"
@@ -294,7 +310,7 @@ gke_test: &gke_test
     - <<: *install_gcloud_sdk
     - setup_remote_docker
     - run:
-        name: Configure Google Clould
+        name: Configure Google Cloud
         command: | 
           gcloud -q config set project $GKE_PROJECT
           export GOOGLE_APPLICATION_CREDENTIALS=/tmp/client_secrets.json
@@ -350,7 +366,7 @@ jobs:
     working_directory: /go/src/github.com/kubeapps/kubeapps
     environment:
       CGO_ENABLED: "0"
-      POSTGRESQL_VERSION: << pipeline.parameters.POSTGRESQL_VERSION >>
+      <<: *common_envars
     docker:
       - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
     steps:
@@ -365,7 +381,7 @@ jobs:
           name: Run go integration tests for DB
           command: | 
             docker run -d --name postgresql --rm --publish 5432:5432 -e ALLOW_EMPTY_PASSWORD=yes bitnami/postgresql:${POSTGRESQL_VERSION}
-            docker run --network container:postgresql -d --name tests circleci/golang:<< pipeline.parameters.GOLANG_VERSION >> tail -f /dev/null
+            docker run --network container:postgresql -d --name tests circleci/golang:${GOLANG_VERSION} tail -f /dev/null
             docker cp /go tests:/
             docker exec -it tests /bin/sh -c "cd /go/src/github.com/kubeapps/kubeapps/ && make test-db"
   test_dashboard:
@@ -396,7 +412,7 @@ jobs:
               cargo test --manifest-path ./cmd/pinniped-proxy/Cargo.toml
   test_chart_render:
     environment:
-      HELM_VERSION: << pipeline.parameters.HELM_VERSION >>
+      <<: *common_envars
     docker:
       - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
     steps:
@@ -440,14 +456,10 @@ jobs:
   local_e2e_tests:
     machine: true
     environment:
-      HELM_VERSION: << pipeline.parameters.HELM_VERSION >>
+      DEFAULT_DEX_IP: "172.18.0.2"
       KUBEAPPS_DB: "postgresql"
       TEST_UPGRADE: "1"
-      OLM_VERSION: << pipeline.parameters.OLM_VERSION >>
-      MKCERT_VERSION: << pipeline.parameters.MKCERT_VERSION >>
-      KUBECTL_VERSION: << pipeline.parameters.KUBECTL_VERSION >>
-      KIND_VERSION: << pipeline.parameters.KIND_VERSION >>
-      K8S_KIND_VERSION: << pipeline.parameters.K8S_KIND_VERSION >>
+      <<: *common_envars
     parameters:
       number:
         type: string
@@ -455,33 +467,29 @@ jobs:
   GKE_1_15_MASTER:
     <<: *gke_test
     environment:
-      HELM_VERSION: << pipeline.parameters.HELM_VERSION >>
-      OLM_VERSION: << pipeline.parameters.OLM_VERSION >>
       GKE_BRANCH: "1.15"
       KUBEAPPS_DB: "postgresql"
+      <<: *common_envars
   GKE_1_15_LATEST_RELEASE:
     <<: *gke_test
     environment:
-      HELM_VERSION: << pipeline.parameters.HELM_VERSION >>
-      OLM_VERSION: << pipeline.parameters.OLM_VERSION >>
       GKE_BRANCH: "1.15"
       KUBEAPPS_DB: "postgresql"
       TEST_LATEST_RELEASE: 1
+      <<: *common_envars
   GKE_1_16_MASTER:
     <<: *gke_test
     environment:
-      HELM_VERSION: << pipeline.parameters.HELM_VERSION >>
-      OLM_VERSION: << pipeline.parameters.OLM_VERSION >>
       GKE_BRANCH: "1.16"
       KUBEAPPS_DB: "postgresql"
+      <<: *common_envars
   GKE_1_16_LATEST_RELEASE:
     <<: *gke_test
     environment:
-      HELM_VERSION: << pipeline.parameters.HELM_VERSION >>
-      OLM_VERSION: << pipeline.parameters.OLM_VERSION >>
       GKE_BRANCH: "1.16"
       KUBEAPPS_DB: "postgresql"
       TEST_LATEST_RELEASE: 1
+      <<: *common_envars
   sync_chart:
     docker:
       - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
@@ -510,7 +518,7 @@ jobs:
           command: | 
             if [[ -z "$CIRCLE_PULL_REQUEST" && -n "$DOCKER_USERNAME" && -n "$DOCKER_PASSWORD" ]]; then
               docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-              for IMAGE in kubeapps/apprepository-controller kubeapps/dashboard kubeapps/asset-syncer kubeapps/assetsvc kubeapps/kubeops kubeapps/pinniped-proxy; do
+              for IMAGE in << pipeline.parameters.IMAGES_TO_PUSH >>; do
                 docker pull ${IMAGE}${IMG_MODIFIER}:${DEV_TAG}
                 docker tag ${IMAGE}${IMG_MODIFIER}:${DEV_TAG} ${IMAGE}:${PROD_TAG}
                 docker push ${IMAGE}:${PROD_TAG}

--- a/integration/use-cases/create-registry.js
+++ b/integration/use-cases/create-registry.js
@@ -11,7 +11,7 @@ test("Creates a registry", async () => {
     document.querySelector("#login-submit-button").click()
   );
 
-  await expect(page).toClick("cds-button", { text: "Add App Repository" });
+  await expect(page).toClick("cds-button", { text: "Add App Repository", timeout: 10000 });
 
   await page.type("input[placeholder=\"example\"]", "my-repo");
 

--- a/integration/use-cases/operator-deployment.js
+++ b/integration/use-cases/operator-deployment.js
@@ -27,7 +27,7 @@ test("Deploys an Operator", async () => {
 
   await utils.retryAndRefresh(page, 2, async () => {
     // The CSV takes a bit to get populated
-    await expect(page).toMatch("Installed");
+    await expect(page).toMatch("Installed", { timeout: 10000 });
   });
 
   // Wait for the operator to be ready to be used
@@ -37,7 +37,8 @@ test("Deploys an Operator", async () => {
     await expect(page).toMatch("Operators", { timeout: 10000 });
 
     // Filter out charts to search only for the prometheus operator
-    await expect(page).toClick("label", { text: "Operators" });
+    await expect(page).toClick("label", { text: "Operators", timeout: 10000 });
+
 
     await expect(page).toMatch("Prometheus");
 


### PR DESCRIPTION
### Description of the change

This PRs aims at providing a DRYer approach to define common env vars in the CI environment.

### Benefits

 It, hopefully, prevents from having this kind of errors (kubectl not being downloaded due to a missing `$KUBECTL_VERSION`

```bash
circleci@3ee4bb67d105:~/project$ cat /usr/local/bin/kubectl
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release//bin/linux/amd64/kubectl</Details></Error>circleci@3ee4bb67d105:~/project$ 
```

### Possible drawbacks

Some vars may not be strictly necessary in some steps, but not a big deal at all.

### Applicable issues

  - related #2376

### Additional information

N/A
