### PR TITLE
Add pinniped-proxy to the official chart

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 6.0.0
+version: 6.0.1

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -89,6 +89,7 @@ updateRepo() {
     replaceImage asset-syncer "${targetChartPath}/values.yaml"
     replaceImage assetsvc "${targetChartPath}/values.yaml"
     replaceImage kubeops "${targetChartPath}/values.yaml"
+    replaceImage pinniped-proxy "${targetChartPath}/values.yaml"
 }
 
 commitAndPushChanges() {


### PR DESCRIPTION
### Description of the change

This PRs adds the `pinniped-proxy` image in the list of imgs to be replaced in the official Bitnami chart (see https://github.com/kubeapps/kubeapps/blob/master/script/chart_sync_utils.sh).

### Benefits

Pinniped-proxy will be available (I mean, the official Bitnami image, not our kubeapps one) as part of the Bitnami chart.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

Since this process is being carried out from our CI system, we should pass this list as an envar, so that we only need to define it once. However, it should be another PR (and once we finish the CI updates).