### PR TITLE
imagePullSecrets: Fix type conversion

### DIFF
--- a/pkg/agent/docker_secrets_postrenderer.go
+++ b/pkg/agent/docker_secrets_postrenderer.go
@@ -152,11 +152,12 @@ func (r *DockerSecretsPostRenderer) updatePodSpecWithPullSecrets(podSpec map[int
 	var imagePullSecrets []map[string]interface{}
 	existingNames := map[string]bool{}
 	if existingPullSecrets, ok := podSpec["imagePullSecrets"]; ok {
-		imagePullSecrets = existingPullSecrets.([]map[string]interface{})
-		for _, s := range imagePullSecrets {
-			if name, ok := s["name"]; ok {
+		for _, s := range existingPullSecrets.([]interface{}) {
+			pullSecret := s.(map[interface{}]interface{})
+			if name, ok := pullSecret["name"]; ok {
 				if n, ok := name.(string); ok {
 					existingNames[n] = true
+					imagePullSecrets = append(imagePullSecrets, map[string]interface{}{"name": n})
 				}
 			}
 		}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Fixes #2634

When converting the key `imagePullSecrets`, the object type is `map[interface{}]interface{}` rather than `map[string]interface{}` (even if the object is `- name: foo`).

I'm using the raw YAML in the tests to be able to reproduce the issue.
