### PR TITLE
Minor CI fix

### DIFF
--- a/integration/use-cases/02-create-private-registry.js
+++ b/integration/use-cases/02-create-private-registry.js
@@ -3,10 +3,7 @@ const utils = require("./lib/utils");
 
 test("Creates a private registry", async () => {
   var token =
-    process.env.USE_MULTICLUSTER_OIDC_ENV === true ||
-      process.env.USE_MULTICLUSTER_OIDC_ENV === "true"
-      ? undefined
-      : process.env.ADMIN_TOKEN;
+    process.env.USE_MULTICLUSTER_OIDC_ENV === "true" ? undefined : process.env.ADMIN_TOKEN;
   page.on("response", response => {
     // retrieves the token after the oidc flow, note this require "--set-authorization-header=true" flag to be enabled in oauth2proxy
     token = response.headers()["authorization"] || token;

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -38,7 +38,7 @@ module.exports = {
   },
   login: async (page, isOIDC, uri, token, username, password) => {
     await page.goto(getUrl(uri));
-    if (isOIDC === true || isOIDC === "true") {
+    if (isOIDC === "true") {
       await page.waitForNavigation();
       await expect(page).toClick("cds-button", {
         text: "Login via OIDC Provider",

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -43,7 +43,10 @@ module.exports = {
       await expect(page).toClick("cds-button", {
         text: "Login via OIDC Provider",
       });
-      await page.waitForNavigation();
+      await page.waitForNavigation({ waitUntil: "domcontentloaded" });
+      await expect(page).toMatchElement(".dex-container button", {
+        text: "Log in with Email",
+      });
       await expect(page).toClick(".dex-container button", {
         text: "Log in with Email",
       });

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -223,7 +223,6 @@ if [[ -z "${TEST_LATEST_RELEASE:-}" ]]; then
   invalidateCacheFlag="--set featureFlags.invalidateCache=true"
 fi
 
-multiclusterFlags=""
 if [ "$USE_MULTICLUSTER_OIDC_ENV" = true ] ; then
   multiclusterFlags=(
     "--set" "ingress.enabled=true"


### PR DESCRIPTION
This PR simply removes a leftover line that is preventing the test to work in master.

Since we are using this shell expansion: `  "${multiclusterFlags[@]+"${multiclusterFlags[@]}"}" `
we are evaluating the array `multiclusterFlags[@]` prior to the actual expansion, so there is no need of initializing the var beforehand. 

See the actual test: https://app.circleci.com/pipelines/github/kubeapps/kubeapps/2682/workflows/b6c780e5-78c6-4eb9-847b-dbbde4ba4fc1