### PR TITLE
Disable (rather than hiding) the Docker Credentials section

### DIFF
--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.test.tsx
@@ -22,6 +22,7 @@ const defaultProps = {
   namespace: "default",
   appVersion: "1.0.0",
   required: false,
+  disabled: false,
 };
 
 let spyOnUseDispatch: jest.SpyInstance;

--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
@@ -7,6 +7,7 @@ import { useDispatch } from "react-redux";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
 import { ISecret, IStoreState } from "../../../shared/types";
+import Tooltip from "components/js/Tooltip";
 
 import "./AppRepoAddDockerCreds.css";
 import { CdsSelect } from "@cds/react/select";
@@ -18,6 +19,7 @@ interface IAppRepoFormProps {
   namespace: string;
   appVersion: string;
   required: boolean;
+  disabled: boolean;
 }
 
 export function AppRepoAddDockerCreds({
@@ -27,6 +29,7 @@ export function AppRepoAddDockerCreds({
   namespace,
   appVersion,
   required,
+  disabled,
 }: IAppRepoFormProps) {
   const dispatch: ThunkDispatch<IStoreState, null, Action> = useDispatch();
   const [secretName, setSecretName] = useState("");
@@ -78,7 +81,29 @@ export function AppRepoAddDockerCreds({
   return (
     <>
       <CdsSelect>
-        <label>Associate Docker Registry Credentials{required ? "" : " (optional)"}</label>
+        <label>
+          Associate Docker Registry Credentials{required ? "" : " (optional)"}{" "}
+          <span className="tooltip-wrapper">
+            <Tooltip
+              label="pending-tooltip"
+              id={`pending-tooltip`}
+              icon="help"
+              position="bottom-right"
+              large={true}
+              iconProps={{ solid: true, size: "sm" }}
+            >
+              You can only associate Docker Registry Credentials to namespaced Application
+              Repositories (non-global). More info{" "}
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/private-app-repository.md#associating-docker-image-pull-secrets-to-an-apprepository"
+              >
+                here
+              </a>
+            </Tooltip>
+          </span>
+        </label>
         {currentImagePullSecrets.length ? (
           <CdsControlMessage>
             Select existing secret(s) to access a private Docker registry and pull images from it.
@@ -99,6 +124,7 @@ export function AppRepoAddDockerCreds({
           value={selectedImagePullSecret}
           required={required}
           onChange={e => selectPullSecret(e.target.value)}
+          disabled={disabled}
         >
           <option />
           {currentImagePullSecrets.map(secret => {
@@ -186,7 +212,7 @@ export function AppRepoAddDockerCreds({
         <button
           className="btn btn-info-outline"
           type="button"
-          disabled={creating}
+          disabled={disabled || creating}
           onClick={toggleCredSubForm}
         >
           Add new credentials

--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
@@ -101,6 +101,7 @@ export function AppRepoAddDockerCreds({
               >
                 here
               </a>
+              .
             </Tooltip>
           </span>
         </label>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -274,12 +274,13 @@ describe("when using a filter", () => {
   });
 });
 
-it("should not show the docker registry credentials section if the namespace is the global one", () => {
+it("should disable the docker registry credentials section if the namespace is the global one", () => {
   const wrapper = mountWrapper(
     defaultStore,
     <AppRepoForm {...defaultProps} kubeappsNamespace={defaultProps.namespace} />,
   );
-  expect(wrapper.html()).not.toContain("Associate Docker Registry Credentials");
+  expect(wrapper.find("select")).toBeDisabled();
+  expect(wrapper.find(".docker-creds-subform-button button")).toBeDisabled();
 });
 
 it("should render the docker registry credentials section", () => {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -440,16 +440,15 @@ export function AppRepoForm(props: IAppRepoFormProps) {
           </div>
         </div>
 
-        {shouldEnableDockerRegistryCreds && (
-          <AppRepoAddDockerCreds
-            imagePullSecrets={imagePullSecrets}
-            selectPullSecret={selectPullSecret}
-            selectedImagePullSecret={selectedImagePullSecret}
-            namespace={namespace}
-            appVersion={appVersion}
-            required={authMethod === AUTH_METHOD_REGISTRY_SECRET}
-          />
-        )}
+        <AppRepoAddDockerCreds
+          imagePullSecrets={imagePullSecrets}
+          selectPullSecret={selectPullSecret}
+          selectedImagePullSecret={selectedImagePullSecret}
+          namespace={namespace}
+          appVersion={appVersion}
+          disabled={!shouldEnableDockerRegistryCreds}
+          required={authMethod === AUTH_METHOD_REGISTRY_SECRET}
+        />
 
         {type === TYPE_OCI ? (
           <CdsTextarea>


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Follow up of https://github.com/kubeapps/kubeapps/pull/2650#discussion_r608603878

Rather than hiding the Docker Credentials section in the AppRepo form (which can be confusing), disable it with a hint:

![Screenshot from 2021-04-07 17-05-40](https://user-images.githubusercontent.com/4025665/113889462-8cb4ad00-97c3-11eb-8be1-b193362c396c.png)

