### PR TITLE
Several fixes to reuse docker reg creds

### DIFF
--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -633,12 +633,21 @@ func apprepoSyncJobEnvVars(apprepo *apprepov1alpha1.AppRepository, config Config
 		},
 	})
 	if apprepo.Spec.Auth.Header != nil {
-		envVars = append(envVars, corev1.EnvVar{
-			Name: "AUTHORIZATION_HEADER",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: secretKeyRefForRepo(apprepo.Spec.Auth.Header.SecretKeyRef, apprepo, config),
-			},
-		})
+		if apprepo.Spec.Auth.Header.SecretKeyRef.Key == ".dockerconfigjson" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name: "DOCKER_CONFIG_JSON",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: secretKeyRefForRepo(apprepo.Spec.Auth.Header.SecretKeyRef, apprepo, config),
+				},
+			})
+		} else {
+			envVars = append(envVars, corev1.EnvVar{
+				Name: "AUTHORIZATION_HEADER",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: secretKeyRefForRepo(apprepo.Spec.Auth.Header.SecretKeyRef, apprepo, config),
+				},
+			})
+		}
 	}
 	return envVars
 }

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -62,15 +62,13 @@ var syncCmd = &cobra.Command{
 
 		authorizationHeader := os.Getenv("AUTHORIZATION_HEADER")
 		// The auth header may be a dockerconfig that we need to parse
-		dockerConfig := &credentialprovider.DockerConfigJson{}
-		err = json.Unmarshal([]byte(authorizationHeader), dockerConfig)
-		if err != nil {
-			// Not an dockerconfig, skip
-		} else {
-			authorizationHeader, err = kube.GetAuthHeaderFromDockerConfig(dockerConfig)
+		if os.Getenv("DOCKER_CONFIG_JSON") != "" {
+			dockerConfig := &credentialprovider.DockerConfigJson{}
+			err = json.Unmarshal([]byte(os.Getenv("DOCKER_CONFIG_JSON")), dockerConfig)
 			if err != nil {
 				logrus.Fatal(err)
 			}
+			authorizationHeader, err = kube.GetAuthHeaderFromDockerConfig(dockerConfig)
 		}
 
 		filters, err := parseFilters(filterRules)

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -1126,6 +1126,7 @@ describe("validateRepo", () => {
     expect(res).toBe(true);
     expect(AppRepository.validate).toHaveBeenCalledWith(
       "default",
+      "kubeapps-namespace",
       "url",
       "oci",
       "",

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -353,12 +353,14 @@ export const validateRepo = (
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     const {
-      clusters: { currentCluster },
+      clusters: { currentCluster, clusters },
     } = getState();
+    const namespace = clusters[currentCluster].currentNamespace;
     try {
       dispatch(repoValidating());
       const data = await AppRepository.validate(
         currentCluster,
+        namespace,
         repoURL,
         type,
         authHeader,

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -108,6 +108,7 @@ export class AppRepository {
 
   public static async validate(
     cluster: string,
+    namespace: string,
     repoURL: string,
     type: string,
     authHeader: string,
@@ -116,17 +117,20 @@ export class AppRepository {
     ociRepositories: string[],
     skipTLS: boolean,
   ) {
-    const { data } = await axiosWithAuth.post<any>(url.backend.apprepositories.validate(cluster), {
-      appRepository: {
-        repoURL,
-        type,
-        authHeader,
-        authRegCreds,
-        customCA,
-        ociRepositories,
-        tlsInsecureSkipVerify: skipTLS,
+    const { data } = await axiosWithAuth.post<any>(
+      url.backend.apprepositories.validate(cluster, namespace),
+      {
+        appRepository: {
+          repoURL,
+          type,
+          authHeader,
+          authRegCreds,
+          customCA,
+          ociRepositories,
+          tlsInsecureSkipVerify: skipTLS,
+        },
       },
-    });
+    );
     return data;
   }
 

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -88,7 +88,8 @@ export const backend = {
     create: (cluster: string, namespace: string) =>
       backend.apprepositories.base(cluster, namespace),
     list: (cluster: string, namespace: string) => backend.apprepositories.base(cluster, namespace),
-    validate: (cluster: string) => `${backend.apprepositories.base(cluster, "kubeapps")}/validate`,
+    validate: (cluster: string, namespace: string) =>
+      `${backend.apprepositories.base(cluster, namespace)}/validate`,
     delete: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,
     refresh: (cluster: string, namespace: string, name: string) =>

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -844,8 +844,7 @@ func TestOCIClient(t *testing.T) {
 		}
 		authSecret := &corev1.Secret{
 			Data: map[string][]byte{
-				// base64('{"auths":{"foo":{"username":"foo","password":"bar"}}}')
-				".dockerconfigjson": []byte("eyJhdXRocyI6eyJmb28iOnsidXNlcm5hbWUiOiJmb28iLCJwYXNzd29yZCI6ImJhciJ9fX0="),
+				".dockerconfigjson": []byte(`{"auths":{"foo":{"username":"foo","password":"bar"}}}`),
 			},
 		}
 		err := cli.InitClient(appRepo, &corev1.Secret{}, authSecret)

--- a/pkg/kube/http_utils.go
+++ b/pkg/kube/http_utils.go
@@ -62,6 +62,9 @@ func (c *clientWithDefaultHeaders) Do(req *http.Request) (*http.Response, error)
 }
 
 func GetAuthHeaderFromDockerConfig(dockerConfig *credentialprovider.DockerConfigJson) (string, error) {
+	if len(dockerConfig.Auths) > 1 {
+		return "", fmt.Errorf("The given config should include one auth entry")
+	}
 	// This is a simplified handler of a Docker config which only looks for the username:password
 	// of the first entry.
 	for _, entry := range dockerConfig.Auths {
@@ -76,11 +79,7 @@ func GetAuthHeaderFromDockerConfig(dockerConfig *credentialprovider.DockerConfig
 func getDataFromRegistrySecret(key string, s *corev1.Secret) (string, error) {
 	dockerConfigJson, ok := s.Data[key]
 	if !ok {
-		authBytes, ok := s.StringData[key]
-		if !ok {
-			return "", fmt.Errorf("secret %q did not contain key %q", s.Name, key)
-		}
-		dockerConfigJson = []byte(authBytes)
+		return "", fmt.Errorf("secret %q did not contain key %q", s.Name, key)
 	}
 
 	dockerConfig := &credentialprovider.DockerConfigJson{}

--- a/pkg/kube/http_utils_test.go
+++ b/pkg/kube/http_utils_test.go
@@ -411,8 +411,7 @@ func Test_getDataFromRegistrySecret(t *testing.T) {
 			name: "retrieves username and password from a dockerconfigjson",
 			secret: &corev1.Secret{
 				Data: map[string][]byte{
-					// base64('{"auths":{"foo":{"username":"foo","password":"bar"}}}')
-					".dockerconfigjson": []byte("eyJhdXRocyI6eyJmb28iOnsidXNlcm5hbWUiOiJmb28iLCJwYXNzd29yZCI6ImJhciJ9fX0="),
+					".dockerconfigjson": []byte(`{"auths":{"foo":{"username":"foo","password":"bar"}}}`),
 				},
 			},
 			// Basic: base64(foo:bar)


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

When testing #2638 and #2650 in real live, I noticed several issues that are fixed in this PR:

 - The asset-syncer needs to be adapted for the case in which a `.dockerconfigjson` is passed
 - When validating a repository that has a `.dockerconfigjson` linked, it's necessary to specify its namespace (before, the kubeapps namespace was being used)
 - When accessing a secret `.Data`, this data is already converted from base64 (there is no need to do it again).
 - The docker credentials secret was not being properly copied to the `kubeapps` namespace for the sync job to use it.
