### PR TITLE
Add namespaces filtering in header

### DIFF
--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -63,11 +63,11 @@ spec:
             {{- if .Values.kubeops.QPS }}
             - --qps={{ .Values.kubeops.QPS }}
             {{- end }}
-            {{- if .Values.kubeops.nsheadername }}
-            - --ns-header-name={{ .Values.kubeops.nsheadername }}
+            {{- if .Values.kubeops.namespaceHeaderName }}
+            - --ns-header-name={{ .Values.kubeops.namespaceHeaderName }}
             {{- end }}
-            {{- if .Values.kubeops.nsheaderpattern }}
-            - --ns-header-pattern={{ .Values.kubeops.nsheaderpattern }}
+            {{- if .Values.kubeops.namespaceHeaderPattern }}
+            - --ns-header-pattern={{ .Values.kubeops.namespaceHeaderPattern }}
             {{- end }}
           {{- if .Values.clusters }}
           volumeMounts:

--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -63,6 +63,12 @@ spec:
             {{- if .Values.kubeops.QPS }}
             - --qps={{ .Values.kubeops.QPS }}
             {{- end }}
+            {{- if .Values.kubeops.nsheadername }}
+            - --ns-header-name={{ .Values.kubeops.nsheadername }}
+            {{- end }}
+            {{- if .Values.kubeops.nsheaderpattern }}
+            - --ns-header-pattern={{ .Values.kubeops.nsheaderpattern }}
+            {{- end }}
           {{- if .Values.clusters }}
           volumeMounts:
             - name: kubeops-config

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -404,6 +404,13 @@ kubeops:
   ## Used when requesting namespaces
   # QPS: 10
   # burst: 15
+  ## Kubeops additional header parameters for trusted namespaces.
+  ## - nsheadername -  header field name, it can be injected by autorization proxy.
+  ## - nsheaderpattern - regular expression that matches only single item from the header list.
+  ##     The first capturing group must match the namespace.
+  ## example: X-Consumer-Groups: namespace:ns1:read, namespace:ns2:write
+  # nsheadername: X-Consumer-Groups
+  # nsheaderpattern: namespace:([\\w-]+):\\w+
 
 ## Assetsvc is used to serve assets metadata over a REST API.
 ##

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -405,12 +405,12 @@ kubeops:
   # QPS: 10
   # burst: 15
   ## Kubeops additional header parameters for trusted namespaces.
-  ## - nsheadername -  header field name, it can be injected by autorization proxy.
-  ## - nsheaderpattern - regular expression that matches only single item from the header list.
+  ## - namespaceHeaderName -  header field name, it can be injected by autorization proxy.
+  ## - namespaceHeaderPattern - regular expression that matches only single item from the header list.
   ##     The first capturing group must match the namespace.
   ## example: X-Consumer-Groups: namespace:ns1:read, namespace:ns2:write
-  # nsheadername: X-Consumer-Groups
-  # nsheaderpattern: namespace:([\\w-]+):\\w+
+  # namespaceHeaderName: X-Consumer-Groups
+  # namespaceHeaderPattern: namespace:([\w-]+):\w+
 
 ## Assetsvc is used to serve assets metadata over a REST API.
 ##

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -410,7 +410,7 @@ kubeops:
   ##     The first capturing group must match the namespace.
   ## example: X-Consumer-Groups: namespace:ns1:read, namespace:ns2:write
   # namespaceHeaderName: X-Consumer-Groups
-  # namespaceHeaderPattern: namespace:([\w-]+):\w+
+  # namespaceHeaderPattern: namespace:^([\w-]+):\w+$
 
 ## Assetsvc is used to serve assets metadata over a REST API.
 ##

--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -38,13 +38,15 @@ type dependentHandler func(cfg Config, w http.ResponseWriter, req *http.Request,
 
 // Options represents options that can be created without a bearer token, i.e. once at application startup.
 type Options struct {
-	ListLimit         int
-	Timeout           int64
-	UserAgent         string
-	KubeappsNamespace string
-	ClustersConfig    kube.ClustersConfig
-	Burst             int
-	QPS               float32
+	ListLimit              int
+	Timeout                int64
+	UserAgent              string
+	KubeappsNamespace      string
+	ClustersConfig         kube.ClustersConfig
+	Burst                  int
+	QPS                    float32
+	NamespaceHeaderName    string
+	NamespaceHeaderPattern string
 }
 
 // Config represents data needed by each handler to be able to create Helm 3 actions.
@@ -99,7 +101,7 @@ func WithHandlerConfig(storageForDriver agent.StorageForDriver, options Options)
 				return
 			}
 
-			kubeHandler, err := kube.NewHandler(options.KubeappsNamespace, options.Burst, options.QPS, options.ClustersConfig)
+			kubeHandler, err := kube.NewHandler(options.KubeappsNamespace, options.NamespaceHeaderName, options.NamespaceHeaderPattern, options.Burst, options.QPS, options.ClustersConfig)
 			if err != nil {
 				log.Errorf("Failed to create handler: %v", err)
 				response.NewErrorResponse(http.StatusInternalServerError, authUserError).Write(w)

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -57,8 +57,8 @@ func init() {
 	pflag.StringVar(&pinnipedProxyURL, "pinniped-proxy-url", "http://kubeapps-internal-pinniped-proxy.kubeapps:3333", "internal url to be used for requests to clusters configured for credential proxying via pinniped")
 	pflag.IntVar(&burst, "burst", 15, "internal burst capacity")
 	pflag.Float32Var(&qps, "qps", 10, "internal QPS rate")
-	pflag.StringVar(&namespaceHeaderName, "ns-header-name", "", "name of the header field")
-	pflag.StringVar(&namespaceHeaderPattern, "ns-header-pattern", "", "regular expression that matches only single group")
+	pflag.StringVar(&namespaceHeaderName, "namespace-header-name", "", "name of the header field, e.g. namespace-header-name=X-Consumer-Groups")
+	pflag.StringVar(&namespaceHeaderPattern, "namespace-header-pattern", "", "regular expression that matches only single group, e.g. namespace-header-pattern=namespace:([\\w]+):\\w+, to match namespace:ns:read")
 }
 
 func main() {

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -58,7 +58,7 @@ func init() {
 	pflag.IntVar(&burst, "burst", 15, "internal burst capacity")
 	pflag.Float32Var(&qps, "qps", 10, "internal QPS rate")
 	pflag.StringVar(&namespaceHeaderName, "namespace-header-name", "", "name of the header field, e.g. namespace-header-name=X-Consumer-Groups")
-	pflag.StringVar(&namespaceHeaderPattern, "namespace-header-pattern", "", "regular expression that matches only single group, e.g. namespace-header-pattern=namespace:([\\w]+):\\w+, to match namespace:ns:read")
+	pflag.StringVar(&namespaceHeaderPattern, "namespace-header-pattern", "", "regular expression that matches only single group, e.g. namespace-header-pattern=^namespace:([\\w]+):\\w+$, to match namespace:ns:read")
 }
 
 func main() {

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -80,7 +80,7 @@ func getNamespaceAndCluster(req *http.Request) (string, string) {
 // getHeaderNamespaces returns a list of namespaces from the header request
 // The name and the value of the header field is specified by 2 variables:
 // - headerName is a name of the expected header field, e.g. X-Consumer-Groups
-// - headerPattern is a regular expression and it matches only single regex group, e.g. namespace:([\w-]+)
+// - headerPattern is a regular expression and it matches only single regex group, e.g. ^namespace:([\w-]+)$
 func getHeaderNamespaces(req *http.Request, headerName, headerPattern string) ([]corev1.Namespace, error) {
 	var namespaces = []corev1.Namespace{}
 	if headerName == "" || headerPattern == "" {

--- a/pkg/http-handler/http-handler_test.go
+++ b/pkg/http-handler/http-handler_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -271,14 +270,14 @@ func TestGetNamespaces(t *testing.T) {
 			headerValue:  "namespace:ns1, namespace:ns2",
 		},
 		{
-			name:         "it should return the list of namespaces and a 200 when header does not match KUBEAPPS_NAMESPACE_HEADER",
+			name:         "it should return the list of namespaces and a 200 when header does not match kubeops arg ns-header-name",
 			namespaces:   []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
 			expectedCode: 200,
 			headerName:   "X-Consumer-Groups",
 			headerValue:  "nspaces:ns1, nspaces:ns2",
 		},
 		{
-			name:         "it should return the list of namespaces and a 200 when when header does not match KUBEAPPS_NAMESPACE_PATTERN",
+			name:         "it should return the list of namespaces and a 200 when when header does not match kubeops arg ns-header-pattern",
 			namespaces:   []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
 			expectedCode: 200,
 			headerName:   "Y-Consumer-Groups",
@@ -289,12 +288,6 @@ func TestGetNamespaces(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			getNSFunc := GetNamespaces(&kube.FakeHandler{Namespaces: tc.namespaces, Err: tc.err})
 			req := httptest.NewRequest("GET", "https://foo.bar/backend/v1/namespaces", nil)
-
-			if tc.headerName != "" {
-				os.Setenv("KUBEAPPS_NAMESPACE_HEADER", "X-Consumer-Groups")
-				os.Setenv("KUBEAPPS_NAMESPACE_PATTERN", "namespace:([\\w-]+)")
-				req.Header.Set(tc.headerName, tc.headerValue)
-			}
 
 			response := httptest.NewRecorder()
 			getNSFunc(response, req)

--- a/pkg/http-handler/http-handler_test.go
+++ b/pkg/http-handler/http-handler_test.go
@@ -276,7 +276,7 @@ func TestGetNamespaces(t *testing.T) {
 			additionalHeader: http.Header{"X-Consumer-Groups": []string{"namespace:ns1", "namespace:ns2"}},
 			namespaceHeaderOptions: kube.KubeOptions{
 				NamespaceHeaderName:    "X-Consumer-Groups",
-				NamespaceHeaderPattern: "namespace:(\\w+)",
+				NamespaceHeaderPattern: "^namespace:(\\w+)$",
 			},
 		},
 		{
@@ -287,18 +287,18 @@ func TestGetNamespaces(t *testing.T) {
 			additionalHeader:   http.Header{"X-Consumer-Groups": []string{"nspace:ns1", "nspace:ns2"}},
 			namespaceHeaderOptions: kube.KubeOptions{
 				NamespaceHeaderName:    "X-Consumer-Groups",
-				NamespaceHeaderPattern: "namespace:(\\w+)",
+				NamespaceHeaderPattern: "^namespace:(\\w+)$",
 			},
 		},
 		{
-			name:               "it should return the existing list of namespaces and a 200 when when header does not match kubeops arg namespace-header-pattern",
+			name:               "it should return the existing list of namespaces and a 200 when header does not match kubeops arg namespace-header-pattern",
 			existingNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
 			expectedNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
 			expectedCode:       200,
 			additionalHeader:   http.Header{"Y-Consumer-Groups": []string{"namespace:ns1", "namespace:ns2"}},
 			namespaceHeaderOptions: kube.KubeOptions{
 				NamespaceHeaderName:    "X-Consumer-Groups",
-				NamespaceHeaderPattern: "namespace:(\\w+)",
+				NamespaceHeaderPattern: "^namespace:(\\w+)$",
 			},
 		},
 		{
@@ -309,7 +309,7 @@ func TestGetNamespaces(t *testing.T) {
 			additionalHeader:   http.Header{"Y-Consumer-Groups": []string{"namespace:ns1", "namespace:ns2"}},
 			namespaceHeaderOptions: kube.KubeOptions{
 				NamespaceHeaderName:    "",
-				NamespaceHeaderPattern: "namespace:(\\w+)",
+				NamespaceHeaderPattern: "^namespace:(\\w+)$",
 			},
 		},
 		{
@@ -321,6 +321,20 @@ func TestGetNamespaces(t *testing.T) {
 			namespaceHeaderOptions: kube.KubeOptions{
 				NamespaceHeaderName:    "X-Consumer-Groups",
 				NamespaceHeaderPattern: "",
+			},
+		},
+		{
+			name:               "it should return some of the namespaces from header and a 200 when not all match namespace-header-pattern",
+			existingNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedNamespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "ns2"}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "ns4"}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}},
+			},
+			expectedCode:     200,
+			additionalHeader: http.Header{"X-Consumer-Groups": []string{"namespace:ns1:read", "namespace:ns2", "ns3", "namespace:ns4", "ns:ns5:write"}},
+			namespaceHeaderOptions: kube.KubeOptions{
+				NamespaceHeaderName:    "X-Consumer-Groups",
+				NamespaceHeaderPattern: "^namespace:(\\w+)$",
 			},
 		},
 	}

--- a/pkg/http-handler/http-handler_test.go
+++ b/pkg/http-handler/http-handler_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -245,17 +246,19 @@ func TestDeleteAppRepository(t *testing.T) {
 
 func TestGetNamespaces(t *testing.T) {
 	testCases := []struct {
-		name         string
-		namespaces   []corev1.Namespace
-		err          error
-		expectedCode int
-		headerName   string
-		headerValue  string
+		name                   string
+		existingNamespaces     []corev1.Namespace
+		expectedNamespaces     []corev1.Namespace
+		err                    error
+		expectedCode           int
+		additionalHeader       http.Header
+		namespaceHeaderOptions kube.KubeOptions
 	}{
 		{
-			name:         "it should return the list of namespaces and a 200 if the repo is created",
-			namespaces:   []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
-			expectedCode: 200,
+			name:               "it should return the list of namespaces and a 200 if the repo is created",
+			existingNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedCode:       200,
 		},
 		{
 			name:         "it should return a 403 when forbidden",
@@ -263,31 +266,72 @@ func TestGetNamespaces(t *testing.T) {
 			expectedCode: 403,
 		},
 		{
-			name:         "it should return the list of namespaces from header and a 200 if the repo is created",
-			namespaces:   []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}}, {ObjectMeta: metav1.ObjectMeta{Name: "ns2"}}},
-			expectedCode: 200,
-			headerName:   "X-Consumer-Groups",
-			headerValue:  "namespace:ns1, namespace:ns2",
+			name:               "it should return the list of namespaces from the header and a 200 if the repo is created",
+			existingNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedNamespaces: []corev1.Namespace{
+				{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "ns2"}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}},
+			},
+			expectedCode:     200,
+			additionalHeader: http.Header{"X-Consumer-Groups": []string{"namespace:ns1", "namespace:ns2"}},
+			namespaceHeaderOptions: kube.KubeOptions{
+				NamespaceHeaderName:    "X-Consumer-Groups",
+				NamespaceHeaderPattern: "namespace:(\\w+)",
+			},
 		},
 		{
-			name:         "it should return the list of namespaces and a 200 when header does not match kubeops arg ns-header-name",
-			namespaces:   []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
-			expectedCode: 200,
-			headerName:   "X-Consumer-Groups",
-			headerValue:  "nspaces:ns1, nspaces:ns2",
+			name:               "it should return the existing list of namespaces and a 200 when header does not match kubeops arg namespace-header-name",
+			existingNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedCode:       200,
+			additionalHeader:   http.Header{"X-Consumer-Groups": []string{"nspace:ns1", "nspace:ns2"}},
+			namespaceHeaderOptions: kube.KubeOptions{
+				NamespaceHeaderName:    "X-Consumer-Groups",
+				NamespaceHeaderPattern: "namespace:(\\w+)",
+			},
 		},
 		{
-			name:         "it should return the list of namespaces and a 200 when when header does not match kubeops arg ns-header-pattern",
-			namespaces:   []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
-			expectedCode: 200,
-			headerName:   "Y-Consumer-Groups",
-			headerValue:  "namespace:ns1, namespace:ns2",
+			name:               "it should return the existing list of namespaces and a 200 when when header does not match kubeops arg namespace-header-pattern",
+			existingNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedCode:       200,
+			additionalHeader:   http.Header{"Y-Consumer-Groups": []string{"namespace:ns1", "namespace:ns2"}},
+			namespaceHeaderOptions: kube.KubeOptions{
+				NamespaceHeaderName:    "X-Consumer-Groups",
+				NamespaceHeaderPattern: "namespace:(\\w+)",
+			},
+		},
+		{
+			name:               "it should return the existing list of namespaces and a 200 when kubeops arg namespace-header-name is empty",
+			existingNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedCode:       200,
+			additionalHeader:   http.Header{"Y-Consumer-Groups": []string{"namespace:ns1", "namespace:ns2"}},
+			namespaceHeaderOptions: kube.KubeOptions{
+				NamespaceHeaderName:    "",
+				NamespaceHeaderPattern: "namespace:(\\w+)",
+			},
+		},
+		{
+			name:               "it should return the existing list of namespaces and a 200 when kubeops arg namespace-header-pattern is empty",
+			existingNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedNamespaces: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}},
+			expectedCode:       200,
+			additionalHeader:   http.Header{"Y-Consumer-Groups": []string{"namespace:ns1", "namespace:ns2"}},
+			namespaceHeaderOptions: kube.KubeOptions{
+				NamespaceHeaderName:    "X-Consumer-Groups",
+				NamespaceHeaderPattern: "",
+			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			getNSFunc := GetNamespaces(&kube.FakeHandler{Namespaces: tc.namespaces, Err: tc.err})
+			getNSFunc := GetNamespaces(&kube.FakeHandler{Namespaces: tc.existingNamespaces, Err: tc.err, Options: tc.namespaceHeaderOptions})
 			req := httptest.NewRequest("GET", "https://foo.bar/backend/v1/namespaces", nil)
+
+			for headerName, headerValue := range tc.additionalHeader {
+				req.Header.Set(headerName, strings.Join(headerValue, ","))
+			}
 
 			response := httptest.NewRecorder()
 			getNSFunc(response, req)
@@ -302,7 +346,7 @@ func TestGetNamespaces(t *testing.T) {
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
-				expectedResponse := namespacesResponse{Namespaces: tc.namespaces}
+				expectedResponse := namespacesResponse{Namespaces: tc.expectedNamespaces}
 				if got, want := nsResponse, expectedResponse; !cmp.Equal(want, got) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 				}

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -47,6 +47,11 @@ func (c *FakeHandler) AsSVC(cluster string) (handler, error) {
 	return c, nil
 }
 
+// NS fakes returning header namespace options
+func (c *FakeHandler) GetOptions() kubeOptions {
+	return kubeOptions{}
+}
+
 // ListAppRepositories fake
 func (c *FakeHandler) ListAppRepositories(requestNamespace string) (*v1alpha1.AppRepositoryList, error) {
 	appRepos := &v1alpha1.AppRepositoryList{}
@@ -88,14 +93,9 @@ func (c *FakeHandler) GetAppRepository(name, namespace string) (*v1alpha1.AppRep
 }
 
 // GetNamespaces fake
-func (c *FakeHandler) GetNamespaces() ([]corev1.Namespace, error) {
-	return c.Namespaces, c.Err
-}
-
-// GetNamespacesFromList fake
-func (c *FakeHandler) GetNamespacesFromList(headerNamespaces []string) ([]corev1.Namespace, error) {
-	if len(headerNamespaces) == 0 {
-		return []corev1.Namespace{}, nil
+func (c *FakeHandler) GetNamespaces(trustedNamespaces []corev1.Namespace) ([]corev1.Namespace, error) {
+	if len(trustedNamespaces) > 0 {
+		return trustedNamespaces, c.Err
 	}
 	return c.Namespaces, c.Err
 }

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -94,9 +94,9 @@ func (c *FakeHandler) GetAppRepository(name, namespace string) (*v1alpha1.AppRep
 }
 
 // GetNamespaces fake
-func (c *FakeHandler) GetNamespaces(whitelistedNamespaces []corev1.Namespace) ([]corev1.Namespace, error) {
-	if len(whitelistedNamespaces) > 0 {
-		return whitelistedNamespaces, c.Err
+func (c *FakeHandler) GetNamespaces(precheckedNamespaces []corev1.Namespace) ([]corev1.Namespace, error) {
+	if len(precheckedNamespaces) > 0 {
+		return precheckedNamespaces, c.Err
 	}
 	return c.Namespaces, c.Err
 }

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -92,6 +92,14 @@ func (c *FakeHandler) GetNamespaces() ([]corev1.Namespace, error) {
 	return c.Namespaces, c.Err
 }
 
+// GetNamespacesFromList fake
+func (c *FakeHandler) GetNamespacesFromList(headerNamespaces []string) ([]corev1.Namespace, error) {
+	if len(headerNamespaces) == 0 {
+		return []corev1.Namespace{}, nil
+	}
+	return c.Namespaces, c.Err
+}
+
 // GetSecret fake
 func (c *FakeHandler) GetSecret(name, namespace string) (*corev1.Secret, error) {
 	for _, r := range c.Secrets {

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -33,6 +33,7 @@ type FakeHandler struct {
 	Namespaces  []corev1.Namespace
 	Secrets     []*corev1.Secret
 	ValRes      *ValidationResponse
+	Options     KubeOptions
 	Err         error
 	Can         bool
 }
@@ -48,8 +49,8 @@ func (c *FakeHandler) AsSVC(cluster string) (handler, error) {
 }
 
 // NS fakes returning header namespace options
-func (c *FakeHandler) GetOptions() kubeOptions {
-	return kubeOptions{}
+func (c *FakeHandler) GetOptions() KubeOptions {
+	return c.Options
 }
 
 // ListAppRepositories fake
@@ -93,9 +94,9 @@ func (c *FakeHandler) GetAppRepository(name, namespace string) (*v1alpha1.AppRep
 }
 
 // GetNamespaces fake
-func (c *FakeHandler) GetNamespaces(trustedNamespaces []corev1.Namespace) ([]corev1.Namespace, error) {
-	if len(trustedNamespaces) > 0 {
-		return trustedNamespaces, c.Err
+func (c *FakeHandler) GetNamespaces(whitelistedNamespaces []corev1.Namespace) ([]corev1.Namespace, error) {
+	if len(whitelistedNamespaces) > 0 {
+		return whitelistedNamespaces, c.Err
 	}
 	return c.Namespaces, c.Err
 }

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -237,7 +237,7 @@ type handler interface {
 	UpdateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error)
 	RefreshAppRepository(repoName string, requestNamespace string) (*v1alpha1.AppRepository, error)
 	DeleteAppRepository(name, namespace string) error
-	GetNamespaces(whitelistedNamespaces []corev1.Namespace) ([]corev1.Namespace, error)
+	GetNamespaces(precheckedNamespaces []corev1.Namespace) ([]corev1.Namespace, error)
 	GetSecret(name, namespace string) (*corev1.Secret, error)
 	GetAppRepository(repoName, repoNamespace string) (*v1alpha1.AppRepository, error)
 	ValidateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*ValidationResponse, error)
@@ -863,15 +863,11 @@ func filterActiveNamespaces(namespaces []corev1.Namespace) []corev1.Namespace {
 }
 
 // GetNamespaces return the list of namespaces that the user has permission to access
-func (a *userHandler) GetNamespaces(whitelistedNamespaces []corev1.Namespace) ([]corev1.Namespace, error) {
+func (a *userHandler) GetNamespaces(precheckedNamespaces []corev1.Namespace) ([]corev1.Namespace, error) {
 	var namespaceList []corev1.Namespace
 
-	if len(whitelistedNamespaces) > 0 {
-		namespaceList = append(namespaceList, whitelistedNamespaces...)
-		// if any, use only overrided namespaces
-		if len(namespaceList) > 0 {
-			return namespaceList, nil
-		}
+	if len(precheckedNamespaces) > 0 {
+		namespaceList = append(namespaceList, precheckedNamespaces...)
 	} else {
 		// Try to list namespaces with the user token, for backward compatibility
 		namespaces, err := a.clientset.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -855,13 +855,13 @@ type existingNs struct {
 func TestGetNamespaces(t *testing.T) {
 
 	testCases := []struct {
-		name                  string
-		existingNamespaces    []existingNs
-		allowed               bool
-		userClientErr         error
-		svcClientErr          error
-		expectedNamespaces    []string
-		whitelistedNamespaces []corev1.Namespace
+		name                 string
+		existingNamespaces   []existingNs
+		allowed              bool
+		userClientErr        error
+		svcClientErr         error
+		expectedNamespaces   []string
+		precheckedNamespaces []corev1.Namespace
 	}{
 		{
 			name: "it lists namespaces if the user client returns the namespaces",
@@ -915,7 +915,7 @@ func TestGetNamespaces(t *testing.T) {
 			existingNamespaces: []existingNs{
 				{"foo", corev1.NamespaceActive},
 			},
-			whitelistedNamespaces: []corev1.Namespace{{
+			precheckedNamespaces: []corev1.Namespace{{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
 				Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 			}},
@@ -927,9 +927,9 @@ func TestGetNamespaces(t *testing.T) {
 			existingNamespaces: []existingNs{
 				{"foo", corev1.NamespaceActive},
 			},
-			whitelistedNamespaces: []corev1.Namespace{},
-			expectedNamespaces:    []string{"foo"},
-			allowed:               true,
+			precheckedNamespaces: []corev1.Namespace{},
+			expectedNamespaces:   []string{"foo"},
+			allowed:              true,
 		},
 	}
 	for _, tc := range testCases {
@@ -985,7 +985,7 @@ func TestGetNamespaces(t *testing.T) {
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}
-			namespaces, err := userHandler.GetNamespaces(tc.whitelistedNamespaces)
+			namespaces, err := userHandler.GetNamespaces(tc.precheckedNamespaces)
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -855,13 +855,13 @@ type existingNs struct {
 func TestGetNamespaces(t *testing.T) {
 
 	testCases := []struct {
-		name               string
-		existingNamespaces []existingNs
-		allowed            bool
-		userClientErr      error
-		svcClientErr       error
-		expectedNamespaces []string
-		trustedNamespaces  []corev1.Namespace
+		name                  string
+		existingNamespaces    []existingNs
+		allowed               bool
+		userClientErr         error
+		svcClientErr          error
+		expectedNamespaces    []string
+		whitelistedNamespaces []corev1.Namespace
 	}{
 		{
 			name: "it lists namespaces if the user client returns the namespaces",
@@ -915,39 +915,21 @@ func TestGetNamespaces(t *testing.T) {
 			existingNamespaces: []existingNs{
 				{"foo", corev1.NamespaceActive},
 			},
-			trustedNamespaces: []corev1.Namespace{{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
-			}},
-			expectedNamespaces: []string{"foo"},
-			allowed:            true,
-		},
-		{
-			name: "it lists namespaces if the userclient fails but the service client succeeds",
-			existingNamespaces: []existingNs{
-				{"bar", corev1.NamespaceActive},
-			},
-			trustedNamespaces: []corev1.Namespace{{
+			whitelistedNamespaces: []corev1.Namespace{{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
 				Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 			}},
-			userClientErr:      k8sErrors.NewForbidden(schema.GroupResource{}, "bang", fmt.Errorf("Bang")),
 			expectedNamespaces: []string{"bar"},
 			allowed:            true,
 		},
 		{
-			name: "it returns namespace from header, despite user and service account forbidden",
+			name: "it lists existing namespaces if the user client sends empty list of the namespaces",
 			existingNamespaces: []existingNs{
-				{"zed", corev1.NamespaceActive},
+				{"foo", corev1.NamespaceActive},
 			},
-			userClientErr: k8sErrors.NewForbidden(schema.GroupResource{}, "bang", fmt.Errorf("Bang")),
-			svcClientErr:  k8sErrors.NewForbidden(schema.GroupResource{}, "bang", fmt.Errorf("Bang")),
-			trustedNamespaces: []corev1.Namespace{{
-				ObjectMeta: metav1.ObjectMeta{Name: "zed"},
-				Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
-			}},
-			expectedNamespaces: []string{"zed"},
-			allowed:            true,
+			whitelistedNamespaces: []corev1.Namespace{},
+			expectedNamespaces:    []string{"foo"},
+			allowed:               true,
 		},
 	}
 	for _, tc := range testCases {
@@ -1003,7 +985,7 @@ func TestGetNamespaces(t *testing.T) {
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}
-			namespaces, err := userHandler.GetNamespaces(tc.trustedNamespaces)
+			namespaces, err := userHandler.GetNamespaces(tc.whitelistedNamespaces)
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}


### PR DESCRIPTION
Signed-off-by: Marcin Gucki <mgucki@coreweave.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This change refers to #2506 and allows passing namespaces in the header. The name of the header field and its value are defined by 2 environment variable:
- `KUBEAPPS_NAMESPACE_HEADER` - the name of the header field, e.g. `X-Consumer-Groups`
- `KUBEAPPS_NAMESPACE_PATTERN` - defines regular expression with the single matching group for the namespace name, e.g. `namespace:([\w-]+)`

For 2 namespaces, the header may look like this: `X-Consumer-Groups: namespace:ns1, namespace:ns2`.


### Benefits

<!-- What benefits will be realized by the code change? -->
It prevents looping over all namespaces in the cluster.
We have too many namespaces and even with parallel workers it takes too long and the number of namespaces is still growing.

The additional header will be injected by our API gateway. This way Kubeapps will only loop over a few namespaces.


### Possible drawbacks

<!-- Describe any known limitations with your change -->
- It applies only to narrow consumers with big infrastructure like ours.
- The deployment of Kubeapps needs additional customization to set the environment variables.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2506

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

