### PR TITLE
Run a shallow sync the first time a repository is processed

### DIFF
--- a/cmd/asset-syncer/postgresql_db_test.go
+++ b/cmd/asset-syncer/postgresql_db_test.go
@@ -412,25 +412,42 @@ func TestRepoAlreadyProcessed(t *testing.T) {
 	defer cleanup()
 
 	// not processed when it doesn't exist
-	if got, want := pam.LastChecksum(repo), ""; got != want {
-		t.Errorf("got: %s, want: %s", got, want)
+	got, err := pam.LastChecksum(repo)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if got != "" {
+		t.Errorf("got: %s, want: %s", got, "")
 	}
 
 	// not processed when repo exists but has not been processed
 	pam.EnsureRepoExists(repoNamespace, repoName)
-	if got, want := pam.LastChecksum(repo), ""; got != want {
-		t.Errorf("got: %s, want: %s", got, want)
+	got, err = pam.LastChecksum(repo)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if got != "" {
+		t.Errorf("got: %s, want: %s", got, "")
 	}
 
 	pam.UpdateLastCheck(repoNamespace, repoName, checksum, time.Now())
 	// processed when checksums match
-	if got, want := pam.LastChecksum(repo), checksum; got != want {
-		t.Errorf("got: %s, want: %s", got, want)
+	pam.EnsureRepoExists(repoNamespace, repoName)
+	got, err = pam.LastChecksum(repo)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if got != checksum {
+		t.Errorf("got: %s, want: %s", got, checksum)
 	}
 
 	// it does not match the same repo in a different namespace
-	if got, want := pam.LastChecksum(models.Repo{Namespace: "other-namespace", Name: repo.Name}), ""; got != want {
-		t.Errorf("got: %s, want: %s", got, want)
+	got, err = pam.LastChecksum(models.Repo{Namespace: "other-namespace", Name: repo.Name})
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if got != "" {
+		t.Errorf("got: %s, want: %s", got, "")
 	}
 }
 

--- a/cmd/asset-syncer/postgresql_db_test.go
+++ b/cmd/asset-syncer/postgresql_db_test.go
@@ -412,30 +412,25 @@ func TestRepoAlreadyProcessed(t *testing.T) {
 	defer cleanup()
 
 	// not processed when it doesn't exist
-	if got, want := pam.RepoAlreadyProcessed(repo, checksum), false; got != want {
-		t.Errorf("got: %t, want: %t", got, want)
+	if got, want := pam.LastChecksum(repo), ""; got != want {
+		t.Errorf("got: %s, want: %s", got, want)
 	}
 
 	// not processed when repo exists but has not been processed
 	pam.EnsureRepoExists(repoNamespace, repoName)
-	if got, want := pam.RepoAlreadyProcessed(repo, checksum), false; got != want {
-		t.Errorf("got: %t, want: %t", got, want)
+	if got, want := pam.LastChecksum(repo), ""; got != want {
+		t.Errorf("got: %s, want: %s", got, want)
 	}
 
-	// not processed when checksum doesn't match
 	pam.UpdateLastCheck(repoNamespace, repoName, checksum, time.Now())
-	if got, want := pam.RepoAlreadyProcessed(repo, "other-checksum"), false; got != want {
-		t.Errorf("got: %t, want: %t", got, want)
-	}
-
 	// processed when checksums match
-	if got, want := pam.RepoAlreadyProcessed(repo, checksum), true; got != want {
-		t.Errorf("got: %t, want: %t", got, want)
+	if got, want := pam.LastChecksum(repo), checksum; got != want {
+		t.Errorf("got: %s, want: %s", got, want)
 	}
 
 	// it does not match the same repo in a different namespace
-	if got, want := pam.RepoAlreadyProcessed(models.Repo{Namespace: "other-namespace", Name: repo.Name}, checksum), false; got != want {
-		t.Errorf("got: %t, want: %t", got, want)
+	if got, want := pam.LastChecksum(models.Repo{Namespace: "other-namespace", Name: repo.Name}), ""; got != want {
+		t.Errorf("got: %s, want: %s", got, want)
 	}
 }
 

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -28,7 +28,6 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/kubeapps/kubeapps/pkg/dbutils"
 	_ "github.com/lib/pq"
-	log "github.com/sirupsen/logrus"
 )
 
 var ErrMultipleRows = fmt.Errorf("more than one row returned in query result")
@@ -72,15 +71,13 @@ func (m *postgresAssetManager) Sync(repo models.Repo, charts []models.Chart) err
 	return m.removeMissingCharts(repo, charts)
 }
 
-func (m *postgresAssetManager) RepoAlreadyProcessed(repo models.Repo, repoChecksum string) bool {
+func (m *postgresAssetManager) LastChecksum(repo models.Repo) string {
 	var lastChecksum string
 	row := m.DB.QueryRow(fmt.Sprintf("SELECT checksum FROM %s WHERE name = $1 AND namespace = $2", dbutils.RepositoryTable), repo.Name, repo.Namespace)
 	if row != nil {
-		err := row.Scan(&lastChecksum)
-		log.Errorf("lastChecksum: %+v", lastChecksum)
-		return err == nil && lastChecksum == repoChecksum
+		row.Scan(&lastChecksum)
 	}
-	return false
+	return lastChecksum
 }
 
 func (m *postgresAssetManager) UpdateLastCheck(repoNamespace, repoName, checksum string, now time.Time) error {

--- a/cmd/asset-syncer/postgresql_utils_test.go
+++ b/cmd/asset-syncer/postgresql_utils_test.go
@@ -37,7 +37,7 @@ func Test_DeletePGRepo(t *testing.T) {
 	}
 }
 
-func Test_PGRepoAlreadyProcessed(t *testing.T) {
+func Test_PGRepoLastChecksum(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
@@ -45,8 +45,8 @@ func Test_PGRepoAlreadyProcessed(t *testing.T) {
 		WithArgs("foo", "repo-namespace").
 		WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("123"))
 
-	if got, want := pgManager.RepoAlreadyProcessed(models.Repo{Namespace: "repo-namespace", Name: "foo"}, "123"), true; got != want {
-		t.Errorf("got: %t, want: %t", got, want)
+	if got, want := pgManager.LastChecksum(models.Repo{Namespace: "repo-namespace", Name: "foo"}), "123"; got != want {
+		t.Errorf("got: %s, want: %s", got, want)
 	}
 }
 

--- a/cmd/asset-syncer/postgresql_utils_test.go
+++ b/cmd/asset-syncer/postgresql_utils_test.go
@@ -45,8 +45,12 @@ func Test_PGRepoLastChecksum(t *testing.T) {
 		WithArgs("foo", "repo-namespace").
 		WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("123"))
 
-	if got, want := pgManager.LastChecksum(models.Repo{Namespace: "repo-namespace", Name: "foo"}), "123"; got != want {
-		t.Errorf("got: %s, want: %s", got, want)
+	got, err := pgManager.LastChecksum(models.Repo{Namespace: "repo-namespace", Name: "foo"})
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if got != "123" {
+		t.Errorf("got: %s, want: %s", got, "123")
 	}
 }
 

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -92,7 +92,10 @@ var syncCmd = &cobra.Command{
 		}
 
 		// Check if the repo has been already processed
-		lastChecksum := manager.LastChecksum(models.Repo{Namespace: repo.Namespace, Name: repo.Name})
+		lastChecksum, err := manager.LastChecksum(models.Repo{Namespace: repo.Namespace, Name: repo.Name})
+		if err != nil {
+			logrus.Fatal(err)
+		}
 		logrus.Infof("Last checksum: %v", lastChecksum)
 		if lastChecksum == checksum {
 			logrus.WithFields(logrus.Fields{"url": repo.URL}).Info("Skipping repository since there are no updates")
@@ -102,15 +105,15 @@ var syncCmd = &cobra.Command{
 		// First filter the list of charts (still without applying custom filters)
 		repoIface.FilterIndex()
 
-		shallowSyncs := []bool{false}
+		fetchLatestOnlySlice := []bool{false}
 		if lastChecksum == "" {
 			// If the repo has never been processed, run first a shallow sync to give early feedback
 			// then sync all the repositories
-			shallowSyncs = []bool{true, false}
+			fetchLatestOnlySlice = []bool{true, false}
 		}
 
-		for _, shallow := range shallowSyncs {
-			charts, err := repoIface.Charts(shallow)
+		for _, fetchLatestOnly := range fetchLatestOnlySlice {
+			charts, err := repoIface.Charts(fetchLatestOnly)
 			if err != nil {
 				logrus.Fatal(err)
 			}
@@ -121,7 +124,7 @@ var syncCmd = &cobra.Command{
 			// Fetch and store chart icons
 			fImporter := fileImporter{manager, netClient}
 			fImporter.fetchFiles(charts, repoIface)
-			logrus.WithFields(logrus.Fields{"shallow": shallow}).Info("Repository synced")
+			logrus.WithFields(logrus.Fields{"shallow": fetchLatestOnly}).Info("Repository synced")
 		}
 
 		// Update cache in the database

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -92,23 +92,37 @@ var syncCmd = &cobra.Command{
 		}
 
 		// Check if the repo has been already processed
-		if manager.RepoAlreadyProcessed(models.Repo{Namespace: repo.Namespace, Name: repo.Name}, checksum) {
+		lastChecksum := manager.LastChecksum(models.Repo{Namespace: repo.Namespace, Name: repo.Name})
+		logrus.Infof("Last checksum: %v", lastChecksum)
+		if lastChecksum == checksum {
 			logrus.WithFields(logrus.Fields{"url": repo.URL}).Info("Skipping repository since there are no updates")
 			return
 		}
 
-		charts, err := repoIface.Charts()
-		if err != nil {
-			logrus.Fatal(err)
+		// First filter the list of charts (still without applying custom filters)
+		repoIface.FilterIndex()
+
+		shallowSyncs := []bool{false}
+		if lastChecksum == "" {
+			// If the repo has never been processed, run first a shallow sync to give early feedback
+			// then sync all the repositories
+			shallowSyncs = []bool{true, false}
 		}
 
-		if err = manager.Sync(models.Repo{Name: repo.Name, Namespace: repo.Namespace}, charts); err != nil {
-			logrus.Fatalf("Can't add chart repository to database: %v", err)
-		}
+		for _, shallow := range shallowSyncs {
+			charts, err := repoIface.Charts(shallow)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+			if err = manager.Sync(models.Repo{Name: repo.Name, Namespace: repo.Namespace}, charts); err != nil {
+				logrus.Fatalf("Can't add chart repository to database: %v", err)
+			}
 
-		// Fetch and store chart icons
-		fImporter := fileImporter{manager, netClient}
-		fImporter.fetchFiles(charts, repoIface)
+			// Fetch and store chart icons
+			fImporter := fileImporter{manager, netClient}
+			fImporter.fetchFiles(charts, repoIface)
+			logrus.WithFields(logrus.Fields{"shallow": shallow}).Info("Repository synced")
+		}
 
 		// Update cache in the database
 		if err = manager.UpdateLastCheck(repo.Namespace, repo.Name, checksum, time.Now()); err != nil {

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -37,6 +37,7 @@ import (
 	"sync"
 	"time"
 
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/disintegration/imaging"
 	"github.com/ghodss/yaml"
@@ -99,7 +100,7 @@ func parseRepoURL(repoURL string) (*url.URL, error) {
 type assetManager interface {
 	Delete(repo models.Repo) error
 	Sync(repo models.Repo, charts []models.Chart) error
-	RepoAlreadyProcessed(repo models.Repo, checksum string) bool
+	LastChecksum(repo models.Repo) string
 	UpdateLastCheck(repoNamespace, repoName, checksum string, now time.Time) error
 	Init() error
 	Close() error
@@ -126,7 +127,8 @@ func getSha256(src []byte) (string, error) {
 type Repo interface {
 	Checksum() (string, error)
 	Repo() *models.RepoInternal
-	Charts() ([]models.Chart, error)
+	FilterIndex()
+	Charts(shallow bool) ([]models.Chart, error)
 	FetchFiles(name string, cv models.ChartVersion) (map[string]string, error)
 }
 
@@ -146,6 +148,11 @@ func (r *HelmRepo) Checksum() (string, error) {
 // Repo returns the repo information
 func (r *HelmRepo) Repo() *models.RepoInternal {
 	return r.RepoInternal
+}
+
+// FilterRepo is a no-op for a Helm repo
+func (r *HelmRepo) FilterIndex() {
+	// no-op
 }
 
 func compileJQ(rule *apprepov1alpha1.FilterRuleSpec) (*gojq.Code, []interface{}, error) {
@@ -217,7 +224,7 @@ func filterCharts(charts []models.Chart, filterRule *apprepov1alpha1.FilterRuleS
 }
 
 // Charts retrieve the list of charts exposed in the repo
-func (r *HelmRepo) Charts() ([]models.Chart, error) {
+func (r *HelmRepo) Charts(shallow bool) ([]models.Chart, error) {
 	index, err := parseRepoIndex(r.content)
 	if err != nil {
 		return []models.Chart{}, err
@@ -229,7 +236,7 @@ func (r *HelmRepo) Charts() ([]models.Chart, error) {
 		URL:       r.URL,
 		Type:      r.Type,
 	}
-	charts := chartsFromIndex(index, repo)
+	charts := chartsFromIndex(index, repo, shallow)
 	if len(charts) == 0 {
 		return []models.Chart{}, fmt.Errorf("no charts in repository index")
 	}
@@ -577,7 +584,8 @@ func chartImportWorker(repoURL *url.URL, r *OCIRegistry, chartJobs <-chan pullCh
 	}
 }
 
-func (r *OCIRegistry) filterTags() {
+// FilterIndex remove non chart tags
+func (r *OCIRegistry) FilterIndex() {
 	unfilteredTags := r.tags
 	r.tags = map[string]TagList{}
 	checktagJobs := make(chan checkTagJob, numWorkers)
@@ -614,24 +622,41 @@ func (r *OCIRegistry) filterTags() {
 					Name: unfilteredTags[res.AppName].Name,
 					Tags: append(r.tags[res.AppName].Tags, res.Tag),
 				}
-				sort.Strings(r.tags[res.AppName].Tags)
 			}
 		} else {
 			log.Errorf("failed to pull chart. Got %v", res.Error)
 		}
 	}
+
+	// Order tags by semver
+	for _, appName := range r.repositories {
+		vs := make([]*semver.Version, len(r.tags[appName].Tags))
+		for i, r := range r.tags[appName].Tags {
+			v, err := semver.NewVersion(r)
+			if err != nil {
+				log.Errorf("Error parsing version: %s", err)
+			}
+			vs[i] = v
+		}
+		sort.Sort(sort.Reverse(semver.Collection(vs)))
+		orderedTags := []string{}
+		for _, v := range vs {
+			orderedTags = append(orderedTags, v.String())
+		}
+		r.tags[appName] = TagList{
+			Name: r.tags[appName].Name,
+			Tags: orderedTags,
+		}
+	}
 }
 
 // Charts retrieve the list of charts exposed in the repo
-func (r *OCIRegistry) Charts() ([]models.Chart, error) {
+func (r *OCIRegistry) Charts(shallow bool) ([]models.Chart, error) {
 	result := map[string]*models.Chart{}
-	url, err := parseRepoURL(r.RepoInternal.URL)
+	repoURL, err := parseRepoURL(r.RepoInternal.URL)
 	if err != nil {
 		return nil, err
 	}
-
-	// Filter the current tags before pulling charts
-	r.filterTags()
 
 	chartJobs := make(chan pullChartJob, numWorkers)
 	chartResults := make(chan pullChartResult, numWorkers)
@@ -640,7 +665,7 @@ func (r *OCIRegistry) Charts() ([]models.Chart, error) {
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)
 		go func() {
-			chartImportWorker(url, r, chartJobs, chartResults)
+			chartImportWorker(repoURL, r, chartJobs, chartResults)
 			wg.Done()
 		}()
 	}
@@ -653,8 +678,12 @@ func (r *OCIRegistry) Charts() ([]models.Chart, error) {
 	log.Debugf("starting %d workers", numWorkers)
 	go func() {
 		for _, appName := range r.repositories {
-			for _, tag := range r.tags[appName].Tags {
-				chartJobs <- pullChartJob{AppName: appName, Tag: tag}
+			if shallow {
+				chartJobs <- pullChartJob{AppName: appName, Tag: r.tags[appName].Tags[0]}
+			} else {
+				for _, tag := range r.tags[appName].Tags {
+					chartJobs <- pullChartJob{AppName: appName, Tag: tag}
+				}
 			}
 		}
 		close(chartJobs)
@@ -769,14 +798,14 @@ func parseRepoIndex(body []byte) (*helmrepo.IndexFile, error) {
 	return &index, nil
 }
 
-func chartsFromIndex(index *helmrepo.IndexFile, r *models.Repo) []models.Chart {
+func chartsFromIndex(index *helmrepo.IndexFile, r *models.Repo, shallow bool) []models.Chart {
 	var charts []models.Chart
 	for _, entry := range index.Entries {
 		if entry[0].GetDeprecated() {
 			log.WithFields(log.Fields{"name": entry[0].GetName()}).Info("skipping deprecated chart")
 			continue
 		}
-		charts = append(charts, newChart(entry, r))
+		charts = append(charts, newChart(entry, r, shallow))
 	}
 	sort.Slice(charts, func(i, j int) bool { return charts[i].ID < charts[j].ID })
 	return charts
@@ -784,10 +813,14 @@ func chartsFromIndex(index *helmrepo.IndexFile, r *models.Repo) []models.Chart {
 
 // Takes an entry from the index and constructs a database representation of the
 // object.
-func newChart(entry helmrepo.ChartVersions, r *models.Repo) models.Chart {
+func newChart(entry helmrepo.ChartVersions, r *models.Repo, shallow bool) models.Chart {
 	var c models.Chart
 	copier.Copy(&c, entry[0])
-	copier.Copy(&c.ChartVersions, entry)
+	if shallow {
+		copier.Copy(&c.ChartVersions, []helmrepo.ChartVersion{*entry[0]})
+	} else {
+		copier.Copy(&c.ChartVersions, entry)
+	}
 	c.Repo = r
 	c.Name = url.PathEscape(c.Name) // escaped chart name eg. foo/bar becomes foo%2Fbar
 	c.ID = fmt.Sprintf("%s/%s", r.Name, c.Name)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/arschles/assert v1.0.0
 	github.com/bugsnag/bugsnag-go v1.5.0 // indirect

--- a/pkg/dbutils/postgresql_utils_test.go
+++ b/pkg/dbutils/postgresql_utils_test.go
@@ -103,7 +103,7 @@ func Test_QueryAll(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
-	expectedCharts := []*models.Chart{&models.Chart{ID: "foo"}, &models.Chart{ID: "bar"}}
+	expectedCharts := []*models.Chart{{ID: "foo"}, {ID: "bar"}}
 	if !cmp.Equal(charts, expectedCharts) {
 		t.Errorf("Unexpected result %v", cmp.Diff(charts, expectedCharts))
 	}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This is a workaround for the second item at #2425. The goal is to reduce the amount of time that takes for an OCI repository to be available through the UI since the user submits it. Ideally, chart versions should be introduced one by one in the database, first starting with the latest version of each chart. Since that'd require to change the database schema (and I don't have time for that this week), I propose to do a shallow sync of the repository (only adding the latest version of each chart), store that in the database and then do a full sync (including all versions).

### Benefits

Saves a considerable amount of time for the user. In this example, a user of this repository of 55 applications, can start using the repository after 4 min (for a total sync of 10 min):

```
time="2021-04-13T11:49:37Z" level=info msg="Last checksum: "
time="2021-04-13T11:53:57Z" level=info msg="Repository synced" shallow=true
time="2021-04-13T11:59:39Z" level=info msg="Repository synced" shallow=false
time="2021-04-13T11:59:39Z" level=info msg="Stored repository update in cache" url="https://registry.pivotal.io/tac-for-tanzu-advanced/charts/"
time="2021-04-13T11:59:39Z" level=info msg="Successfully added the chart repository tac to database"
```

Note that just retrieving and validating all the tags takes ~2 min so the time to sync a repository is:
 - 2' for the tags retrieval
 - 2' for syncing the latest tag of each app
 - 6' for syncing the rest of tags

### Possible drawbacks

At the moment, the latest version is retrieved twice (once for the shallow run and another one for the full sync), we can improve this a little bit more.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #2425

### Additional information

Note that the shallow run is only performed the first time an apprepo is synced. After that, each loop interval will perform directly a full sync.
