### PR TITLE
Remove name auto-generation of release names

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -39,7 +39,6 @@
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
-    "moniker-native": "^0.1.6",
     "normalize.css": "^8.0.1",
     "prop-types": "15.7.2",
     "protobufjs": "^6.8.4",

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -168,13 +168,11 @@ it("triggers a deployment when submitting the form", async () => {
     handleValuesChange("foo: bar");
   });
 
-  // Set the release name
-  const releaseNameInput = wrapper.find("#releaseName");
-  releaseNameInput.getDOMNode<HTMLInputElement>().value = releaseName;
-  releaseNameInput.simulate("change");
+  wrapper.find("#releaseName").simulate("change", { target: { value: releaseName } });
 
   wrapper.update();
   expect(wrapper.find(DeploymentFormBody).prop("appValues")).toBe("foo: bar");
+  expect(wrapper.find(DeploymentForm).find("#releaseName").prop("value")).toBe(releaseName);
 
   await act(async () => {
     // Simulating "submit" causes a console.warning

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.test.tsx
@@ -1,5 +1,4 @@
 import { shallow } from "enzyme";
-import * as Moniker from "moniker-native";
 import * as ReactRedux from "react-redux";
 
 import ChartHeader from "components/ChartView/ChartHeader";
@@ -30,12 +29,9 @@ const defaultProps = {
 const versions = [
   { id: "foo", attributes: { version: "1.2.3" }, relationships: { chart: { data: { repo: {} } } } },
 ] as IChartVersion[];
-let monikerChooseMock: jest.Mock;
 
 let spyOnUseDispatch: jest.SpyInstance;
 beforeEach(() => {
-  monikerChooseMock = jest.fn().mockReturnValue(releaseName);
-  Moniker.choose = monikerChooseMock;
   const mockDispatch = jest.fn();
   spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
 });
@@ -92,25 +88,6 @@ describe("renders an error", () => {
     expect(wrapper.find(Alert)).toExist();
     expect(wrapper.find(ChartHeader)).not.toExist();
   });
-});
-
-it("renders a release name by default, relying in Monickers output", () => {
-  monikerChooseMock.mockReturnValueOnce("foo").mockReturnValueOnce("bar");
-
-  let wrapper = mountWrapper(
-    defaultStore,
-    <DeploymentForm {...defaultProps} selected={{ versions, version: versions[0] }} />,
-  );
-  const name1 = wrapper.find("#releaseName").prop("value");
-  expect(name1).toBe("foo");
-
-  // When reloading the name should change
-  wrapper = mountWrapper(
-    defaultStore,
-    <DeploymentForm {...defaultProps} selected={{ versions, version: versions[0] }} />,
-  );
-  const name2 = wrapper.find("#releaseName").prop("value");
-  expect(name2).toBe("bar");
 });
 
 it("forwards the appValues when modified", () => {
@@ -190,6 +167,12 @@ it("triggers a deployment when submitting the form", async () => {
   act(() => {
     handleValuesChange("foo: bar");
   });
+
+  // Set the release name
+  const releaseNameInput = wrapper.find("#releaseName");
+  releaseNameInput.getDOMNode<HTMLInputElement>().value = releaseName;
+  releaseNameInput.simulate("change");
+
   wrapper.update();
   expect(wrapper.find(DeploymentFormBody).prop("appValues")).toBe("foo: bar");
 

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -1,5 +1,4 @@
 import { RouterAction } from "connected-react-router";
-import * as Moniker from "moniker-native";
 import { useEffect, useState } from "react";
 
 import { JSONSchema4 } from "json-schema";
@@ -56,7 +55,7 @@ function DeploymentForm({
   kubeappsNamespace,
 }: IDeploymentFormProps) {
   const [isDeploying, setDeploying] = useState(false);
-  const [releaseName, setReleaseName] = useState(Moniker.choose());
+  const [releaseName, setReleaseName] = useState("");
   const [appValues, setAppValues] = useState(selected.values || "");
   const [valuesModified, setValuesModified] = useState(false);
   const { version } = selected;

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -82,8 +82,8 @@ function DeploymentForm({
     setValuesModified(true);
   };
 
-  const handleReleaseNameChange = (e: React.FormEvent<HTMLInputElement>) => {
-    setReleaseName(e.currentTarget.value);
+  const handleReleaseNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setReleaseName(e.target.value);
   };
 
   const handleDeploy = async (e: React.FormEvent<HTMLFormElement>) => {

--- a/dashboard/src/moniker-native.d.ts
+++ b/dashboard/src/moniker-native.d.ts
@@ -1,1 +1,0 @@
-declare module "moniker-native";

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -9613,11 +9613,6 @@ mock-socket@^9.0.3:
   dependencies:
     url-parse "^1.4.4"
 
-moniker-native@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/moniker-native/-/moniker-native-0.1.6.tgz#019af026841c32c78edb420695c14b24dd095d09"
-  integrity sha1-AZrwJoQcMseO20IGlcFLJN0JXQk=
-
 moo@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"


### PR DESCRIPTION
### Description of the change

After some users reported some inappropriate names being generated by our generator (Moniker), I performed a quick review of replacement alternatives. Even if some of them have dictionaries with appropriate words, there is still a chance of having an unlikely bad combination.

After an internal discussion, we decided to drop the autogeneration feature, as also Helm 3 did. 

### Benefits

No more unfortunate combinations of autogenerated release names.

### Possible drawbacks

Users will no longer have an autogenerated name, so they will have to come up with one.

### Applicable issues

  - fixes #2570
  - fixes #2649



### Additional information

We have the frontend validation:

![image](https://user-images.githubusercontent.com/11535726/114684809-94b7a400-9d11-11eb-8633-6276322c186b.png)

As well as the backend one:

![image](https://user-images.githubusercontent.com/11535726/114686116-c41ae080-9d12-11eb-83bb-db85e8bde8f4.png)

