### PR TITLE
Ignore errors when syncing and fix e2e tests

### DIFF
--- a/cmd/asset-syncer/postgresql_db_test.go
+++ b/cmd/asset-syncer/postgresql_db_test.go
@@ -412,20 +412,14 @@ func TestRepoAlreadyProcessed(t *testing.T) {
 	defer cleanup()
 
 	// not processed when it doesn't exist
-	got, err := pam.LastChecksum(repo)
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
+	got := pam.LastChecksum(repo)
 	if got != "" {
 		t.Errorf("got: %s, want: %s", got, "")
 	}
 
 	// not processed when repo exists but has not been processed
 	pam.EnsureRepoExists(repoNamespace, repoName)
-	got, err = pam.LastChecksum(repo)
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
+	got = pam.LastChecksum(repo)
 	if got != "" {
 		t.Errorf("got: %s, want: %s", got, "")
 	}
@@ -433,19 +427,13 @@ func TestRepoAlreadyProcessed(t *testing.T) {
 	pam.UpdateLastCheck(repoNamespace, repoName, checksum, time.Now())
 	// processed when checksums match
 	pam.EnsureRepoExists(repoNamespace, repoName)
-	got, err = pam.LastChecksum(repo)
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
+	got = pam.LastChecksum(repo)
 	if got != checksum {
 		t.Errorf("got: %s, want: %s", got, checksum)
 	}
 
 	// it does not match the same repo in a different namespace
-	got, err = pam.LastChecksum(models.Repo{Namespace: "other-namespace", Name: repo.Name})
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
+	got = pam.LastChecksum(models.Repo{Namespace: "other-namespace", Name: repo.Name})
 	if got != "" {
 		t.Errorf("got: %s, want: %s", got, "")
 	}

--- a/cmd/asset-syncer/postgresql_utils.go
+++ b/cmd/asset-syncer/postgresql_utils.go
@@ -20,7 +20,6 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -72,16 +71,13 @@ func (m *postgresAssetManager) Sync(repo models.Repo, charts []models.Chart) err
 	return m.removeMissingCharts(repo, charts)
 }
 
-func (m *postgresAssetManager) LastChecksum(repo models.Repo) (string, error) {
+func (m *postgresAssetManager) LastChecksum(repo models.Repo) string {
 	var lastChecksum string
 	row := m.DB.QueryRow(fmt.Sprintf("SELECT checksum FROM %s WHERE name = $1 AND namespace = $2", dbutils.RepositoryTable), repo.Name, repo.Namespace)
 	if row != nil {
-		err := row.Scan(&lastChecksum)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) && !strings.Contains(err.Error(), "converting NULL to string is unsupported") {
-			return "", err
-		}
+		row.Scan(&lastChecksum)
 	}
-	return lastChecksum, nil
+	return lastChecksum
 }
 
 func (m *postgresAssetManager) UpdateLastCheck(repoNamespace, repoName, checksum string, now time.Time) error {

--- a/cmd/asset-syncer/postgresql_utils_test.go
+++ b/cmd/asset-syncer/postgresql_utils_test.go
@@ -45,10 +45,7 @@ func Test_PGRepoLastChecksum(t *testing.T) {
 		WithArgs("foo", "repo-namespace").
 		WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("123"))
 
-	got, err := pgManager.LastChecksum(models.Repo{Namespace: "repo-namespace", Name: "foo"})
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
+	got := pgManager.LastChecksum(models.Repo{Namespace: "repo-namespace", Name: "foo"})
 	if got != "123" {
 		t.Errorf("got: %s, want: %s", got, "123")
 	}

--- a/cmd/asset-syncer/sync.go
+++ b/cmd/asset-syncer/sync.go
@@ -92,10 +92,7 @@ var syncCmd = &cobra.Command{
 		}
 
 		// Check if the repo has been already processed
-		lastChecksum, err := manager.LastChecksum(models.Repo{Namespace: repo.Namespace, Name: repo.Name})
-		if err != nil {
-			logrus.Fatal(err)
-		}
+		lastChecksum := manager.LastChecksum(models.Repo{Namespace: repo.Namespace, Name: repo.Name})
 		logrus.Infof("Last checksum: %v", lastChecksum)
 		if lastChecksum == checksum {
 			logrus.WithFields(logrus.Fields{"url": repo.URL}).Info("Skipping repository since there are no updates")

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -100,7 +100,7 @@ func parseRepoURL(repoURL string) (*url.URL, error) {
 type assetManager interface {
 	Delete(repo models.Repo) error
 	Sync(repo models.Repo, charts []models.Chart) error
-	LastChecksum(repo models.Repo) (string, error)
+	LastChecksum(repo models.Repo) string
 	UpdateLastCheck(repoNamespace, repoName, checksum string, now time.Time) error
 	Init() error
 	Close() error

--- a/integration/use-cases/01-add-multicluster-deployment.js
+++ b/integration/use-cases/01-add-multicluster-deployment.js
@@ -24,6 +24,9 @@ test("Deploys an application with the values by default", async () => {
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
+  await expect(page).toMatchElement("#releaseName", { text: "" });
+  await page.type("#releaseName", utils.getRandomName("my-app"));
+
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   await expect(page).toMatch("Ready", { timeout: 60000 });

--- a/integration/use-cases/04-default-deployment.js
+++ b/integration/use-cases/04-default-deployment.js
@@ -17,6 +17,9 @@ test("Deploys an application with the values by default", async () => {
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
+  await expect(page).toMatchElement("#releaseName", { text: "" });
+  await page.type("#releaseName", utils.getRandomName("my-app"));
+
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   await expect(page).toMatch("Ready", { timeout: 60000 });

--- a/integration/use-cases/05-missing-permissions.js
+++ b/integration/use-cases/05-missing-permissions.js
@@ -17,6 +17,9 @@ test("Fails to deploy an application due to missing permissions", async () => {
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
+  await expect(page).toMatchElement("#releaseName", { text: "" });
+  await page.type("#releaseName", utils.getRandomName("my-app"));
+
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   await expect(page).toMatch("missing permissions", { timeout: 60000 });

--- a/integration/use-cases/07-upgrade.js
+++ b/integration/use-cases/07-upgrade.js
@@ -48,6 +48,9 @@ test("Upgrades an application", async () => {
   await expect(page).toClick("li", { text: "Changes" });
   await expect(page).toMatch("replicaCount: 2");
 
+  await expect(page).toMatchElement("#releaseName", { text: "" });
+  await page.type("#releaseName", utils.getRandomName("my-app"));
+
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   await expect(page).toMatch("Update Now", { timeout: 60000 });

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -76,4 +76,9 @@ module.exports = {
       await page.click("#login-submit-button");
     }
   },
+  getRandomName: base => {
+    const randomNumber = Math.floor(Math.random() * Math.floor(100));
+    const name = base + "-" + randomNumber;
+    return name;
+  },
 };


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Context at https://github.com/kubeapps/kubeapps/pull/2677#discussion_r612942869

So I tried to handle the error when getting the latest checksum but when running the e2e tests, a new error appeared:

```
time="2021-04-15T09:08:58Z" level=fatal msg="pq: relation \"repos\" does not exist"
```

Rather than adding another exception, I left the code as it was before (ignoring the error). In any case, that operation (checking the last checksum) is not critical for the rest of the process.

[EDIT]

Seems that the CI was misbehaving yesterday? #2680 was also merged with a green but the e2e tests require some adaptation to type down the name of the releases. Fixed that as well here.

### Benefits

Fixes master

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

I merged it because I saw a green in #2677 but it seems that I clicked in the interval before the e2e tests were triggered (weird).
