### PR TITLE
Improve wait strategy during ci login

### DIFF
--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -39,7 +39,7 @@ module.exports = {
   login: async (page, isOIDC, uri, token, username, password) => {
     await page.goto(getUrl(uri));
     if (isOIDC === "true") {
-      await page.waitForNavigation();
+      await page.waitForNavigation({ waitUntil: "domcontentloaded" });
       await expect(page).toClick("cds-button", {
         text: "Login via OIDC Provider",
       });
@@ -50,7 +50,7 @@ module.exports = {
       await expect(page).toClick(".dex-container button", {
         text: "Log in with Email",
       });
-      await page.waitForNavigation();
+      await page.waitForNavigation({ waitUntil: "domcontentloaded" });
       await page.type('input[id="login"]', username);
       await page.type('input[id="password"]', password);
       await page.waitForSelector("#submit-login", {


### PR DESCRIPTION
### Description of the change

As some CI checks are still failing, it seems that changing the default `.wait` strategy could benefit the reliability of the tests. 

### Benefits

This PRs should reduce the amount of  `Execution context was destroyed, most likely because of a navigation.` we receive.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A