### PR TITLE
Limit secret requests when listing app repositories

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -190,53 +190,6 @@ describe("fetchRepos", () => {
         type: getType(repoActions.receiveRepos),
         payload: { foo: "bar" },
       },
-      {
-        type: getType(repoActions.receiveReposSecrets),
-        payload: [],
-      },
-    ];
-
-    await store.dispatch(repoActions.fetchRepos(namespace));
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-
-  it("includes secrets that are owned by an apprepo", async () => {
-    const appRepoSecret = {
-      metadata: {
-        name: "foo",
-        ownerReferences: [
-          {
-            kind: "AppRepository",
-          },
-        ],
-      },
-    };
-    const otherSecret = {
-      metadata: {
-        name: "bar",
-        ownerReferences: [
-          {
-            kind: "Other",
-          },
-        ],
-      },
-    };
-    Secret.list = jest.fn().mockReturnValue({
-      items: [appRepoSecret, otherSecret],
-    });
-    const expectedActions = [
-      {
-        type: getType(repoActions.requestRepos),
-        payload: namespace,
-      },
-      {
-        type: getType(repoActions.receiveRepos),
-        payload: { foo: "bar" },
-      },
-      {
-        type: getType(repoActions.receiveReposSecrets),
-        payload: [appRepoSecret],
-      },
     ];
 
     await store.dispatch(repoActions.fetchRepos(namespace));
@@ -283,10 +236,6 @@ describe("fetchRepos", () => {
         payload: kubeappsNamespace,
       },
       {
-        type: getType(repoActions.receiveReposSecrets),
-        payload: [],
-      },
-      {
         type: getType(repoActions.receiveRepos),
         payload: [
           { name: "repo1", metadata: { uid: "123" } },
@@ -322,10 +271,6 @@ describe("fetchRepos", () => {
       {
         type: getType(repoActions.requestRepos),
         payload: kubeappsNamespace,
-      },
-      {
-        type: getType(repoActions.receiveReposSecrets),
-        payload: [],
       },
       {
         type: getType(repoActions.receiveRepos),
@@ -364,66 +309,9 @@ describe("fetchRepos", () => {
         type: getType(repoActions.receiveRepos),
         payload: [{ name: "repo1", metadata: { uid: "123" } }],
       },
-      {
-        type: getType(repoActions.receiveReposSecrets),
-        payload: [],
-      },
     ];
 
     await store.dispatch(repoActions.fetchRepos(kubeappsNamespace, true));
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-});
-
-describe("fetchRepoSecrets", () => {
-  const namespace = "default";
-  it("dispatches receiveReposSecrets if no error", async () => {
-    const appRepoSecret = {
-      metadata: {
-        name: "foo",
-        ownerReferences: [{ kind: "AppRepository" }],
-      },
-    };
-    const otherSecret = {
-      metadata: {
-        name: "bar",
-        ownerReferences: [{ kind: "Other" }],
-      },
-    };
-    Secret.list = jest.fn().mockReturnValue({
-      items: [appRepoSecret, otherSecret],
-    });
-    const expectedActions = [
-      {
-        type: getType(repoActions.receiveReposSecrets),
-        payload: [
-          {
-            metadata: {
-              name: "foo",
-              ownerReferences: [{ kind: "AppRepository" }],
-            },
-          },
-        ],
-      },
-    ];
-
-    await store.dispatch(repoActions.fetchRepoSecrets(namespace));
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-
-  it("dispatches errorRepos if error fetching secrets", async () => {
-    Secret.list = jest.fn().mockImplementationOnce(() => {
-      throw new Error("Boom!");
-    });
-
-    const expectedActions = [
-      {
-        type: getType(repoActions.errorRepos),
-        payload: { err: new Error("Boom!"), op: "fetch" },
-      },
-    ];
-
-    await store.dispatch(repoActions.fetchRepoSecrets(namespace));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -1143,11 +1031,8 @@ describe("fetchImagePullSecrets", () => {
     const secret1 = {
       type: "kubernetes.io/dockerconfigjson",
     };
-    const secret2 = {
-      type: "Opaque",
-    };
     Secret.list = jest.fn().mockReturnValue({
-      items: [secret1, secret2],
+      items: [secret1],
     });
     const expectedActions = [
       {

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -158,27 +158,27 @@ export const resyncAllRepos = (
   };
 };
 
-export const fetchRepoSecrets = (
-  namespace: string,
-): ThunkAction<Promise<void>, IStoreState, null, AppReposAction> => {
-  return async (dispatch, getState) => {
-    const {
-      clusters: { currentCluster },
-    } = getState();
-    try {
-      // TODO(andresmgot): Create an endpoint for returning credentials related to an AppRepository
-      // to avoid listing secrets
-      // https://github.com/kubeapps/kubeapps/issues/1686
-      const secrets = await Secret.list(currentCluster, namespace);
-      const repoSecrets = secrets.items?.filter(s =>
-        s.metadata.ownerReferences?.some(ownerRef => ownerRef.kind === "AppRepository"),
-      );
-      dispatch(receiveReposSecrets(repoSecrets));
-    } catch (e) {
-      dispatch(errorRepos(e, "fetch"));
-    }
-  };
-};
+// export const fetchRepoSecrets = (
+//   namespace: string,
+// ): ThunkAction<Promise<void>, IStoreState, null, AppReposAction> => {
+//   return async (dispatch, getState) => {
+//     const {
+//       clusters: { currentCluster },
+//     } = getState();
+//     try {
+//       // TODO(andresmgot): Create an endpoint for returning credentials related to an AppRepository
+//       // to avoid listing secrets
+//       // https://github.com/kubeapps/kubeapps/issues/1686
+//       const secrets = await Secret.list(currentCluster, namespace);
+//       const repoSecrets = secrets.items?.filter(s =>
+//         s.metadata.ownerReferences?.some(ownerRef => ownerRef.kind === "AppRepository"),
+//       );
+//       dispatch(receiveReposSecrets(repoSecrets));
+//     } catch (e) {
+//       dispatch(errorRepos(e, "fetch"));
+//     }
+//   };
+// };
 
 export const fetchRepoSecret = (
   namespace: string,
@@ -210,7 +210,6 @@ export const fetchRepos = (
     try {
       dispatch(requestRepos(namespace));
       const repos = await AppRepository.list(currentCluster, namespace);
-      dispatch(fetchRepoSecrets(namespace));
       if (!listGlobal || namespace === kubeappsNamespace) {
         dispatch(receiveRepos(repos.items));
       } else {
@@ -417,11 +416,12 @@ export function fetchImagePullSecrets(
       // TODO(andresmgot): Create an endpoint for returning just the list of secret names
       // to avoid listing all the secrets with protected information
       // https://github.com/kubeapps/kubeapps/issues/1686
-      const secrets = await Secret.list(currentCluster, namespace);
-      const imgPullSecrets = secrets.items?.filter(
-        s => s.type === "kubernetes.io/dockerconfigjson",
+      const secrets = await Secret.list(
+        currentCluster,
+        namespace,
+        "type=kubernetes.io/dockerconfigjson",
       );
-      dispatch(receiveImagePullSecrets(imgPullSecrets));
+      dispatch(receiveImagePullSecrets(secrets.items));
     } catch (e) {
       dispatch(errorRepos(e, "fetch"));
     }

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -158,28 +158,6 @@ export const resyncAllRepos = (
   };
 };
 
-// export const fetchRepoSecrets = (
-//   namespace: string,
-// ): ThunkAction<Promise<void>, IStoreState, null, AppReposAction> => {
-//   return async (dispatch, getState) => {
-//     const {
-//       clusters: { currentCluster },
-//     } = getState();
-//     try {
-//       // TODO(andresmgot): Create an endpoint for returning credentials related to an AppRepository
-//       // to avoid listing secrets
-//       // https://github.com/kubeapps/kubeapps/issues/1686
-//       const secrets = await Secret.list(currentCluster, namespace);
-//       const repoSecrets = secrets.items?.filter(s =>
-//         s.metadata.ownerReferences?.some(ownerRef => ownerRef.kind === "AppRepository"),
-//       );
-//       dispatch(receiveReposSecrets(repoSecrets));
-//     } catch (e) {
-//       dispatch(errorRepos(e, "fetch"));
-//     }
-//   };
-// };
-
 export const fetchRepoSecret = (
   namespace: string,
   name: string,

--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { CdsControlMessage } from "@cds/react/forms";
 import { CdsInput } from "@cds/react/input";
@@ -49,6 +49,12 @@ export function AppRepoAddDockerCreds({
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value);
   const handleServerChange = (e: React.ChangeEvent<HTMLInputElement>) => setServer(e.target.value);
   const toggleCredSubForm = () => setShowSecretSubForm(!showSecretSubForm);
+
+  useEffect(() => {
+    if (imagePullSecrets.length && !currentImagePullSecrets.length) {
+      setCurrentImagePullSecrets(imagePullSecrets);
+    }
+  }, [imagePullSecrets, currentImagePullSecrets]);
 
   const handleInstallClick = async () => {
     setCreating(true);

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -42,7 +42,6 @@ afterEach(() => {
 it("fetches repos and imagePullSecrets", () => {
   mountWrapper(defaultStore, <AppRepoList />);
   expect(actions.repos.fetchRepos).toHaveBeenCalledWith(namespace, true);
-  expect(actions.repos.fetchImagePullSecrets).toHaveBeenCalledWith(namespace);
 });
 
 it("fetches repos only from the kubeappsNamespace", () => {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -25,7 +25,7 @@ function AppRepoList() {
   const dispatch = useDispatch();
   const location = useLocation();
   const {
-    repos: { errors, isFetching, repos, repoSecrets },
+    repos: { errors, isFetchingElem, repos, repoSecrets },
     clusters: { clusters, currentCluster },
     config: { kubeappsCluster, kubeappsNamespace },
   } = useSelector((state: IStoreState) => state);
@@ -93,12 +93,6 @@ function AppRepoList() {
       kubeappsNamespace,
     ).then(allowed => setCanEditGlobalRepos(allowed));
   }, [cluster, kubeappsCluster, kubeappsNamespace]);
-
-  useEffect(() => {
-    if (repos) {
-      dispatch(actions.repos.fetchImagePullSecrets(namespace));
-    }
-  }, [dispatch, repos, namespace]);
 
   const globalRepos: IAppRepository[] = [];
   const namespaceRepos: IAppRepository[] = [];
@@ -208,7 +202,7 @@ function AppRepoList() {
               <LoadingWrapper
                 className="margin-t-xxl"
                 loadingText="Fetching Application Repositories..."
-                loaded={!isFetching}
+                loaded={!isFetchingElem.repositories}
               >
                 <h3>Global Repositories:</h3>
                 <p>Global repositories are available for all Kubeapps users.</p>

--- a/dashboard/src/reducers/repos.test.ts
+++ b/dashboard/src/reducers/repos.test.ts
@@ -118,7 +118,7 @@ describe("reposReducer", () => {
     });
 
     it("receives a repo secret", () => {
-      const secret = { metadata: { name: "foo" } } as any;
+      const secret = { metadata: { name: "foo", namespace: "bar" } } as any;
       const modifiedSecret = { ...secret, spec: { foo: "bar" } };
       expect(
         reposReducer(

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -89,12 +89,18 @@ const reposReducer = (
       return { ...state, repoSecrets: action.payload };
     case getType(actions.repos.receiveReposSecret): {
       const secret = action.payload;
-      const repoSecrets = state.repoSecrets.map(s =>
-        s.metadata.name === secret.metadata.name &&
-        s.metadata.namespace === secret.metadata.namespace
-          ? secret
-          : s,
+      const existingSecret = state.repoSecrets.findIndex(
+        s =>
+          s.metadata.name === secret.metadata.name &&
+          s.metadata.namespace === secret.metadata.namespace,
       );
+      let repoSecrets: ISecret[];
+      if (existingSecret > -1) {
+        repoSecrets = [...state.repoSecrets];
+        repoSecrets[existingSecret] = secret;
+      } else {
+        repoSecrets = state.repoSecrets.concat(secret);
+      }
       return { ...state, repoSecrets };
     }
     case getType(actions.repos.requestRepos):

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -9,8 +9,8 @@ export default class Secret {
     return data;
   }
 
-  public static async list(cluster: string, namespace: string) {
-    const u = url.api.k8s.secrets(cluster, namespace);
+  public static async list(cluster: string, namespace: string, fieldSelector?: string) {
+    const u = url.api.k8s.secrets(cluster, namespace, fieldSelector);
     const { data } = await axiosWithAuth.get<IK8sList<ISecret, {}>>(u);
     return data;
   }

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -203,8 +203,10 @@ export const api = {
           cluster,
         )}/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/${name}`,
     },
-    secrets: (cluster: string, namespace: string) =>
-      `${api.k8s.namespace(cluster, namespace)}/secrets`,
+    secrets: (cluster: string, namespace: string, fieldSelector?: string) =>
+      `${api.k8s.namespace(cluster, namespace)}/secrets${
+        fieldSelector ? `?fieldSelector=${encodeURIComponent(fieldSelector)}` : ""
+      }`,
     secret: (cluster: string, namespace: string, name: string) =>
       `${api.k8s.secrets(cluster, namespace)}/${name}`,
   },


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

We were requesting all the secrets in a namespace when listing the app repositories. This was for later on, being able to render secrets associated to a repo or to select some docker registry credentials. This PR changes that:

 - The request is now done only when rendering the new/edit repo form.
 - We are listing only docker registry secrets
 - We are getting just the secret associated to a repository (when editing it).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1686 

### Additional information

If you request some changes, I will eventually come back to this and address your comments :) 