### PR TITLE
Docs: installing kubeapps with OIDC using the pinniped impersonation proxy

### DIFF
--- a/docs/user/using-an-OIDC-provider-with-pinniped.md
+++ b/docs/user/using-an-OIDC-provider-with-pinniped.md
@@ -80,9 +80,9 @@ The [Kubeapps auth-proxy configuration](./using-an-OIDC-provider.md#deploying-an
 
 With those changes, Kubeapps is ready to send any request for a specific cluster via Pinniped so that the OIDC `id_token` can be exchanged for client certificates accepted by the Kubernetes API server.
 
-[Under the hood](https://pinniped.dev/posts/bringing-the-concierge-to-more-clusters/), what Pinniped does is looking for a `kube-controller-manager` pod in the `kube-system` namespace that reads the cluster signing certificate and key. Then it loads them into an in-memory certificate signer.
+[Under the hood](https://pinniped.dev/posts/bringing-the-concierge-to-more-clusters/), Pinniped looks for a `kube-controller-manager` pod in the `kube-system` namespace that reads the cluster signing certificate and key and loads them into an in-memory certificate signer.
 
-But, what if this `kube-controller-manager` is not a normal pod on a schedulable cluster node? In that scenario (usual in managed clusters, such AKS), an alternative way is required: the impersonation proxy. Have a look at the [enabling OIDC login in managed clusters](#enabling-oidc-login-in-managed-clusters) section to know how to configure Kubeapps for using Pinniped 0.7.0 onwards.
+But, what if this `kube-controller-manager` is not a normal pod on a schedulable cluster node? In that scenario (usual in managed clusters, such AKS), an alternative way is required: the Pinniped impersonation proxy. Have a look at the [enabling OIDC login in managed clusters](#enabling-oidc-login-in-managed-clusters) section to know how to configure Kubeapps for using Pinniped 0.7.0 onwards on managed clusters.
 
 ### Enabling OIDC login in managed clusters
 

--- a/docs/user/using-an-OIDC-provider-with-pinniped.md
+++ b/docs/user/using-an-OIDC-provider-with-pinniped.md
@@ -86,9 +86,7 @@ But, what if this `kube-controller-manager` is not a normal pod on a schedulable
 
 ### Enabling OIDC login in managed clusters
 
-In managed clusters, such as AKS, Pinniped cannot read the cluster's certificate and key. In this case, Pinniped will have a fallback mechanism: the [impersonation proxy](https://pinniped.dev/docs/background/architecture/). It simply creates a LoadBalancer service that proxies the actual Kubernetes API.
-
-> TL;DR - when using Kubeapps in managed clusters using Pinniped, you'll need to use the Impersonation Proxy URL instead of the usual k8s API server URL.
+In managed clusters, such as AKS, Pinniped cannot read the cluster's certificate and key. In this case, Pinniped will have a fallback mechanism: the [impersonation proxy](https://pinniped.dev/docs/background/architecture/). It simply creates a LoadBalancer service that proxies the actual Kubernetes API. For this reason, when using Kubeapps in managed clusters using Pinniped, you'll need to use the Impersonation Proxy URL (and CA certificate) instead of the usual k8s API server URL.
 
 Assuming you have successfully [installed Pinniped](#installing-pinniped) and configured the [JWTAuthenticator](#configure-pinniped-to-trust-your-oidc-identity-provider), you have to retrieve the Impersonation Proxy IP  by executing this command:
 

--- a/docs/user/using-an-OIDC-provider-with-pinniped.md
+++ b/docs/user/using-an-OIDC-provider-with-pinniped.md
@@ -4,10 +4,10 @@ The [Pinniped project](https://pinniped.dev/) exists to "Simplify user authentic
 
 ## Installing Pinniped
 
-Install Pinniped 0.6.0 into a `pinniped-concierge` namespace on your cluster with:
+Install Pinniped into a `pinniped-concierge` namespace on your cluster with:
 
 ```bash
-kubectl apply -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.6.0/install-pinniped-concierge.yaml
+kubectl apply -f https://get.pinniped.dev/latest/install-pinniped-concierge.yaml
 ```
 
 **NOTE**: Due to a breaking change in [Pinniped 0.6.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.6.0), the minimum version supported by Kubeapps is 0.6.0. Furthermore, [custom API suffixes](https://pinniped.dev/posts/multiple-pinnipeds) (introduced in Pinniped 0.5.0) are not yet fully supported. If your platform uses this feature, please [drop us an issue](https://github.com/kubeapps/kubeapps/issues/new).

--- a/script/deploy-dev-for-pinniped.mk
+++ b/script/deploy-dev-for-pinniped.mk
@@ -24,10 +24,10 @@ deploy-dependencies-for-pinniped: deploy-dex-for-pinniped deploy-openldap-for-pi
 	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} create namespace kubeapps
 
 deploy-pinniped:
-	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.6.0/install-pinniped-concierge.yaml
+	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/v0.7.0/install-pinniped-concierge.yaml
 
 deploy-pinniped-additional:
-	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.6.0/install-pinniped-concierge.yaml
+	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} apply -f https://get.pinniped.dev/v0.7.0/install-pinniped-concierge.yaml
 
 add-pinniped-jwt-authenticator:
 	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} apply -f ./docs/user/manifests/kubeapps-pinniped-jwt-authenticator.yaml
@@ -38,8 +38,8 @@ delete-pinniped-jwt-authenticator:
 	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} delete -f ./docs/user/manifests/kubeapps-pinniped-jwt-authenticator.yaml
 
 delete-pinniped:
-	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.6.0/install-pinniped-concierge.yaml
-	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://github.com/vmware-tanzu/pinniped/releases/download/v0.6.0/install-pinniped-concierge.yaml
+	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://get.pinniped.dev/v0.7.0/install-pinniped-concierge.yaml
+	kubectl --kubeconfig=${ADDITIONAL_CLUSTER_CONFIG_FOR_PINNIPED} delete -f https://get.pinniped.dev/v0.7.0/install-pinniped-concierge.yaml
 
 deploy-dev-kubeapps-for-pinniped:
 	kubectl --kubeconfig=${CLUSTER_CONFIG_FOR_PINNIPED} -n kubeapps delete secret localhost-tls  || true


### PR DESCRIPTION
### Description of the change

This PR brings two main changes: i) adds a section in the docs on how to install kubeapps with OIDC using the pinniped impersonation proxy; ii) changes the Pinniped download endpoints to match their official docs (and defaults to `latest` instead of sticking to a certain version)

### Benefits

Users will be able to (know how to) install Kubeapps in managed clusters.

### Possible drawbacks

N/A

### Applicable issues

  - fixes #2691

### Additional information

Currently, there is an open issue (https://github.com/kubeapps/kubeapps/issues/2692) that prevents users from using Kubeapps if using this guide in a single-cluster environment.
