### PR TITLE
Fix rollback html event handling

### DIFF
--- a/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackButton.test.tsx
+++ b/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackButton.test.tsx
@@ -12,7 +12,7 @@ const defaultProps = {
   cluster: "default",
   namespace: "kubeapps",
   releaseName: "foo",
-  revision: 2,
+  revision: 3,
 };
 
 let spyOnUseDispatch: jest.SpyInstance;
@@ -40,6 +40,10 @@ it("rolls back an application", async () => {
   });
   wrapper.update();
   expect(wrapper.find(CdsModal)).toExist();
+  wrapper
+    .find("select")
+    .at(0)
+    .simulate("change", { target: { value: "1" } });
   await act(async () => {
     await (wrapper
       .find(CdsButton)

--- a/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackDialog.tsx
+++ b/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackDialog.tsx
@@ -28,8 +28,8 @@ function RollbackDialog({
   const options: number[] = [];
   // If there are no revisions to rollback to, disable
   const disableRollback = currentRevision === 1;
-  const selectRevision = (e: React.FormEvent<HTMLSelectElement>) => {
-    setTargetRevision(Number(e.currentTarget.value));
+  const selectRevision = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setTargetRevision(Number(e.target.value));
   };
   const onClick = () => {
     onConfirm(targetRevision);


### PR DESCRIPTION
### Description of the change

Well... it seems the rollback form was broken and the unit test was not covering the `<select>` change, so we supposed everything was working fine when we (I, indeed) changed the form/modal to the new cds one.

### Benefits

Rollback now will work again

### Possible drawbacks

N/A

### Applicable issues

  - fixes #2697


### Additional information

N/A
