### PR TITLE
Assume inCluster config when no cluster is passed 

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -178,7 +178,7 @@ func CreateRelease(cfg Config, w http.ResponseWriter, req *http.Request, params 
 		return
 	}
 	// TODO: currently app repositories are only supported on the cluster on which Kubeapps is installed. #1982
-	appRepo, caCertSecret, authSecret, err := chart.GetAppRepoAndRelatedSecrets(chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, cfg.KubeHandler, cfg.Token, cfg.Options.ClustersConfig.KubeappsClusterName, cfg.Options.KubeappsNamespace)
+	appRepo, caCertSecret, authSecret, err := chart.GetAppRepoAndRelatedSecrets(chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, cfg.KubeHandler, cfg.Token, cfg.Options.ClustersConfig.KubeappsClusterName, cfg.Options.KubeappsNamespace, cfg.Options.ClustersConfig.KubeappsClusterName)
 	if err != nil {
 		returnErrMessage(fmt.Errorf("unable to get app repository %q: %v", chartDetails.AppRepositoryResourceName, err), w)
 		return
@@ -231,7 +231,7 @@ func upgradeRelease(cfg Config, w http.ResponseWriter, req *http.Request, params
 		returnErrMessage(err, w)
 		return
 	}
-	appRepo, caCertSecret, authSecret, err := chart.GetAppRepoAndRelatedSecrets(chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, cfg.KubeHandler, cfg.Token, cfg.Cluster, cfg.Options.KubeappsNamespace)
+	appRepo, caCertSecret, authSecret, err := chart.GetAppRepoAndRelatedSecrets(chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, cfg.KubeHandler, cfg.Token, cfg.Cluster, cfg.Options.KubeappsNamespace, cfg.Options.ClustersConfig.KubeappsClusterName)
 	if err != nil {
 		returnErrMessage(fmt.Errorf("unable to get app repository %q: %v", chartDetails.AppRepositoryResourceName, err), w)
 		return

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -97,7 +97,7 @@ export const backend = {
     update: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,
   },
-  canI: (cluster: string) => `api/v1/clusters${cluster ? "/" + cluster : ""}/can-i`,
+  canI: (cluster: string) => `api/v1/clusters/${cluster}/can-i`,
 };
 
 export const kubeops = {

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -97,7 +97,7 @@ export const backend = {
     update: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,
   },
-  canI: (cluster: string) => `api/v1/clusters/${cluster}/can-i`,
+  canI: (cluster: string) => `api/v1/clusters${cluster ? "/" + cluster : ""}/can-i`,
 };
 
 export const kubeops = {

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -268,8 +268,9 @@ func ParseDetails(data []byte) (*Details, error) {
 // Depending on the repo namespace and the
 func GetAppRepoAndRelatedSecrets(appRepoName, appRepoNamespace string, handler kube.AuthHandler, userAuthToken, cluster, kubeappsNamespace string) (*appRepov1.AppRepository, *corev1.Secret, *corev1.Secret, error) {
 	client, err := handler.AsUser(userAuthToken, cluster)
-	if kubeappsNamespace == appRepoNamespace {
-		// If we're parsing a global repository (from the kubeappsNamespace), use a service client.
+	if cluster == "" || kubeappsNamespace == appRepoNamespace {
+		// If we're parsing a global repository (from the kubeappsNamespace),
+		// or we don't specify any cluster, use a service client.
 		// AppRepositories are only allowed in the default cluster for the moment
 		client, err = handler.AsSVC(cluster)
 	}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -271,7 +271,7 @@ func GetAppRepoAndRelatedSecrets(appRepoName, appRepoNamespace string, handler k
 	// If the UI clusters configuration did not include the cluster on which Kubeapps is installed then
 	// we won't know the kubeappsNamespace but it will be empty. In this scenario Kubeapps only supports
 	// global app repositories (#1982 ).
-	nonUIKubeappsCluster = (cluster == "" && kubeappsNamespace == "")
+	nonUIKubeappsCluster := (cluster == "" && kubeappsNamespace == "")
 	if nonUIKubeappsCluster || kubeappsNamespace == appRepoNamespace {
 		// If we're parsing a global repository then use a service client.
 		// AppRepositories are only allowed in the default cluster for the moment

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -268,9 +268,12 @@ func ParseDetails(data []byte) (*Details, error) {
 // Depending on the repo namespace and the
 func GetAppRepoAndRelatedSecrets(appRepoName, appRepoNamespace string, handler kube.AuthHandler, userAuthToken, cluster, kubeappsNamespace string) (*appRepov1.AppRepository, *corev1.Secret, *corev1.Secret, error) {
 	client, err := handler.AsUser(userAuthToken, cluster)
-	if cluster == "" || kubeappsNamespace == appRepoNamespace {
-		// If we're parsing a global repository (from the kubeappsNamespace),
-		// or we don't specify any cluster, use a service client.
+	// If the UI clusters configuration did not include the cluster on which Kubeapps is installed then
+	// we won't know the kubeappsNamespace but it will be empty. In this scenario Kubeapps only supports
+	// global app repositories (#1982 ).
+	nonUIKubeappsCluster = (cluster == "" && kubeappsNamespace == "")
+	if nonUIKubeappsCluster || kubeappsNamespace == appRepoNamespace {
+		// If we're parsing a global repository then use a service client.
 		// AppRepositories are only allowed in the default cluster for the moment
 		client, err = handler.AsSVC(cluster)
 	}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -266,13 +266,15 @@ func ParseDetails(data []byte) (*Details, error) {
 
 // GetAppRepoAndRelatedSecrets retrieves the given repo from its namespace
 // Depending on the repo namespace and the
-func GetAppRepoAndRelatedSecrets(appRepoName, appRepoNamespace string, handler kube.AuthHandler, userAuthToken, cluster, kubeappsNamespace string) (*appRepov1.AppRepository, *corev1.Secret, *corev1.Secret, error) {
+func GetAppRepoAndRelatedSecrets(appRepoName, appRepoNamespace string, handler kube.AuthHandler, userAuthToken, cluster, kubeappsNamespace string, kubeappsCluster string) (*appRepov1.AppRepository, *corev1.Secret, *corev1.Secret, error) {
 	client, err := handler.AsUser(userAuthToken, cluster)
 	// If the UI clusters configuration did not include the cluster on which Kubeapps is installed then
 	// we won't know the kubeappsNamespace but it will be empty. In this scenario Kubeapps only supports
-	// global app repositories (#1982 ).
-	nonUIKubeappsCluster := (cluster == "" && kubeappsNamespace == "")
-	if nonUIKubeappsCluster || kubeappsNamespace == appRepoNamespace {
+	// global app repositories (#1982).
+	isKubeappsCluster := cluster == kubeappsCluster
+	nonUIKubeappsCluster := cluster == ""
+	isGlobalAppRepository := kubeappsNamespace == appRepoNamespace
+	if isKubeappsCluster && (nonUIKubeappsCluster || isGlobalAppRepository) {
 		// If we're parsing a global repository then use a service client.
 		// AppRepositories are only allowed in the default cluster for the moment
 		client, err = handler.AsSVC(cluster)

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -226,7 +226,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 		kubeappsCluster   string
 	}{
 		{
-			name: "default cert pool without auth (as svc)",
+			name: "default cert pool without auth (as svc because cluster and kubeappsCluster are empty)",
 			details: &Details{
 				AppRepositoryResourceName:      appRepoName,
 				AppRepositoryResourceNamespace: appRepoNamespace,
@@ -237,7 +237,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 			kubeappsCluster:   "",
 		},
 		{
-			name: "default cert pool without auth (as user)",
+			name: "default cert pool without auth (as user because cluster is something other than kubeapps cluster)",
 			details: &Details{
 				AppRepositoryResourceName:      appRepoName,
 				AppRepositoryResourceNamespace: appRepoNamespace,

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -216,19 +216,47 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name             string
-		details          *Details
-		appRepoSpec      appRepov1.AppRepositorySpec
-		errorExpected    bool
-		numCertsExpected int
+		name              string
+		details           *Details
+		appRepoSpec       appRepov1.AppRepositorySpec
+		errorExpected     bool
+		numCertsExpected  int
+		cluster           string
+		kubeappsNamespace string
+		kubeappsCluster   string
 	}{
+		{
+			name: "default cert pool without auth (as svc)",
+			details: &Details{
+				AppRepositoryResourceName:      appRepoName,
+				AppRepositoryResourceNamespace: appRepoNamespace,
+			},
+			numCertsExpected:  len(systemCertPool.Subjects()),
+			cluster:           "",
+			kubeappsNamespace: appRepoNamespace,
+			kubeappsCluster:   "",
+		},
+		{
+			name: "default cert pool without auth (as user)",
+			details: &Details{
+				AppRepositoryResourceName:      appRepoName,
+				AppRepositoryResourceNamespace: appRepoNamespace,
+			},
+			numCertsExpected:  len(systemCertPool.Subjects()),
+			cluster:           "target-cluster",
+			kubeappsNamespace: appRepoNamespace,
+			kubeappsCluster:   "",
+		},
 		{
 			name: "default cert pool without auth",
 			details: &Details{
 				AppRepositoryResourceName:      appRepoName,
 				AppRepositoryResourceNamespace: appRepoNamespace,
 			},
-			numCertsExpected: len(systemCertPool.Subjects()),
+			numCertsExpected:  len(systemCertPool.Subjects()),
+			cluster:           "",
+			kubeappsNamespace: "",
+			kubeappsCluster:   "",
 		},
 		{
 			name: "custom CA added when passed an AppRepository CRD",
@@ -246,7 +274,10 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 					},
 				},
 			},
-			numCertsExpected: len(systemCertPool.Subjects()) + 1,
+			numCertsExpected:  len(systemCertPool.Subjects()) + 1,
+			cluster:           "",
+			kubeappsNamespace: "",
+			kubeappsCluster:   "",
 		},
 		{
 			name: "errors if secret for custom CA secret cannot be found",
@@ -264,7 +295,10 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 					},
 				},
 			},
-			errorExpected: true,
+			errorExpected:     true,
+			cluster:           "",
+			kubeappsNamespace: "",
+			kubeappsCluster:   "",
 		},
 		{
 			name: "authorization header added when passed an AppRepository CRD",
@@ -282,7 +316,10 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 					},
 				},
 			},
-			numCertsExpected: len(systemCertPool.Subjects()),
+			numCertsExpected:  len(systemCertPool.Subjects()),
+			cluster:           "",
+			kubeappsNamespace: "",
+			kubeappsCluster:   "",
 		},
 		{
 			name: "errors if auth secret cannot be found",
@@ -300,7 +337,10 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 					},
 				},
 			},
-			errorExpected: true,
+			errorExpected:     true,
+			cluster:           "",
+			kubeappsNamespace: "",
+			kubeappsCluster:   "",
 		},
 		{
 			name: "authorization header added when passed an AppRepository CRD",
@@ -318,7 +358,10 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 					},
 				},
 			},
-			numCertsExpected: len(systemCertPool.Subjects()),
+			numCertsExpected:  len(systemCertPool.Subjects()),
+			cluster:           "",
+			kubeappsNamespace: "",
+			kubeappsCluster:   "",
 		},
 	}
 
@@ -359,7 +402,7 @@ func TestParseDetailsForHTTPClient(t *testing.T) {
 		}}
 
 		t.Run(tc.name, func(t *testing.T) {
-			appRepo, caCertSecret, authSecret, err := GetAppRepoAndRelatedSecrets(tc.details.AppRepositoryResourceName, appRepoNamespace, &kube.FakeHandler{Secrets: secrets, AppRepos: apprepos}, "", "", "")
+			appRepo, caCertSecret, authSecret, err := GetAppRepoAndRelatedSecrets(tc.details.AppRepositoryResourceName, appRepoNamespace, &kube.FakeHandler{Secrets: secrets, AppRepos: apprepos}, "", tc.cluster, tc.kubeappsNamespace, tc.kubeappsCluster)
 			if err != nil {
 				if tc.errorExpected {
 					return

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -338,10 +338,8 @@ func SetupDefaultRoutes(r *mux.Router, burst int, qps float32, clustersConfig ku
 	if err != nil {
 		return err
 	}
-	r.Methods("POST").Path("/clusters/can-i").Handler(http.HandlerFunc(CanI(backendHandler)))
 	r.Methods("POST").Path("/clusters/{cluster}/can-i").Handler(http.HandlerFunc(CanI(backendHandler)))
 	r.Methods("GET").Path("/clusters/{cluster}/namespaces").Handler(http.HandlerFunc(GetNamespaces(backendHandler)))
-	// r.Methods("GET").Path("/clusters/apprepositories").Handler(http.HandlerFunc(ListAppRepositories(backendHandler)))
 	r.Methods("GET").Path("/clusters/{cluster}/apprepositories").Handler(http.HandlerFunc(ListAppRepositories(backendHandler)))
 	r.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/apprepositories").Handler(http.HandlerFunc(ListAppRepositories(backendHandler)))
 	r.Methods("POST").Path("/clusters/{cluster}/namespaces/{namespace}/apprepositories").Handler(http.HandlerFunc(CreateAppRepository(backendHandler)))

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -303,11 +303,6 @@ func CanI(kubeHandler kube.AuthHandler) func(w http.ResponseWriter, req *http.Re
 
 		clientset, err := kubeHandler.AsUser(token, requestCluster)
 
-		// If the UI clusters configuration did not include the cluster on which Kubeapps is installed, two
-		// the requestCluster will be empty. We will try using the service account instead.
-		if requestCluster == "" {
-			clientset, err = kubeHandler.AsSVC(requestCluster)
-		}
 		if err != nil {
 			returnK8sError(err, w)
 			return

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -103,7 +103,9 @@ func NewClusterConfig(inClusterConfig *rest.Config, userToken string, cluster st
 	config.BearerToken = userToken
 	config.BearerTokenFile = ""
 
-	// If the cluster is not provided, let's assume inClusterConfig
+	// If the cluster is empty, we assume the rest of the inClusterConfig is correct. This can be the case when
+	// the cluster on which Kubeapps is installed is not one presented in the UI as a target (hence not in the
+	// `clusters` configuration).
 	if cluster == "" {
 		return config, nil
 	}

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -103,6 +103,11 @@ func NewClusterConfig(inClusterConfig *rest.Config, userToken string, cluster st
 	config.BearerToken = userToken
 	config.BearerTokenFile = ""
 
+	// If the cluster is not provided, let's assume inClusterConfig
+	if cluster == "" {
+		return config, nil
+	}
+
 	clusterConfig, ok := clustersConfig.Clusters[cluster]
 	if !ok {
 		return nil, fmt.Errorf("cluster %q has no configuration", cluster)
@@ -252,7 +257,7 @@ func (a *kubeHandler) getSvcClientsetForCluster(cluster string, config *rest.Con
 	// cluster, the namespace selector remains unpopulated.
 	var svcClientset combinedClientsetInterface
 	var err error
-	if cluster == a.clustersConfig.KubeappsClusterName {
+	if cluster == "" || cluster == a.clustersConfig.KubeappsClusterName {
 		svcClientset = a.kubeappsSvcClientset
 	} else {
 		additionalCluster, ok := a.clustersConfig.Clusters[cluster]

--- a/pkg/kube/kube_handler_test.go
+++ b/pkg/kube/kube_handler_test.go
@@ -1188,6 +1188,30 @@ func TestNewClusterConfig(t *testing.T) {
 			},
 		},
 		{
+			name:      "returns an in-cluster config when no cluster is specified",
+			userToken: "token-1",
+			cluster:   "",
+			clustersConfig: ClustersConfig{
+				KubeappsClusterName: "",
+				Clusters: map[string]ClusterConfig{
+					"cluster-1": {
+						APIServiceURL:                   "https://cluster-1.example.com:7890",
+						CertificateAuthorityData:        "Y2EtZmlsZS1kYXRhCg==",
+						CertificateAuthorityDataDecoded: "ca-file-data",
+						CAFile:                          "/tmp/ca-file-data",
+					},
+				},
+			},
+			inClusterConfig: &rest.Config{
+				BearerToken:     "something-else",
+				BearerTokenFile: "/foo/bar",
+			},
+			expectedConfig: &rest.Config{
+				BearerToken:     "token-1",
+				BearerTokenFile: "",
+			},
+		},
+		{
 			name:      "returns a config setup for an additional cluster",
 			userToken: "token-1",
 			cluster:   "cluster-1",


### PR DESCRIPTION
### Description of the change

As per the discussion in https://github.com/kubeapps/kubeapps/issues/2692#issuecomment-822940480, this PR allows using the inCluster configuration if no clusters have been configured.

Specifically, it will allow configurations like this one, when we prevent users from deploying apps in the cluster in which Kubeapps has been installed on.

```yaml
clusters:
- name: target-cluster
  apiServiceURL: url
  isKubeappsCluster: false
# - name: kubeapps-cluster
```

This PR now simply brings three changes (+ tests)
  - Make `GetAppRepoAndRelatedSecrets` use the asSVC if `isKubeappsCluster && (nonUIKubeappsCluster || isGlobalAppRepository) `. 
  - Make `NewClusterConfig` use the `inCluster` config if the cluster is empty.
  - Make `getSvcClientsetForCluster` use the asSVC approach if the cluster is empty.

Furthermore, as a result of the discussions, two issues have been created: https://github.com/kubeapps/kubeapps/issues/2717 and  https://github.com/kubeapps/kubeapps/issues/2719

### Benefits

Kubeapps will work in scenarios with management/workload clusters.

### Possible drawbacks

~~Currently, this approach is still not valid in case the Kubeapps cluster is a managed one using Pinniped. We still need to declare the impersonation proxy under `clusters:`~~ Not an issue, as per https://github.com/kubeapps/kubeapps/pull/2712#pullrequestreview-644192147

### Applicable issues

  - closes #2692

### Additional information

Related to PR https://github.com/kubeapps/kubeapps/pull/2696