### PR TITLE
Add --proxy-websockets arg to the oauth2-proxy binary

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 6.1.1
+version: 6.1.2

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 6.1.0
+version: 6.1.1

--- a/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-deployment.yaml
@@ -68,6 +68,7 @@ spec:
             - --pass-basic-auth=false
             - --pass-access-token=true
             - --pass-authorization-header=true
+            - --proxy-websockets=true
             - --skip-auth-regex=^\/config\.json$
             - --skip-auth-regex=^\/manifest\.json$
             - --skip-auth-regex=^\/custom_style\.css$


### PR DESCRIPTION
### Description of the change

I was perusing the oauth2-proxy docs looking for something else and noticed that there's an explicit arg for proxying websocket requests. It's not been noticed since we fallback to polling, but I'm guessing without this option the plain OIDC setup would be polling.

### Benefits

Updates for in-progress deployments can now be handled by websocket requests when using OIDC (but not pinniped, we still need to update pinniped-proxy to handle that, see #2615).

