### PR TITLE
Enables user-provided tls cert to be used again.

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,8 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-<<<<<<< HEAD
 version: 6.1.2
-=======
-version: 6.1.3
->>>>>>> Set chart version based on other PRs to land.

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,4 +25,8 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
+<<<<<<< HEAD
 version: 6.1.2
+=======
+version: 6.1.3
+>>>>>>> Set chart version based on other PRs to land.

--- a/chart/kubeapps/templates/tls-secrets.yaml
+++ b/chart/kubeapps/templates/tls-secrets.yaml
@@ -14,7 +14,7 @@ data:
 ---
 {{- end }}
 {{- end }}
-{{- if and .Values.ingress.tls (.Values.ingress.selfSigned) }}
+{{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
 {{- $ca := genCA "kubeapps-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
 apiVersion: v1

--- a/chart/kubeapps/templates/tls-secrets.yaml
+++ b/chart/kubeapps/templates/tls-secrets.yaml
@@ -14,19 +14,4 @@ data:
 ---
 {{- end }}
 {{- end }}
-{{- if and .Values.ingress.tls (not .Values.ingress.certManager) }}
-{{- $ca := genCA "kubeapps-ca" 365 }}
-{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ printf "%s-tls" .Values.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
-  labels: {{ include "kubeapps.labels" . | nindent 4 }}
-type: kubernetes.io/tls
-data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-{{- end }}
 {{- end }}

--- a/chart/kubeapps/templates/tls-secrets.yaml
+++ b/chart/kubeapps/templates/tls-secrets.yaml
@@ -14,4 +14,19 @@ data:
 ---
 {{- end }}
 {{- end }}
+{{- if and .Values.ingress.tls (.Values.ingress.selfSigned) }}
+{{- $ca := genCA "kubeapps-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "kubeapps.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -67,6 +67,10 @@ ingress:
   ##
   certManager: false
 
+  ## Set this to true in order to have the chart generate a self-signed TLS cert
+  ## for use.
+  selfSigned: false
+
   ## When the ingress is enabled, a host pointing to this will be created
   ##
   hostname: kubeapps.local

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -28,8 +28,8 @@ deploy-dependencies: deploy-dex deploy-openldap devel/localhost-cert.pem
 		--key ./devel/localhost-key.pem \
 		--cert ./devel/localhost-cert.pem
 
-deploy-dev-kubeapps: 
-	helm --kubeconfig=${CLUSTER_CONFIG} install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \
+deploy-dev-kubeapps:
+	helm --kubeconfig=${CLUSTER_CONFIG} upgrade --install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml


### PR DESCRIPTION
### Description of the change

See #2730 for a description of the problem.

Note: needs to be landed after #2728 due to chart version bumps.

### Benefits

Users can again provide their own (trusted) tls cert and have Kubeapps use that.

### Possible drawbacks

Not sure - I've asked for more info on why we'd want the chart to generate an untrusted cert.

### Applicable issues

  - fixes #2730
