### PR TITLE
Add try/catch in CI test to check the latest released version

### DIFF
--- a/integration/use-cases/02-create-private-registry.js
+++ b/integration/use-cases/02-create-private-registry.js
@@ -55,8 +55,13 @@ test("Creates a private registry", async () => {
   });
 
   // Select the new secret
-  await expect(page).toMatch(secret);
-  await expect(page).toSelect("form > cds-form-group > cds-select > select", secret);
+  try {
+    await expect(page).toMatch(secret);
+    await expect(page).toSelect("form > cds-form-group > cds-select > select", secret);
+  } catch(e) {
+    // TODO(agamez): Remove this catch block once 2.3.2 is released
+    await expect(page).toClick("label", { text: secret });
+  }
 
   await expect(page).toClick("cds-button", { text: "Install Repo" });
 


### PR DESCRIPTION
### Description of the change

Add try/catch to prevent CI to fail in master when testing the latest released version (which does not have the UI change)

### Benefits

CI will work on master

### Possible drawbacks

N/A

### Applicable issues

  N/A

### Additional information

This change should be reverted once we got the new release since it's no longer necessary. 