### PR TITLE
Minor curl fix in the replaceImage script

### DIFF
--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -49,13 +49,16 @@ replaceImage() {
     local currentImageEscaped="kubeapps\/${service}"
     local targetImageEscaped="bitnami\/kubeapps-${service}"
 
-    local header=""
+    echo "Replacing ${service}"...
+
+    local curl_opts=()
     if [[ $ACCESS_TOKEN != "" ]]; then
-        header="-H 'Authorization: token ${ACCESS_TOKEN}'"
+        curl_opts=(-s -H "Authorization: token ${ACCESS_TOKEN}")
     fi
 
     # Get the latest tag from the bitnami repository
-    local tag=`curl ${header} https://api.github.com/repos/bitnami/${repoName}/tags | jq -r '.[0].name'`
+   local tag=`curl "${curl_opts[@]}" "https://api.github.com/repos/bitnami/${repoName}/tags" | jq -r '.[0].name'`
+
     if [[ $tag == "" ]]; then
         echo "ERROR: Unable to obtain latest tag for ${repoName}. Aborting"
         exit 1


### PR DESCRIPTION
### Description of the change

Minor curl fix in the replaceImage script to pass properly the token so that we won't rate-limited

### Benefits

Not that much... just avoiding getting rate-limited if you're debugging the script

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

I gues we are gonna remove this script soon, so it will be just an ethereal ephemeral change :P   
