### PR TITLE
Disable sync_chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,14 +117,14 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      - sync_chart:
-          <<: *build_on_master
-          requires:
-            - local_e2e_tests
-            - GKE_1_17_MASTER
-            - GKE_1_17_LATEST_RELEASE
-            - GKE_1_18_MASTER
-            - GKE_1_18_LATEST_RELEASE
+      # - sync_chart:
+      #     <<: *build_on_master
+      #     requires:
+      #       - local_e2e_tests
+      #       - GKE_1_17_MASTER
+      #       - GKE_1_17_LATEST_RELEASE
+      #       - GKE_1_18_MASTER
+      #       - GKE_1_18_LATEST_RELEASE
       - push_images:
           <<: *build_on_master
           requires:
@@ -193,7 +193,7 @@ build_images: &build_images
     - <<: *exports
     - run:
         name: Build and push CI images
-        command: | 
+        command: |
           mkdir -p images/
           read -ra IMG_ARRAY \<<< "$IMAGES"
           if [[ -n "${CIRCLE_TAG}" ]]; then
@@ -333,7 +333,7 @@ install_multicluster_deps: &install_multicluster_deps
     command: |
       sed -i -e "s/172.18.0.2/$DEFAULT_DEX_IP/g;s/localhost/kubeapps-ci.kubeapps/g" ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
       helm repo add stable https://charts.helm.sh/stable
-      
+
       # Install dex
       kubectl create namespace dex
       helm install dex stable/dex --namespace dex --values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
@@ -372,7 +372,7 @@ gke_test: &gke_test
     - checkout
     - run:
         name: Check conditions
-        command: | 
+        command: |
           source ./script/chart_sync_utils.sh
 
           # In the case of GKE we will only want to build if it is
@@ -393,7 +393,7 @@ gke_test: &gke_test
     - setup_remote_docker
     - run:
         name: Configure Google Cloud
-        command: | 
+        command: |
           gcloud -q config set project $GKE_PROJECT
           export GOOGLE_APPLICATION_CREDENTIALS=/tmp/client_secrets.json
           echo $GCLOUD_KEY > $GOOGLE_APPLICATION_CREDENTIALS
@@ -404,11 +404,11 @@ gke_test: &gke_test
     # A GKE cluster name cannot contain non-alphanumeric characters (nor uppercase letters)
     - run:
         name: Export escaped GKE cluster name
-        command: | 
+        command: |
           echo "export ESCAPED_GKE_CLUSTER=$(echo ${GKE_CLUSTER}-${CIRCLE_BRANCH:-$CIRCLE_TAG}-${TEST_LATEST_RELEASE}-${GKE_BRANCH}-ci | sed 's/[^a-z0-9-]//g')" >> $BASH_ENV
     - run:
         name: Start GKE environment
-        command: | 
+        command: |
           ./script/start-gke-env.sh $ESCAPED_GKE_CLUSTER $GKE_ZONE $GKE_BRANCH $GKE_ADMIN > /dev/null
     - <<: *install_helm_cli
     - <<: *run_e2e_tests
@@ -459,12 +459,12 @@ jobs:
       - <<: *exports
       - run:
           name: Run go unit tests
-          command: | 
+          command: |
             make test
       - setup_remote_docker
       - run:
           name: Run go integration tests for DB
-          command: | 
+          command: |
             docker run -d --name postgresql --rm --publish 5432:5432 -e ALLOW_EMPTY_PASSWORD=yes bitnami/postgresql:${POSTGRESQL_VERSION}
             docker run --network container:postgresql -d --name tests circleci/golang:${GOLANG_VERSION} tail -f /dev/null
             docker cp /go tests:/
@@ -476,15 +476,15 @@ jobs:
       - checkout
       - run:
           name: Install dashboard dependencies
-          command: | 
+          command: |
             yarn install --cwd=dashboard --frozen-lockfile
       - run:
           name: Run dashboard linter
-          command: | 
+          command: |
             yarn --cwd=dashboard run lint
       - run:
           name: Run dashboard unit tests
-          command: | 
+          command: |
             yarn --cwd=dashboard run test --maxWorkers=4 --coverage
   test_pinniped_proxy:
     docker:
@@ -493,8 +493,8 @@ jobs:
       - checkout
       - run:
           name: Run rust unit tests
-          command: | 
-              cargo test --manifest-path ./cmd/pinniped-proxy/Cargo.toml
+          command: |
+            cargo test --manifest-path ./cmd/pinniped-proxy/Cargo.toml
   test_chart_render:
     environment:
       <<: *common_envars
@@ -506,7 +506,7 @@ jobs:
       - <<: *install_helm_cli
       - run:
           name: Run chart template test
-          command: | 
+          command: |
             ./script/chart-template-test.sh
   build_go_images:
     docker:
@@ -536,7 +536,7 @@ jobs:
       - checkout
       - run:
           name: Create release
-          command: | 
+          command: |
             REPO_DOMAIN=kubeapps REPO_NAME=kubeapps ./script/create_release.sh ${CIRCLE_TAG}
   local_e2e_tests:
     machine: true
@@ -580,23 +580,24 @@ jobs:
       TEST_LATEST_RELEASE: 1
       USE_MULTICLUSTER_OIDC_ENV: "false"
       <<: *common_envars
-  sync_chart:
-    docker:
-      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
-    steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "cc:ed:2d:1f:74:3b:32:c3:99:62:d7:7d:81:af:01:e0"
-      - run:
-          name: Configure ssh keys
-          command: | 
-            if ls ~/.ssh/id_rsa_* 1> /dev/null 2>&1; then
-              # Change order to use configured ssh_key first
-              ssh-add -D
-              ssh-add ~/.ssh/id_rsa_* ~/.ssh/id_rsa
-            fi
-            ./script/chart_sync.sh kubernetes-bitnami kubernetes@bitnami.com
+  # WARNING: this job is currently disabled as we are still defining how we will be syncing the chart with the bitnami/chart repo.
+  # sync_chart:
+  #   docker:
+  #     - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+  #   steps:
+  #     - checkout
+  #     - add_ssh_keys:
+  #         fingerprints:
+  #           - "cc:ed:2d:1f:74:3b:32:c3:99:62:d7:7d:81:af:01:e0"
+  #     - run:
+  #         name: Configure ssh keys
+  #         command: | 
+  #           if ls ~/.ssh/id_rsa_* 1> /dev/null 2>&1; then
+  #             # Change order to use configured ssh_key first
+  #             ssh-add -D
+  #             ssh-add ~/.ssh/id_rsa_* ~/.ssh/id_rsa
+  #           fi
+  #           ./script/chart_sync.sh kubernetes-bitnami kubernetes@bitnami.com
   push_images:
     docker:
       - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
@@ -605,7 +606,7 @@ jobs:
       - <<: *exports
       - run:
           name: Push images
-          command: | 
+          command: |
             if [[ -z "$CIRCLE_PULL_REQUEST" && -n "$DOCKER_USERNAME" && -n "$DOCKER_PASSWORD" ]]; then
               docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
               for IMAGE in << pipeline.parameters.IMAGES_TO_PUSH >>; do

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,14 +117,6 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
-      # - sync_chart:
-      #     <<: *build_on_master
-      #     requires:
-      #       - local_e2e_tests
-      #       - GKE_1_17_MASTER
-      #       - GKE_1_17_LATEST_RELEASE
-      #       - GKE_1_18_MASTER
-      #       - GKE_1_18_LATEST_RELEASE
       - push_images:
           <<: *build_on_master
           requires:
@@ -580,24 +572,6 @@ jobs:
       TEST_LATEST_RELEASE: 1
       USE_MULTICLUSTER_OIDC_ENV: "false"
       <<: *common_envars
-  # WARNING: this job is currently disabled as we are still defining how we will be syncing the chart with the bitnami/chart repo.
-  # sync_chart:
-  #   docker:
-  #     - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
-  #   steps:
-  #     - checkout
-  #     - add_ssh_keys:
-  #         fingerprints:
-  #           - "cc:ed:2d:1f:74:3b:32:c3:99:62:d7:7d:81:af:01:e0"
-  #     - run:
-  #         name: Configure ssh keys
-  #         command: | 
-  #           if ls ~/.ssh/id_rsa_* 1> /dev/null 2>&1; then
-  #             # Change order to use configured ssh_key first
-  #             ssh-add -D
-  #             ssh-add ~/.ssh/id_rsa_* ~/.ssh/id_rsa
-  #           fi
-  #           ./script/chart_sync.sh kubernetes-bitnami kubernetes@bitnami.com
   push_images:
     docker:
       - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ helm install kubeapps --namespace kubeapps bitnami/kubeapps
 
 ***Note:*** Kubeapps 2.0 and onwards supports Helm 3 only. While only the Helm 3 API is supported, in most cases, charts made for Helm 2 will still work. For detailed instructions on how to install and use Kubeapps follow the [Getting Started Guide](./docs/user/getting-started.md).
 
+> Please also take into account that Kubeapps is using the [Bitnami chart](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) as the official one. The chart inside this repository is only intended to be used for development purposes.
+
 ## Developer Documentation
 
 Please refer to:

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -284,7 +284,7 @@ Kubeapps uses the currently logged-in user credential to retrieve the list of al
 To reduce this time, you can increase the number of checks that Kubeapps will perform in parallel (per connection) setting the value: `kubeops.burst=<desired_number>` and `kubeops.QPS=<desired_number>`. The default value, if not set, is 15 burst requests and 10 QPS afterwards.
 
 ### Why am I seeing two charts?
-The official Kubeapps chart is [the one provided by Bitnami](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps), however, exclusively for development purposes, the Kubeapps repository also has its [own chart](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps) with the latest development versions.
+The official Kubeapps chart is [the one provided by Bitnami](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps), however, exclusively for development purposes, the Kubeapps repository also has its [own chart](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps) with the latest development changes.
 
 
 ### More questions? 

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -198,6 +198,7 @@ kubectl delete namespace kubeapps
 - [Why can't I configure global private repositories?](#why-cant-i-configure-global-private-repositories)
 - [Does Kubeapps support Operators?](#does-kubeapps-support-operators)
 - [Slow response when listing namespaces?](#slow-response-when-listing-namespaces)
+- [Why am I seeing two charts?](#why-am-i-seeing-two-charts?)
 - [More questions?](#more-questions)
 
 ### How to install Kubeapps for demo purposes?
@@ -281,6 +282,10 @@ Yes! You can get started by following the [operators documentation](https://gith
 Kubeapps uses the currently logged-in user credential to retrieve the list of all namespaces. If the user doesn't have permission to list namespaces, the backend will try again with its own service account to list all namespaces and then iterate through each namespace to check if the user has permissions to get secrets for each namespace (to verify if they should be allowed to use that namespace or not and hence whether it is included in the selector). This can lead to a slow response if the number of namespaces on the cluster is large.
 
 To reduce this time, you can increase the number of checks that Kubeapps will perform in parallel (per connection) setting the value: `kubeops.burst=<desired_number>` and `kubeops.QPS=<desired_number>`. The default value, if not set, is 15 burst requests and 10 QPS afterwards.
+
+### Why am I seeing two charts?
+The official Kubeapps chart is [the one provided by Bitnami](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps), however, exclusively for development purposes, the Kubeapps repository also has its [own chart](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps) with the latest development versions.
+
 
 ### More questions? 
 

--- a/docs/developer/ci.md
+++ b/docs/developer/ci.md
@@ -2,30 +2,29 @@
 
 Kubeapps leverages CircleCI for running the tests (both unit and integration tests), pushing the images and syncing the chart with the official [Bitnami chart](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps). The following image depicts how a successful workflow looks like (after a push to master).
 
-![CircleCI workflow after pushing to master](../img/ci-workflow-master.png
-"CircleCI workflow after pushing to master")
+![CircleCI workflow after pushing to master](../img/ci-workflow-master.png "CircleCI workflow after pushing to master")
 
 The main configuration is located at this [CircleCI config file](../../.circleci/config.yml)). At a glance, it contains:
 
-* **Build conditions**: `build_always`, `build_on_master` and `build_on_tag`. They will be added to each job to determine whether or not it should be executed. Whereas some should always be run, others only make sense when pushing to master or when a new tag has been created.
-* **Workflows**: we only use a single workflow named `kubeapps` with multiple jobs.
-* **Jobs**: the actual commands that are executed depending on the build conditions.
-    * `test_go` (always): it runs every unit test for those projects written in Golang (that is, it runs `make test`) as well as it runs some DB-dependent tests.
-    * `test_dashboard` (always): it runs the dashboard linter and unit tests (`yarn lint` and `yarn test`)
-    * `test_pinniped_proxy` (always): it runs the Rust unit tests of the pinniped-proxy project (`cargo test`).
-    * `test_chart_render` (always): it runs the chart template test defined in the script [`chart-template-test.sh](../../script/chart-template-test.sh).
-    * `build_go_images` (always): it builds the CI golang images for `kubeops`, `apprepository-controller`, `asset-syncer` and `assetsvc`.
-    * `build_dashboard` (always): it builds the CI node image for `dashboard`.
-    * `build_pinniped_proxy` (always): it builds the CI rust image for `pinniped-proxy`.
-    * `local_e2e_tests` (always): it runs locally (i.e., inside the CircleCI environment) the e2e tests. Please refer to the [e2e tests documentation](./end-to-end-tests.md) for further information. In this job, before executing the script [`script/e2e-test.sh](../../script/e2e-test.sh), the proper environment is created. Namely:
-        * Install the required binaries (kind, kubectl, mkcert, helm).
-        * Spin up two Kind clusters.
-        * Load the CI images into the cluster.
-        * Run the integration tests.
-    * `GKE_x_xx_MASTER` and `GKE_X_XX_LATEST_RELEASE` (on master): there is a job for each [Kubernetes version supported by Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/release-notes) (GKE). It will run the e2e tests in a GKE cluster (version X.XX) using either the code in `master` or in the latest released version.
-    * `sync_chart` (on master): it will modify the official [Bitnami chart](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) so that it gets synced with the latest Kubeapps chart version. In the event of a new component being added to Kubeapps, this script must be updated in accordance.
-    * `push_images` (on master): the CI images (which have already been built) get re-tagged and pushed to the `kubeapps` account.
-    * `release` (on tag): it creates a GitHub release based on the current tag by executing the script [script/create_release.sh](../../script/create_release.sh).
+- **Build conditions**: `build_always`, `build_on_master` and `build_on_tag`. They will be added to each job to determine whether or not it should be executed. Whereas some should always be run, others only make sense when pushing to master or when a new tag has been created.
+- **Workflows**: we only use a single workflow named `kubeapps` with multiple jobs.
+- **Jobs**: the actual commands that are executed depending on the build conditions.
+  - `test_go` (always): it runs every unit test for those projects written in Golang (that is, it runs `make test`) as well as it runs some DB-dependent tests.
+  - `test_dashboard` (always): it runs the dashboard linter and unit tests (`yarn lint` and `yarn test`)
+  - `test_pinniped_proxy` (always): it runs the Rust unit tests of the pinniped-proxy project (`cargo test`).
+  - `test_chart_render` (always): it runs the chart template test defined in the script [`chart-template-test.sh](../../script/chart-template-test.sh).
+  - `build_go_images` (always): it builds the CI golang images for `kubeops`, `apprepository-controller`, `asset-syncer` and `assetsvc`.
+  - `build_dashboard` (always): it builds the CI node image for `dashboard`.
+  - `build_pinniped_proxy` (always): it builds the CI rust image for `pinniped-proxy`.
+  - `local_e2e_tests` (always): it runs locally (i.e., inside the CircleCI environment) the e2e tests. Please refer to the [e2e tests documentation](./end-to-end-tests.md) for further information. In this job, before executing the script [`script/e2e-test.sh](../../script/e2e-test.sh), the proper environment is created. Namely:
+    - Install the required binaries (kind, kubectl, mkcert, helm).
+    - Spin up two Kind clusters.
+    - Load the CI images into the cluster.
+    - Run the integration tests.
+  - `GKE_x_xx_MASTER` and `GKE_X_XX_LATEST_RELEASE` (on master): there is a job for each [Kubernetes version supported by Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/release-notes) (GKE). It will run the e2e tests in a GKE cluster (version X.XX) using either the code in `master` or in the latest released version. If a change affecting the UI is pushed to master, the e2e test might fail here. Use a try/catch block to temporarily work around this.
+  - `push_images` (on master): the CI images (which have already been built) get re-tagged and pushed to the `kubeapps` account.
+  - `release` (on tag): it creates a GitHub release based on the current tag by executing the script [script/create_release.sh](../../script/create_release.sh).
 
+Note that this process is independent of the release of the official Bitnami images and chart. These Bitnami images will be created according to their internal process (so the Golang, Node or Rust versions we define here are not used by them. Manual coordination is expected here if a major version bump happens to occur).
 
- Note that this process is independent of the release of the official Bitnami images. These Bitnami images will be created according to their internal process. From the Kubeapps end, we are only in charge of pushing the updates to the [chart repository]((https://github.com/bitnami/charts/tree/master/bitnami/kubeapps)).
+Additionally, currently is the Kubeapps team who is in charge of sending a PR to the [chart repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) each time a new chart version is pushed to the main branch.

--- a/docs/developer/ci.md
+++ b/docs/developer/ci.md
@@ -27,4 +27,4 @@ The main configuration is located at this [CircleCI config file](../../.circleci
 
 Note that this process is independent of the release of the official Bitnami images and chart. These Bitnami images will be created according to their internal process (so the Golang, Node or Rust versions we define here are not used by them. Manual coordination is expected here if a major version bump happens to occur).
 
-Additionally, currently is the Kubeapps team who is in charge of sending a PR to the [chart repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) each time a new chart version is pushed to the main branch.
+Additionally, currently the Kubeapps team is responsible for sending a PR to the [chart repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) each time a new chart version is pushed to the main branch.


### PR DESCRIPTION
### Description of the change

This PR removes the sync_chart job in our CI and clarifies that the we are using the bitnami chart as the official one. 

### Benefits

The chart will no longer be pushed to the bitnami/repo, we are now in charge of sending the PR to the repo once we detect changes in the chart.

### Possible drawbacks

We have to come up with a way to systematically update the chart, if not, some inconsistencies may appear.

### Applicable issues

  - fixes #2704

### Additional information

I've commented the code instead of removing it in case we later go ahead with this idea: https://github.com/kubeapps/kubeapps/issues/2704#issuecomment-829080612
