### PR TITLE
Automatic chart syncing in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -616,17 +616,17 @@ jobs:
       - <<: *install_github
       - add_ssh_keys:
           fingerprints:
-            # Deployment key uploaded to the bitnami/charts repository
-            - "ba:56:29:3b:70:d7:bb:14:a9:db:42:7b:73:42:23:e4"
+            # Deployment key uploaded to the kubeapps-bot/charts repository
+            - "59:81:2a:95:a6:54:a7:46:e5:15:f5:37:b3:4f:6c:ad"
       - run:
           # This is a key pair: https://circleci.com/docs/2.0/gh-bb-integration/
-          # public key uploaded to GitHub as a deploy key with write permissions in both kubeapps and bitnami/charts
+          # public key uploaded to GitHub as a deploy key with write permissions in both kubeapps and kubeapps-bot/charts
           # private key uploaded to CircleCI with hostname "github.com"
           name: Start ssh-agent and configure the key
           command: |
             eval "$(ssh-agent -s)"
             # the name is always "id_rsa_"+fingerprint without ":""
-            ssh-add ~/.ssh/id_rsa_ba56293b70d7bb14a9db427b734223e4
+            ssh-add ~/.ssh/id_rsa_59812a95a654a746e515f537b34f6cad
       - run:
           name: Execute the chart_sync script
           command: |
@@ -642,7 +642,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             # Deployment key uploaded to the kubeapps/kubeapps repository
-            - "60:9f:97:43:bc:e0:61:b1:76:8b:71:0f:00:cf:f7:69"
+            - "20:5e:d1:68:7c:10:67:c1:ab:e2:6e:33:e3:7a:64:6e"
       - run:
           # This is a key pair: https://circleci.com/docs/2.0/gh-bb-integration/
           # public key uploaded to GitHub as a deploy key with write permissions
@@ -651,8 +651,11 @@ jobs:
           command: |
             eval "$(ssh-agent -s)"
             # the name is always "id_rsa_"+fingerprint without ":""
-            ssh-add ~/.ssh/id_rsa_609f9743bce061b1768b710f00cff769
+            ssh-add ~/.ssh/id_rsa_205ed1687c1067c1abe26e33e37a646e
       - run:
+          # Assuming there is a personal access token created in GitHub granted with the scopes
+          # "repo:status", "public_repo" and "read:org"
+          # This token is passed as a GITHUB_TOKEN env var via CircleCI
           name: Execute the check_upstream_chart script
           command: |
             ./script/chart_upstream_checker.sh kubernetes-bitnami kubernetes@bitnami.com

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ setup_gpg: &setup_gpg
       gpg --import --no-tty --batch --yes private.key
       
       # Trusting the imported GPG private key
-      (echo 5; echo y; echo save) |  gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "${GPG_KEY_ID}" trust
+      (echo 5; echo y; echo save) |  gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "<< pipeline.parameters.CI_BOT_GPG >>" trust
       
       # Listing the key to verify the import process succeeded
       gpg --list-secret-keys << pipeline.parameters.CI_BOT_EMAIL >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ parameters:
   KUBECTL_VERSION:
     type: "string"
     default: "v1.19.10"
+  GITHUB_VERSION:
+    type: "string"
+    default: "1.9.2"
   KIND_VERSION:
     type: "string"
     default: "v0.10.0"
@@ -89,6 +92,8 @@ workflows:
             - build_go_images
             - build_dashboard
             - build_pinniped_proxy
+      - sync_chart_from_bitnami:
+          <<: *build_on_master
       - GKE_1_17_MASTER:
           <<: *build_on_master
           requires:
@@ -96,6 +101,8 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
+            - build_pinniped_proxy
+            - sync_chart_from_bitnami
       - GKE_1_17_LATEST_RELEASE:
           <<: *build_on_master
           requires:
@@ -103,6 +110,8 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
+            - build_pinniped_proxy
+            - sync_chart_from_bitnami
       - GKE_1_18_MASTER:
           <<: *build_on_master
           requires:
@@ -110,6 +119,8 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
+            - build_pinniped_proxy
+            - sync_chart_from_bitnami
       - GKE_1_18_LATEST_RELEASE:
           <<: *build_on_master
           requires:
@@ -117,8 +128,18 @@ workflows:
             - test_dashboard
             - build_go_images
             - build_dashboard
+            - build_pinniped_proxy
+            - sync_chart_from_bitnami
       - push_images:
           <<: *build_on_master
+          requires:
+            - local_e2e_tests
+            - GKE_1_17_MASTER
+            - GKE_1_17_LATEST_RELEASE
+            - GKE_1_18_MASTER
+            - GKE_1_18_LATEST_RELEASE
+      - sync_chart_to_bitnami:
+          <<: *build_on_tag
           requires:
             - local_e2e_tests
             - GKE_1_17_MASTER
@@ -142,6 +163,7 @@ common_envars: &common_envars
   K8S_KIND_VERSION: << pipeline.parameters.K8S_KIND_VERSION >>
   KIND_VERSION: << pipeline.parameters.KIND_VERSION >>
   KUBECTL_VERSION: << pipeline.parameters.KUBECTL_VERSION >>
+  GITHUB_VERSION: << pipeline.parameters.GITHUB_VERSION >>
   MKCERT_VERSION: << pipeline.parameters.MKCERT_VERSION >>
   NODE_VERSION: << pipeline.parameters.NODE_VERSION >>
   OLM_VERSION: << pipeline.parameters.OLM_VERSION >>
@@ -319,6 +341,18 @@ install_mkcert: &install_mkcert
       chmod +x "mkcert-${MKCERT_VERSION}-linux-amd64"
       sudo mv "mkcert-${MKCERT_VERSION}-linux-amd64" /usr/local/bin/mkcert
       mkcert -install
+install_github: &install_github
+  run:
+    # Assuming there is a personal access token created in GitHub granted with the scopes
+    # "repo:status", "public_repo" and "read:org"
+    # This token is passed as a GITHUB_TOKEN env var via CircleCI
+    name: "Install GitHub CLI"
+    command: |
+      cd /tmp
+      wget https://github.com/cli/cli/releases/download/v${GITHUB_VERSION}/gh_${GITHUB_VERSION}_linux_amd64.tar.gz
+      tar zxf gh_${GITHUB_VERSION}_linux_amd64.tar.gz
+      rm gh_${GITHUB_VERSION}_linux_amd64.tar.gz
+      sudo mv gh_${GITHUB_VERSION}_linux_amd64/bin/gh /usr/local/bin/
 install_multicluster_deps: &install_multicluster_deps
   run:
     name: "Install multicluster deps"
@@ -572,6 +606,56 @@ jobs:
       TEST_LATEST_RELEASE: 1
       USE_MULTICLUSTER_OIDC_ENV: "false"
       <<: *common_envars
+  sync_chart_to_bitnami:
+    environment:
+      <<: *common_envars
+    docker:
+      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+    steps:
+      - checkout
+      - <<: *install_github
+      - add_ssh_keys:
+          fingerprints:
+            # Deployment key uploaded to the bitnami/charts repository
+            - "ba:56:29:3b:70:d7:bb:14:a9:db:42:7b:73:42:23:e4"
+      - run:
+          # This is a key pair: https://circleci.com/docs/2.0/gh-bb-integration/
+          # public key uploaded to GitHub as a deploy key with write permissions in both kubeapps and bitnami/charts
+          # private key uploaded to CircleCI with hostname "github.com"
+          name: Start ssh-agent and configure the key
+          command: |
+            eval "$(ssh-agent -s)"
+            # the name is always "id_rsa_"+fingerprint without ":""
+            ssh-add ~/.ssh/id_rsa_ba56293b70d7bb14a9db427b734223e4
+      - run:
+          name: Execute the chart_sync script
+          command: |
+            ./script/chart_sync.sh kubernetes-bitnami kubernetes@bitnami.com
+  sync_chart_from_bitnami:
+    environment:
+      <<: *common_envars
+    docker:
+      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+    steps:
+      - checkout
+      - <<: *install_github
+      - add_ssh_keys:
+          fingerprints:
+            # Deployment key uploaded to the kubeapps/kubeapps repository
+            - "60:9f:97:43:bc:e0:61:b1:76:8b:71:0f:00:cf:f7:69"
+      - run:
+          # This is a key pair: https://circleci.com/docs/2.0/gh-bb-integration/
+          # public key uploaded to GitHub as a deploy key with write permissions
+          # private key uploaded to CircleCI with hostname "github.com"
+          name: Start ssh-agent and configure the key
+          command: |
+            eval "$(ssh-agent -s)"
+            # the name is always "id_rsa_"+fingerprint without ":""
+            ssh-add ~/.ssh/id_rsa_609f9743bce061b1768b710f00cff769
+      - run:
+          name: Execute the check_upstream_chart script
+          command: |
+            ./script/chart_upstream_checker.sh kubernetes-bitnami kubernetes@bitnami.com
   push_images:
     docker:
       - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,12 +381,12 @@ setup_gpg: &setup_gpg
     name: "Install the GPG key"
     command: |
       # Creating the files from the GPG_KEY_PUBLIC and GPG_KEY_PRIVATE env vars
-      echo -e ${GPG_KEY_PUBLIC} > public.key
-      echo -e ${GPG_KEY_PRIVATE} > private.key
+      echo -e ${GPG_KEY_PUBLIC} > /tmp/public.key
+      echo -e ${GPG_KEY_PRIVATE} > /tmp/private.key
       
       # Importing the GPG keys
-      gpg --import public.key
-      gpg --import --no-tty --batch --yes private.key
+      gpg --import /tmp/public.key
+      gpg --import --no-tty --batch --yes /tmp/private.key
       
       # Trusting the imported GPG private key
       (echo 5; echo y; echo save) |  gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "<< pipeline.parameters.CI_BOT_GPG >>" trust

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,14 +383,14 @@ setup_gpg: &setup_gpg
       # Creating the files from the GPG_KEY_PUBLIC and GPG_KEY_PRIVATE env vars
       echo -e ${GPG_KEY_PUBLIC} > /tmp/public.key
       echo -e ${GPG_KEY_PRIVATE} > /tmp/private.key
-      
+
       # Importing the GPG keys
       gpg --import /tmp/public.key
       gpg --import --no-tty --batch --yes /tmp/private.key
-      
+
       # Trusting the imported GPG private key
       (echo 5; echo y; echo save) |  gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "<< pipeline.parameters.CI_BOT_GPG >>" trust
-      
+
       # Listing the key to verify the import process succeeded
       gpg --list-secret-keys << pipeline.parameters.CI_BOT_EMAIL >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ parameters:
   GITHUB_VERSION:
     type: "string"
     default: "1.9.2"
+  SEMVER_VERSION:
+    type: "string"
+    default: "3.2.0"
   KIND_VERSION:
     type: "string"
     default: "v0.10.0"
@@ -173,6 +176,7 @@ common_envars: &common_envars
   KIND_VERSION: << pipeline.parameters.KIND_VERSION >>
   KUBECTL_VERSION: << pipeline.parameters.KUBECTL_VERSION >>
   GITHUB_VERSION: << pipeline.parameters.GITHUB_VERSION >>
+  SEMVER_VERSION: << pipeline.parameters.SEMVER_VERSION >>
   MKCERT_VERSION: << pipeline.parameters.MKCERT_VERSION >>
   NODE_VERSION: << pipeline.parameters.NODE_VERSION >>
   OLM_VERSION: << pipeline.parameters.OLM_VERSION >>
@@ -362,6 +366,16 @@ install_github: &install_github
       tar zxf gh_${GITHUB_VERSION}_linux_amd64.tar.gz
       rm gh_${GITHUB_VERSION}_linux_amd64.tar.gz
       sudo mv gh_${GITHUB_VERSION}_linux_amd64/bin/gh /usr/local/bin/
+install_semver: &install_semver
+  run:
+    name: "Install semver bash tool"
+    command: |
+      cd /tmp
+      wget https://github.com/fsaintjacques/semver-tool/archive/refs/tags/${SEMVER_VERSION}.tar.gz
+      tar zxf ${SEMVER_VERSION}.tar.gz
+      rm ${SEMVER_VERSION}.tar.gz
+      cd semver-tool-${SEMVER_VERSION}
+      sudo make install
 setup_gpg: &setup_gpg
   run:
     name: "Install the GPG key"
@@ -641,6 +655,7 @@ jobs:
     steps:
       - checkout
       - <<: *install_github
+      - <<: *install_semver
       - <<: *setup_gpg
       - add_ssh_keys:
           fingerprints:
@@ -670,6 +685,7 @@ jobs:
     steps:
       - checkout
       - <<: *install_github
+      - <<: *install_semver
       - <<: *setup_gpg
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,15 @@ parameters:
   IMAGES_TO_PUSH:
     type: "string"
     default: "kubeapps/apprepository-controller kubeapps/dashboard kubeapps/asset-syncer kubeapps/assetsvc kubeapps/kubeops kubeapps/pinniped-proxy"
+  CI_BOT_USERNAME:
+    type: "string"
+    default: "kubeapps-bot"
+  CI_BOT_EMAIL:
+    type: "string"
+    default: "tanzu-kubeapps-team@vmware.com"
+  CI_BOT_GPG:
+    type: "string"
+    default: "80B6EB16B1328FB18DFF2A073EBA68F3347E319D"
 
 ## Build conditions
 # Build in any branch or tag
@@ -353,6 +362,24 @@ install_github: &install_github
       tar zxf gh_${GITHUB_VERSION}_linux_amd64.tar.gz
       rm gh_${GITHUB_VERSION}_linux_amd64.tar.gz
       sudo mv gh_${GITHUB_VERSION}_linux_amd64/bin/gh /usr/local/bin/
+setup_gpg: &setup_gpg
+  run:
+    name: "Install the GPG key"
+    command: |
+      # Creating the files from the GPG_KEY_PUBLIC and GPG_KEY_PRIVATE env vars
+      echo -e ${GPG_KEY_PUBLIC} > public.key
+      echo -e ${GPG_KEY_PRIVATE} > private.key
+      
+      # Importing the GPG keys
+      gpg --import public.key
+      gpg --import --no-tty --batch --yes private.key
+      
+      # Trusting the imported GPG private key
+      (echo 5; echo y; echo save) |  gpg --command-fd 0 --no-tty --no-greeting -q --edit-key "${GPG_KEY_ID}" trust
+      
+      # Listing the key to verify the import process succeeded
+      gpg --list-secret-keys << pipeline.parameters.CI_BOT_EMAIL >>
+
 install_multicluster_deps: &install_multicluster_deps
   run:
     name: "Install multicluster deps"
@@ -614,6 +641,7 @@ jobs:
     steps:
       - checkout
       - <<: *install_github
+      - <<: *setup_gpg
       - add_ssh_keys:
           fingerprints:
             # Deployment key uploaded to the kubeapps-bot/charts repository
@@ -628,9 +656,12 @@ jobs:
             # the name is always "id_rsa_"+fingerprint without ":""
             ssh-add ~/.ssh/id_rsa_59812a95a654a746e515f537b34f6cad
       - run:
+          # Assuming there is a personal access token created in GitHub granted with the scopes
+          # "repo:status", "public_repo" and "read:org"
+          # This token is passed as a GITHUB_TOKEN env var via CircleCI
           name: Execute the chart_sync script
           command: |
-            ./script/chart_sync.sh kubernetes-bitnami kubernetes@bitnami.com
+            ./script/chart_sync.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >>
   sync_chart_from_bitnami:
     environment:
       <<: *common_envars
@@ -639,6 +670,7 @@ jobs:
     steps:
       - checkout
       - <<: *install_github
+      - <<: *setup_gpg
       - add_ssh_keys:
           fingerprints:
             # Deployment key uploaded to the kubeapps/kubeapps repository
@@ -658,7 +690,7 @@ jobs:
           # This token is passed as a GITHUB_TOKEN env var via CircleCI
           name: Execute the check_upstream_chart script
           command: |
-            ./script/chart_upstream_checker.sh kubernetes-bitnami kubernetes@bitnami.com
+            ./script/chart_upstream_checker.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >>
   push_images:
     docker:
       - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>

--- a/docs/developer/ci.md
+++ b/docs/developer/ci.md
@@ -1,8 +1,8 @@
 # Understanding the CircleCI configuration
 
-Kubeapps leverages CircleCI for running the tests (both unit and integration tests), pushing the images and syncing the chart with the official [Bitnami chart](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps). The following image depicts how a successful workflow looks like (after a push to master).
+Kubeapps leverages CircleCI for running the tests (both unit and integration tests), pushing the images and syncing the chart with the official [Bitnami chart](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps). The following image depicts how a successful workflow looks like (after a push to the main branch).
 
-![CircleCI workflow after pushing to master](../img/ci-workflow-master.png "CircleCI workflow after pushing to master")
+![CircleCI workflow after pushing to the main branch](../img/ci-workflow-master.png "CircleCI workflow after pushing to the main branch")
 
 The main configuration is located at this [CircleCI config file](../../.circleci/config.yml)). At a glance, it contains:
 
@@ -21,10 +21,67 @@ The main configuration is located at this [CircleCI config file](../../.circleci
     - Spin up two Kind clusters.
     - Load the CI images into the cluster.
     - Run the integration tests.
-  - `GKE_x_xx_MASTER` and `GKE_X_XX_LATEST_RELEASE` (on master): there is a job for each [Kubernetes version supported by Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/release-notes) (GKE). It will run the e2e tests in a GKE cluster (version X.XX) using either the code in `master` or in the latest released version. If a change affecting the UI is pushed to master, the e2e test might fail here. Use a try/catch block to temporarily work around this.
+  - `sync_chart_from_bitnami` (on master): each time a new commit is pushed to the main branch, it brings the current changes in the upstream [bitnami/charts repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) and merge the changes. This step involves:
+    - Checking if the chart versions differ.
+    - Deleting the local `chart/kubeapps` folder.may the 4th
+    - Pulling the latest version of the chart provided by Bitnami.
+    - Renaming the production images (`bitnami/kubeapps-xxx`) by the development ones (`kubeapps/xxx`) with the `latest` tag.
+    - Using `DEVEL` as the `appVersion`.
+    - Sending a PR in the Kubeapps repository with these changes.
+  - `GKE_X_XX_MASTER` and `GKE_X_XX_LATEST_RELEASE` (on master): there is a job for each [Kubernetes version supported by Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/release-notes) (GKE). It will run the e2e tests in a GKE cluster (version X.XX) using either the code in `master` or in the latest released version. If a change affecting the UI is pushed to the main branch, the e2e test might fail here. Use a try/catch block to temporarily work around this.
   - `push_images` (on master): the CI images (which have already been built) get re-tagged and pushed to the `kubeapps` account.
+  - `sync_chart_to_bitnami` (on tag): when releasing, it will synchronize our development chart with the [bitnami/charts repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) and merge the changes. This step involves:
+    - Deleting the local `bitnami/kubeapps` folder.
+    - Pulling the latest version of the chart provided by Kubeapps.
+    - Renaming the development images (`kubeapps/xxx`) by the production ones (`bitnami/kubeapps-xxx`) with the `vX.X.X` tag.
+    - Using `vX.X.X` as the `appVersion`.
+    - Sending a PR in the Bitnami Charts repository with these changes.
   - `release` (on tag): it creates a GitHub release based on the current tag by executing the script [script/create_release.sh](../../script/create_release.sh).
 
 Note that this process is independent of the release of the official Bitnami images and chart. These Bitnami images will be created according to their internal process (so the Golang, Node or Rust versions we define here are not used by them. Manual coordination is expected here if a major version bump happens to occur).
 
-Additionally, currently the Kubeapps team is responsible for sending a PR to the [chart repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) each time a new chart version is pushed to the main branch.
+Also note it is the Kubeapps team that is responsible for sending a PR to the [chart repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) each time a new chart version is pushed to the main branch. Even this process is automatic (using the `sync_chart_to_bitnami` workflow), Kubeapps maintainers may decide to send a manual PR early.
+
+# Credentials
+
+Besides other usual credentials or secrets passed through environment variables via the CircleCI user interface, it is important to highlight how we grant commit and PR access to our robot account `kubernetes-bitnami <kubernetes@bitnami.com>`. The process is twofold:
+
+- Create a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the robot account, granted, at least, with: `repo:status`, `public_repo` and `read:org`.
+  - That will allow the GitHub CLI to create PRs from the command line on behalf of our robot account.
+- Add deployment keys to the repositories in which the CI will commit. Currently, they are `kubeapps/kubeapps` and `bitnami/charts`.
+  - This step allows pushing branches to the target repositories, otherwise, we would have to create a private fork under the robot account. However, the CI never pushes to the main branch as it tries to create a pull request.
+
+## Generating and configuring the deployment keys
+
+This step is only run once, and it is very unlikely to change. However, it is important to know it in case of secret rotations or further events.
+
+```bash
+# COPY THIS CONTENT TO GITHUB (with write access):
+## https://github.com/kubeapps/kubeapps/settings/keys
+ssh-keygen -t ed25519 -C "user@example.com" -q -N "" -f circleci-kubeapps-deploymentkey
+echo "Kubeapps deployment key (public)"
+cat circleci-kubeapps-deploymentkey.pub
+
+# COPY THIS CONTENT TO GITHUB (with write access):
+## https://github.com/bitnami/charts/settings/keys
+ssh-keygen -t ed25519 -C "user@example.com" -q -N "" -f circleci-charts-deploymentkey
+echo "Charts deployment key (public)"
+cat circleci-charts-deploymentkey.pub
+
+# COPY THIS CONTENT TO CIRCLECI (hostname: github.com):
+## https://app.circleci.com/settings/project/github/kubeapps/kubeapps/ssh
+echo "Kubeapps deployment key (private)"
+cat circleci-kubeapps-deploymentkey
+
+echo "Charts deployment key (private)"
+cat circleci-charts-deploymentkey
+
+# COPY THE FINGERPRINTS TO ".circleci/config.yml"
+## sync_chart_from_bitnami
+echo "Charts deployment key (fingerprint) - edit 'sync_chart_from_bitnami'"
+ssh-keygen -l -E md5 -f circleci-kubeapps-deploymentkey.pub
+
+## sync_chart_to_bitnami
+echo "Charts deployment key (fingerprint) - edit 'sync_chart_to_bitnami'"
+ssh-keygen -l -E md5 -f circleci-charts-deploymentkey.pub
+```

--- a/docs/developer/ci.md
+++ b/docs/developer/ci.md
@@ -21,21 +21,22 @@ The main configuration is located at this [CircleCI config file](../../.circleci
     - Spin up two Kind clusters.
     - Load the CI images into the cluster.
     - Run the integration tests.
-  - `sync_chart_from_bitnami` (on master): each time a new commit is pushed to the main branch, it brings the current changes in the upstream [bitnami/charts repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) and merge the changes. This step involves:
-    - Checking if the chart versions differ.
-    - Deleting the local `chart/kubeapps` folder.
+  - `sync_chart_from_bitnami` (on master): each time a new commit is pushed to the main branch, it brings the current changes in the upstream [bitnami/charts repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) and merges the changes. This step involves:
+    - Checking if the Bitnami chart version is greater than the Kubeapps development chart version. If not, abort.
+    - Deleting the local `chart/kubeapps` folder (note that the changes are already commited in git).
     - Pulling the latest version of the chart provided by Bitnami.
     - Renaming the production images (`bitnami/kubeapps-xxx`) by the development ones (`kubeapps/xxx`) with the `latest` tag.
     - Using `DEVEL` as the `appVersion`.
-    - Sending a PR in the Kubeapps repository with these changes.
+    - Sending a PR in the Kubeapps repository with these changes (from a pushed branch in the Kubeapps repository).
   - `GKE_X_XX_MASTER` and `GKE_X_XX_LATEST_RELEASE` (on master): there is a job for each [Kubernetes version supported by Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/release-notes) (GKE). It will run the e2e tests in a GKE cluster (version X.XX) using either the code in `master` or in the latest released version. If a change affecting the UI is pushed to the main branch, the e2e test might fail here. Use a try/catch block to temporarily work around this.
   - `push_images` (on master): the CI images (which have already been built) get re-tagged and pushed to the `kubeapps` account.
   - `sync_chart_to_bitnami` (on tag): when releasing, it will synchronize our development chart with the [bitnami/charts repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) and merge the changes. This step involves:
-    - Deleting the local `bitnami/kubeapps` folder.
+    - Checking if the Kubeapps development chart version is greater than the Bitnami chart version. If not, abort.
+    - Deleting the local `bitnami/kubeapps` folder (note that the changes are already commited in git).
     - Pulling the latest version of the chart provided by Kubeapps.
     - Renaming the development images (`kubeapps/xxx`) by the production ones (`bitnami/kubeapps-xxx`) with the `vX.X.X` tag.
     - Using `vX.X.X` as the `appVersion`.
-    - Sending a PR in the Bitnami Charts repository with these changes.
+    - Sending a PR to the Bitnami Charts repository with these changes (from the robot account's personal fork)
   - `release` (on tag): it creates a GitHub release based on the current tag by executing the script [script/create_release.sh](../../script/create_release.sh).
 
 Note that this process is independent of the release of the official Bitnami images and chart. These Bitnami images will be created according to their internal process (so the Golang, Node or Rust versions we define here are not used by them. Manual coordination is expected here if a major version bump happens to occur).
@@ -44,12 +45,15 @@ Also, note it is the Kubeapps team that is responsible for sending a PR to the [
 
 # Credentials
 
-Besides other usual credentials or secrets passed through environment variables via the CircleCI user interface, it is important to highlight how we grant commit and PR access to our robot account `kubeapps-bot <tanzu-kubeapps-team@vmware.com>`. The process is twofold:
+Besides other usual credentials or secrets passed through environment variables via the CircleCI user interface, it is important to highlight how we grant commit and PR access to our robot account `kubeapps-bot <tanzu-kubeapps-team@vmware.com>`. The process is threefold:
 
-- Create a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the robot account, granted, at least, with: `repo:status`, `public_repo` and `read:org`.
+- Create a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the robot account, granted, at least, with: `repo:status`, `public_repo` and `read:org`. This token must be stored as the environment variable `GITHUB_TOKEN` (is where Github CLI will look for)
   - That will allow the GitHub CLI to create PRs from the command line on behalf of our robot account.
-- Add deployment keys to the repositories in which the CI will commit. Currently, they are `kubeapps/kubeapps` and `bitnami/charts`.
-  - This step allows pushing branches to the target repositories, otherwise, we would have to create a private fork under the robot account. However, the CI never pushes to the main branch as it tries to create a pull request.
+  - Also, this token will be used for performing authenticated GitHub API calls.
+- Add deployment keys to the repositories in which the CI will commit. Currently, they are `kubeapps/kubeapps` and `kubeapps-bot/charts`.
+  - This step allows the robot account to push branches remotely. However, the CI will never push to the main branch as it always tries to create a pull request.
+- Add the robot account GPG key pair in the `GPG_KEY_PUBLIC` and `GPG_KEY_PRIVATE` environment variables.
+  - The public key must be also uploaded in the robot account GPG settings in GitHub. It will be used for signing the commits and tags created by this account.
 
 ## Generating and configuring the deployment keys
 
@@ -58,13 +62,13 @@ This step is only run once, and it is very unlikely to change. However, it is im
 ```bash
 # COPY THIS CONTENT TO GITHUB (with write access):
 ## https://github.com/kubeapps/kubeapps/settings/keys
-ssh-keygen -t ed25519 -C "user@example.com" -q -N "" -f circleci-kubeapps-deploymentkey
+ssh-keygen -t ed25519 -C "tanzu-kubeapps-team@vmware.com" -q -N "" -f circleci-kubeapps-deploymentkey
 echo "Kubeapps deployment key (public)"
 cat circleci-kubeapps-deploymentkey.pub
 
 # COPY THIS CONTENT TO GITHUB (with write access):
-## https://github.com/bitnami/charts/settings/keys
-ssh-keygen -t ed25519 -C "user@example.com" -q -N "" -f circleci-charts-deploymentkey
+## https://github.com/kubeapps-bot/charts/settings/keys
+ssh-keygen -t ed25519 -C "tanzu-kubeapps-team@vmware.com" -q -N "" -f circleci-charts-deploymentkey
 echo "Charts deployment key (public)"
 cat circleci-charts-deploymentkey.pub
 

--- a/docs/developer/ci.md
+++ b/docs/developer/ci.md
@@ -44,7 +44,7 @@ Also, note it is the Kubeapps team that is responsible for sending a PR to the [
 
 # Credentials
 
-Besides other usual credentials or secrets passed through environment variables via the CircleCI user interface, it is important to highlight how we grant commit and PR access to our robot account `kubernetes-bitnami <kubernetes@bitnami.com>`. The process is twofold:
+Besides other usual credentials or secrets passed through environment variables via the CircleCI user interface, it is important to highlight how we grant commit and PR access to our robot account `kubeapps-bot <tanzu-kubeapps-team@vmware.com>`. The process is twofold:
 
 - Create a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the robot account, granted, at least, with: `repo:status`, `public_repo` and `read:org`.
   - That will allow the GitHub CLI to create PRs from the command line on behalf of our robot account.

--- a/docs/developer/ci.md
+++ b/docs/developer/ci.md
@@ -40,7 +40,7 @@ The main configuration is located at this [CircleCI config file](../../.circleci
 
 Note that this process is independent of the release of the official Bitnami images and chart. These Bitnami images will be created according to their internal process (so the Golang, Node or Rust versions we define here are not used by them. Manual coordination is expected here if a major version bump happens to occur).
 
-Also note it is the Kubeapps team that is responsible for sending a PR to the [chart repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) each time a new chart version is pushed to the main branch. Even this process is automatic (using the `sync_chart_to_bitnami` workflow), Kubeapps maintainers may decide to send a manual PR early.
+Also, note it is the Kubeapps team that is responsible for sending a PR to the [chart repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) each time a new chart version is to be released. Even this process is automatic (using the `sync_chart_to_bitnami` workflow), Kubeapps maintainers may decide to send a manual PR early.
 
 # Credentials
 

--- a/docs/developer/ci.md
+++ b/docs/developer/ci.md
@@ -27,7 +27,7 @@ The main configuration is located at this [CircleCI config file](../../.circleci
     - Pulling the latest version of the chart provided by Bitnami.
     - Renaming the production images (`bitnami/kubeapps-xxx`) by the development ones (`kubeapps/xxx`) with the `latest` tag.
     - Using `DEVEL` as the `appVersion`.
-    - Sending a PR in the Kubeapps repository with these changes (from a pushed branch in the Kubeapps repository).
+    - Sending a draft PR in the Kubeapps repository with these changes (from a pushed branch in the Kubeapps repository).
   - `GKE_X_XX_MASTER` and `GKE_X_XX_LATEST_RELEASE` (on master): there is a job for each [Kubernetes version supported by Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/release-notes) (GKE). It will run the e2e tests in a GKE cluster (version X.XX) using either the code in `master` or in the latest released version. If a change affecting the UI is pushed to the main branch, the e2e test might fail here. Use a try/catch block to temporarily work around this.
   - `push_images` (on master): the CI images (which have already been built) get re-tagged and pushed to the `kubeapps` account.
   - `sync_chart_to_bitnami` (on tag): when releasing, it will synchronize our development chart with the [bitnami/charts repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) and merge the changes. This step involves:
@@ -36,12 +36,12 @@ The main configuration is located at this [CircleCI config file](../../.circleci
     - Pulling the latest version of the chart provided by Kubeapps.
     - Renaming the development images (`kubeapps/xxx`) by the production ones (`bitnami/kubeapps-xxx`) with the `vX.X.X` tag.
     - Using `vX.X.X` as the `appVersion`.
-    - Sending a PR to the Bitnami Charts repository with these changes (from the robot account's personal fork)
+    - Sending a draft PR to the Bitnami Charts repository with these changes (from the robot account's personal fork)
   - `release` (on tag): it creates a GitHub release based on the current tag by executing the script [script/create_release.sh](../../script/create_release.sh).
 
 Note that this process is independent of the release of the official Bitnami images and chart. These Bitnami images will be created according to their internal process (so the Golang, Node or Rust versions we define here are not used by them. Manual coordination is expected here if a major version bump happens to occur).
 
-Also, note it is the Kubeapps team that is responsible for sending a PR to the [chart repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) each time a new chart version is to be released. Even this process is automatic (using the `sync_chart_to_bitnami` workflow), Kubeapps maintainers may decide to send a manual PR early.
+Also, note it is the Kubeapps team that is responsible for sending a PR to the [chart repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) each time a new chart version is to be released. Even this process is automatic (using the `sync_chart_to_bitnami` workflow), Kubeapps maintainers must manually review the draft PR and convert it into a normal one once it is ready for review.
 
 # Credentials
 

--- a/docs/developer/ci.md
+++ b/docs/developer/ci.md
@@ -23,7 +23,7 @@ The main configuration is located at this [CircleCI config file](../../.circleci
     - Run the integration tests.
   - `sync_chart_from_bitnami` (on master): each time a new commit is pushed to the main branch, it brings the current changes in the upstream [bitnami/charts repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) and merge the changes. This step involves:
     - Checking if the chart versions differ.
-    - Deleting the local `chart/kubeapps` folder.may the 4th
+    - Deleting the local `chart/kubeapps` folder.
     - Pulling the latest version of the chart provided by Bitnami.
     - Renaming the production images (`bitnami/kubeapps-xxx`) by the development ones (`kubeapps/xxx`) with the `latest` tag.
     - Using `DEVEL` as the `appVersion`.

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -58,7 +58,7 @@ Even though the official [Bitnami chart](https://github.com/bitnami/charts/tree/
 
 #### 0.3.1 - Chart images
 
-Currenty, the [values.yaml](../../chart/kubeapps/values.yaml) uses the following container images:
+Currently, the [values.yaml](../../chart/kubeapps/values.yaml) uses the following container images:
 
 - [bitnami/nginx](https://hub.docker.com/r/bitnami/nginx/tags)
 - [bitnami/kubectl](https://hub.docker.com/r/bitnami/kubectl/tags)
@@ -115,11 +115,14 @@ cargo update
 
 > As part of this release process, the dashboard deps _must_ be updated, the golang deps _should_ be updated, the rust deps _should_ be updated and the security check _must_ be performed.
 
-## 1 - Send a PR to the bitnami/chart repository
+## 1 - Wait until the PR to the bitnami/chart repository is accepted
 
-Since the chart that we host in the Kubeapps repository is only intended for development purposes, we need to synchronize it with the official one in the [bitnami/charts repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps). To this end, we need to send a PR with the changes to their repository and wait until it gets accepted. Please note that the changes in both charts may involve additions and deletions, so we need to handle them properly (e.g., deleting the files first, performing a rsync, etc.).
+Since the chart that we host in the Kubeapps repository is only intended for development purposes, we need to synchronize it with the official one in the [bitnami/charts repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps).
 
-> This step is currently manual albeit prone to change shortly.
+To this end, our CI system will automatically (in the `sync_chart_from_bitnami` workflow, as described in the [CI documentation](./ci.md).) send to send a PR with the current development changes to [their repository](https://github.com/bitnami/charts/pulls) whenever a new release is triggered.
+Once the PR has been created, wait for someone from the Bitnami team to review and accept it.
+
+> If the PR solely includes minor changes in the image versions, this wait can be safely skipped.
 
 ## 2 - Select the commit to tag and perform a manual test
 

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -119,7 +119,7 @@ cargo update
 
 Since the chart that we host in the Kubeapps repository is only intended for development purposes, we need to synchronize it with the official one in the [bitnami/charts repository](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps).
 
-To this end, our CI system will automatically (in the `sync_chart_from_bitnami` workflow, as described in the [CI documentation](./ci.md).) send to send a PR with the current development changes to [their repository](https://github.com/bitnami/charts/pulls) whenever a new release is triggered.
+To this end, our CI system will automatically (in the `sync_chart_from_bitnami` workflow, as described in the [CI documentation](./ci.md).) send a PR with the current development changes to [their repository](https://github.com/bitnami/charts/pulls) whenever a new release is triggered.
 Once the PR has been created, wait for someone from the Bitnami team to review and accept it.
 
 > If the PR solely includes minor changes in the image versions, this wait can be safely skipped.

--- a/script/PR_external_chart_template.md
+++ b/script/PR_external_chart_template.md
@@ -2,7 +2,7 @@ Signed-off-by: <USER> <EMAIL>
 
 **Description of the change**
 
-This is an automatic PR for synchronizing the changes performed externally at the [kubeapps development chart](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps) official chart.
+This is an automatic PR for synchronizing the changes performed externally at the [kubeapps development chart](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps) to the official Bitnami chart.
 
 **Benefits**
 
@@ -10,7 +10,7 @@ The Kubeapps [bitnami/kubeapps chart](https://github.com/bitnami/charts/tree/mas
 
 **Possible drawbacks**
 
-Even unlikely, some changes implemented by the Kubeapps team may not be 100% compatible with the current chart version.
+Although unlikely, some changes implemented by the Kubeapps team may not be 100% compatible with the current chart version.
 
 **Applicable issues**
 

--- a/script/PR_external_chart_template.md
+++ b/script/PR_external_chart_template.md
@@ -1,0 +1,27 @@
+Signed-off-by: <USER> <EMAIL>
+
+**Description of the change**
+
+This is an automatic PR for synchronizing the changes performed externally at the [kubeapps development chart](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps) official chart.
+
+**Benefits**
+
+The Kubeapps [bitnami/kubeapps chart](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) will get the newest changes, including image version updates and other updates.
+
+**Possible drawbacks**
+
+Even unlikely, some changes implemented by the Kubeapps team may not be 100% compatible with the current chart version.
+
+**Applicable issues**
+
+N/A
+
+**Additional information**
+
+This is an automatic PR managed by the Kubeapps team.
+
+**Checklist**
+
+- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
+- [ ] Variables are documented in the README.md
+- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

--- a/script/PR_internal_chart_template.md
+++ b/script/PR_internal_chart_template.md
@@ -1,0 +1,19 @@
+### Description of the change
+
+This is an automatic PR for synchronizing the changes performed externally at the [bitnami/kubeapps](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) official chart.
+
+### Benefits
+
+The Kubeapps [development chart](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps) will get the newest changes, including image version updates and other updates.
+
+### Possible drawbacks
+
+Even unlikely, some changes implemented by the Bitnami team may not be 100% compatible with the current Kubeapps version.
+
+### Applicable issues
+
+N/A
+
+### Additional information
+
+This PR is marked as a draft until a Kubeapps maintainer manually reviews it.

--- a/script/PR_internal_chart_template.md
+++ b/script/PR_internal_chart_template.md
@@ -1,6 +1,6 @@
 ### Description of the change
 
-This is an automatic PR for synchronizing the changes performed externally at the [bitnami/kubeapps](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) official chart.
+This is an automatic PR for synchronizing the changes performed externally at the [bitnami/kubeapps official chart](https://github.com/bitnami/charts/tree/master/bitnami/kubeapps) to the Kubeapps development version.
 
 ### Benefits
 
@@ -8,7 +8,7 @@ The Kubeapps [development chart](https://github.com/kubeapps/kubeapps/tree/maste
 
 ### Possible drawbacks
 
-Even unlikely, some changes implemented by the Bitnami team may not be 100% compatible with the current Kubeapps version.
+Although unlikely, some changes implemented by the Bitnami team may not be 100% compatible with the current Kubeapps version.
 
 ### Applicable issues
 

--- a/script/chart_sync.sh
+++ b/script/chart_sync.sh
@@ -19,12 +19,13 @@ source $(dirname $0)/chart_sync_utils.sh
 
 user=${1:?}
 email=${2:?}
+gpg=${3:?}
 if changedVersion; then
     tempDir=$(mktemp -u)/charts
     mkdir -p $tempDir
     git clone https://github.com/${CHARTS_REPO} $tempDir --depth 1 --no-single-branch 
-    configUser $tempDir $user $email
-    configUser $PROJECT_DIR $user $email
+    configUser $tempDir $user $email $gpg
+    configUser $PROJECT_DIR $user $email $gpg
     latestVersion=$(latestReleaseTag $PROJECT_DIR)
     updateRepoWithLocalChanges $tempDir $latestVersion
     commitAndSendExternalPR $tempDir "kubeapps-bump-${latestVersion}"

--- a/script/chart_sync.sh
+++ b/script/chart_sync.sh
@@ -20,17 +20,23 @@ source $(dirname $0)/chart_sync_utils.sh
 user=${1:?}
 email=${2:?}
 gpg=${3:?}
-if changedVersion; then
+
+currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep -oP '(?<=^version: ).*' )
+externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO_ORIGINAL}/master/${CHART_REPO_PATH}/Chart.yaml | grep -oP '(?<=^version: ).*' )
+semverCompare=$(semver compare "${currentVersion}" "${externalVersion}")
+# If current version is greater than the chart external version, then send a PR bumping up the version externally 
+if [[ ${semverCompare} -gt 0 ]]; then
+    echo "Current chart version ("${currentVersion}") is greater than the chart external version ("${externalVersion}")"
     tempDir=$(mktemp -u)/charts
     mkdir -p $tempDir
-    git clone https://github.com/${CHARTS_REPO} $tempDir --depth 1 --no-single-branch 
-    git remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
-    git pull upstream master
+    git clone https://github.com/${CHARTS_REPO} $tempDir --depth 1 --no-single-branch
     configUser $tempDir $user $email $gpg
     configUser $PROJECT_DIR $user $email $gpg
     latestVersion=$(latestReleaseTag $PROJECT_DIR)
     updateRepoWithLocalChanges $tempDir $latestVersion
-    commitAndSendExternalPR $tempDir "kubeapps-bump-${latestVersion}"
+    commitAndSendExternalPR $tempDir "kubeapps-bump-${currentVersion}"
+elif [[ ${semverCompare} -lt 0 ]]; then
+    echo "Skipping Chart sync. WARNING Current chart version ("${currentVersion}") is less than the chart external version ("${externalVersion}")"
 else
-    echo "Skipping Chart sync. The version has not changed"
+    echo "Skipping Chart sync. The chart version ("${currentVersion}") has not changed"
 fi

--- a/script/chart_sync.sh
+++ b/script/chart_sync.sh
@@ -24,6 +24,8 @@ if changedVersion; then
     tempDir=$(mktemp -u)/charts
     mkdir -p $tempDir
     git clone https://github.com/${CHARTS_REPO} $tempDir --depth 1 --no-single-branch 
+    git remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
+    git pull upstream master
     configUser $tempDir $user $email $gpg
     configUser $PROJECT_DIR $user $email $gpg
     latestVersion=$(latestReleaseTag $PROJECT_DIR)

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -41,9 +41,13 @@ configUser() {
     local targetRepo=${1:?}
     local user=${2:?}
     local email=${3:?}
+    local gpg=${4:?}
     cd $targetRepo
     git config user.name "$user"
     git config user.email "$email"
+    git config user.signingkey "$gpg"
+    git config --global commit.gpgSign true
+    git config --global tag.gpgSign true
     cd -
 }
 

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -21,7 +21,7 @@ set -e
 ## the development chart repository (KUBEAPPS_REPO)
 CHARTS_REPO_ORIGINAL="bitnami/charts"
 CHARTS_REPO="kubeapps-bot/charts"
-KUBEAPPS_REPO="bitnami/kubeapps"
+KUBEAPPS_REPO="kubeapps/kubeapps"
 
 CHART_REPO_PATH="bitnami/kubeapps"
 PROJECT_DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd`

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -171,7 +171,7 @@ commitAndSendExternalPR() {
     git commit -m "kubeapps: bump chart version to $chartVersion"
     # NOTE: This expects to have a loaded SSH key
     git push -u origin $targetBranch
-    gh pr create -B master -R ${CHARTS_REPO_ORIGINAL} -F ${PR_EXTERNAL_TEMPLATE_FILE} --title "[bitnami/kubeapps] Bump chart version to $chartVersion"
+    gh pr create -d -B master -R ${CHARTS_REPO_ORIGINAL} -F ${PR_EXTERNAL_TEMPLATE_FILE} --title "[bitnami/kubeapps] Bump chart version to $chartVersion"
     cd -
 }
 
@@ -197,5 +197,5 @@ commitAndSendInternalPR() {
     git commit -m "bump chart version to $chartVersion"
     # NOTE: This expects to have a loaded SSH key
     git push -u origin $targetBranch
-    gh pr create -d-B master -R ${KUBEAPPS_REPO} -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"
+    gh pr create -d -B master -R ${KUBEAPPS_REPO} -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"
 }

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -106,6 +106,9 @@ updateRepoWithLocalChanges() {
         echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
         return 1
     fi
+    git -C "${targetRepo}" remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
+    git -C "${targetRepo}" pull upstream master
+    git -C "${targetRepo}" push origin master
     rm -rf "${targetChartPath}"
     cp -R "${KUBEAPPS_CHART_DIR}" "${targetChartPath}"
     # Update Chart.yaml with new version
@@ -163,9 +166,6 @@ commitAndSendExternalPR() {
     sed -i.bk -e "s/<USER>/`git config user.name`/g" "${PR_EXTERNAL_TEMPLATE_FILE}"
     sed -i.bk -e "s/<EMAIL>/`git config user.email`/g" "${PR_EXTERNAL_TEMPLATE_FILE}"
     local chartVersion=$(grep -e '^version:' ${chartYaml} | awk '{print $2}')
-    git remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
-    git pull upstream master
-    git push origin master
     git checkout -b $targetBranch
     git add --all .
     git commit -m "kubeapps: bump chart version to $chartVersion"
@@ -197,5 +197,5 @@ commitAndSendInternalPR() {
     git commit -m "bump chart version to $chartVersion"
     # NOTE: This expects to have a loaded SSH key
     git push -u origin $targetBranch
-    gh pr create -B master -R ${KUBEAPPS_REPO} -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"
+    gh pr create -d-B master -R ${KUBEAPPS_REPO} -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"
 }

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -57,8 +57,8 @@ replaceImage_latestToProduction() {
     echo "Replacing ${service}"...
 
     local curl_opts=()
-    if [[ $ACCESS_TOKEN != "" ]]; then
-        curl_opts=(-s -H "Authorization: token ${ACCESS_TOKEN}")
+    if [[ $GITHUB_TOKEN != "" ]]; then
+        curl_opts=(-s -H "Authorization: token ${GITHUB_TOKEN}")
     fi
 
     # Get the latest tag from the bitnami repository
@@ -165,7 +165,7 @@ commitAndSendExternalPR() {
     git commit -m "kubeapps: bump chart version to $chartVersion"
     # NOTE: This expects to have a loaded SSH key
     git push origin $targetBranch
-     git config --local "remote.origin.gh-resolved" ${CHARTS_REPO}
+    git config --local "remote.origin.gh-resolved" ${CHARTS_REPO}
     gh pr create -H $targetBranch -B master -F ${PR_EXTERNAL_TEMPLATE_FILE} --title "[bitnami/kubeapps] Bump chart version to $chartVersion"
     cd -
 }
@@ -190,7 +190,7 @@ commitAndSendInternalPR() {
     git checkout -b $targetBranch
     git add --all .
     git commit -m "bump chart version to $chartVersion"
-    # NOTE: This expecs to have a loaded SSH key
+    # NOTE: This expects to have a loaded SSH key
     git push origin $targetBranch
     git config --local "remote.origin.gh-resolved" ${KUBEAPPS_REPO}
     gh pr create -H $targetBranch -d -B master -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -37,18 +37,18 @@ latestReleaseTag() {
     }
 
 changedVersion() {
-    local currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep "version:")
-    local externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO}/master/${CHART_REPO_PATH}/Chart.yaml | grep "version:")
+    local currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep -oP '(?<=^version: ).*' )
+    local externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO}/master/${CHART_REPO_PATH}/Chart.yaml | grep -oP '(?<=^version: ).*' )
     local semverCompare=$(semver compare "${currentVersion}" "${externalVersion}")
     if [[ ${semverCompare} -lt 0 ]]; then
         echo "Current chart version ("${currentVersion}") is less than the chart external version ("${externalVersion}")"
         true
     elif [[ ${semverCompare} -eq 0 ]]; then
-        echo "Both chart versions are equal"
+        echo "Both chart versions ("${currentVersion}") and ("${externalVersion}") are equal"
         false
     else
-        echo "WARNING: the current chart version ("${currentVersion}") is greater than the chart external version ("${externalVersion}")."
-        false
+        echo "Current current chart version ("${currentVersion}") is greater than the chart external version ("${externalVersion}")"
+        true
     fi
 }
 

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -16,14 +16,19 @@
 set -e
 
 CHARTS_REPO="bitnami/charts"
+KUBEAPPS_REPO="bitnami/kubeapps"
 CHART_REPO_PATH="bitnami/kubeapps"
 PROJECT_DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd`
 KUBEAPPS_CHART_DIR="${PROJECT_DIR}/chart/kubeapps"
+PR_INTERNAL_TEMPLATE_FILE="${PROJECT_DIR}/script/PR_internal_chart_template.md"
+PR_EXTERNAL_TEMPLATE_FILE="${PROJECT_DIR}/script/PR_external_chart_template.md"
 
 # Returns the tag for the latest release
 latestReleaseTag() {
-  git describe --tags $(git rev-list --tags --max-count=1)
-}
+    local targetRepo=${1:?}
+    git -C "${targetRepo}/.git" fetch --tags
+    git -C "${targetRepo}/.git" describe --tags $(git rev-list --tags --max-count=1)
+    }
 
 changedVersion() {
     local currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep "version:")
@@ -42,7 +47,7 @@ configUser() {
     cd -
 }
 
-replaceImage() {
+replaceImage_latestToProduction() {
     local service=${1:?}
     local file=${2:?}
     local repoName="bitnami-docker-kubeapps-${service}"
@@ -71,7 +76,24 @@ replaceImage() {
     rm "${file}.bk"
 }
 
-updateRepo() {
+replaceImage_productionToLatest() {
+    local service=${1:?}
+    local file=${2:?}
+    local targetTag=${3:?}
+    local repoName="bitnami-docker-kubeapps-${service}"
+    local currentImageEscaped="bitnami\/kubeapps-${service}"
+    local targetImageEscaped="kubeapps\/${service}"
+
+    echo "Replacing ${service}"...
+
+    # Replace image and tag from the values.yaml
+    sed -i.bk -e '1h;2,$H;$!d;g' -re  \
+      's/repository: '${currentImageEscaped}'\n    tag: \S*/repository: '${targetImageEscaped}'\n    tag: latest/g' \
+      ${file}
+    rm "${file}.bk"
+}
+
+updateRepoWithLocalChanges() {
     local targetRepo=${1:?}
     local targetTag=${2:?}
     local targetTagWithoutV=${targetTag#v}
@@ -87,15 +109,40 @@ updateRepo() {
     sed -i.bk 's/appVersion: DEVEL/appVersion: '"${targetTagWithoutV}"'/g' "${chartYaml}"
     rm "${targetChartPath}/Chart.yaml.bk"
     # Replace images for the latest available
-    replaceImage dashboard "${targetChartPath}/values.yaml"
-    replaceImage apprepository-controller "${targetChartPath}/values.yaml"
-    replaceImage asset-syncer "${targetChartPath}/values.yaml"
-    replaceImage assetsvc "${targetChartPath}/values.yaml"
-    replaceImage kubeops "${targetChartPath}/values.yaml"
-    replaceImage pinniped-proxy "${targetChartPath}/values.yaml"
+    replaceImage_latestToProduction dashboard "${targetChartPath}/values.yaml"
+    replaceImage_latestToProduction apprepository-controller "${targetChartPath}/values.yaml"
+    replaceImage_latestToProduction asset-syncer "${targetChartPath}/values.yaml"
+    replaceImage_latestToProduction assetsvc "${targetChartPath}/values.yaml"
+    replaceImage_latestToProduction kubeops "${targetChartPath}/values.yaml"
+    replaceImage_latestToProduction pinniped-proxy "${targetChartPath}/values.yaml"
 }
 
-commitAndPushChanges() {
+updateRepoWithRemoteChanges() {
+    local targetRepo=${1:?}
+    local targetTag=${2:?}
+    local targetTagWithoutV=${targetTag#v}
+    local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
+    local remoteChartYaml="${targetChartPath}/Chart.yaml"
+    local localChartYaml="${KUBEAPPS_CHART_DIR}/Chart.yaml"
+    if [ ! -f "${remoteChartYaml}" ]; then
+        echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
+        return 1
+    fi
+    rm -rf "${KUBEAPPS_CHART_DIR}"
+    cp -R "${targetChartPath}" "${KUBEAPPS_CHART_DIR}"
+    # Update Chart.yaml with new version
+    sed -i.bk "s/appVersion: "${targetTagWithoutV}"/appVersion: DEVEL/g" "${localChartYaml}"
+    rm "${KUBEAPPS_CHART_DIR}/Chart.yaml.bk"
+    # Replace images for the latest available
+    replaceImage_productionToLatest dashboard "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
+    replaceImage_productionToLatest apprepository-controller "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
+    replaceImage_productionToLatest asset-syncer "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
+    replaceImage_productionToLatest assetsvc "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
+    replaceImage_productionToLatest kubeops "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
+    replaceImage_productionToLatest pinniped-proxy "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
+}
+
+commitAndSendExternalPR() {
     local targetRepo=${1:?}
     local targetBranch=${2:-"master"}
     local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
@@ -109,11 +156,43 @@ commitAndPushChanges() {
         echo "Not found any change to commit" > /dev/stderr
         cd -
         return 1
-    fi
+    fi 
+    sed -i.bk -e "s/<USER>/`git config user.name`/g" "${PR_EXTERNAL_TEMPLATE_FILE}"
+    sed -i.bk -e "s/<EMAIL>/`git config user.email`/g" "${PR_EXTERNAL_TEMPLATE_FILE}"
     local chartVersion=$(grep -e '^version:' ${chartYaml} | awk '{print $2}')
+    git checkout -b $targetBranch
     git add --all .
     git commit -m "kubeapps: bump chart version to $chartVersion"
     # NOTE: This expects to have a loaded SSH key
     git push origin $targetBranch
+     git config --local "remote.origin.gh-resolved" ${CHARTS_REPO}
+    gh pr create -H $targetBranch -B master -F ${PR_EXTERNAL_TEMPLATE_FILE} --title "[bitnami/kubeapps] Bump chart version to $chartVersion"
+    cd -
+}
+
+commitAndSendInternalPR() {
+    local targetRepo=${1:?}
+    local targetBranch=${2:-"master"}
+    local targetChartPath="${KUBEAPPS_CHART_DIR}/Chart.yaml"
+    local localChartYaml="${KUBEAPPS_CHART_DIR}/Chart.yaml"
+
+    if [ ! -f "${localChartYaml}" ]; then
+        echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
+        return 1
+    fi
+    cd $targetRepo
+    if [[ ! $(git diff-index HEAD) ]]; then
+        echo "Not found any change to commit" > /dev/stderr
+        cd -
+        return 1
+    fi
+    local chartVersion=$(grep -e '^version:' ${localChartYaml} | awk '{print $2}')
+    git checkout -b $targetBranch
+    git add --all .
+    git commit -m "bump chart version to $chartVersion"
+    # NOTE: This expecs to have a loaded SSH key
+    git push origin $targetBranch
+    git config --local "remote.origin.gh-resolved" ${KUBEAPPS_REPO}
+    gh pr create -H $targetBranch -d -B master -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"
     cd -
 }

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -15,8 +15,14 @@
 
 set -e
 
-CHARTS_REPO="bitnami/charts"
+# Remote github repostories for:
+## the upstream chart repository fork (CHARTS_REPO)
+## the upstream chart original repository (CHARTS_REPO_ORIGINAL)
+## the development chart repository (KUBEAPPS_REPO)
+CHARTS_REPO_ORIGINAL="bitnami/charts"
+CHARTS_REPO="kubeapps-bot/charts"
 KUBEAPPS_REPO="bitnami/kubeapps"
+
 CHART_REPO_PATH="bitnami/kubeapps"
 PROJECT_DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd`
 KUBEAPPS_CHART_DIR="${PROJECT_DIR}/chart/kubeapps"

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -36,22 +36,6 @@ latestReleaseTag() {
     git -C "${targetRepo}/.git" describe --tags $(git rev-list --tags --max-count=1)
     }
 
-changedVersion() {
-    local currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep -oP '(?<=^version: ).*' )
-    local externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO}/master/${CHART_REPO_PATH}/Chart.yaml | grep -oP '(?<=^version: ).*' )
-    local semverCompare=$(semver compare "${currentVersion}" "${externalVersion}")
-    if [[ ${semverCompare} -lt 0 ]]; then
-        echo "Current chart version ("${currentVersion}") is less than the chart external version ("${externalVersion}")"
-        true
-    elif [[ ${semverCompare} -eq 0 ]]; then
-        echo "Both chart versions ("${currentVersion}") and ("${externalVersion}") are equal"
-        false
-    else
-        echo "Current current chart version ("${currentVersion}") is greater than the chart external version ("${externalVersion}")"
-        true
-    fi
-}
-
 configUser() {
     local targetRepo=${1:?}
     local user=${2:?}
@@ -179,13 +163,15 @@ commitAndSendExternalPR() {
     sed -i.bk -e "s/<USER>/`git config user.name`/g" "${PR_EXTERNAL_TEMPLATE_FILE}"
     sed -i.bk -e "s/<EMAIL>/`git config user.email`/g" "${PR_EXTERNAL_TEMPLATE_FILE}"
     local chartVersion=$(grep -e '^version:' ${chartYaml} | awk '{print $2}')
+    git remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
+    git pull upstream master
+    git push origin master
     git checkout -b $targetBranch
     git add --all .
     git commit -m "kubeapps: bump chart version to $chartVersion"
     # NOTE: This expects to have a loaded SSH key
-    git push origin $targetBranch
-    git config --local "remote.origin.gh-resolved" ${CHARTS_REPO}
-    gh pr create -H $targetBranch -B master -F ${PR_EXTERNAL_TEMPLATE_FILE} --title "[bitnami/kubeapps] Bump chart version to $chartVersion"
+    git push -u origin $targetBranch
+    gh pr create -B master -R ${CHARTS_REPO_ORIGINAL} -F ${PR_EXTERNAL_TEMPLATE_FILE} --title "[bitnami/kubeapps] Bump chart version to $chartVersion"
     cd -
 }
 
@@ -210,8 +196,6 @@ commitAndSendInternalPR() {
     git add --all .
     git commit -m "bump chart version to $chartVersion"
     # NOTE: This expects to have a loaded SSH key
-    git push origin $targetBranch
-    git config --local "remote.origin.gh-resolved" ${KUBEAPPS_REPO}
-    gh pr create -H $targetBranch -d -B master -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"
-    cd -
+    git push -u origin $targetBranch
+    gh pr create -B master -R ${KUBEAPPS_REPO} -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"
 }

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -33,8 +33,17 @@ latestReleaseTag() {
 changedVersion() {
     local currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep "version:")
     local externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO}/master/${CHART_REPO_PATH}/Chart.yaml | grep "version:")
-    # NOTE: If curl returns an error this will return always true
-    [[ "$currentVersion" != "$externalVersion" ]]
+    local semverCompare=$(semver compare "${currentVersion}" "${externalVersion}")
+    if [[ ${semverCompare} -lt 0 ]]; then
+        echo "Current chart version ("${currentVersion}") is less than the chart external version ("${externalVersion}")"
+        true
+    elif [[ ${semverCompare} -eq 0 ]]; then
+        echo "Both chart versions are equal"
+        false
+    else
+        echo "WARNING: the current chart version ("${currentVersion}") is greater than the chart external version ("${externalVersion}")."
+        false
+    fi
 }
 
 configUser() {

--- a/script/chart_upstream_checker.sh
+++ b/script/chart_upstream_checker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018 Bitnami
+# Copyright (c) 2021 Bitnami
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/script/chart_upstream_checker.sh
+++ b/script/chart_upstream_checker.sh
@@ -19,12 +19,13 @@ source $(dirname $0)/chart_sync_utils.sh
 
 user=${1:?}
 email=${2:?}
+gpg=${3:?}
 if changedVersion; then
     tempDir=$(mktemp -u)/charts
     mkdir -p $tempDir
     git clone https://github.com/${CHARTS_REPO} $tempDir  --depth 1 --no-single-branch 
-    configUser $tempDir $user $email
-    configUser $PROJECT_DIR $user $email
+    configUser $tempDir $user $email $gpg
+    configUser $PROJECT_DIR $user $email $gpg
     latestVersion=$(latestReleaseTag $PROJECT_DIR)
     updateRepoWithRemoteChanges $tempDir $latestVersion
     commitAndSendInternalPR ${PROJECT_DIR} "sync-chart-changes-${latestVersion}"

--- a/script/chart_upstream_checker.sh
+++ b/script/chart_upstream_checker.sh
@@ -22,12 +22,12 @@ email=${2:?}
 if changedVersion; then
     tempDir=$(mktemp -u)/charts
     mkdir -p $tempDir
-    git clone https://github.com/${CHARTS_REPO} $tempDir --depth 1 --no-single-branch 
+    git clone https://github.com/${CHARTS_REPO} $tempDir  --depth 1 --no-single-branch 
     configUser $tempDir $user $email
     configUser $PROJECT_DIR $user $email
     latestVersion=$(latestReleaseTag $PROJECT_DIR)
-    updateRepoWithLocalChanges $tempDir $latestVersion
-    commitAndSendExternalPR $tempDir "kubeapps-bump-${latestVersion}"
+    updateRepoWithRemoteChanges $tempDir $latestVersion
+    commitAndSendInternalPR ${PROJECT_DIR} "sync-chart-changes-${latestVersion}"
 else
     echo "Skipping Chart sync. The version has not changed"
 fi

--- a/script/chart_upstream_checker.sh
+++ b/script/chart_upstream_checker.sh
@@ -23,7 +23,9 @@ gpg=${3:?}
 if changedVersion; then
     tempDir=$(mktemp -u)/charts
     mkdir -p $tempDir
-    git clone https://github.com/${CHARTS_REPO} $tempDir  --depth 1 --no-single-branch 
+    git clone https://github.com/${CHARTS_REPO} $tempDir --depth 1 --no-single-branch
+    git remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
+    git pull upstream master
     configUser $tempDir $user $email $gpg
     configUser $PROJECT_DIR $user $email $gpg
     latestVersion=$(latestReleaseTag $PROJECT_DIR)

--- a/script/chart_upstream_checker.sh
+++ b/script/chart_upstream_checker.sh
@@ -20,17 +20,23 @@ source $(dirname $0)/chart_sync_utils.sh
 user=${1:?}
 email=${2:?}
 gpg=${3:?}
-if changedVersion; then
+
+currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep -oP '(?<=^version: ).*' )
+externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO_ORIGINAL}/master/${CHART_REPO_PATH}/Chart.yaml | grep -oP '(?<=^version: ).*' )
+semverCompare=$(semver compare "${currentVersion}" "${externalVersion}")
+# If current version is less than the chart external version, then retrieve the changes and send an internal PR with them
+if [[ ${semverCompare} -lt 0 ]]; then
+    echo "Current chart version ("${currentVersion}") is less than the chart external version ("${externalVersion}")"
     tempDir=$(mktemp -u)/charts
     mkdir -p $tempDir
     git clone https://github.com/${CHARTS_REPO} $tempDir --depth 1 --no-single-branch
-    git remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
-    git pull upstream master
     configUser $tempDir $user $email $gpg
     configUser $PROJECT_DIR $user $email $gpg
     latestVersion=$(latestReleaseTag $PROJECT_DIR)
     updateRepoWithRemoteChanges $tempDir $latestVersion
-    commitAndSendInternalPR ${PROJECT_DIR} "sync-chart-changes-${latestVersion}"
+    commitAndSendInternalPR ${PROJECT_DIR} "sync-chart-changes-${externalVersion}"
+elif [[ ${semverCompare} -gt 0 ]]; then
+    echo "Skipping Chart sync. WARNING Current chart version ("${currentVersion}") is greater than the chart external version ("${externalVersion}")"
 else
-    echo "Skipping Chart sync. The version has not changed"
+    echo "Skipping Chart sync. The chart version ("${currentVersion}") has not changed"
 fi

--- a/script/create_release.sh
+++ b/script/create_release.sh
@@ -12,12 +12,12 @@ if [[ -z "$REPO_NAME" || -z "$REPO_DOMAIN" ]]; then
   exit 1
 fi
 
-if [[ -z "$ACCESS_TOKEN" ]]; then
+if [[ -z "$GITHUB_TOKEN" ]]; then
   echo "Unable to release: Github Token not specified" > /dev/stderr
   exit 1
 fi
 
-repo_check=`curl -H "Authorization: token $ACCESS_TOKEN" -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME`
+repo_check=`curl -H "Authorization: token $GITHUB_TOKEN" -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME`
 if [[ $repo_check == *"Not Found"* ]]; then
   echo "Not found a Github repository for $REPO_DOMAIN/$REPO_NAME, it is not possible to publish it" > /dev/stderr
   exit 1

--- a/script/release_utils.sh
+++ b/script/release_utils.sh
@@ -41,9 +41,9 @@ function update_release_tag {
   local tag=${1:?}
   local repo_domain=${2:?}
   local repo_name=${3:?}
-  local release_id=$(curl -H "Authorization: token $ACCESS_TOKEN" -s https://api.github.com/repos/$repo_domain/$repo_name/releases | jq  --raw-output '.[0].id')
+  local release_id=$(curl -H "Authorization: token $GITHUB_TOKEN" -s https://api.github.com/repos/$repo_domain/$repo_name/releases | jq  --raw-output '.[0].id')
   local body=$(get_release_body $tag $repo_domain $repo_name)
-  local release=`curl -H "Authorization: token $ACCESS_TOKEN" -s --request PATCH --data $body  https://api.github.com/repos/$repo_domain/$repo_name/releases/$release_id`
+  local release=`curl -H "Authorization: token $GITHUB_TOKEN" -s --request PATCH --data $body  https://api.github.com/repos/$repo_domain/$repo_name/releases/$release_id`
   echo $release
 }
 
@@ -52,7 +52,7 @@ function release_tag {
   local repo_domain=${2:?}
   local repo_name=${3:?}
   local body=$(get_release_body $tag $repo_domain $repo_name)
-  local release=`curl -H "Authorization: token $ACCESS_TOKEN" -s --request POST --data "$body" https://api.github.com/repos/$repo_domain/$repo_name/releases`
+  local release=`curl -H "Authorization: token $GITHUB_TOKEN" -s --request POST --data "$body" https://api.github.com/repos/$repo_domain/$repo_name/releases`
   echo $release
 }
 
@@ -69,7 +69,7 @@ function upload_asset {
   else
     local content_type="application/octet-stream"
   fi
-  curl -H "Authorization: token $ACCESS_TOKEN" \
+  curl -H "Authorization: token $GITHUB_TOKEN" \
     -H "Content-Type: $content_type" \
     --data-binary @"$asset" \
     "https://uploads.github.com/repos/$repo_domain/$repo_name/releases/$release_id/assets?name=$filename"


### PR DESCRIPTION
### Description of the change

This PR brings an automated way to fetch changes from the Bitnami chart and, analouglsy, send our changes back to them,
All the process is being done through pull requests; however, push access is still needed just to avoid creating our own bitnami/chart fork.

### Benefits

The synchronization process will be full-duplex automatic :)

### Possible drawbacks

The process assumes a linear series of events: for instance, multiple ongoing PRs are not supported.
So, what is expected is:

- Perfect sync
- Push to master: no new chart version
- Bitnami update some images
- Push to master: pull changes from bitnami (via PR)
- New PR: kubeapps accepts it
- Push to master: no new chart version
- Kubeapps perform some changes in the chart
- Kubeapps release: push changes to bitnami (via PR)
- Bitnami accepts the PR
- Kubeapps got released

### Applicable issues

- rel #2704

### Additional information

Example PRs:

1. From Bitnami to Kubeapps: https://github.com/antgamdia/kubeapps/pull/205
2. From Kubeapps to Bitnami: https://github.com/antgamdia/charts/pull/4
