### PR TITLE
Update chart version for development.

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/kubeapps/kubeapps
 # This chart is for development only. Please use the official Bitnami Kubeapps chart
 # for anything other than development purposes.
-version: 6.1.3-devel
+version: 6.1.3-devel.1

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,4 +25,6 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 6.1.2
+# This chart is for development only. Please use the official Bitnami Kubeapps chart
+# for anything other than development purposes.
+version: 6.1.3-devel


### PR DESCRIPTION
### Description of the change

While updating #2731 I realised that, given that we're no longer pushing changes from our chart here to the bitnami repo, we need to rethink how we version our development chart.

I think the requirements are:

* The development chart should not have the same version as the upstream bitnami chart unless it is identical
* The version is required to be semver so should have meaning (ie. we could use 0.0.0 but that isn't meaningful).

With that in mind, I'm proposing that when we make a change to the development chart, we ensure that the version is a pre-release version of the next patch version (ie. lower in precedence than the next patch version from bitnami).
We can increment the metadata (devel.1 -> devel.2) as further changes are made that have not yet been included in the upstream chart.

When our devel chart is identical to the bitnami chart, it should be reset to the next patch version with -devel.0 (eg. if the released bitnami chart is 6.1.3 and all changes are synced back to our devel with no other changes on our devel chart yet, it should have the version 6.1.4-devel.0)

Note: I've made it 6.1.3-devel11 here because of the change in #2371.

### Benefits

It is clear when people install and report on issues when using the chart in our repository.

### Possible drawbacks

Too complicated? Not sure if there's a simpler policy here.

### Applicable issues

  - #2704

### Additional information

Let me know if you think this makes sense, or if you have a better idea.
