### PR TITLE
Fix chart to use helper for pinniped-proxy full name.

### DIFF
--- a/chart/kubeapps/templates/kubeapps-frontend-config.yaml
+++ b/chart/kubeapps/templates/kubeapps-frontend-config.yaml
@@ -82,7 +82,7 @@ data:
     {{- if .certificateAuthorityData }}
         proxy_set_header PINNIPED_PROXY_API_SERVER_CERT {{ .certificateAuthorityData }};
     {{- end }}
-        proxy_pass http://kubeapps-internal-pinniped-proxy.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
+        proxy_pass http://{{ template "kubeapps.pinniped-proxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
     {{- else }}
         # Otherwise we route directly through to the clusters with existing credentials.
         proxy_pass {{ $apiServiceBaseURL }};

--- a/chart/kubeapps/templates/kubeops-deployment.yaml
+++ b/chart/kubeapps/templates/kubeops-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --clusters-config-path=/config/clusters.conf
             {{- end }}
             {{- if .Values.pinnipedProxy.enabled }}
-            - --pinniped-proxy-url=http://kubeapps-internal-pinniped-proxy.{{ .Release.Namespace }}:{{ .Values.pinnipedProxy.service.port }}
+            - --pinniped-proxy-url=http://{{ template "kubeapps.pinniped-proxy.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.pinnipedProxy.service.port }}
             {{- end }}
             {{- if .Values.kubeops.burst }}
             - --burst={{ .Values.kubeops.burst }}


### PR DESCRIPTION
### Description of the change

See #2767 for more details.

Without this change, if kubeapps is deployed with a release name that does not include `kubeapps`, then the URLs fail to match:

```
$ helm template apps ./chart/kubeapps --values docs/user/manifests/kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml --set pinnipedProxy.enabled=true --values docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml | grep internal-pinniped-proxy 

        proxy_pass http://kubeapps-internal-pinniped-proxy.default:3333;
        proxy_pass http://kubeapps-internal-pinniped-proxy.default:3333;
  name: apps-kubeapps-internal-pinniped-proxy
            - --pinniped-proxy-url=http://kubeapps-internal-pinniped-proxy.default:3333

```

### Benefits

With the change, the URLs match the service definition:

```
$ helm template apps ./chart/kubeapps --values docs/user/manifests/kubeapps-local-dev-additional-kind-cluster-for-pinniped.yaml --set pinnipedProxy.enabled=true --values docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml | grep internal-pinniped-proxy

        proxy_pass http://apps-kubeapps-internal-pinniped-proxy.default:3333;
        proxy_pass http://apps-kubeapps-internal-pinniped-proxy.default:3333;
  name: apps-kubeapps-internal-pinniped-proxy
            - --pinniped-proxy-url=http://apps-kubeapps-internal-pinniped-proxy.default:3333
```

### Possible drawbacks

None.

### Applicable issues

  - fixes #2767

### Additional information

Links to original slack chat on issue.
