### PR TITLE
Fix wrong link in docs

### DIFF
--- a/docs/user/using-an-OIDC-provider-with-pinniped.md
+++ b/docs/user/using-an-OIDC-provider-with-pinniped.md
@@ -120,7 +120,7 @@ clusters:
 
 ## Debugging auth failures when using OIDC
 
-For general OIDC issues, have a look at [this OIDC debugging guide](./using-an-OIDC-provider-with-pinniped.md#debugging-auth-failures-when-using-OIDC).
+For general OIDC issues, have a look at [this OIDC debugging guide](./using-an-OIDC-provider.md#debugging-auth-failures-when-using-OIDC).
 
 ### Pinniped not trusting your OIDC provider
 


### PR DESCRIPTION
### Description of the change

Fixing a wrong link in the oidc debug docs.

### Benefits

The link will point to somewhere :P 

### Possible drawbacks

I can't think of a more harmless PR than this one.

### Applicable issues

N/A

### Additional information

N/A
