### PR TITLE
Update stalebot rules to comply the triage

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,8 +4,9 @@ daysUntilStale: 90
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - pinned
-  - security
+  - priority/unbreak-now
+  - priority/high
+  - priority/medium
   - kind/bug
   - kind/feature
 # Label to use when marking an issue as stale


### PR DESCRIPTION
### Description of the change

Update the stalebot exemptLabels and the label to use when marking an issue as stale.

### Benefits

Have more control about issues automatically labeled to be staled according to kind and priority.

### Possible drawbacks

N/A

### Applicable issues
-#2714

### Additional information

N/A
