### PR TITLE
Add integration dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/integration"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -44,13 +44,22 @@ The versions used there _must_ match the ones used for building the container im
 
 > As part of this release process, these variables _must_ be updated accordingly. Other variable changes _should_ be tracked in a separate PR.
 
-#### 0.2.2 - CI integration image
+#### 0.2.2 - CI integration image and dependencies
 
-- The [integration/Dockerfile](../../integration/Dockerfile) uses a [bitnami/node](https://hub.docker.com/r/bitnami/node/tags) image for running the e2e test.
+We use a separate integration image for running the e2e tests consisting of a simple Node image with a set of dependencies. Therefore, upgrading it includes:
 
-> As part of this release process, this image tag _may_ be updated to the latest minor/patch version. In case of a major version, the change _should_ be tracked in a separate PR.
+- The [integration dependencies](../../dashboard/package.json) can be updated by running:
 
-> **Note**: this image is not being built automatically. Consequently, a [manual build process](./end-to-end-tests.md#building-the-"kubeapps/integration-tests"-image) _must_ be triggered if you happen to upgrade the integration image.
+```bash
+cd integration
+yarn upgrade
+```
+
+- The [integration/Dockerfile](../../integration/Dockerfile) uses a [bitnami/node](https://hub.docker.com/r/bitnami/node/tags) image for running the e2e tests.
+
+> As part of this release process, this Node image tag _may_ be updated to the latest minor/patch version. In case of a major version, the change _should_ be tracked in a separate PR. Analogously, its dependencies _may_ also be updated, but in case of a major change, it _should_ be tracked in a separate PR.
+
+> **Note**: this image is not being built automatically. Consequently, a [manual build process](./end-to-end-tests.md#building-the-"kubeapps/integration-tests"-image) _must_ be triggered if you happen to upgrade the integration image or its dependencies.
 
 ### 0.3 - Development chart
 


### PR DESCRIPTION
### Description of the change

This PR updates the current dependabot config to also upgrade our integration deps periodically. The release process docs have also been updated accordingly

### Benefits

The bot will send PRs for the integration dependencies as well. We no longer will get notified about security issues in these deps (though they are not part of the kubeapps code itself).

### Possible drawbacks

Please note the integration image is *not* being created automatically. According to our release process, this image might be updated when releasing a new kubeapps version. **Direct consequence:** the current code in the main branch won't match the actual code in the image container image.

Alternatives:

A) We just assume the integration image won't match the declared dependencies in the main branch. They eventually sync once we release a new Kubeapps version (albeit not guaranteed according to the current process documentation)

B) We push ourselves to create a new integration image version. It implies:
  - Dependabot creates a PR in the integration image
  -  We pull that PR branch (once we've got the green light), build the integration image, tag with a new patch version, push to the image registry and bump the version up in the circle configuration.
  - We merge the PR, so the next CI execution will run with the new image.

If B) we will have to update our docs to show these instructions.

A B' is possible, where we send another PR in addition to the dependabot one, but I personally think it will generate more overhead rather than being useful.


### Applicable issues

- fixes #2782 

### Additional information

Additional idea: what if we build the integration image in CI-runtime? This way it's guaranteed it'll use the latest deps versions.

PS: woah - it was supposed to be a straightforward one-line change indeed...