### PR TITLE
Ci hotfix

### DIFF
--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -163,7 +163,7 @@ pushChart() {
 installOrUpgradeKubeapps() {
     local chartSource=$1
     # Install Kubeapps
-    info "Installing Kubeapps..."
+    info "Installing Kubeapps from ${chartSource}..."
     kubectl -n kubeapps delete secret localhost-tls || true
 
     helm upgrade --install kubeapps-ci --namespace kubeapps "${chartSource}" \
@@ -259,12 +259,12 @@ if [[ -n "${TEST_UPGRADE}" ]]; then
   installOrUpgradeKubeapps bitnami/kubeapps \
     "--set" "apprepository.initialRepos=null"
 
-  info "Waiting for Kubeapps components to be ready..."
+  info "Waiting for Kubeapps components to be ready (bitnami chart)..."
   k8s_wait_for_deployment kubeapps kubeapps-ci
 fi
 
 installOrUpgradeKubeapps "${ROOT_DIR}/chart/kubeapps"
-info "Waiting for Kubeapps components to be ready..."
+info "Waiting for Kubeapps components to be ready (local chart)..."
 k8s_wait_for_deployment kubeapps kubeapps-ci
 installChartmuseum admin password
 pushChart apache 7.3.15 admin password

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -254,15 +254,19 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm dep up "${ROOT_DIR}/chart/kubeapps"
 kubectl create ns kubeapps
 
-if [[ -n "${TEST_UPGRADE}" ]]; then
-  # To test the upgrade, first install the latest version published
-  info "Installing latest Kubeapps chart available"
-  installOrUpgradeKubeapps bitnami/kubeapps \
-    "--set" "apprepository.initialRepos=null"
+# TODO(agamez): uncomment this as soon as the local chart version is >=7.0.0
+# Currently, breaking changes in the chart prevent us to perform an automatic upgrade
+# https://github.com/kubeapps/kubeapps/pull/2795
 
-  info "Waiting for Kubeapps components to be ready (bitnami chart)..."
-  k8s_wait_for_deployment kubeapps kubeapps-ci
-fi
+# if [[ -n "${TEST_UPGRADE}" ]]; then
+#   # To test the upgrade, first install the latest version published
+#   info "Installing latest Kubeapps chart available"
+#   installOrUpgradeKubeapps bitnami/kubeapps \
+#     "--set" "apprepository.initialRepos=null"
+
+#   info "Waiting for Kubeapps components to be ready (bitnami chart)..."
+#   k8s_wait_for_deployment kubeapps kubeapps-ci
+# fi
 
 installOrUpgradeKubeapps "${ROOT_DIR}/chart/kubeapps"
 info "Waiting for Kubeapps components to be ready (local chart)..."

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -228,6 +228,7 @@ if [ "$USE_MULTICLUSTER_OIDC_ENV" = true ] ; then
     "--set" "ingress.enabled=true"
     "--set" "ingress.hostname=localhost"
     "--set" "ingress.tls=true"
+    "--set" "ingress.selfSigned=true"
     "--set" "authProxy.enabled=true"
     "--set" "authProxy.provider=oidc"
     "--set" "authProxy.clientID=default"


### PR DESCRIPTION
### Description of the change

This PR brings two minor, but important, changes to the CI aimed at solving:

- Automatic upgrade is not possible since the breaking changes related to the labels.
  - Solution: hotfix ignoring the upgrade test until we merge this PR
-  The bitnami/kubeapps chart wasn't being installed (i.e., `Error: no objects visited`)
    - Solution: We just needed to add `ingress.selfSigned=true` as part of the flags we were already passing.

I'm gonna land a hotfix with these two changes (as they only affect the CI, which is already broken). As soon as we merge this PR, we can undo it.

See [here](https://app.circleci.com/pipelines/github/kubeapps/kubeapps/2906/workflows/c389e6d4-a47e-448b-88f8-fd5f0bae0524/jobs/45632) an example of a successful CI job after the hotfix.

### Benefits

CI will work again

### Possible drawbacks

No chart upgrade tests atm

### Applicable issues

  - fixes #2800

### Additional information

N/A