### PR TITLE
Check if remote branch already exists to prevents git push failures

### DIFF
--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -170,8 +170,12 @@ commitAndSendExternalPR() {
     git add --all .
     git commit -m "kubeapps: bump chart version to $chartVersion"
     # NOTE: This expects to have a loaded SSH key
-    git push -u origin $targetBranch
-    gh pr create -d -B master -R ${CHARTS_REPO_ORIGINAL} -F ${PR_EXTERNAL_TEMPLATE_FILE} --title "[bitnami/kubeapps] Bump chart version to $chartVersion"
+    if [[ -n "$(git ls-remote origin $targetBranch  | wc -l)" ]]; then
+     echo "The remote branch '$targetBranch' already exists, please check if there is already an open PR at the repository '${CHARTS_REPO_ORIGINAL}'"
+    else
+        git push -u origin $targetBranch
+        gh pr create -d -B master -R ${CHARTS_REPO_ORIGINAL} -F ${PR_EXTERNAL_TEMPLATE_FILE} --title "[bitnami/kubeapps] Bump chart version to $chartVersion"
+    fi
     cd -
 }
 
@@ -196,6 +200,11 @@ commitAndSendInternalPR() {
     git add --all .
     git commit -m "bump chart version to $chartVersion"
     # NOTE: This expects to have a loaded SSH key
-    git push -u origin $targetBranch
-    gh pr create -d -B master -R ${KUBEAPPS_REPO} -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"
+    if [[ -n "$(git ls-remote origin $targetBranch  | wc -l)" ]]; then
+     echo "The remote branch '$targetBranch' already exists, please check if there is already an open PR at the repository '${KUBEAPPS_REPO}'"
+    else
+        git push -u origin $targetBranch
+        gh pr create -d -B master -R ${KUBEAPPS_REPO} -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"
+    fi
+    cd -
 }


### PR DESCRIPTION
### Description of the change

Minor CI hotfix to check if the remote branch exists prior to perform a `git push`. 

### Benefits

Builds in master will no longer fail if we:

1. Have an open PR bumping the chart version
2. Push any commit to master

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
