### PR TITLE
Update dockerfile frontend to 1.2, buildkit support graduated from experimental

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 dashboard/node_modules
 .git
 docs
-pinniped-proxy/target
+cmd/pinniped-proxy/target

--- a/cmd/apprepository-controller/Dockerfile
+++ b/cmd/apprepository-controller/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:experimental
+# syntax = docker/dockerfile:1.2
 
 FROM bitnami/golang:1.16.3 as builder
 WORKDIR /go/src/github.com/kubeapps/kubeapps

--- a/cmd/apprepository-controller/Dockerfile
+++ b/cmd/apprepository-controller/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.2
+# syntax = docker/dockerfile:1
 
 FROM bitnami/golang:1.16.3 as builder
 WORKDIR /go/src/github.com/kubeapps/kubeapps

--- a/cmd/assetsvc/Dockerfile
+++ b/cmd/assetsvc/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:experimental
+# syntax = docker/dockerfile:1.2
 
 FROM bitnami/golang:1.16.3 as builder
 WORKDIR /go/src/github.com/kubeapps/kubeapps

--- a/cmd/assetsvc/Dockerfile
+++ b/cmd/assetsvc/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.2
+# syntax = docker/dockerfile:1
 
 FROM bitnami/golang:1.16.3 as builder
 WORKDIR /go/src/github.com/kubeapps/kubeapps

--- a/cmd/kubeops/Dockerfile
+++ b/cmd/kubeops/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:experimental
+# syntax = docker/dockerfile:1.2
 
 FROM bitnami/golang:1.16.3 as builder
 WORKDIR /go/src/github.com/kubeapps/kubeapps

--- a/cmd/kubeops/Dockerfile
+++ b/cmd/kubeops/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.2
+# syntax = docker/dockerfile:1
 
 FROM bitnami/golang:1.16.3 as builder
 WORKDIR /go/src/github.com/kubeapps/kubeapps

--- a/cmd/pinniped-proxy/.dockerignore
+++ b/cmd/pinniped-proxy/.dockerignore
@@ -1,5 +1,0 @@
-target
-Dockerfile
-.dockerignore
-.git
-.gitignore

--- a/cmd/pinniped-proxy/Dockerfile
+++ b/cmd/pinniped-proxy/Dockerfile
@@ -1,21 +1,20 @@
+# syntax = docker/dockerfile:1
+
 FROM rust:1.51 as builder
 
-# Create a new project and build pinniped-proxy dependencies only, so that they
-# are built as a layer on their own, to reduce build times when only our code
-# changes.
-RUN USER=root cargo new --bin pinniped-proxy
 WORKDIR /pinniped-proxy
-COPY ./cmd/pinniped-proxy/Cargo.* ./
-RUN cargo build --release && rm src/*.rs
 
 # Create a release build of pinniped-proxy itself.
-ADD ./cmd/pinniped-proxy ./
-RUN rm ./target/release/deps/pinniped_proxy*
-RUN cargo build --release
+COPY ./cmd/pinniped-proxy ./
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/pinniped-proxy/target \
+    cargo build --release
+RUN --mount=type=cache,target=/pinniped-proxy/target \
+    cp /pinniped-proxy/target/release/pinniped-proxy /pinniped-proxy/pinniped-proxy
 
 FROM bitnami/minideb:buster
 RUN apt-get update && apt-get install -y ca-certificates libssl1.1 && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /pinniped-proxy/target/release/pinniped-proxy /pinniped-proxy
+COPY --from=builder /pinniped-proxy/pinniped-proxy /pinniped-proxy
 ENV PATH="/:$PATH"
 
 EXPOSE 3333


### PR DESCRIPTION
### Description of the change

Noticed while adding a Dockerfile that we were still referring to the experimental (unversioned) docker frontend even though the buildkit support (for which it was added) graduated into 1.2.

### Benefits

Stay on a stable API.

### Possible drawbacks

Let's see what CI says.

