### PR TITLE
Add dev-only deployment of kubeapps-apis

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -73,6 +73,13 @@ http://{{ include "kubeapps.kubeops.fullname" . }}:{{ .Values.kubeops.service.po
 {{- end -}}
 
 {{/*
+Create name for kubeappsapis based on the fullname
+*/}}
+{{- define "kubeapps.kubeappsapis.fullname" -}}
+{{- printf "%s-internal-kubeappsapis" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create name for the secrets related to oauth2_proxy
 */}}
 {{- define "kubeapps.oauth2_proxy-secret.name" -}}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.featureFlags.kubeappsAPIsServer }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "kubeapps.kubeappsapis.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: kubeappsapis
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" . ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.kubeappsapis.replicaCount }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: kubeappsapis
+  template:
+    metadata:
+      {{- if .Values.kubeappsapis.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: kubeappsapis
+        {{- if .Values.kubeappsapis.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- include "kubeapps.imagePullSecrets" . | indent 6 }}
+      serviceAccountName: {{ template "kubeapps.kubeappsapis.fullname" . }}
+      {{- if .Values.kubeappsapis.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      # Increase termination timeout to let remaining operations to finish before killing the pods
+      # This is because new releases/upgrades/deletions are synchronous operations
+      {{- if .Values.kubeappsapis.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.kubeappsapis.podAffinityPreset "component" "kubeappsapis" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.kubeappsapis.podAntiAffinityPreset "component" "kubeappsapis" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.kubeappsapis.nodeAffinityPreset.type "key" .Values.kubeappsapis.nodeAffinityPreset.key "values" .Values.kubeappsapis.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.kubeappsapis.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubeappsapis.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubeappsapis.priorityClassName }}
+      priorityClassName: {{ .Values.kubeappsapis.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.kubeappsapis.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.kubeappsapis.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.kubeappsapis.terminationGracePeriodSeconds }}
+      containers:
+        - name: kubeappsapis
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.kubeappsapis.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.kubeappsapis.image.pullPolicy | quote }}
+          {{- if .Values.kubeappsapis.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.kubeappsapis.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.kubeappsapis.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          command:
+            - /kubeapps-apis
+          args:
+            - --plugin-dir
+            - /plugins/
+          env:
+            - name: PORT
+              value: {{ .Values.kubeappsapis.containerPort | quote }}
+            {{- if .Values.kubeappsapis.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.kubeappsapis.extraEnvVarsCM .Values.kubeappsapis.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.kubeappsapis.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.kubeappsapis.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.kubeappsapis.containerPort }}
+          {{- if .Values.kubeappsapis.livenessProbe.enabled }}
+          livenessProbe: {{- omit .Values.kubeappsapis.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- else if .Values.kubeappsapis.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.kubeappsapis.readinessProbe.enabled }}
+          readinessProbe: {{- omit .Values.kubeappsapis.readinessProbe "enabled" | toYaml | nindent 12 }}
+          {{- else if .Values.kubeappsapis.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.kubeappsapis.resources }}
+          resources: {{- toYaml .Values.kubeappsapis.resources | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/chart/kubeapps/templates/kubeappsapis/rbac.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/rbac.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.featureFlags.kubeappsAPIsServer }}
+{{- if .Values.rbac.create -}}
+# Dev-only RBAC for experimental APIs server until user auth added.
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: "kubeapps:controller:kubeapps-apis-dev-{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: kubeappsapis
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" . ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  # TODO: Remove in favour of user's own creds used for request.
+  - apiGroups:
+      - ""
+      - "package.carvel.dev"
+    resources: ['*']
+    verbs: ['*']
+---
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: "kubeapps:controller:kubeapps-apis-dev-{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: kubeappsapis
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" . ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "kubeapps:controller:kubeapps-apis-dev-{{ .Release.Namespace }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubeapps.kubeappsapis.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/chart/kubeapps/templates/kubeappsapis/service.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/service.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.featureFlags.kubeappsAPIsServer }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kubeapps.kubeappsapis.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: kubeappsapis
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" . ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.kubeappsapis.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.kubeappsapis.service.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.kubeappsapis.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: kubeappsapis
+{{- end }}

--- a/chart/kubeapps/templates/kubeappsapis/serviceaccount.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.featureFlags.kubeappsAPIsServer }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "kubeapps.kubeappsapis.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: kubeappsapis
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" . ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1445,6 +1445,7 @@ clusters:
 ##
 featureFlags:
   invalidateCache: true
+  kubeappsAPIsServer: false
 ## RBAC configuration
 ##
 rbac:

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -1,0 +1,36 @@
+# syntax = docker/dockerfile:experimental
+
+FROM bitnami/golang:1.16.3 as builder
+WORKDIR /go/src/github.com/kubeapps/kubeapps
+COPY go.mod go.sum ./
+COPY pkg pkg
+COPY cmd cmd
+# With the trick below, Go's build cache is kept between builds.
+# https://github.com/golang/go/issues/27719#issuecomment-514747274
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build ./cmd/kubeapps-apis
+# Build the current standard plugins
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build \
+    -o /kapp-controller-packages-v1alpha1-plugin.so -buildmode=plugin \
+    ./cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build \
+    -o /helm-operator-packages-v1alpha1-plugin.so -buildmode=plugin \
+    ./cmd/kubeapps-apis/plugins/helm_operator/packages/v1alpha1/main.go
+
+# Note: unlike the other docker images for go, we cannot use scratch as the plugins
+# are loaded using the dynamic linker.
+FROM bitnami/minideb:buster
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /go/src/github.com/kubeapps/kubeapps/kubeapps-apis /kubeapps-apis
+COPY --from=builder /kapp-controller-packages-v1alpha1-plugin.so /plugins/
+COPY --from=builder /helm-operator-packages-v1alpha1-plugin.so /plugins/
+
+EXPOSE 50051
+USER 1001
+ENTRYPOINT [ "/kubeapps-apis" ]
+CMD [ "--help" ]

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:experimental
+# syntax = docker/dockerfile:1
 
 FROM bitnami/golang:1.16.3 as builder
 WORKDIR /go/src/github.com/kubeapps/kubeapps

--- a/docs/developer/manifests/values.dev.yaml
+++ b/docs/developer/manifests/values.dev.yaml
@@ -1,0 +1,197 @@
+## The extra value fields below are currently not included in the chart so as to not document
+## experimental functionality until we're ready to include it in the published chart.
+
+## @section kubeappsapis parameters
+
+## KubeappsAPIs parameters
+##
+kubeappsapis:
+  ## Bitnami Kubeapps-APIs image
+  ## ref: https://hub.docker.com/r/bitnami/kubeapps-apis/tags/
+  ## @param kubeappsapis.image.registry Kubeapps-APIs image registry
+  ## @param kubeappsapis.image.repository Kubeapps-APIs image repository
+  ## @param kubeappsapis.image.tag Kubeapps-APIs image tag (immutable tags are recommended)
+  ## @param kubeappsapis.image.pullPolicy Kubeapps-APIs image pull policy
+  ## @param kubeappsapis.image.pullSecrets Kubeapps-APIs image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: kubeapps/kubeapps-apis
+    tag: latest
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  replicaCount: 2
+  ## @param kubeappsapis.terminationGracePeriodSeconds The grace time period for sig term
+  ## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
+  ##
+  terminationGracePeriodSeconds: 300
+  ## @param kubeappsapis.extraEnvVars Array with extra environment variables to add to the KubeappsAPIs container
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param kubeappsapis.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for the KubeappsAPIs container
+  ##
+  extraEnvVarsCM:
+  ## @param kubeappsapis.extraEnvVarsSecret Name of existing Secret containing extra env vars for the KubeappsAPIs container
+  ##
+  extraEnvVarsSecret:
+  ## @param kubeappsapis.containerPort KubeappsAPIs HTTP container port
+  ##
+  containerPort: 50051
+  ## KubeappsAPIs containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param kubeappsapis.resources.limits.cpu The CPU limits for the KubeappsAPIs container
+  ## @param kubeappsapis.resources.limits.memory The memory limits for the KubeappsAPIs container
+  ## @param kubeappsapis.resources.requests.cpu The requested CPU for the KubeappsAPIs container
+  ## @param kubeappsapis.resources.requests.memory The requested memory for the KubeappsAPIs container
+  ##
+  resources:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+    requests:
+      cpu: 25m
+      memory: 32Mi
+  ## Configure Pods Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param kubeappsapis.podSecurityContext.enabled Enabled KubeappsAPIs pods' Security Context
+  ## @param kubeappsapis.podSecurityContext.fsGroup Set KubeappsAPIs pod's Security Context fsGroup
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+  ## Configure Container Security Context (only main container)
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param kubeappsapis.containerSecurityContext.enabled Enabled KubeappsAPIs containers' Security Context
+  ## @param kubeappsapis.containerSecurityContext.runAsUser Set KubeappsAPIs container's Security Context runAsUser
+  ## @param kubeappsapis.containerSecurityContext.runAsNonRoot Set KubeappsAPIs container's Security Context runAsNonRoot
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+    runAsNonRoot: true
+  ## Configure extra options for KubeappsAPIs containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param kubeappsapis.livenessProbe.enabled Enable livenessProbe
+  ## @skip kubeappsapis.livenessProbe.httpGet
+  ## @param kubeappsapis.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param kubeappsapis.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param kubeappsapis.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param kubeappsapis.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param kubeappsapis.livenessProbe.successThreshold Success threshold for livenessProbe
+  ## KubeappsAPIs containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    enabled: false
+    httpGet:
+      path: /live
+      port: 50051
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param kubeappsapis.readinessProbe.enabled Enable readinessProbe
+  ## @skip kubeappsapis.readinessProbe.httpGet
+  ## @param kubeappsapis.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param kubeappsapis.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param kubeappsapis.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param kubeappsapis.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param kubeappsapis.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: false
+    httpGet:
+      path: /ready
+      port: 50051
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param kubeappsapis.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param kubeappsapis.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param kubeappsapis.lifecycleHooks Custom lifecycle hooks for KubeappsAPIs containers
+  ##
+  lifecycleHooks: {}
+  ## @param kubeappsapis.podLabels Extra labels for KubeappsAPIs pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param kubeappsapis.podAnnotations Annotations for KubeappsAPIs pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param kubeappsapis.podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAffinityPreset: ""
+  ## @param kubeappsapis.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAntiAffinityPreset: soft
+  ## nodeAffinityPreset Node affinity preset
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ##
+  nodeAffinityPreset:
+    ## @param kubeappsapis.nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ##
+    type: ""
+    ## @param kubeappsapis.nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
+    ##
+    key: ""
+    ## @param kubeappsapis.nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## @param kubeappsapis.affinity Affinity for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## NOTE: kubeappsapis.podAffinityPreset, kubeappsapis.podAntiAffinityPreset, and kubeappsapis.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+  ## @param kubeappsapis.nodeSelector Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param kubeappsapis.tolerations Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param kubeappsapis.priorityClassName Priority class name for KubeappsAPIs pods
+  ##
+  priorityClassName:
+  ## @param kubeappsapis.hostAliases Custom host aliases for KubeappsAPIs pods
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## kubeappsapis service parameters
+  ##
+  service:
+    ## @param kubeappsapis.service.port KubeappsAPIs service HTTP port
+    ##
+    port: 8080
+    ## @param kubeappsapis.service.annotations Additional custom annotations for KubeappsAPIs service
+    ##
+    annotations: {}

--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -12,6 +12,8 @@ kubeops:
 postgresql:
   replication:
     enabled: false
+kubeappsapis:
+  replicaCount: 1
 ingress:
   enabled: true
   hostname: localhost


### PR DESCRIPTION
### Description of the change

Follows #2805. Adds the chart templating to deploy the kubeapps-apis service behind a feature flag.

Note that the local dev env is currently broken due to the upstream Kubeapps chart changes which we synced. I'll deal with that in a separate PR, but with this current change I'm able to deploy Kubeapps, port-forward the service, then curl it with:

```
curl http://localhost:8080/core/plugins/v1alpha1/configured-plugins

{"plugins":["foobar.package.v1"]}
```

### Benefits

Easier testing and further development of the kubeapps-apis service.

### Possible drawbacks

None that I see.

### Applicable issues

  - Ref: #2773

### Additional information

I've not updated the main values.yaml with all the options so as to avoid the auto-documentation of those in the upstream published chart when we merge. Instead, I've put them in a `docs/developer/manifests/values.dev.yaml` that I'll include in the dev env (once I fix the dev env in the separate PR).
