### PR TITLE
Add implementation for kapp-controller GetAvailablePackages.

### DIFF
--- a/chart/kubeapps/templates/kubeappsapis/rbac.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/rbac.yaml
@@ -16,9 +16,11 @@ metadata:
   {{- end }}
 rules:
   # TODO: Remove in favour of user's own creds used for request.
+  # While developing without user auth, add the required RBAC here for the CRD group
+  # you're dealing with.
   - apiGroups:
-      - ""
       - "package.carvel.dev"
+      - "install.package.carvel.dev"
     resources: ['*']
     verbs: ['*']
 ---

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -15,12 +15,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build \
     -o /kapp-controller-packages-v1alpha1-plugin.so -buildmode=plugin \
-    ./cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+    ./cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/*.go
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build \
     -o /helm-operator-packages-v1alpha1-plugin.so -buildmode=plugin \
-    ./cmd/kubeapps-apis/plugins/helm_operator/packages/v1alpha1/main.go
+    ./cmd/kubeapps-apis/plugins/helm_operator/packages/v1alpha1/*.go
 
 # Note: unlike the other docker images for go, we cannot use scratch as the plugins
 # are loaded using the dynamic linker.

--- a/cmd/kubeapps-apis/Makefile
+++ b/cmd/kubeapps-apis/Makefile
@@ -14,8 +14,8 @@
 
 # Build the helm and kapp package plugins with the output in the devel directory.
 build-plugins:
-	go build -o devel/kapp-controller-packages-v1alpha1-plugin.so -buildmode=plugin plugins/kapp_controller/packages/v1alpha1/main.go
-	go build -o devel/helm-operator-packages-v1alpha1-plugin.so -buildmode=plugin plugins/helm_operator/packages/v1alpha1/main.go
+	go build -o devel/kapp-controller-packages-v1alpha1-plugin.so -buildmode=plugin plugins/kapp_controller/packages/v1alpha1/*.go
+	go build -o devel/helm-operator-packages-v1alpha1-plugin.so -buildmode=plugin plugins/helm_operator/packages/v1alpha1/*.go
 
 
 # Ensure the required version of cli tooling in tools/tools.go is installed.

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
@@ -31,33 +31,3 @@ func RegisterWithGRPCServer(s grpc.ServiceRegistrar) {
 func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 	return v1alpha1.RegisterPackagesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }
-
-// Server implements the kapp-controller packages v1alpha1 interface.
-type Server struct {
-	v1alpha1.UnimplementedPackagesServiceServer
-}
-
-// func (s *Server) GetAvailablePackages(request *v1.GetAvailablePackagesRequest, stream PackageRepositoriesService_GetAvailablePackagesServer) error {
-// 	repo := &v1.PackageRepository{
-// 		Name:      "bitnami",
-// 		Namespace: "kubeapps",
-// 	}
-// 	availablePackages := []*v1.AvailablePackage{
-// 		{
-// 			Name:          "package-a",
-// 			LatestVersion: "1.2.0",
-// 			Repository:    repo,
-// 			IconUrl:       "http://example.com/package-a.jpg",
-// 		},
-// 		{
-// 			Name:          "package-b",
-// 			Repository:    repo,
-// 			LatestVersion: "1.4.0",
-// 			IconUrl:       "http://example.com/package-b.jpg",
-// 		},
-// 	}
-// 	for _, pkg := range availablePackages {
-// 		stream.Send(pkg)
-// 	}
-// 	return nil
-// }

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	// v1 "github.com/kubeapps/kubeapps/cmd/kubeapps-api-service/kubeappsapis/core/packagerepositories/v1"
+	// *sigh*, seems different versions of the k8s client.go (at the time of writing, kapp-controller
+	// is using client-go v0.19.2) means that we can't use the client here directly, as get errors like:
+	/*
+				gitub.com/vmware-tanzu/carvel-kapp-controller@v0.18.0/pkg/client/clientset/versioned/typed/kappctrl/v1alpha1/app.go:58:5: not enough arguments in call to c.client.Get().Namespace(c.ns).Resource("apps").Name(name).VersionedParams(&options, scheme.ParameterCodec).Do
+		        have ()
+		        want (context.Context)
+	*/
+	// So instead we use the dynamic (untyped) client.
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
+	"k8s.io/client-go/rest"
+)
+
+// Server implements the kapp-controller packages v1alpha1 interface.
+type Server struct {
+	v1alpha1.UnimplementedPackagesServiceServer
+}
+
+// GetAvailablePackages streams the available packages based on the request.
+func (s *Server) GetAvailablePackages(ctx context.Context, request *corev1.GetAvailablePackagesRequest) (*corev1.GetAvailablePackagesResponse, error) {
+	// TODO: replace incluster config with the user config using token from request meta.
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create incluster config: %w", err)
+	}
+
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create dynamic client: %w", err)
+	}
+
+	packageResource := schema.GroupVersionResource{Group: "package.carvel.dev", Version: "v1alpha1", Resource: "packages"}
+
+	pkgs, err := client.Resource(packageResource).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list kapp-controller packages: %w", err)
+	}
+
+	responsePackages := []*corev1.AvailablePackage{}
+	for _, pkgUnstructured := range pkgs.Items {
+		pkg := &corev1.AvailablePackage{}
+		name, found, err := unstructured.NestedString(pkgUnstructured.Object, "spec", "publicName")
+		if err != nil || !found {
+			return nil, fmt.Errorf("required field publicName not found on kapp-controller package: %w:\n%v", err, pkgUnstructured.Object)
+		}
+		pkg.Name = name
+
+		version, found, err := unstructured.NestedString(pkgUnstructured.Object, "spec", "version")
+		if err != nil || !found {
+			return nil, fmt.Errorf("required field version not found on kapp-controller package: %w:\n%v", err, pkgUnstructured.Object)
+		}
+		pkg.Version = version
+		responsePackages = append(responsePackages, pkg)
+	}
+	return &corev1.GetAvailablePackagesResponse{
+		Packages: responsePackages,
+	}, nil
+}

--- a/docs/developer/manifests/values.dev.yaml
+++ b/docs/developer/manifests/values.dev.yaml
@@ -6,7 +6,7 @@
 ## KubeappsAPIs parameters
 ##
 featureFlags:
-  kubeappsAPIsServer: trusted
+  kubeappsAPIsServer: true
 
 kubeappsapis:
   ## Bitnami Kubeapps-APIs image

--- a/docs/developer/manifests/values.dev.yaml
+++ b/docs/developer/manifests/values.dev.yaml
@@ -5,6 +5,9 @@
 
 ## KubeappsAPIs parameters
 ##
+featureFlags:
+  kubeappsAPIsServer: trusted
+
 kubeappsapis:
   ## Bitnami Kubeapps-APIs image
   ## ref: https://hub.docker.com/r/bitnami/kubeapps-apis/tags/
@@ -31,7 +34,7 @@ kubeappsapis:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-  replicaCount: 2
+  replicaCount: 1
   ## @param kubeappsapis.terminationGracePeriodSeconds The grace time period for sig term
   ## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
   ##

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -50,6 +50,11 @@ deploy-dev: deploy-dependencies deploy-dev-kubeapps
 reset-dev-kubeapps:
 	kubectl delete namespace --wait kubeapps
 
+# The kapp-controller support for the new Package and PackageRepository CRDs is currently
+# only available in an alpha release.
+deploy-kapp-controller:
+	kubectl --kubeconfig=${CLUSTER_CONFIG} apply -f https://raw.githubusercontent.com/vmware-tanzu/carvel-kapp-controller/develop/alpha-releases/v0.19.0-alpha.8.yml
+
 reset-dev:
 	helm --kubeconfig=${CLUSTER_CONFIG} -n kubeapps delete kubeapps  || true
 	helm --kubeconfig=${CLUSTER_CONFIG} -n dex delete dex  || true


### PR DESCRIPTION
### Description of the change

Adds the implementation for the kapp_controller plugin's GetAvailablePackages endpoint.

While port-forwarding to the kubeapps-apis service with

```
kubectl -n kubeapps port-forward svc/kubeapps-internal-kubeappsapis 8080:8080
```

http endpoint responds with:
```
curl -s http://localhost:8080/kapp_controller/packages/v1alpha1 | jq .
{
  "packages": [
    {
      "name": "app1.example.com",
      "version": "0.11.3",
      "iconUrl": "",
      "repository": null
    },
    {
      "name": "app2.example.com",
      "version": "3.11.3",
      "iconUrl": "",
      "repository": null
    },
```

while with grpcurl:

```
grpcurl -plaintext localhost:8080 kubeappsapis.plugins.kapp_controller.packages.v1alpha1.PackagesService.GetAvailablePackages
{
  "packages": [
    {
      "name": "app1.example.com",
      "version": "0.11.3"
    },
    {
      "name": "app2.example.com",
      "version": "3.11.3"
    },
    ...
```

**Note**: I still need to check the fake dynamic client to see the form unit-tests will take. I'll those in a subsequent PR.

### Benefits

Demonstrate using the dynamic client to query the plugin backend.

### Applicable issues

  - Ref #2775

