### PR TITLE
Example of unit-testing with dynamic client.

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -37,6 +37,16 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	packageGroup     = "package.carvel.dev"
+	packageVersion   = "v1alpha1"
+	packagesResource = "packages"
+
+	installPackageGroup   = "install.package.carvel.dev"
+	installPackageVersion = "v1alpha1"
+	repositoriesResource  = "packagerepositories"
+)
+
 // Server implements the kapp-controller packages v1alpha1 interface.
 type Server struct {
 	v1alpha1.UnimplementedPackagesServiceServer
@@ -80,7 +90,7 @@ func (s *Server) GetAvailablePackages(ctx context.Context, request *corev1.GetAv
 		return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get client : %v", err))
 	}
 
-	packageResource := schema.GroupVersionResource{Group: "package.carvel.dev", Version: "v1alpha1", Resource: "packages"}
+	packageResource := schema.GroupVersionResource{Group: packageGroup, Version: packageVersion, Resource: packagesResource}
 
 	pkgs, err := client.Resource(packageResource).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -121,7 +131,7 @@ func (s *Server) GetPackageRepositories(ctx context.Context, request *corev1.Get
 		return nil, fmt.Errorf("unable to create dynamic client: %w", err)
 	}
 
-	repositoryResource := schema.GroupVersionResource{Group: "install.package.carvel.dev", Version: "v1alpha1", Resource: "packagerepositories"}
+	repositoryResource := schema.GroupVersionResource{Group: installPackageGroup, Version: installPackageVersion, Resource: repositoriesResource}
 
 	// Currently checks globally. Update to handle namespaced requests (?)
 	repos, err := client.Resource(repositoryResource).List(ctx, metav1.ListOptions{})

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -38,10 +38,12 @@ import (
 )
 
 const (
+	// See https://carvel.dev/kapp-controller/docs/latest/packaging/#package-cr
 	packageGroup     = "package.carvel.dev"
 	packageVersion   = "v1alpha1"
 	packagesResource = "packages"
 
+	// See https://carvel.dev/kapp-controller/docs/latest/packaging/#packagerepository-cr
 	installPackageGroup   = "install.package.carvel.dev"
 	installPackageVersion = "v1alpha1"
 	repositoriesResource  = "packagerepositories"
@@ -51,6 +53,9 @@ const (
 type Server struct {
 	v1alpha1.UnimplementedPackagesServiceServer
 
+	// clientGetter is a field so that it can be switched in tests for
+	// a fake client. NewServer() below sets this automatically with the
+	// non-test implementation.
 	clientGetter func(context.Context) (dynamic.Interface, error)
 }
 

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -84,7 +84,7 @@ func (s *Server) GetAvailablePackages(ctx context.Context, request *corev1.GetAv
 
 	pkgs, err := client.Resource(packageResource).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to list kapp-controller packages: %w", err)
+		return nil, status.Errorf(codes.Internal, fmt.Sprintf("unable to list kapp-controller packages: %v", err))
 	}
 
 	responsePackages := []*corev1.AvailablePackage{}
@@ -92,13 +92,13 @@ func (s *Server) GetAvailablePackages(ctx context.Context, request *corev1.GetAv
 		pkg := &corev1.AvailablePackage{}
 		name, found, err := unstructured.NestedString(pkgUnstructured.Object, "spec", "publicName")
 		if err != nil || !found {
-			return nil, fmt.Errorf("required field publicName not found on kapp-controller package: %w:\n%v", err, pkgUnstructured.Object)
+			return nil, status.Errorf(codes.Internal, "required field publicName not found on kapp-controller package: %v:\n%v", err, pkgUnstructured.Object)
 		}
 		pkg.Name = name
 
 		version, found, err := unstructured.NestedString(pkgUnstructured.Object, "spec", "version")
 		if err != nil || !found {
-			return nil, fmt.Errorf("required field version not found on kapp-controller package: %w:\n%v", err, pkgUnstructured.Object)
+			return nil, status.Errorf(codes.Internal, "required field version not found on kapp-controller package: %v:\n%v", err, pkgUnstructured.Object)
 		}
 		pkg.Version = version
 		responsePackages = append(responsePackages, pkg)

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -53,7 +53,7 @@ func TestGetAvailablePackagesStatus(t *testing.T) {
 				return fake.NewSimpleDynamicClientWithCustomListKinds(
 					runtime.NewScheme(),
 					map[schema.GroupVersionResource]string{
-						{Group: "package.carvel.dev", Version: "v1alpha1", Resource: "packages"}: "PackageList",
+						{Group: packageGroup, Version: packageVersion, Resource: packagesResource}: "PackageList",
 					},
 					packageFromSpec(map[string]interface{}{
 						"version": "1.2.3",
@@ -68,7 +68,7 @@ func TestGetAvailablePackagesStatus(t *testing.T) {
 				return fake.NewSimpleDynamicClientWithCustomListKinds(
 					runtime.NewScheme(),
 					map[schema.GroupVersionResource]string{
-						{Group: "package.carvel.dev", Version: "v1alpha1", Resource: "packages"}: "PackageList",
+						{Group: packageGroup, Version: packageVersion, Resource: packagesResource}: "PackageList",
 					},
 					packageFromSpec(map[string]interface{}{
 						"publicName": "someName",
@@ -83,7 +83,7 @@ func TestGetAvailablePackagesStatus(t *testing.T) {
 				return fake.NewSimpleDynamicClientWithCustomListKinds(
 					runtime.NewScheme(),
 					map[schema.GroupVersionResource]string{
-						{Group: "package.carvel.dev", Version: "v1alpha1", Resource: "packages"}: "PackageList",
+						{Group: packageGroup, Version: packageVersion, Resource: packagesResource}: "PackageList",
 					},
 					packageFromSpec(map[string]interface{}{
 						"publicName": "someName",
@@ -116,7 +116,7 @@ func TestGetAvailablePackagesStatus(t *testing.T) {
 func packageFromSpec(spec map[string]interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "package.carvel.dev/v1alpha1",
+			"apiVersion": fmt.Sprintf("%s/%s", packageGroup, packageVersion),
 			"kind":       "Package",
 			"metadata": map[string]interface{}{
 				"name": fmt.Sprintf("%s.%s", spec["publicName"], spec["version"]),
@@ -173,7 +173,7 @@ func TestGetAvailablePackages(t *testing.T) {
 					return fake.NewSimpleDynamicClientWithCustomListKinds(
 						runtime.NewScheme(),
 						map[schema.GroupVersionResource]string{
-							{Group: "package.carvel.dev", Version: "v1alpha1", Resource: "packages"}: "PackageList",
+							{Group: packageGroup, Version: packageVersion, Resource: packagesResource}: "PackageList",
 						},
 						pkgs...,
 					), nil

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright © 2021 VMware
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+func TestGetAvailabelPackagesBadConfig(t *testing.T) {
+	testCases := []struct {
+		name         string
+		clientGetter func(context.Context) (dynamic.Interface, error)
+		statusCode   codes.Code
+	}{
+		{
+			name:         "returns internal error when no getter configured",
+			clientGetter: nil,
+			statusCode:   codes.Internal,
+		},
+		{
+			name: "returns unknown with the original error message when configGetter errors",
+			clientGetter: func(context.Context) (dynamic.Interface, error) {
+				return nil, fmt.Errorf("Bang!")
+			},
+			statusCode: codes.FailedPrecondition,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := Server{clientGetter: tc.clientGetter}
+
+			_, err := s.GetAvailablePackages(context.Background(), &corev1.GetAvailablePackagesRequest{})
+
+			if err == nil {
+				t.Fatalf("got: nil, want: error")
+			}
+
+			if got, want := status.Code(err), tc.statusCode; got != want {
+				t.Errorf("got: %+v, want: %+v", got, want)
+			}
+		})
+	}
+
+}
+
+func packageFromSpec(spec map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "package.carvel.dev/v1alpha1",
+			"kind":       "Package",
+			"metadata": map[string]interface{}{
+				"name": fmt.Sprintf("%s.%s", spec["publicName"], spec["version"]),
+			},
+			"spec": spec,
+		},
+	}
+}
+
+func packagesFromSpecs(specs []map[string]interface{}) []*unstructured.Unstructured {
+	pkgs := []*unstructured.Unstructured{}
+	for _, s := range specs {
+		pkgs = append(pkgs, packageFromSpec(s))
+	}
+	return pkgs
+}
+
+func TestGetAvailablePackages(t *testing.T) {
+	testCases := []struct {
+		name             string
+		packageSpecs     []map[string]interface{}
+		expectedPackages []*corev1.AvailablePackage
+	}{
+		{
+			name: "it returns carvel packages from the cluster",
+			packageSpecs: []map[string]interface{}{
+				{
+					"publicName": "tetris.foo.example.com",
+					"version":    "1.2.3",
+				},
+				{
+					"publicName": "another.foo.example.com",
+					"version":    "1.2.5",
+				},
+			},
+			expectedPackages: []*corev1.AvailablePackage{
+				{
+					Name:    "another.foo.example.com",
+					Version: "1.2.5",
+				},
+				{
+					Name:    "tetris.foo.example.com",
+					Version: "1.2.3",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pkgs := packagesFromSpecs(tc.packageSpecs)
+			s := Server{
+				clientGetter: func(context.Context) (dynamic.Interface, error) {
+					return fake.NewSimpleDynamicClientWithCustomListKinds(
+						runtime.NewScheme(),
+						map[schema.GroupVersionResource]string{
+							{Group: "package.carvel.dev", Version: "v1alpha1", Resource: "packages"}: "PackageList",
+						},
+						// TODO: Not clear why
+						// pkgs...
+						// won't work.
+						pkgs[0],
+						pkgs[1],
+					), nil
+				},
+			}
+
+			response, err := s.GetAvailablePackages(context.Background(), &corev1.GetAvailablePackagesRequest{})
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+
+			if got, want := response.Packages, tc.expectedPackages; !cmp.Equal(got, want, cmp.Comparer(pkgEqual)) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, cmp.Comparer(pkgEqual)))
+			}
+		})
+	}
+
+}
+
+func pkgEqual(a, b *corev1.AvailablePackage) bool {
+	return a.Name == b.Name && a.Version == b.Version
+}


### PR DESCRIPTION
### Description of the change

Establish a pattern for testing with the dynamic k8s client in plugin code.

### Benefits

We'll have a pattern to follow and improve on when adding further code.

### Possible drawbacks

N/A

### Applicable issues

  - Ref #2849

