### PR TITLE
Pass additional ssh key to the script. Extracted ssh values to global ci vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,18 @@ parameters:
   CI_BOT_GPG:
     type: "string"
     default: "80B6EB16B1328FB18DFF2A073EBA68F3347E319D"
+  CI_BOT_KUBEAPPS_KUBEAPPS_DEPLOYKEY_FINGERPRINT:
+    type: "string"
+    default: "20:5e:d1:68:7c:10:67:c1:ab:e2:6e:33:e3:7a:64:6e"
+  CI_BOT_KUBEAPPS_KUBEAPPS_DEPLOYKEY_FILENAME:
+    type: "string"
+    default: "id_rsa_205ed1687c1067c1abe26e33e37a646e"
+  CI_BOT_FORKED_CHARTS_DEPLOYKEY_FINGERPRINT:
+    type: "string"
+    default: "59:81:2a:95:a6:54:a7:46:e5:15:f5:37:b3:4f:6c:ad"
+  CI_BOT_FORKED_CHARTS_DEPLOYKEY_FILENAME:
+    type: "string"
+    default: "id_rsa_59812a95a654a746e515f537b34f6cad"
 
 ## Build conditions
 # Build in any branch or tag
@@ -660,7 +672,8 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             # Deployment key uploaded to the kubeapps-bot/charts repository
-            - "59:81:2a:95:a6:54:a7:46:e5:15:f5:37:b3:4f:6c:ad"
+            - << pipeline.parameters.CI_BOT_FORKED_CHARTS_DEPLOYKEY_FINGERPRINT >>
+
       - run:
           # This is a key pair: https://circleci.com/docs/2.0/gh-bb-integration/
           # public key uploaded to GitHub as a deploy key with write permissions in both kubeapps and kubeapps-bot/charts
@@ -670,7 +683,7 @@ jobs:
             eval "$(ssh-agent -s)"
             # the name is always "id_rsa_"+fingerprint without ":""
             # Deployment key uploaded to the kubeapps-bot/charts repository
-            ssh-add ~/.ssh/id_rsa_59812a95a654a746e515f537b34f6cad
+            ssh-add ~/.ssh/<< pipeline.parameters.CI_BOT_FORKED_CHARTS_DEPLOYKEY_FILENAME >>
       - run:
           # Assuming there is a personal access token created in GitHub granted with the scopes
           # "repo:status", "public_repo" and "read:org"
@@ -691,9 +704,9 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             # Deployment key uploaded to the kubeapps/kubeapps repository
-            - "20:5e:d1:68:7c:10:67:c1:ab:e2:6e:33:e3:7a:64:6e"
+            - << pipeline.parameters.CI_BOT_KUBEAPPS_KUBEAPPS_DEPLOYKEY_FINGERPRINT >>
             # Deployment key uploaded to the kubeapps-bot/charts repository
-            - "59:81:2a:95:a6:54:a7:46:e5:15:f5:37:b3:4f:6c:ad"
+            - << pipeline.parameters.CI_BOT_FORKED_CHARTS_DEPLOYKEY_FINGERPRINT >>
 
       - run:
           # This is a key pair: https://circleci.com/docs/2.0/gh-bb-integration/
@@ -704,16 +717,16 @@ jobs:
             eval "$(ssh-agent -s)"
             # the name is always "id_rsa_"+fingerprint without ":""
             # Deployment key uploaded to the kubeapps/kubeapps repository
-            ssh-add ~/.ssh/id_rsa_205ed1687c1067c1abe26e33e37a646e
+            ssh-add ~/.ssh/<< pipeline.parameters.CI_BOT_KUBEAPPS_KUBEAPPS_DEPLOYKEY_FILENAME >>
             # Deployment key uploaded to the kubeapps-bot/charts repository
-            ssh-add ~/.ssh/id_rsa_59812a95a654a746e515f537b34f6cad
+            ssh-add ~/.ssh/<< pipeline.parameters.CI_BOT_FORKED_CHARTS_DEPLOYKEY_FILENAME >>
       - run:
           # Assuming there is a personal access token created in GitHub granted with the scopes
           # "repo:status", "public_repo" and "read:org"
           # This token is passed as a GITHUB_TOKEN env var via CircleCI
           name: Execute the check_upstream_chart script
           command: |
-            ./script/chart_upstream_checker.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >>
+            ./script/chart_upstream_checker.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >> << pipeline.parameters.CI_BOT_FORKED_CHARTS_DEPLOYKEY_FILENAME >>
   push_images:
     docker:
       - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -106,6 +106,7 @@ updateRepoWithLocalChanges() {
         echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
         return 1
     fi
+    # Fetch latest upstream changes, and commit&push them to the forked charts repo
     git -C "${targetRepo}" remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
     git -C "${targetRepo}" pull upstream master
     git -C "${targetRepo}" push origin master
@@ -126,6 +127,7 @@ updateRepoWithLocalChanges() {
 updateRepoWithRemoteChanges() {
     local targetRepo=${1:?}
     local targetTag=${2:?}
+    local forkSSHKeyFilename=${3:?}
     local targetTagWithoutV=${targetTag#v}
     local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
     local remoteChartYaml="${targetChartPath}/Chart.yaml"
@@ -134,9 +136,10 @@ updateRepoWithRemoteChanges() {
         echo "Wrong repo path. You should provide the root of the repository" > /dev/stderr
         return 1
     fi
+    # Fetch latest upstream changes, and commit&push them to the forked charts repo
     git -C "${targetRepo}" remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
     git -C "${targetRepo}" pull upstream master
-    git -C "${targetRepo}" push origin master
+    GIT_SSH_COMMAND="ssh -i ~/.ssh/${forkSSHKeyFilename}" git -C "${targetRepo}" push origin master
     rm -rf "${KUBEAPPS_CHART_DIR}"
     cp -R "${targetChartPath}" "${KUBEAPPS_CHART_DIR}"
     # Update Chart.yaml with new version

--- a/script/chart_upstream_checker.sh
+++ b/script/chart_upstream_checker.sh
@@ -20,6 +20,7 @@ source $(dirname $0)/chart_sync_utils.sh
 user=${1:?}
 email=${2:?}
 gpg=${3:?}
+forkSSHKeyFilename=${4:?}
 
 currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep -oP '(?<=^version: ).*' )
 externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO_ORIGINAL}/master/${CHART_REPO_PATH}/Chart.yaml | grep -oP '(?<=^version: ).*' )
@@ -33,7 +34,7 @@ if [[ ${semverCompare} -lt 0 ]]; then
     configUser $tempDir $user $email $gpg
     configUser $PROJECT_DIR $user $email $gpg
     latestVersion=$(latestReleaseTag $PROJECT_DIR)
-    updateRepoWithRemoteChanges $tempDir $latestVersion
+    updateRepoWithRemoteChanges $tempDir $latestVersion $forkSSHKeyFilename
     commitAndSendInternalPR ${PROJECT_DIR} "sync-chart-changes-${externalVersion}" ${externalVersion}
 elif [[ ${semverCompare} -gt 0 ]]; then
     echo "Skipping Chart sync. WARNING Current chart version ("${currentVersion}") is greater than the chart external version ("${externalVersion}")"


### PR DESCRIPTION
### Description of the change

This PR tries to solve a lack of permission issue since the default ssh key loaded is not valid for the forked repository.
At the same time, I've extracted the ssh-related params to CI variables, as passing manually the values is so error-prone


### Benefits

Syncing charts working... hopefully

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

An alternative is to define "labeled" host like:

```
Host github-as-kubeappsbot
  HostName github.com
  User git
  IdentityFile ~/.ssh/id_rsa.xxxxx
  IdentitiesOnly yes
```

But since we just need permission for pushing, it's clearer to just pass the key explicitly
