### PR TITLE
Add kubeappsapis behind nginx

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.0.5-dev1
+version: 7.0.5-dev2

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -73,6 +73,13 @@ http://{{ include "kubeapps.kubeops.fullname" . }}:{{ .Values.kubeops.service.po
 {{- end -}}
 
 {{/*
+Create proxy_pass for the kubeappsapis
+*/}}
+{{- define "kubeapps.kubeappsapis.proxy_pass" -}}
+http://{{ include "kubeapps.kubeappsapis.fullname" . }}:{{ .Values.kubeappsapis.service.port }}
+{{- end -}}
+
+{{/*
 Create name for kubeappsapis based on the fullname
 */}}
 {{- define "kubeapps.kubeappsapis.fullname" -}}

--- a/chart/kubeapps/templates/frontend/configmap.yaml
+++ b/chart/kubeapps/templates/frontend/configmap.yaml
@@ -140,9 +140,9 @@ data:
       }
 
     {{- if .Values.featureFlags.kubeappsAPIsServer }}
-      location ~* /api/kubeappsapis {
+      location ~* /apis {
         rewrite ^ $request_uri; # pass the encoded url downstream as is,
-        rewrite /api/kubeappsapis([^?]*) $1?$args break;
+        rewrite /apis([^?]*) $1?$args break;
     {{- if .Values.frontend.proxypassExtraSetHeader }}
         proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
     {{- end }}

--- a/chart/kubeapps/templates/frontend/configmap.yaml
+++ b/chart/kubeapps/templates/frontend/configmap.yaml
@@ -139,6 +139,22 @@ data:
     {{- end }}
       }
 
+    {{- if .Values.featureFlags.kubeappsAPIsServer }}
+      location ~* /api/kubeappsapis {
+        rewrite ^ $request_uri; # pass the encoded url downstream as is,
+        rewrite /api/kubeappsapis([^?]*) $1?$args break;
+    {{- if .Values.frontend.proxypassExtraSetHeader }}
+        proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
+    {{- end }}
+        proxy_pass {{ include "kubeapps.kubeappsapis.proxy_pass" . -}};
+
+    {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
+        # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
+        proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
+    {{- end }}
+      }
+    {{- end }}
+
       # The route for the Kubeapps backend API is not prefixed.
       location ~* /api/ {
         rewrite /api/(.*) /backend/$1 break;


### PR DESCRIPTION
### Description of the change

This PR simply adds (if the feature flag is enabled) the current kubeapps-apis behind the nginx reverse proxy. This way, we can pass through the authentication token as in the rest of the services.

### Benefits

Besides paving the way for #2851, it also allows using the API without any port-forwarding. 

### Possible drawbacks

Note that -currently- it uses a privileged SA to list everything, but it is not a production-ready thing and we soon change are changing it to use the user's credentials, it's not a big deal.

### Applicable issues

N/A

### Additional information

I hope to be sending the auth PR soon :S