### PR TITLE
Fix Helm template CI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,12 @@ parameters:
   DOCKER_VERSION:
     type: string
     default: "19.03.13"
-  HELM_VERSION:
+  HELM_VERSION_MIN:
     type: "string"
     default: "v3.1.0"
+  HELM_VERSION_STABLE:
+    type: "string"
+    default: "v3.6.0"
   OLM_VERSION:
     type: "string"
     default: "v0.17.0"
@@ -183,7 +186,8 @@ workflows:
 common_envars: &common_envars
   DOCKER_VERSION: << pipeline.parameters.DOCKER_VERSION >>
   GOLANG_VERSION: << pipeline.parameters.GOLANG_VERSION >>
-  HELM_VERSION: << pipeline.parameters.HELM_VERSION >>
+  HELM_VERSION_MIN: << pipeline.parameters.HELM_VERSION_MIN >>
+  HELM_VERSION_STABLE: << pipeline.parameters.HELM_VERSION_STABLE >>
   K8S_KIND_VERSION: << pipeline.parameters.K8S_KIND_VERSION >>
   KIND_VERSION: << pipeline.parameters.KIND_VERSION >>
   KUBECTL_VERSION: << pipeline.parameters.KUBECTL_VERSION >>
@@ -207,11 +211,15 @@ install_gcloud_sdk: &install_gcloud_sdk
       fi
 install_helm_cli: &install_helm_cli
   run:
-    name: "Install helm"
+    name: "Install helm (minimum and stable)"
     command: |
-      wget https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz
-      tar zxf helm-$HELM_VERSION-linux-amd64.tar.gz
+      wget https://get.helm.sh/helm-${HELM_VERSION_MIN}-linux-amd64.tar.gz
+      tar zxf helm-$HELM_VERSION_MIN-linux-amd64.tar.gz
       sudo mv linux-amd64/helm /usr/local/bin/
+
+      wget https://get.helm.sh/helm-${HELM_VERSION_STABLE}-linux-amd64.tar.gz
+      tar zxf helm-$HELM_VERSION_STABLE-linux-amd64.tar.gz
+      sudo mv linux-amd64/helm /usr/local/bin/helm-stable
 exports: &exports
   run:
     name: "Export variables"

--- a/script/chart-template-test.sh
+++ b/script/chart-template-test.sh
@@ -20,5 +20,9 @@ ROOT_DIR=`cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd`
 CHART_DIR=$ROOT_DIR/chart/kubeapps/
 helm dep up $CHART_DIR
 
-# tests
-helm template $CHART_DIR
+# test with the minium supported helm version
+helm template $CHART_DIR --debug
+
+# test with the latest stable helm version
+helm-stable template $CHART_DIR --debug 
+

--- a/script/libtest.sh
+++ b/script/libtest.sh
@@ -56,8 +56,8 @@ k8s_wait_for_deployment() {
       exit_code=0;
       until $rolloutCmd || [ $attempts -eq $extraAttempts ]; do
         $rolloutCmd 
-        extraAttempts=$((attempts + 1))
-        info "Retrying after $extraAttemptsWait..."
+        attempts=$((attempts + 1))
+        info "$attempts/$extraAttempts - Retrying after $extraAttemptsWait s..."
         sleep $extraAttemptsWait
       done
     fi

--- a/script/libtest.sh
+++ b/script/libtest.sh
@@ -51,11 +51,11 @@ k8s_wait_for_deployment() {
         sleep $retriesWait
         retries=$((retries - 1))
     done
-  if [ $retries == 0 ]; then
-      info "Error while rolling out deployment ${deployment} in ns ${namespace}"
-      exit 1
-  fi
-   return $exit_code
+    if [ $retries == 0 ]; then
+        info "Error while rolling out deployment ${deployment} in ns ${namespace}"
+        exit 1
+    fi
+    return $exit_code
 }
 
 ########################

--- a/script/libtest.sh
+++ b/script/libtest.sh
@@ -38,30 +38,24 @@ k8s_wait_for_deployment() {
     namespace=${1:?namespace is missing}
     deployment=${2:?deployment name is missing}
     local -i exit_code=0
-    local -i attempts=0
+    local retries=5
+    local retriesWait=10
 
-    local extraAttempts=3
-    local extraAttemptsWait=10
-
-    local rolloutCmd="silence kubectl rollout status --namespace "$namespace" deployment "$deployment" -w --timeout=60s"
-
-    debug "Waiting for deployment ${deployment} to be successfully rolled out..."
-    # Avoid to exit the function if the rollout fails
-    $rolloutCmd || exit_code=$?
-    debug "Rollout exit code: '${exit_code}'"
-    if [ ${exit_code} -ne 0 ]
-    then
-      info "Rollout failed, attempting $extraAttempts times more"
-      kubectl get pods --namespace "$namespace"
-      exit_code=0;
-      until $rolloutCmd || [ $attempts -eq $extraAttempts ]; do
-        $rolloutCmd 
-        attempts=$((attempts + 1))
-        info "$attempts/$extraAttempts - Retrying after $extraAttemptsWait s..."
-        sleep $extraAttemptsWait
-      done
-    fi
-    return $exit_code
+    info "Checking rollout status in deployment ${deployment} in ns ${namespace}"
+    until [[ $retries == 0 ]]; do
+        silence kubectl rollout status --namespace "${namespace}" deployment "${deployment}" -w --timeout=60s || exit_code=$?
+        if [[ $exit_code -eq 0 ]]; then
+            break
+        fi
+        info "Attempt failed, retrying after ${retriesWait}... (remaining attempts: ${retries})"
+        sleep $retriesWait
+        retries=$((retries - 1))
+    done
+  if [ $retries == 0 ]; then
+      info "Error while rolling out deployment ${deployment} in ns ${namespace}"
+      exit 1
+  fi
+   return $exit_code
 }
 
 ########################


### PR DESCRIPTION
### Description of the change

Follow up of #2950. After analyzing the root cause (besides the lack of enough time to terminate/create the pod), it was a silly issue with the template (I always forget Helm doesn't have lazy evaluation...). The problem is that our CI was unable to catch this error since Helm 3.1 wasn't returning any information or errors.  

### Benefits

This PR performs two changes: a) minor change in the logic introduced in #2950 (silly typo in the counter variable name...); b) installing a new helm version (latest stable) available at `helm-stable` just for performing an additional `helm template` check to avoid these errors. 

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

Example of the former bug being caught: https://app.circleci.com/pipelines/github/antgamdia/kubeapps/590/workflows/ee637b9f-8426-4db2-b87c-78eb1ef184d5/jobs/4006