### PR TITLE
Fix a null pointer in fetchNamespaces

### DIFF
--- a/dashboard/src/actions/namespace.test.tsx
+++ b/dashboard/src/actions/namespace.test.tsx
@@ -83,6 +83,22 @@ describe("fetchNamespaces", () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
+  it("dispatches errorNamespace if the request returns no 'namespaces'", async () => {
+    Namespace.list = jest.fn().mockImplementationOnce(() => {
+      return {};
+    });
+    const err = new Error("The current account does not have access to any namespaces");
+    const expectedActions = [
+      {
+        type: getType(errorNamespaces),
+        payload: { cluster: "default-c", err, op: "list" },
+      },
+    ];
+
+    await store.dispatch(fetchNamespaces("default-c"));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
   it("dispatches errorNamespace if error listing namespaces", async () => {
     const err = new Error("Bang!");
     Namespace.list = jest.fn().mockImplementationOnce(() => Promise.reject(err));

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -55,7 +55,11 @@ export function fetchNamespaces(
   return async dispatch => {
     try {
       const namespaceList = await Namespace.list(cluster);
-      const namespaceStrings = namespaceList.namespaces.map((n: IResource) => n.metadata.name);
+
+      const namespaceStrings =
+        namespaceList.namespaces === undefined
+          ? []
+          : namespaceList.namespaces.map((n: IResource) => n.metadata.name);
       if (namespaceStrings.length === 0) {
         dispatch(
           errorNamespaces(

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -1,5 +1,6 @@
 import { ThunkAction } from "redux-thunk";
 import { Kube } from "shared/Kube";
+import { get } from "lodash";
 
 import { ActionType, deprecated } from "typesafe-actions";
 
@@ -55,11 +56,9 @@ export function fetchNamespaces(
   return async dispatch => {
     try {
       const namespaceList = await Namespace.list(cluster);
-
-      const namespaceStrings =
-        namespaceList.namespaces === undefined
-          ? []
-          : namespaceList.namespaces.map((n: IResource) => n.metadata.name);
+      const namespaceStrings = get(namespaceList, "namespaces", []).map(
+        (n: IResource) => n.metadata.name,
+      );
       if (namespaceStrings.length === 0) {
         dispatch(
           errorNamespaces(


### PR DESCRIPTION
### Description of the change

We had an unhandled null in the `fetchNamespaces` action; this PR simply adds a check to display the proper error message back to the user

### Benefits

No more "cannot read property .map from undefined"  ugly errors : )

### Possible drawbacks

N/A

### Applicable issues

  - fixes #2956

### Additional information

N/A