### PR TITLE
Update port name for kubeapps-apis to be clear it includes both grpc and http.

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.1.1-dev3
+version: 7.1.1-dev4

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -100,7 +100,7 @@ spec:
             {{- end }}
           {{- end }}
           ports:
-            - name: http
+            - name: grpc_http
               containerPort: {{ .Values.kubeappsapis.containerPort }}
           {{- if .Values.kubeappsapis.livenessProbe.enabled }}
           livenessProbe: {{- omit .Values.kubeappsapis.livenessProbe "enabled" | toYaml | nindent 12 }}

--- a/chart/kubeapps/templates/kubeappsapis/service.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/service.yaml
@@ -22,9 +22,9 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.kubeappsapis.service.port }}
-      targetPort: http
+      targetPort: grpc_http
       protocol: TCP
-      name: http
+      name: grpc_http
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: kubeappsapis
 {{- end }}


### PR DESCRIPTION
### Description of the change

Just a follow-up from a [discussion on a previous PR](https://github.com/kubeapps/kubeapps/pull/2819#discussion_r634193991).

### Benefits

It is clear from the k8s config that the port is used for both http and grpc.

