### PR TITLE
fix: kubeopps ns-header-* parameter(s) typo

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.1.1-dev3
+version: 7.1.2-dev3

--- a/chart/kubeapps/templates/kubeops/deployment.yaml
+++ b/chart/kubeapps/templates/kubeops/deployment.yaml
@@ -83,10 +83,10 @@ spec:
             - --qps={{ .Values.kubeops.QPS }}
             {{- end }}
             {{- if .Values.kubeops.namespaceHeaderName }}
-            - --ns-header-name={{ .Values.kubeops.namespaceHeaderName }}
+            - --namespace-header-name={{ .Values.kubeops.namespaceHeaderName }}
             {{- end }}
             {{- if .Values.kubeops.namespaceHeaderPattern }}
-            - --ns-header-pattern={{ .Values.kubeops.namespaceHeaderPattern }}
+            - --namespace-header-pattern={{ .Values.kubeops.namespaceHeaderPattern }}
             {{- end }}
           env:
             - name: POD_NAMESPACE


### PR DESCRIPTION
Typo! `unknown flag: --ns-header-name`

```
unknown flag: --ns-header-name
Usage of /kubeops:
unknown flag: --ns-header-name
      --assetsvc-url string               URL to the internal assetsvc (default "https://kubeapps-internal-assetsvc:8080")
      --burst int                         internal burst capacity (default 15)
      --clusters-config-path string       Configuration for clusters
      --debug                             Enable verbose output
      --helm-driver string                which Helm driver type to use
      --home string                       Location of your Helm config. Overrides $HELM_HOME (default "/.helm")
      --host string                       Address of Tiller. Overrides $HELM_HOST
      --kube-context string               Name of the kubeconfig context to use
      --kubeconfig string                 Absolute path of the kubeconfig file to be used
      --list-max int                      maximum number of releases to fetch (default 256)
      --namespace-header-name string      name of the header field, e.g. namespace-header-name=X-Consumer-Groups
      --namespace-header-pattern string   regular expression that matches only single group, e.g. namespace-header-pattern=^namespace:([\w]+):\w+$, to match namespace:ns:read
      --pinniped-proxy-url string         internal url to be used for requests to clusters configured for credential proxying via pinniped (default "http://kubeapps-internal-pinniped-proxy.kubeapps:3333")
      --qps float32                       internal QPS rate (default 10)
      --tiller-connection-timeout int     The duration (in seconds) Helm will wait to establish a connection to Tiller (default 300)
      --tiller-namespace string           Namespace of Tiller (default "kube-system")
      --timeout int                       Timeout to perform release operations (install, upgrade, rollback, delete) (default 300)
      --user-agent-comment string         UserAgent comment used during outbound requests
```