### PR TITLE
Distribute dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,22 +7,26 @@ updates:
     directory: "/dashboard"
     schedule:
       interval: "daily"
+      time: "00:00"
     open-pull-requests-limit: 2
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+      time: "01:00"
     open-pull-requests-limit: 2
 
   - package-ecosystem: "cargo"
     directory: "/cmd/pinniped-proxy"
     schedule:
       interval: "daily"
+      time: "02:00"
     open-pull-requests-limit: 2
 
   - package-ecosystem: "npm"
     directory: "/integration"
     schedule:
       interval: "daily"
+      time: "03:00"
     open-pull-requests-limit: 2


### PR DESCRIPTION
### Description of the change

This PR simply distributes the dependabot checks in 1-hour intervals so that the CI doesn't get exhausted.
(The default behavior is to check everything at 05:00 UTC)

### Benefits

Ci will handle the eventual PRs better

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

For the record, the first check begins at 10am (AUS)/ 2am (ES, dst)