### PR TITLE
Fix non-alpha label for port

### DIFF
--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -100,7 +100,7 @@ spec:
             {{- end }}
           {{- end }}
           ports:
-            - name: grpc_http
+            - name: grpc-http
               containerPort: {{ .Values.kubeappsapis.containerPort }}
           {{- if .Values.kubeappsapis.livenessProbe.enabled }}
           livenessProbe: {{- omit .Values.kubeappsapis.livenessProbe "enabled" | toYaml | nindent 12 }}

--- a/chart/kubeapps/templates/kubeappsapis/service.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/service.yaml
@@ -22,9 +22,9 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.kubeappsapis.service.port }}
-      targetPort: grpc_http
+      targetPort: grpc-http
       protocol: TCP
-      name: grpc_http
+      name: grpc-http
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: kubeappsapis
 {{- end }}


### PR DESCRIPTION
### Description of the change

I didn't check the label change with a deploy, can't use underscores.

I'm testing this in a deploy now and won't land it unless it works (since we don't have CI testing kubeappsapis yet).

### Benefits

Can deploy in dev again.

### Possible drawbacks

None (assuming it works as advertised).

