### PR TITLE
Update the postgresql asset manager to be publicly exported.

### DIFF
--- a/cmd/assetsvc/handler.go
+++ b/cmd/assetsvc/handler.go
@@ -135,7 +135,7 @@ func extractChartQueryFromRequest(namespace, repo string, req *http.Request) Cha
 }
 
 func getAllChartCategories(cq ChartQuery) (apiChartCategoryListResponse, error) {
-	chartCategories, err := manager.getAllChartCategories(cq)
+	chartCategories, err := manager.GetAllChartCategories(cq)
 	return newChartCategoryListResponse(chartCategories), err
 }
 
@@ -166,7 +166,7 @@ func getChart(w http.ResponseWriter, req *http.Request, params Params) {
 	}
 	chartID := getChartID(repo, params["chartName"]) // chartName remains encoded
 
-	chart, err := manager.getChart(namespace, chartID)
+	chart, err := manager.GetChart(namespace, chartID)
 	if err != nil {
 		log.WithError(err).Errorf("could not find chart with id %s", chartID)
 		response.NewErrorResponse(http.StatusNotFound, "could not find chart").Write(w)
@@ -186,7 +186,7 @@ func listChartVersions(w http.ResponseWriter, req *http.Request, params Params) 
 	}
 	chartID := getChartID(repo, params["chartName"]) // chartName remains encoded
 
-	chart, err := manager.getChart(namespace, chartID)
+	chart, err := manager.GetChart(namespace, chartID)
 	if err != nil {
 		log.WithError(err).Errorf("could not find chart with id %s", chartID)
 		response.NewErrorResponse(http.StatusNotFound, "could not find chart").Write(w)
@@ -206,7 +206,7 @@ func getChartVersion(w http.ResponseWriter, req *http.Request, params Params) {
 	}
 	chartID := getChartID(repo, params["chartName"]) // chartName remains encoded
 
-	chart, err := manager.getChartVersion(namespace, chartID, version)
+	chart, err := manager.GetChartVersion(namespace, chartID, version)
 	if err != nil {
 		log.WithError(err).Errorf("could not find chart with id %s", chartID)
 		response.NewErrorResponse(http.StatusNotFound, "could not find chart version").Write(w)
@@ -226,7 +226,7 @@ func getChartIcon(w http.ResponseWriter, req *http.Request, params Params) {
 	}
 	chartID := getChartID(repo, params["chartName"]) // chartName remains encoded
 
-	chart, err := manager.getChart(namespace, chartID)
+	chart, err := manager.GetChart(namespace, chartID)
 	if err != nil {
 		log.WithError(err).Errorf("could not find chart with id %s", chartID)
 		http.NotFound(w, req)
@@ -256,7 +256,7 @@ func getChartVersionReadme(w http.ResponseWriter, req *http.Request, params Para
 	}
 	fileID := fmt.Sprintf("%s-%s", getChartID(repo, params["chartName"]), version) // chartName remains encoded
 
-	files, err := manager.getChartFiles(namespace, fileID)
+	files, err := manager.GetChartFiles(namespace, fileID)
 	if err != nil {
 		log.WithError(err).Errorf("could not find files with id %s", fileID)
 		http.NotFound(w, req)
@@ -280,7 +280,7 @@ func getChartVersionValues(w http.ResponseWriter, req *http.Request, params Para
 	}
 	fileID := fmt.Sprintf("%s-%s", getChartID(repo, params["chartName"]), version) // chartName remains encoded
 
-	files, err := manager.getChartFiles(namespace, fileID)
+	files, err := manager.GetChartFiles(namespace, fileID)
 	if err != nil {
 		log.WithError(err).Errorf("could not find values.yaml with id %s", fileID)
 		http.NotFound(w, req)
@@ -299,7 +299,7 @@ func getChartVersionSchema(w http.ResponseWriter, req *http.Request, params Para
 	}
 	fileID := fmt.Sprintf("%s-%s", getChartID(repo, params["chartName"]), version) // chartName remains encoded
 
-	files, err := manager.getChartFiles(namespace, fileID)
+	files, err := manager.GetChartFiles(namespace, fileID)
 	if err != nil {
 		log.WithError(err).Errorf("could not find values.schema.json with id %s", fileID)
 		http.NotFound(w, req)
@@ -319,7 +319,7 @@ func listChartsWithFilters(w http.ResponseWriter, req *http.Request, params Para
 	cq := extractChartQueryFromRequest(namespace, repo, req)
 
 	pageNumber, pageSize := getPageAndSizeParams(req)
-	charts, totalPages, err := manager.getPaginatedChartListWithFilters(cq, pageNumber, pageSize)
+	charts, totalPages, err := manager.GetPaginatedChartListWithFilters(cq, pageNumber, pageSize)
 	if err != nil {
 		log.WithError(err).Errorf("could not find charts with the given namespace=%s, chartName=%s, version=%s, appversion=%s, repos=%s, categories=%s, searchQuery=%s",
 			cq.namespace, cq.chartName, cq.version, cq.appVersion, cq.repos, cq.categories, cq.searchQuery,

--- a/cmd/assetsvc/handler_test.go
+++ b/cmd/assetsvc/handler_test.go
@@ -76,7 +76,7 @@ func setMockManager(t *testing.T) (sqlmock.Sqlmock, func()) {
 	// TODO(absoludity): Let's not use globals for storing state like this.
 	origManager := manager
 
-	manager = &postgresAssetManager{&dbutils.PostgresAssetManager{DB: db, KubeappsNamespace: kubeappsNamespace}}
+	manager = &PostgresAssetManager{&dbutils.PostgresAssetManager{DB: db, KubeappsNamespace: kubeappsNamespace}}
 
 	return mock, func() { db.Close(); manager = origManager }
 }

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -31,7 +31,7 @@ import (
 const pathPrefix = "/v1"
 
 // TODO(absoludity): Let's not use globals for storing state like this.
-var manager assetManager
+var manager AssetManager
 
 func setupRoutes() http.Handler {
 	r := mux.NewRouter()

--- a/cmd/assetsvc/postgres_db_test.go
+++ b/cmd/assetsvc/postgres_db_test.go
@@ -33,9 +33,9 @@ import (
 	_ "github.com/lib/pq"
 )
 
-func getInitializedManager(t *testing.T) (*postgresAssetManager, func()) {
+func getInitializedManager(t *testing.T) (*PostgresAssetManager, func()) {
 	pam, cleanup := pgtest.GetInitializedManager(t)
-	return &postgresAssetManager{pam}, cleanup
+	return &PostgresAssetManager{pam}, cleanup
 }
 
 func TestGetChart(t *testing.T) {

--- a/cmd/assetsvc/postgres_db_test.go
+++ b/cmd/assetsvc/postgres_db_test.go
@@ -90,7 +90,7 @@ func TestGetChart(t *testing.T) {
 				pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repoName, Namespace: namespace})
 			}
 
-			chart, err := pam.getChart(tc.namespace, tc.chartId)
+			chart, err := pam.GetChart(tc.namespace, tc.chartId)
 
 			if got, want := err, tc.expectedErr; got != want {
 				t.Fatalf("In '"+tc.name+"': "+"got: %+v, want: %+v", got, want)
@@ -175,7 +175,7 @@ func TestGetVersion(t *testing.T) {
 				pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repoName, Namespace: namespace})
 			}
 
-			chart, err := pam.getChartVersion(tc.namespace, tc.chartId, tc.requestedVersion)
+			chart, err := pam.GetChartVersion(tc.namespace, tc.chartId, tc.requestedVersion)
 
 			if got, want := err, tc.expectedErr; got != want {
 				t.Fatalf("got: %+v, want: %+v", got, want)
@@ -387,7 +387,7 @@ func TestGetPaginatedChartList(t *testing.T) {
 				}
 			}
 
-			charts, numPages, err := pam.getPaginatedChartListWithFilters(ChartQuery{namespace: tc.namespace, repos: []string{tc.repo}}, 1, 10)
+			charts, numPages, err := pam.GetPaginatedChartListWithFilters(ChartQuery{namespace: tc.namespace, repos: []string{tc.repo}}, 1, 10)
 
 			if got, want := err, tc.expectedErr; got != want {
 				t.Fatalf("In '"+tc.name+"': "+"got err: %+v, want: %+v", got, want)
@@ -509,7 +509,7 @@ func TestGetChartsWithFilters(t *testing.T) {
 				}
 			}
 
-			charts, _, err := pam.getPaginatedChartListWithFilters(ChartQuery{namespace: tc.namespace, chartName: tc.chartName, version: tc.chartVersion, appVersion: tc.appVersion}, 1, 0)
+			charts, _, err := pam.GetPaginatedChartListWithFilters(ChartQuery{namespace: tc.namespace, chartName: tc.chartName, version: tc.chartVersion, appVersion: tc.appVersion}, 1, 0)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -35,7 +35,7 @@ var ErrChartVersionNotFound = errors.New("chart version not found")
 // TODO(agamez): temporary flag, use the fallback behavior just when necessary, not globally
 var enableFallbackQueryMode = true
 
-type postgresAssetManager struct {
+type PostgresAssetManager struct {
 	dbutils.PostgresAssetManagerIface
 }
 
@@ -44,10 +44,10 @@ func NewPGManager(config datastore.Config, kubeappsNamespace string) (AssetManag
 	if err != nil {
 		return nil, err
 	}
-	return &postgresAssetManager{m}, nil
+	return &PostgresAssetManager{m}, nil
 }
 
-func (m *postgresAssetManager) GetAllChartCategories(cq ChartQuery) ([]*models.ChartCategory, error) {
+func (m *PostgresAssetManager) GetAllChartCategories(cq ChartQuery) ([]*models.ChartCategory, error) {
 	whereQuery, whereQueryParams := m.GenerateWhereClause(cq)
 	dbQuery := fmt.Sprintf("SELECT (info ->> 'category') AS name, COUNT( (info ->> 'category')) AS count FROM %s %s GROUP BY (info ->> 'category') ORDER BY (info ->> 'category') ASC", dbutils.ChartTable, whereQuery)
 
@@ -58,7 +58,7 @@ func (m *postgresAssetManager) GetAllChartCategories(cq ChartQuery) ([]*models.C
 	return chartsCategories, nil
 }
 
-func (m *postgresAssetManager) GetPaginatedChartList(whereQuery string, whereQueryParams []interface{}, pageNumber, pageSize int) ([]*models.Chart, int, error) {
+func (m *PostgresAssetManager) GetPaginatedChartList(whereQuery string, whereQueryParams []interface{}, pageNumber, pageSize int) ([]*models.Chart, int, error) {
 	// Default (pageNumber,pageSize) = (1, 0) as in the handler.go
 	if pageNumber <= 0 {
 		pageNumber = 1
@@ -88,11 +88,11 @@ func (m *postgresAssetManager) GetPaginatedChartList(whereQuery string, whereQue
 	return charts, numPages, nil
 }
 
-func (m *postgresAssetManager) GetChart(namespace, chartID string) (models.Chart, error) {
+func (m *PostgresAssetManager) GetChart(namespace, chartID string) (models.Chart, error) {
 	return m.GetChartWithFallback(namespace, chartID, enableFallbackQueryMode)
 }
 
-func (m *postgresAssetManager) GetChartWithFallback(namespace, chartID string, withFallback bool) (models.Chart, error) {
+func (m *PostgresAssetManager) GetChartWithFallback(namespace, chartID string, withFallback bool) (models.Chart, error) {
 	var chart models.ChartIconString
 
 	err := m.QueryOne(&chart, fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_id = $2", dbutils.ChartTable), namespace, chartID)
@@ -135,11 +135,11 @@ func (m *postgresAssetManager) GetChartWithFallback(namespace, chartID string, w
 	}, nil
 }
 
-func (m *postgresAssetManager) GetChartVersion(namespace, chartID, version string) (models.Chart, error) {
+func (m *PostgresAssetManager) GetChartVersion(namespace, chartID, version string) (models.Chart, error) {
 	return m.GetChartVersionWithFallback(namespace, chartID, version, enableFallbackQueryMode)
 }
 
-func (m *postgresAssetManager) GetChartVersionWithFallback(namespace, chartID, version string, withFallback bool) (models.Chart, error) {
+func (m *PostgresAssetManager) GetChartVersionWithFallback(namespace, chartID, version string, withFallback bool) (models.Chart, error) {
 
 	var chart models.Chart
 	err := m.QueryOne(&chart, fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_id = $2", dbutils.ChartTable), namespace, chartID)
@@ -173,11 +173,11 @@ func (m *postgresAssetManager) GetChartVersionWithFallback(namespace, chartID, v
 	return chart, nil
 }
 
-func (m *postgresAssetManager) GetChartFiles(namespace, filesID string) (models.ChartFiles, error) {
+func (m *PostgresAssetManager) GetChartFiles(namespace, filesID string) (models.ChartFiles, error) {
 	return m.GetChartFilesWithFallback(namespace, filesID, enableFallbackQueryMode)
 }
 
-func (m *postgresAssetManager) GetChartFilesWithFallback(namespace, filesID string, withFallback bool) (models.ChartFiles, error) {
+func (m *PostgresAssetManager) GetChartFilesWithFallback(namespace, filesID string, withFallback bool) (models.ChartFiles, error) {
 	var chartFiles models.ChartFiles
 	err := m.QueryOne(&chartFiles, fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_files_id = $2", dbutils.ChartFilesTable), namespace, filesID)
 	if err != nil {
@@ -199,7 +199,7 @@ func (m *postgresAssetManager) GetChartFilesWithFallback(namespace, filesID stri
 	return chartFiles, nil
 }
 
-func (m *postgresAssetManager) GetPaginatedChartListWithFilters(cq ChartQuery, pageNumber, pageSize int) ([]*models.Chart, int, error) {
+func (m *PostgresAssetManager) GetPaginatedChartListWithFilters(cq ChartQuery, pageNumber, pageSize int) ([]*models.Chart, int, error) {
 	whereQuery, whereQueryParams := m.GenerateWhereClause(cq)
 	charts, numPages, err := m.GetPaginatedChartList(whereQuery, whereQueryParams, pageNumber, pageSize)
 	if err != nil {
@@ -208,7 +208,7 @@ func (m *postgresAssetManager) GetPaginatedChartListWithFilters(cq ChartQuery, p
 	return charts, numPages, nil
 }
 
-func (m *postgresAssetManager) GenerateWhereClause(cq ChartQuery) (string, []interface{}) {
+func (m *PostgresAssetManager) GenerateWhereClause(cq ChartQuery) (string, []interface{}) {
 	whereClauses := []string{}
 	whereQueryParams := []interface{}{}
 	whereQuery := ""

--- a/cmd/assetsvc/postgresql_utils.go
+++ b/cmd/assetsvc/postgresql_utils.go
@@ -39,7 +39,7 @@ type postgresAssetManager struct {
 	dbutils.PostgresAssetManagerIface
 }
 
-func newPGManager(config datastore.Config, kubeappsNamespace string) (assetManager, error) {
+func NewPGManager(config datastore.Config, kubeappsNamespace string) (AssetManager, error) {
 	m, err := dbutils.NewPGManager(config, kubeappsNamespace)
 	if err != nil {
 		return nil, err
@@ -47,8 +47,8 @@ func newPGManager(config datastore.Config, kubeappsNamespace string) (assetManag
 	return &postgresAssetManager{m}, nil
 }
 
-func (m *postgresAssetManager) getAllChartCategories(cq ChartQuery) ([]*models.ChartCategory, error) {
-	whereQuery, whereQueryParams := m.generateWhereClause(cq)
+func (m *postgresAssetManager) GetAllChartCategories(cq ChartQuery) ([]*models.ChartCategory, error) {
+	whereQuery, whereQueryParams := m.GenerateWhereClause(cq)
 	dbQuery := fmt.Sprintf("SELECT (info ->> 'category') AS name, COUNT( (info ->> 'category')) AS count FROM %s %s GROUP BY (info ->> 'category') ORDER BY (info ->> 'category') ASC", dbutils.ChartTable, whereQuery)
 
 	chartsCategories, err := m.QueryAllChartCategories(dbQuery, whereQueryParams...)
@@ -58,7 +58,7 @@ func (m *postgresAssetManager) getAllChartCategories(cq ChartQuery) ([]*models.C
 	return chartsCategories, nil
 }
 
-func (m *postgresAssetManager) getPaginatedChartList(whereQuery string, whereQueryParams []interface{}, pageNumber, pageSize int) ([]*models.Chart, int, error) {
+func (m *postgresAssetManager) GetPaginatedChartList(whereQuery string, whereQueryParams []interface{}, pageNumber, pageSize int) ([]*models.Chart, int, error) {
 	// Default (pageNumber,pageSize) = (1, 0) as in the handler.go
 	if pageNumber <= 0 {
 		pageNumber = 1
@@ -88,11 +88,11 @@ func (m *postgresAssetManager) getPaginatedChartList(whereQuery string, whereQue
 	return charts, numPages, nil
 }
 
-func (m *postgresAssetManager) getChart(namespace, chartID string) (models.Chart, error) {
-	return m.getChartWithFallback(namespace, chartID, enableFallbackQueryMode)
+func (m *postgresAssetManager) GetChart(namespace, chartID string) (models.Chart, error) {
+	return m.GetChartWithFallback(namespace, chartID, enableFallbackQueryMode)
 }
 
-func (m *postgresAssetManager) getChartWithFallback(namespace, chartID string, withFallback bool) (models.Chart, error) {
+func (m *postgresAssetManager) GetChartWithFallback(namespace, chartID string, withFallback bool) (models.Chart, error) {
 	var chart models.ChartIconString
 
 	err := m.QueryOne(&chart, fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_id = $2", dbutils.ChartTable), namespace, chartID)
@@ -135,11 +135,11 @@ func (m *postgresAssetManager) getChartWithFallback(namespace, chartID string, w
 	}, nil
 }
 
-func (m *postgresAssetManager) getChartVersion(namespace, chartID, version string) (models.Chart, error) {
-	return m.getChartVersionWithFallback(namespace, chartID, version, enableFallbackQueryMode)
+func (m *postgresAssetManager) GetChartVersion(namespace, chartID, version string) (models.Chart, error) {
+	return m.GetChartVersionWithFallback(namespace, chartID, version, enableFallbackQueryMode)
 }
 
-func (m *postgresAssetManager) getChartVersionWithFallback(namespace, chartID, version string, withFallback bool) (models.Chart, error) {
+func (m *postgresAssetManager) GetChartVersionWithFallback(namespace, chartID, version string, withFallback bool) (models.Chart, error) {
 
 	var chart models.Chart
 	err := m.QueryOne(&chart, fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_id = $2", dbutils.ChartTable), namespace, chartID)
@@ -173,11 +173,11 @@ func (m *postgresAssetManager) getChartVersionWithFallback(namespace, chartID, v
 	return chart, nil
 }
 
-func (m *postgresAssetManager) getChartFiles(namespace, filesID string) (models.ChartFiles, error) {
-	return m.getChartFilesWithFallback(namespace, filesID, enableFallbackQueryMode)
+func (m *postgresAssetManager) GetChartFiles(namespace, filesID string) (models.ChartFiles, error) {
+	return m.GetChartFilesWithFallback(namespace, filesID, enableFallbackQueryMode)
 }
 
-func (m *postgresAssetManager) getChartFilesWithFallback(namespace, filesID string, withFallback bool) (models.ChartFiles, error) {
+func (m *postgresAssetManager) GetChartFilesWithFallback(namespace, filesID string, withFallback bool) (models.ChartFiles, error) {
 	var chartFiles models.ChartFiles
 	err := m.QueryOne(&chartFiles, fmt.Sprintf("SELECT info FROM %s WHERE repo_namespace = $1 AND chart_files_id = $2", dbutils.ChartFilesTable), namespace, filesID)
 	if err != nil {
@@ -199,16 +199,16 @@ func (m *postgresAssetManager) getChartFilesWithFallback(namespace, filesID stri
 	return chartFiles, nil
 }
 
-func (m *postgresAssetManager) getPaginatedChartListWithFilters(cq ChartQuery, pageNumber, pageSize int) ([]*models.Chart, int, error) {
-	whereQuery, whereQueryParams := m.generateWhereClause(cq)
-	charts, numPages, err := m.getPaginatedChartList(whereQuery, whereQueryParams, pageNumber, pageSize)
+func (m *postgresAssetManager) GetPaginatedChartListWithFilters(cq ChartQuery, pageNumber, pageSize int) ([]*models.Chart, int, error) {
+	whereQuery, whereQueryParams := m.GenerateWhereClause(cq)
+	charts, numPages, err := m.GetPaginatedChartList(whereQuery, whereQueryParams, pageNumber, pageSize)
 	if err != nil {
 		return []*models.Chart{}, 0, err
 	}
 	return charts, numPages, nil
 }
 
-func (m *postgresAssetManager) generateWhereClause(cq ChartQuery) (string, []interface{}) {
+func (m *postgresAssetManager) GenerateWhereClause(cq ChartQuery) (string, []interface{}) {
 	whereClauses := []string{}
 	whereQueryParams := []interface{}{}
 	whereQuery := ""

--- a/cmd/assetsvc/postgresql_utils_test.go
+++ b/cmd/assetsvc/postgresql_utils_test.go
@@ -40,7 +40,7 @@ func getMockManager(t *testing.T) (*postgresAssetManager, sqlmock.Sqlmock, func(
 	return pgManager, mock, func() { db.Close() }
 }
 
-func Test_PGgetChart(t *testing.T) {
+func Test_PGGetChart(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
@@ -58,7 +58,7 @@ func Test_PGgetChart(t *testing.T) {
 		WithArgs("namespace", "foo").
 		WillReturnRows(sqlmock.NewRows([]string{"info"}).AddRow(string(dbChartJSON)))
 
-	chart, err := pgManager.getChart("namespace", "foo")
+	chart, err := pgManager.GetChart("namespace", "foo")
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}
@@ -71,7 +71,7 @@ func Test_PGgetChart(t *testing.T) {
 	}
 }
 
-func Test_PGgetChartVersion(t *testing.T) {
+func Test_PGGetChartVersion(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
@@ -90,7 +90,7 @@ func Test_PGgetChartVersion(t *testing.T) {
 		WithArgs("namespace", "foo").
 		WillReturnRows(sqlmock.NewRows([]string{"info"}).AddRow(string(dbChartJSON)))
 
-	chart, err := pgManager.getChartVersion("namespace", "foo", "1.0.0")
+	chart, err := pgManager.GetChartVersion("namespace", "foo", "1.0.0")
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}
@@ -105,7 +105,7 @@ func Test_PGgetChartVersion(t *testing.T) {
 	}
 }
 
-func Test_getChartFiles(t *testing.T) {
+func Test_GetChartFiles(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
@@ -118,7 +118,7 @@ func Test_getChartFiles(t *testing.T) {
 		WithArgs("namespace", "foo").
 		WillReturnRows(sqlmock.NewRows([]string{"info"}).AddRow(string(filesJSON)))
 
-	files, err := pgManager.getChartFiles("namespace", "foo")
+	files, err := pgManager.GetChartFiles("namespace", "foo")
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}
@@ -127,7 +127,7 @@ func Test_getChartFiles(t *testing.T) {
 	}
 }
 
-func Test_getChartFiles_withSlashes(t *testing.T) {
+func Test_GetChartFiles_withSlashes(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
@@ -140,7 +140,7 @@ func Test_getChartFiles_withSlashes(t *testing.T) {
 		WithArgs("namespace", "fo%2Fo").
 		WillReturnRows(sqlmock.NewRows([]string{"info"}).AddRow(string(filesJSON)))
 
-	files, err := pgManager.getChartFiles("namespace", "fo%2Fo")
+	files, err := pgManager.GetChartFiles("namespace", "fo%2Fo")
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}
@@ -149,7 +149,7 @@ func Test_getChartFiles_withSlashes(t *testing.T) {
 	}
 }
 
-func Test_getChartsWithFilters(t *testing.T) {
+func Test_GetChartsWithFilters(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
@@ -173,7 +173,7 @@ func Test_getChartsWithFilters(t *testing.T) {
 		WithArgs("namespace", "kubeapps", "foo", parametrizedJsonbLiteral).
 		WillReturnRows(sqlmock.NewRows([]string{"info"}).AddRow(dbChartJSON))
 
-	charts, _, err := pgManager.getPaginatedChartListWithFilters(ChartQuery{namespace: "namespace", chartName: "foo", version: version, appVersion: appVersion}, 1, 0)
+	charts, _, err := pgManager.GetPaginatedChartListWithFilters(ChartQuery{namespace: "namespace", chartName: "foo", version: version, appVersion: appVersion}, 1, 0)
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}
@@ -189,7 +189,7 @@ func Test_getChartsWithFilters(t *testing.T) {
 	}
 }
 
-func Test_getChartsWithFilters_withSlashes(t *testing.T) {
+func Test_GetChartsWithFilters_withSlashes(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
@@ -213,7 +213,7 @@ func Test_getChartsWithFilters_withSlashes(t *testing.T) {
 		WithArgs("namespace", "kubeapps", "fo%2Fo", parametrizedJsonbLiteral).
 		WillReturnRows(sqlmock.NewRows([]string{"info"}).AddRow(dbChartJSON))
 
-	charts, _, err := pgManager.getPaginatedChartListWithFilters(ChartQuery{namespace: "namespace", chartName: "fo%2Fo", version: version, appVersion: appVersion}, 1, 0)
+	charts, _, err := pgManager.GetPaginatedChartListWithFilters(ChartQuery{namespace: "namespace", chartName: "fo%2Fo", version: version, appVersion: appVersion}, 1, 0)
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}
@@ -229,7 +229,7 @@ func Test_getChartsWithFilters_withSlashes(t *testing.T) {
 	}
 }
 
-func Test_getAllChartCategories(t *testing.T) {
+func Test_GetAllChartCategories(t *testing.T) {
 
 	tests := []struct {
 		name                    string
@@ -276,7 +276,7 @@ func Test_getAllChartCategories(t *testing.T) {
 				WithArgs(expectedParams...).
 				WillReturnRows(rows)
 
-			chartCategories, err := pgManager.getAllChartCategories(ChartQuery{namespace: tt.namespace, repos: []string{tt.repo}})
+			chartCategories, err := pgManager.GetAllChartCategories(ChartQuery{namespace: tt.namespace, repos: []string{tt.repo}})
 			if err != nil {
 				t.Fatalf("Found error %v", err)
 			}
@@ -286,7 +286,7 @@ func Test_getAllChartCategories(t *testing.T) {
 		})
 	}
 }
-func Test_getPaginatedChartList(t *testing.T) {
+func Test_GetPaginatedChartList(t *testing.T) {
 	availableCharts := []*models.Chart{
 		{ID: "bar", ChartVersions: []models.ChartVersion{{Digest: "456"}}},
 		{ID: "copyFoo", ChartVersions: []models.ChartVersion{{Digest: "123"}}},
@@ -424,7 +424,7 @@ func Test_getPaginatedChartList(t *testing.T) {
 			mock.ExpectQuery("^SELECT count(.+) FROM").
 				WillReturnRows(rowCount)
 
-			charts, totalPages, err := pgManager.getPaginatedChartListWithFilters(ChartQuery{namespace: tt.namespace, repos: []string{tt.repo}}, tt.pageNumber, tt.pageSize)
+			charts, totalPages, err := pgManager.GetPaginatedChartListWithFilters(ChartQuery{namespace: tt.namespace, repos: []string{tt.repo}}, tt.pageNumber, tt.pageSize)
 			if err != nil {
 				t.Fatalf("Found error %v", err)
 			}
@@ -443,7 +443,7 @@ func Test_getPaginatedChartList(t *testing.T) {
 	}
 }
 
-func Test_generateWhereClause(t *testing.T) {
+func Test_GenerateWhereClause(t *testing.T) {
 	tests := []struct {
 		name           string
 		namespace      string
@@ -663,7 +663,7 @@ func Test_generateWhereClause(t *testing.T) {
 				repos:       tt.repos,
 				categories:  tt.categories,
 			}
-			whereQuery, whereQueryParams := pgManager.generateWhereClause(cq)
+			whereQuery, whereQueryParams := pgManager.GenerateWhereClause(cq)
 
 			if tt.expectedClause != whereQuery {
 				t.Errorf("Expecting query:\n'%s'\nreceived query:\n'%s'\nin '%s'", tt.expectedClause, whereQuery, tt.name)

--- a/cmd/assetsvc/postgresql_utils_test.go
+++ b/cmd/assetsvc/postgresql_utils_test.go
@@ -29,13 +29,13 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/dbutils"
 )
 
-func getMockManager(t *testing.T) (*postgresAssetManager, sqlmock.Sqlmock, func()) {
+func getMockManager(t *testing.T) (*PostgresAssetManager, sqlmock.Sqlmock, func()) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
 
-	pgManager := &postgresAssetManager{&dbutils.PostgresAssetManager{DB: db, KubeappsNamespace: "kubeapps"}}
+	pgManager := &PostgresAssetManager{&dbutils.PostgresAssetManager{DB: db, KubeappsNamespace: "kubeapps"}}
 
 	return pgManager, mock, func() { db.Close() }
 }

--- a/cmd/assetsvc/utils.go
+++ b/cmd/assetsvc/utils.go
@@ -21,14 +21,14 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 )
 
-type assetManager interface {
+type AssetManager interface {
 	Init() error
 	Close() error
-	getChart(namespace, chartID string) (models.Chart, error)
-	getChartVersion(namespace, chartID, version string) (models.Chart, error)
-	getChartFiles(namespace, filesID string) (models.ChartFiles, error)
-	getPaginatedChartListWithFilters(cq ChartQuery, pageNumber, pageSize int) ([]*models.Chart, int, error)
-	getAllChartCategories(cq ChartQuery) ([]*models.ChartCategory, error)
+	GetChart(namespace, chartID string) (models.Chart, error)
+	GetChartVersion(namespace, chartID, version string) (models.Chart, error)
+	GetChartFiles(namespace, filesID string) (models.ChartFiles, error)
+	GetPaginatedChartListWithFilters(cq ChartQuery, pageNumber, pageSize int) ([]*models.Chart, int, error)
+	GetAllChartCategories(cq ChartQuery) ([]*models.ChartCategory, error)
 }
 
 // ChartQuery is a container for passing the supported query paramters for generating the WHERE query
@@ -42,6 +42,6 @@ type ChartQuery struct {
 	categories  []string
 }
 
-func newManager(databaseType string, config datastore.Config, kubeappsNamespace string) (assetManager, error) {
-	return newPGManager(config, kubeappsNamespace)
+func newManager(databaseType string, config datastore.Config, kubeappsNamespace string) (AssetManager, error) {
+	return NewPGManager(config, kubeappsNamespace)
 }


### PR DESCRIPTION

### Description of the change

Potential prequel for #3022, so that the plugin can just export the required manager and functions from the existing code.

Just does:
-  Public interface `assetManager` -> `AssetManager` (interface is just because we transition from mongo and supported both implementations for a while).
-  Public NewPGManager
-  Public PostgresAssetManager. (woops, I'll add a commit with this in a bit).
-  Public methods on the postgres asset manager

### Benefits

Let's Antonio focus on 3022

### Possible drawbacks

?

### Applicable issues

  - Ref #2993

