### PR TITLE
Add typed client to plugin client getter.

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
@@ -16,16 +16,16 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
-	"k8s.io/client-go/dynamic"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 )
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter func(context.Context) (dynamic.Interface, error)) interface{} {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesClientGetter) interface{} {
 	svr := NewServer(clientGetter)
 	v1alpha1.RegisterFluxV2PackagesServiceServer(s, svr)
 	return svr

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	chart "github.com/kubeapps/kubeapps/pkg/chart/models"
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
 
@@ -55,12 +56,12 @@ type Server struct {
 	// clientGetter is a field so that it can be switched in tests for
 	// a fake client. NewServer() below sets this automatically with the
 	// non-test implementation.
-	clientGetter func(context.Context) (dynamic.Interface, error)
+	clientGetter server.KubernetesClientGetter
 }
 
 // NewServer returns a Server automatically configured with a function to obtain
 // the k8s client config.
-func NewServer(clientGetter func(context.Context) (dynamic.Interface, error)) *Server {
+func NewServer(clientGetter server.KubernetesClientGetter) *Server {
 	return &Server{
 		clientGetter: clientGetter,
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -73,11 +73,11 @@ func (s *Server) GetClients(ctx context.Context) (kubernetes.Interface, dynamic.
 	if s.clientGetter == nil {
 		return nil, nil, status.Errorf(codes.Internal, "server not configured with configGetter")
 	}
-	_, client, err := s.clientGetter(ctx)
+	typedClient, dynamicClient, err := s.clientGetter(ctx)
 	if err != nil {
 		return nil, nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get client : %v", err))
 	}
-	return nil, client, nil
+	return typedClient, dynamicClient, nil
 }
 
 // ===== general note on error handling ========

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
@@ -67,16 +68,16 @@ func NewServer(clientGetter server.KubernetesClientGetter) *Server {
 	}
 }
 
-// getClient ensures a client getter is available and uses it to return the client.
-func (s *Server) GetClient(ctx context.Context) (dynamic.Interface, error) {
+// getClients ensures a client getter is available and uses it to return both a typed and dynamic k8s client.
+func (s *Server) GetClients(ctx context.Context) (kubernetes.Interface, dynamic.Interface, error) {
 	if s.clientGetter == nil {
-		return nil, status.Errorf(codes.Internal, "server not configured with configGetter")
+		return nil, nil, status.Errorf(codes.Internal, "server not configured with configGetter")
 	}
-	client, err := s.clientGetter(ctx)
+	_, client, err := s.clientGetter(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get client : %v", err))
+		return nil, nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get client : %v", err))
 	}
-	return client, nil
+	return nil, client, nil
 }
 
 // ===== general note on error handling ========
@@ -208,7 +209,7 @@ func (s *Server) pullChartTarball(ctx context.Context, packageRef *corev1.Availa
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid package ref identifier: [%s]", packageRef.Identifier)
 	}
 
-	client, err := s.GetClient(ctx)
+	_, client, err := s.GetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +299,7 @@ func (s *Server) pullChartTarball(ctx context.Context, packageRef *corev1.Availa
 
 // namespace maybe "", in which case repositories from all namespaces are returned
 func (s *Server) getHelmRepos(ctx context.Context, namespace string) (*unstructured.UnstructuredList, error) {
-	client, err := s.GetClient(ctx)
+	_, client, err := s.GetClients(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
@@ -16,11 +16,11 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
-	"k8s.io/client-go/dynamic"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 )
 
 // Set the pluginDetail once during a module init function so the single struct
@@ -36,7 +36,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter func(context.Context) (dynamic.Interface, error)) interface{} {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesClientGetter) interface{} {
 	svr := NewServer(clientGetter)
 	v1alpha1.RegisterHelmPackagesServiceServer(s, svr)
 	return svr

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -45,7 +45,7 @@ func NewServer(clientGetter server.KubernetesClientGetter) *Server {
 	}
 }
 
-// getClients ensures a client getter is available and uses it to return both a typed and dynamic k8s client.
+// GetClients ensures a client getter is available and uses it to return both a typed and dynamic k8s client.
 func (s *Server) GetClients(ctx context.Context) (kubernetes.Interface, dynamic.Interface, error) {
 	if s.clientGetter == nil {
 		return nil, nil, status.Errorf(codes.Internal, "server not configured with configGetter")

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 )
 
 // Compile-time statement to ensure this service implementation satisfies the core packaging API
@@ -44,14 +45,14 @@ func NewServer(clientGetter server.KubernetesClientGetter) *Server {
 	}
 }
 
-// getClient ensures a client getter is available and uses it to return the client.
-func (s *Server) GetClient(ctx context.Context) (dynamic.Interface, error) {
+// getClients ensures a client getter is available and uses it to return both a typed and dynamic k8s client.
+func (s *Server) GetClients(ctx context.Context) (kubernetes.Interface, dynamic.Interface, error) {
 	if s.clientGetter == nil {
-		return nil, status.Errorf(codes.Internal, "server not configured with configGetter")
+		return nil, nil, status.Errorf(codes.Internal, "server not configured with configGetter")
 	}
-	client, err := s.clientGetter(ctx)
+	typedClient, dynamicClient, err := s.clientGetter(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get client : %v", err))
+		return nil, nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get client : %v", err))
 	}
-	return client, nil
+	return typedClient, dynamicClient, nil
 }

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -18,12 +18,11 @@ import (
 
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/client-go/dynamic"
 )
-
-const ()
 
 // Compile-time statement to ensure this service implementation satisfies the core packaging API
 var _ corev1.PackagesServiceServer = (*Server)(nil)
@@ -34,12 +33,12 @@ type Server struct {
 	// clientGetter is a field so that it can be switched in tests for
 	// a fake client. NewServer() below sets this automatically with the
 	// non-test implementation.
-	clientGetter func(context.Context) (dynamic.Interface, error)
+	clientGetter server.KubernetesClientGetter
 }
 
 // NewServer returns a Server automatically configured with a function to obtain
 // the k8s client config.
-func NewServer(clientGetter func(context.Context) (dynamic.Interface, error)) *Server {
+func NewServer(clientGetter server.KubernetesClientGetter) *Server {
 	return &Server{
 		clientGetter: clientGetter,
 	}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
@@ -16,11 +16,11 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
-	"k8s.io/client-go/dynamic"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 )
 
 // Set the pluginDetail once during a module init function so the single struct
@@ -36,7 +36,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter func(context.Context) (dynamic.Interface, error)) interface{} {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesClientGetter) interface{} {
 	svr := NewServer(clientGetter)
 	v1alpha1.RegisterKappControllerPackagesServiceServer(s, svr)
 	return svr

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -34,6 +34,7 @@ import (
 
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -63,12 +64,12 @@ type Server struct {
 	// clientGetter is a field so that it can be switched in tests for
 	// a fake client. NewServer() below sets this automatically with the
 	// non-test implementation.
-	clientGetter func(context.Context) (dynamic.Interface, error)
+	clientGetter server.KubernetesClientGetter
 }
 
 // NewServer returns a Server automatically configured with a function to obtain
 // the k8s client config.
-func NewServer(clientGetter func(context.Context) (dynamic.Interface, error)) *Server {
+func NewServer(clientGetter server.KubernetesClientGetter) *Server {
 	return &Server{
 		clientGetter: clientGetter,
 	}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -76,7 +76,7 @@ func NewServer(clientGetter server.KubernetesClientGetter) *Server {
 	}
 }
 
-// getClients ensures a client getter is available and uses it to return both a typed and dynamic k8s client.
+// GetClients ensures a client getter is available and uses it to return both a typed and dynamic k8s client.
 func (s *Server) GetClients(ctx context.Context) (kubernetes.Interface, dynamic.Interface, error) {
 	if s.clientGetter == nil {
 		return nil, nil, status.Errorf(codes.Internal, "server not configured with configGetter")

--- a/cmd/kubeapps-apis/server/plugins.go
+++ b/cmd/kubeapps-apis/server/plugins.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	log "k8s.io/klog/v2"
@@ -48,7 +49,7 @@ const (
 )
 
 // KubernetesClientGetter is a function type used by plugins to get a k8s client
-type KubernetesClientGetter func(context.Context) (dynamic.Interface, error)
+type KubernetesClientGetter func(context.Context) (kubernetes.Interface, dynamic.Interface, error)
 
 // pkgsPluginWithServer stores the plugin detail together with its implementation.
 type pkgsPluginWithServer struct {
@@ -301,33 +302,34 @@ func createClientGetterWithParams(inClusterConfig *rest.Config, serveOpts ServeO
 
 	// return the closure fuction that takes the context, but preserving the required scope,
 	// 'inClusterConfig' and 'config'
-	return func(ctx context.Context) (dynamic.Interface, error) {
+	return func(ctx context.Context) (kubernetes.Interface, dynamic.Interface, error) {
 		var err error
 		token, err := extractToken(ctx)
 		if err != nil {
-			return nil, status.Errorf(codes.Unauthenticated, "invalid authorization metadata: %v", err)
+			return nil, nil, status.Errorf(codes.Unauthenticated, "invalid authorization metadata: %v", err)
 		}
 
-		var client dynamic.Interface
+		var config *rest.Config
 		if !serveOpts.UnsafeUseDemoSA {
 			// We are using the KubeappsClusterName, but if the endpoint was cluster-scoped,
 			// we should pass the cluster name instead
-			restConfig, err := kube.NewClusterConfig(inClusterConfig, token, clustersConfig.KubeappsClusterName, clustersConfig)
+			config, err = kube.NewClusterConfig(inClusterConfig, token, clustersConfig.KubeappsClusterName, clustersConfig)
 			if err != nil {
-				return nil, fmt.Errorf("unable to get clusterConfig: %w", err)
-			}
-			client, err = dynamic.NewForConfig(restConfig)
-			if err != nil {
-				return nil, fmt.Errorf("unable to create dynamic client: %w", err)
+				return nil, nil, fmt.Errorf("unable to get clusterConfig: %w", err)
 			}
 		} else {
 			// Just using the created SA, no user account is used
-			client, err = dynamic.NewForConfig(inClusterConfig)
-			if err != nil {
-				return nil, fmt.Errorf("unable to create dynamic client: %w", err)
-			}
+			config = inClusterConfig
 		}
-		return client, nil
+		dynamicClient, err := dynamic.NewForConfig(config)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to create dynamic client: %w", err)
+		}
+		typedClient, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to create typed client: %w", err)
+		}
+		return typedClient, dynamicClient, nil
 	}, nil
 }
 

--- a/cmd/kubeapps-apis/server/plugins.go
+++ b/cmd/kubeapps-apis/server/plugins.go
@@ -39,10 +39,6 @@ import (
 	log "k8s.io/klog/v2"
 )
 
-// Add plugin message to proto. then include in struct here with client?
-// How to create client dynamically? Perhaps return client when registering each?
-// Perhaps define an interface that client must implement (based on server?)
-
 const (
 	pluginRootDir           = "/"
 	grpcRegisterFunction    = "RegisterWithGRPCServer"
@@ -50,6 +46,9 @@ const (
 	pluginDetailFunction    = "GetPluginDetail"
 	clustersCAFilesPrefix   = "/etc/additional-clusters-cafiles"
 )
+
+// KubernetesClientGetter is a function type used by plugins to get a k8s client
+type KubernetesClientGetter func(context.Context) (dynamic.Interface, error)
 
 // pkgsPluginWithServer stores the plugin detail together with its implementation.
 type pkgsPluginWithServer struct {
@@ -145,16 +144,16 @@ func (s *pluginsServer) registerPlugins(pluginPaths []string, grpcReg grpc.Servi
 }
 
 // registerGRPC finds and calls the required function for registering the plugin for the GRPC server.
-func (s *pluginsServer) registerGRPC(p *plugin.Plugin, pluginDetail *plugins.Plugin, registrar grpc.ServiceRegistrar, clientGetter func(context.Context) (dynamic.Interface, error)) error {
+func (s *pluginsServer) registerGRPC(p *plugin.Plugin, pluginDetail *plugins.Plugin, registrar grpc.ServiceRegistrar, clientGetter KubernetesClientGetter) error {
 	grpcRegFn, err := p.Lookup(grpcRegisterFunction)
 	if err != nil {
 		return fmt.Errorf("unable to lookup %q for %v: %w", grpcRegisterFunction, pluginDetail, err)
 	}
-	type grpcRegisterFunctionType = func(grpc.ServiceRegistrar, func(context.Context) (dynamic.Interface, error)) interface{}
+	type grpcRegisterFunctionType = func(grpc.ServiceRegistrar, KubernetesClientGetter) interface{}
 
 	grpcFn, ok := grpcRegFn.(grpcRegisterFunctionType)
 	if !ok {
-		var dummyFn grpcRegisterFunctionType = func(grpc.ServiceRegistrar, func(context.Context) (dynamic.Interface, error)) interface{} { return nil }
+		var dummyFn grpcRegisterFunctionType = func(grpc.ServiceRegistrar, KubernetesClientGetter) interface{} { return nil }
 		return fmt.Errorf("unable to use %q in plugin %v due to mismatched signature.\nwant: %T\ngot: %T", grpcRegisterFunction, pluginDetail, dummyFn, grpcRegFn)
 	}
 
@@ -256,7 +255,7 @@ func listSOFiles(fsys fs.FS, pluginDirs []string) ([]string, error) {
 // createClientGetter returns a function closure for creating the k8s client to interact with the cluster.
 // The returned function utilizes the user credential present in the request context.
 // The plugins just have to call this function passing the context in order to retrieve the configured k8s client
-func createClientGetter(serveOpts ServeOptions) (func(context.Context) (dynamic.Interface, error), error) {
+func createClientGetter(serveOpts ServeOptions) (KubernetesClientGetter, error) {
 	var restConfig *rest.Config
 	var clustersConfig kube.ClustersConfig
 	var err error
@@ -298,7 +297,7 @@ func createClientGetter(serveOpts ServeOptions) (func(context.Context) (dynamic.
 
 // createClientGetter takes the required params and returns the closure fuction.
 // it's splitted for testing this fn separately
-func createClientGetterWithParams(inClusterConfig *rest.Config, serveOpts ServeOptions, clustersConfig kube.ClustersConfig) (func(context.Context) (dynamic.Interface, error), error) {
+func createClientGetterWithParams(inClusterConfig *rest.Config, serveOpts ServeOptions, clustersConfig kube.ClustersConfig) (KubernetesClientGetter, error) {
 
 	// return the closure fuction that takes the context, but preserving the required scope,
 	// 'inClusterConfig' and 'config'


### PR DESCRIPTION
### Description of the change

As per discussion on #3022, we originally tried the typed client for interacting with packaging CRs but hit the issue that we'd need the same version of client-go used by those packaging systems, which leads to dependency hell. So we switched to use a dynamic client for the plugins.

That said, now that certain plugins also need to interact with the core k8s api resources, a typed client(set) would also be useful (and nicer to work with) for interacting with those core resources.

This PR updates so that plugins are provided with both - a type clientset and a dynamic clientset.

### Benefits

Plugins don't need to use unstructured objects when interacting with the core k8s resources.

### Possible drawbacks

None (assuming the client works IRL, which we'll test in a subsequent PR that uses the typed client for the direct helm plugin).

### Applicable issues

  - ref #2993

### Additional information

Antonio, if you want to land this so you can use it in your PR, that's fine, or if you'd rather not depend on it but move forward with your unstructured work-around and switch later, that's fine too :)
