### PR TITLE
Improve credentials handling when fetching repo resources

### DIFF
--- a/cmd/apprepository-controller/controller.go
+++ b/cmd/apprepository-controller/controller.go
@@ -608,6 +608,10 @@ func apprepoSyncJobArgs(apprepo *apprepov1alpha1.AppRepository, config Config) [
 		args = append(args, "--tls-insecure-skip-verify")
 	}
 
+	if apprepo.Spec.PassCredentials {
+		args = append(args, "--pass-credentials")
+	}
+
 	if apprepo.Spec.FilterRule.JQ != "" {
 		rulesJSON, err := json.Marshal(apprepo.Spec.FilterRule)
 		if err != nil {

--- a/cmd/apprepository-controller/controller_test.go
+++ b/cmd/apprepository-controller/controller_test.go
@@ -1109,6 +1109,89 @@ func Test_newSyncJob(t *testing.T) {
 			},
 		},
 		{
+			"Paas credentials",
+			"",
+			&apprepov1alpha1.AppRepository{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AppRepository",
+					APIVersion: "kubeapps.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-charts",
+					Namespace: "kubeapps",
+					Labels: map[string]string{
+						"name":       "my-charts",
+						"created-by": "kubeapps",
+					},
+				},
+				Spec: apprepov1alpha1.AppRepositorySpec{
+					Type:            "oci",
+					URL:             "https://charts.acme.com/my-charts",
+					OCIRepositories: []string{"apache", "jenkins"},
+					PassCredentials: true,
+				},
+			},
+			batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "apprepo-kubeapps-sync-my-charts-",
+					OwnerReferences: []metav1.OwnerReference{
+						*metav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
+							schema.GroupVersionKind{
+								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
+								Version: apprepov1alpha1.SchemeGroupVersion.Version,
+								Kind:    "AppRepository",
+							},
+						),
+					},
+				},
+				Spec: batchv1.JobSpec{
+					TTLSecondsAfterFinished: &defaultTTL,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								LabelRepoName:      "my-charts",
+								LabelRepoNamespace: "kubeapps",
+							},
+						},
+						Spec: corev1.PodSpec{
+							RestartPolicy: "OnFailure",
+							Containers: []corev1.Container{
+								{
+									Name:            "sync",
+									Image:           repoSyncImage,
+									ImagePullPolicy: "IfNotPresent",
+									Command:         []string{"/chart-repo"},
+									Args: []string{
+										"sync",
+										"--database-url=postgresql.kubeapps",
+										"--database-user=admin",
+										"--database-name=assets",
+										"--namespace=kubeapps",
+										"my-charts",
+										"https://charts.acme.com/my-charts",
+										"oci",
+										"--oci-repositories",
+										"apache,jenkins",
+										"--pass-credentials",
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: "DB_PASSWORD",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+										},
+									},
+									VolumeMounts: nil,
+								},
+							},
+							Volumes: nil,
+						},
+					},
+				},
+			},
+		},
+		{
 			"Repository with filters",
 			"",
 			&apprepov1alpha1.AppRepository{

--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
@@ -54,7 +54,7 @@ type AppRepositorySpec struct {
 	FilterRule FilterRuleSpec `json:"filterRule,omitempty"`
 	// (optional) description
 	Description string `json:"description,omitempty"`
-	// PassCredentials allows passing credentials to all domains
+	// PassCredentials allows passing credentials with requests to other domains linked from the repository
 	PassCredentials bool `json:"passCredentials,omitempty"`
 }
 

--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
@@ -54,6 +54,8 @@ type AppRepositorySpec struct {
 	FilterRule FilterRuleSpec `json:"filterRule,omitempty"`
 	// (optional) description
 	Description string `json:"description,omitempty"`
+	// PassCredentials allows passing credentials to all domains
+	PassCredentials bool `json:"passCredentials,omitempty"`
 }
 
 // AppRepositoryAuth is the auth for an AppRepository resource

--- a/cmd/asset-syncer/main.go
+++ b/cmd/asset-syncer/main.go
@@ -32,6 +32,7 @@ var (
 	ociRepositories       []string
 	tlsInsecureSkipVerify bool
 	filterRules           string
+	passCredentials       bool
 )
 
 var rootCmd = &cobra.Command{
@@ -59,6 +60,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "verbose logging")
 	rootCmd.PersistentFlags().BoolVar(&tlsInsecureSkipVerify, "tls-insecure-skip-verify", false, "Skip TLS verification")
 	rootCmd.PersistentFlags().StringVar(&filterRules, "filter-rules", "", "JSON blob with the rules to filter assets")
+	rootCmd.PersistentFlags().BoolVar(&passCredentials, "pass-credentials", false, "pass credentials to all domains")
 
 	databasePassword = os.Getenv("DB_PASSWORD")
 

--- a/cmd/asset-syncer/utils.go
+++ b/cmd/asset-syncer/utils.go
@@ -239,7 +239,7 @@ func (r *HelmRepo) FetchFiles(name string, cv models.ChartVersion) (map[string]s
 	authorizationHeader := ""
 	chartTarballURL := chartTarballURL(r.RepoInternal, cv)
 
-	if (passCredentials || compareURLDomains(chartTarballURL, r.URL)) && len(r.AuthorizationHeader) > 0 {
+	if passCredentials || len(r.AuthorizationHeader) > 0 && isURLDomainEqual(chartTarballURL, r.URL) {
 		authorizationHeader = r.AuthorizationHeader
 	}
 
@@ -790,7 +790,7 @@ func (f *fileImporter) fetchAndImportIcon(c models.Chart, r *models.RepoInternal
 		return err
 	}
 	req.Header.Set("User-Agent", userAgent())
-	if (passCredentials || compareURLDomains(c.Icon, r.URL)) && len(r.AuthorizationHeader) > 0 {
+	if passCredentials || len(r.AuthorizationHeader) > 0 && isURLDomainEqual(c.Icon, r.URL) {
 		req.Header.Set("Authorization", r.AuthorizationHeader)
 	}
 
@@ -885,7 +885,7 @@ func (f *fileImporter) fetchAndImportFiles(name string, repo Repo, cv models.Cha
 
 // Check if two URL strings are in the same domain.
 // Return true if so, and false otherwise or when an error occurs
-func compareURLDomains(url1Str, url2Str string) bool {
+func isURLDomainEqual(url1Str, url2Str string) bool {
 	url1, err := url.ParseRequestURI(url1Str)
 	if err != nil {
 		return false
@@ -895,8 +895,5 @@ func compareURLDomains(url1Str, url2Str string) bool {
 		return false
 	}
 
-	a := url1.Hostname()
-	b := url2.Hostname()
-	// return url1.Hostname() == url2.Hostname()
-	return a == b
+	return url1.Scheme == url2.Scheme && url1.Host == url2.Host
 }

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -143,7 +143,7 @@ type svgIconClient struct{}
 
 func (h *svgIconClient) Do(req *http.Request) (*http.Response, error) {
 	w := httptest.NewRecorder()
-	w.Write([]byte("foo"))
+	w.Write([]byte("<svg width='100' height='100'></svg>"))
 	res := w.Result()
 	res.Header.Set("Content-Type", "image/svg")
 	return res, nil

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -81,6 +81,24 @@ func (h *goodHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return w.Result(), nil
 }
 
+type goodAuthenticatedHTTPClient struct{}
+
+func (h *goodAuthenticatedHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	w := httptest.NewRecorder()
+
+	// Ensure we're sending an Authorization header
+	if req.Header.Get("Authorization") == "" {
+		w.WriteHeader(401)
+	}
+	// Ensure we're sending the right Authorization header
+	if !strings.Contains(req.Header.Get("Authorization"), "Bearer ThisSecretAccessTokenAuthenticatesTheClient") {
+		w.WriteHeader(403)
+	}
+
+	w.Write(iconBytes())
+	return w.Result(), nil
+}
+
 type authenticatedHTTPClient struct{}
 
 func (h *authenticatedHTTPClient) Do(req *http.Request) (*http.Response, error) {
@@ -373,6 +391,8 @@ func Test_newManager(t *testing.T) {
 
 func Test_fetchAndImportIcon(t *testing.T) {
 	repo := &models.RepoInternal{Name: "test", Namespace: "repo-namespace"}
+	repoWithAuthorization := &models.RepoInternal{Name: "test", Namespace: "repo-namespace", AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient"}
+
 	t.Run("no icon", func(t *testing.T) {
 		pgManager, _, cleanup := getMockManager(t)
 		defer cleanup()
@@ -429,6 +449,52 @@ func Test_fetchAndImportIcon(t *testing.T) {
 
 		fImporter := fileImporter{pgManager, netClient}
 		assert.NoErr(t, fImporter.fetchAndImportIcon(c, repo))
+	})
+
+	t.Run("valid icon (not passing through the auth header by default)", func(t *testing.T) {
+		pgManager, _, cleanup := getMockManager(t)
+		defer cleanup()
+		netClient := &goodAuthenticatedHTTPClient{}
+
+		fImporter := fileImporter{pgManager, netClient}
+		assert.Err(t, fmt.Errorf("401 %s", charts[0].Icon), fImporter.fetchAndImportIcon(charts[0], repo))
+	})
+
+	t.Run("valid icon (not passing through the auth header)", func(t *testing.T) {
+		pgManager, _, cleanup := getMockManager(t)
+		defer cleanup()
+		netClient := &goodAuthenticatedHTTPClient{}
+
+		fImporter := fileImporter{pgManager, netClient}
+		passCredentials = false
+		assert.Err(t, fmt.Errorf("401 %s", charts[0].Icon), fImporter.fetchAndImportIcon(charts[0], repo))
+	})
+
+	// t.Run("valid icon (passing through if same domain)", func(t *testing.T) {
+	// 	pgManager, mock, cleanup := getMockManager(t)
+	// 	defer cleanup()
+	// 	netClient := &goodAuthenticatedHTTPClient{}
+
+	// 	mock.ExpectQuery("UPDATE charts SET info *").
+	// 		WithArgs("test/acs-engine-autoscaler", "repo-namespace", "test").
+	// 		WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
+
+	// 	fImporter := fileImporter{pgManager, netClient}
+	// 	assert.NoErr(t, fImporter.fetchAndImportIcon(charts[0], repoWithAuthorization))
+	// })
+
+	t.Run("valid icon (passing through the auth header)", func(t *testing.T) {
+		pgManager, mock, cleanup := getMockManager(t)
+		defer cleanup()
+		netClient := &goodAuthenticatedHTTPClient{}
+
+		mock.ExpectQuery("UPDATE charts SET info *").
+			WithArgs("test/acs-engine-autoscaler", "repo-namespace", "test").
+			WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
+
+		fImporter := fileImporter{pgManager, netClient}
+		passCredentials = true
+		assert.NoErr(t, fImporter.fetchAndImportIcon(charts[0], repoWithAuthorization))
 	})
 }
 
@@ -1229,6 +1295,48 @@ func Test_filterCharts(t *testing.T) {
 					t.Fatalf("Unexpected error %v", err)
 				}
 			}
+			if !cmp.Equal(res, tt.expected) {
+				t.Errorf("Unexpected result: %v", cmp.Diff(res, tt.expected))
+			}
+		})
+	}
+}
+
+func Test_compareURLDomains(t *testing.T) {
+	tests := []struct {
+		name     string
+		url1     string
+		url2     string
+		expected bool
+	}{
+		{
+			"it returns false if a url is malformed",
+			"abc",
+			"https://bitnami.com/assets/stacks/airflow/img/airflow-stack-220x234.png",
+			false,
+		},
+		{
+			"it returns false if they are different subdomains",
+			"https://charts.bitnami.com/bitnami/index.yaml",
+			"https://bitnami.com/assets/stacks/airflow/img/airflow-stack-220x234.png",
+			false,
+		},
+		{
+			"it returns false if they are under different subdomains",
+			"https://bitnami.com/bitnami/index.yaml",
+			"https://charts.bitnami.com/assets/stacks/airflow/img/airflow-stack-220x234.png",
+			false,
+		},
+		{
+			"it returns true if they are under the same",
+			"https://charts.bitnami.com/bitnami/airflow-10.2.0.tgz",
+			"https://charts.bitnami.com/assets/stacks/airflow/img/airflow-stack-220x234.png",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := compareURLDomains(tt.url1, tt.url2)
 			if !cmp.Equal(res, tt.expected) {
 				t.Errorf("Unexpected result: %v", cmp.Diff(res, tt.expected))
 			}

--- a/cmd/asset-syncer/utils_test.go
+++ b/cmd/asset-syncer/utils_test.go
@@ -391,7 +391,7 @@ func Test_newManager(t *testing.T) {
 
 func Test_fetchAndImportIcon(t *testing.T) {
 	repo := &models.RepoInternal{Name: "test", Namespace: "repo-namespace"}
-	repoWithAuthorization := &models.RepoInternal{Name: "test", Namespace: "repo-namespace", AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient"}
+	repoWithAuthorization := &models.RepoInternal{Name: "test", Namespace: "repo-namespace", AuthorizationHeader: "Bearer ThisSecretAccessTokenAuthenticatesTheClient", URL: "https://github.com/"}
 
 	t.Run("no icon", func(t *testing.T) {
 		pgManager, _, cleanup := getMockManager(t)
@@ -470,7 +470,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 		assert.Err(t, fmt.Errorf("401 %s", charts[0].Icon), fImporter.fetchAndImportIcon(charts[0], repo))
 	})
 
-	t.Run("valid icon (passing through if same domain)", func(t *testing.T) {
+	t.Run("valid icon (passing through the auth header if same domain)", func(t *testing.T) {
 		pgManager, mock, cleanup := getMockManager(t)
 		defer cleanup()
 		netClient := &goodAuthenticatedHTTPClient{}

--- a/dashboard/public/openapi.yaml
+++ b/dashboard/public/openapi.yaml
@@ -18,9 +18,9 @@ servers:
 info:
   description: |
     [![CircleCI](https://circleci.com/gh/kubeapps/kubeapps/tree/master.svg?style=svg)](https://circleci.com/gh/kubeapps/kubeapps/tree/master)
-     
+
      [Kubeapps](https://github.com/kubeapps/kubeapps) is a web-based UI for deploying and managing applications in Kubernetes clusters.
-     
+
      Note: this API documentation is still in an initial stage and is subject to change. Before coupling to it, please [drop us an issue](https://github.com/kubeapps/kubeapps/issues/new/choose) or reach us [via Slack](https://kubernetes.slack.com/messages/kubeapps) to know more about your use case and see how we can assist you.
      #### Developer Documentation
      - The [Kubeapps architecture overview](https://github.com/kubeapps/kubeapps/blob/master/docs/architecture/overview.md).
@@ -2016,6 +2016,8 @@ components:
             type: string
         tlsInsecureSkipVerify:
           type: boolean
+        passCredentials:
+          type: boolean
     # pkg/kube/kube_handler.go
     ValidationResponse:
       type: object
@@ -2097,6 +2099,8 @@ components:
           type: boolean
         description:
           type: string
+        passCredentials:
+          type: boolean
     # cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
     AppRepositoryStatus:
       type: object

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -377,6 +377,7 @@ describe("installRepo", () => {
     [],
     [],
     false,
+    false,
     undefined,
   );
 
@@ -393,6 +394,7 @@ describe("installRepo", () => {
       "",
       [],
       [],
+      false,
       false,
       undefined,
     );
@@ -413,6 +415,7 @@ describe("installRepo", () => {
         [],
         [],
         false,
+        false,
         undefined,
       );
     });
@@ -432,6 +435,7 @@ describe("installRepo", () => {
           [],
           ["apache", "jenkins"],
           false,
+          false,
           undefined,
         ),
       );
@@ -448,6 +452,7 @@ describe("installRepo", () => {
         {},
         [],
         ["apache", "jenkins"],
+        false,
         false,
         undefined,
       );
@@ -468,6 +473,7 @@ describe("installRepo", () => {
           [],
           [],
           true,
+          false,
           undefined,
         ),
       );
@@ -485,6 +491,7 @@ describe("installRepo", () => {
         [],
         [],
         true,
+        false,
         undefined,
       );
     });
@@ -509,6 +516,7 @@ describe("installRepo", () => {
       [],
       [],
       false,
+      false,
       undefined,
     );
 
@@ -527,6 +535,7 @@ describe("installRepo", () => {
         {},
         [],
         [],
+        false,
         false,
         undefined,
       );
@@ -553,6 +562,7 @@ describe("installRepo", () => {
             [],
             [],
             false,
+            false,
             undefined,
           ),
         );
@@ -572,6 +582,7 @@ describe("installRepo", () => {
           },
           [],
           [],
+          false,
           false,
           undefined,
         );
@@ -595,6 +606,7 @@ describe("installRepo", () => {
             unsafeYAMLTemplate,
             [],
             [],
+            false,
             false,
             undefined,
           ),
@@ -620,6 +632,7 @@ describe("installRepo", () => {
         {},
         [],
         [],
+        false,
         false,
         undefined,
       );
@@ -689,6 +702,7 @@ describe("installRepo", () => {
         ["repo-1"],
         [],
         false,
+        false,
         undefined,
       ),
     );
@@ -706,6 +720,7 @@ describe("installRepo", () => {
       {},
       ["repo-1"],
       [],
+      false,
       false,
       undefined,
     );
@@ -726,6 +741,7 @@ describe("installRepo", () => {
         [],
         ["apache", "jenkins"],
         false,
+        false,
         undefined,
       ),
     );
@@ -742,6 +758,7 @@ describe("installRepo", () => {
       {},
       [],
       ["apache", "jenkins"],
+      false,
       false,
       undefined,
     );
@@ -787,6 +804,7 @@ describe("updateRepo", () => {
         ["repo-1"],
         [],
         false,
+        false,
         undefined,
       ),
     );
@@ -804,6 +822,7 @@ describe("updateRepo", () => {
       { spec: { containers: [{ env: [{ name: "FOO", value: "BAR" }] }] } },
       ["repo-1"],
       [],
+      false,
       false,
       undefined,
     );
@@ -847,6 +866,7 @@ describe("updateRepo", () => {
         ["repo-1"],
         [],
         false,
+        false,
         undefined,
       ),
     );
@@ -864,6 +884,7 @@ describe("updateRepo", () => {
       { spec: { containers: [{ env: [{ name: "FOO", value: "BAR" }] }] } },
       ["repo-1"],
       [],
+      false,
       false,
       undefined,
     );
@@ -897,6 +918,7 @@ describe("updateRepo", () => {
         [],
         [],
         false,
+        false,
         undefined,
       ),
     );
@@ -921,6 +943,7 @@ describe("updateRepo", () => {
         [],
         ["apache", "jenkins"],
         false,
+        false,
         undefined,
       ),
     );
@@ -937,6 +960,7 @@ describe("updateRepo", () => {
       {},
       [],
       ["apache", "jenkins"],
+      false,
       false,
       undefined,
     );
@@ -960,6 +984,7 @@ describe("updateRepo", () => {
         [],
         ["apache", "jenkins"],
         false,
+        false,
         undefined,
       ),
     );
@@ -976,6 +1001,7 @@ describe("updateRepo", () => {
       {},
       [],
       ["apache", "jenkins"],
+      false,
       false,
       undefined,
     );
@@ -1050,7 +1076,7 @@ describe("validateRepo", () => {
     ];
 
     const res = await store.dispatch(
-      repoActions.validateRepo("url", "helm", "auth", "", "cert", [], false),
+      repoActions.validateRepo("url", "helm", "auth", "", "cert", [], false, false),
     );
     expect(store.getActions()).toEqual(expectedActions);
     expect(res).toBe(true);
@@ -1071,7 +1097,7 @@ describe("validateRepo", () => {
       },
     ];
     const res = await store.dispatch(
-      repoActions.validateRepo("url", "helm", "auth", "", "cert", [], false),
+      repoActions.validateRepo("url", "helm", "auth", "", "cert", [], false, false),
     );
     expect(store.getActions()).toEqual(expectedActions);
     expect(res).toBe(false);
@@ -1095,7 +1121,7 @@ describe("validateRepo", () => {
       },
     ];
     const res = await store.dispatch(
-      repoActions.validateRepo("url", "helm", "auth", "", "cert", [], false),
+      repoActions.validateRepo("url", "helm", "auth", "", "cert", [], false, false),
     );
     expect(store.getActions()).toEqual(expectedActions);
     expect(res).toBe(false);
@@ -1106,7 +1132,7 @@ describe("validateRepo", () => {
       code: 200,
     });
     const res = await store.dispatch(
-      repoActions.validateRepo("url", "oci", "", "", "", ["apache", "jenkins"], false),
+      repoActions.validateRepo("url", "oci", "", "", "", ["apache", "jenkins"], false, false),
     );
     expect(res).toBe(true);
     expect(AppRepository.validate).toHaveBeenCalledWith(
@@ -1118,6 +1144,7 @@ describe("validateRepo", () => {
       "",
       "",
       ["apache", "jenkins"],
+      false,
       false,
     );
   });

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -225,6 +225,7 @@ export const installRepo = (
   registrySecrets: string[],
   ociRepositories: string[],
   skipTLS: boolean,
+  passCredentials: boolean,
   filter?: IAppRepositoryFilter,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
@@ -248,6 +249,7 @@ export const installRepo = (
         registrySecrets,
         ociRepositories,
         skipTLS,
+        passCredentials,
         filter,
       );
       dispatch(addedRepo(data.appRepository));
@@ -273,6 +275,7 @@ export const updateRepo = (
   registrySecrets: string[],
   ociRepositories: string[],
   skipTLS: boolean,
+  passCredentials: boolean,
   filter?: IAppRepositoryFilter,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
@@ -296,6 +299,7 @@ export const updateRepo = (
         registrySecrets,
         ociRepositories,
         skipTLS,
+        passCredentials,
         filter,
       );
       dispatch(repoUpdated(data.appRepository));
@@ -331,6 +335,7 @@ export const validateRepo = (
   customCA: string,
   ociRepositories: string[],
   skipTLS: boolean,
+  passCredentials: boolean,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> => {
   return async (dispatch, getState) => {
     const {
@@ -349,6 +354,7 @@ export const validateRepo = (
         customCA,
         ociRepositories,
         skipTLS,
+        passCredentials,
       );
       if (data.code === 200) {
         dispatch(repoValidated(data));

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -47,6 +47,7 @@ export function AppRepoAddButton({
     registrySecrets: string[],
     ociRepositories: string[],
     skipTLS: boolean,
+    passCredentials: boolean,
     filter?: IAppRepositoryFilter,
   ) => {
     if (repo) {
@@ -64,6 +65,7 @@ export function AppRepoAddButton({
           registrySecrets,
           ociRepositories,
           skipTLS,
+          passCredentials,
           filter,
         ),
       );
@@ -82,6 +84,7 @@ export function AppRepoAddButton({
           registrySecrets,
           ociRepositories,
           skipTLS,
+          passCredentials,
           filter,
         ),
       );

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -146,6 +146,7 @@ it("should call the install method with OCI information", async () => {
     [],
     ["apache", "jenkins"],
     false,
+    false,
     undefined,
   );
 });
@@ -176,6 +177,39 @@ it("should call the install skipping TLS verification", async () => {
     "",
     [],
     [],
+    true,
+    false,
+    undefined,
+  );
+});
+
+it("should call the install passing credentials", async () => {
+  const validateRepo = jest.fn().mockReturnValue(true);
+  const install = jest.fn().mockReturnValue(true);
+  actions.repos = {
+    ...actions.repos,
+    validateRepo,
+  };
+  const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} onSubmit={install} />);
+  wrapper.find("#kubeapps-repo-url").simulate("change", { target: { value: "helm.repo" } });
+  wrapper.find("#kubeapps-repo-pass-credentials").simulate("change");
+  const form = wrapper.find("form");
+  await act(async () => {
+    await (form.prop("onSubmit") as (e: any) => Promise<any>)({ preventDefault: jest.fn() });
+  });
+  wrapper.update();
+  expect(install).toHaveBeenCalledWith(
+    "",
+    "https://helm.repo",
+    "helm",
+    "",
+    "",
+    "",
+    "",
+    "",
+    [],
+    [],
+    false,
     true,
     undefined,
   );
@@ -211,6 +245,7 @@ describe("when using a filter", () => {
       "",
       [],
       [],
+      false,
       false,
       { jq: ".name == $var0 or .name == $var1", variables: { $var0: "nginx", $var1: "wordpress" } },
     );
@@ -248,6 +283,7 @@ describe("when using a filter", () => {
       [],
       [],
       false,
+      false,
       { jq: ".name | test($var) | not", variables: { $var: "nginx" } },
     );
   });
@@ -283,6 +319,7 @@ describe("when using a filter", () => {
       [],
       [],
       false,
+      false,
       undefined,
     );
   });
@@ -317,6 +354,7 @@ describe("when using a description", () => {
       "",
       [],
       [],
+      false,
       false,
       undefined,
     );
@@ -385,6 +423,7 @@ it("should call the install method with the selected docker credentials", async 
     ["repo-1"],
     [],
     false,
+    false,
     undefined,
   );
 });
@@ -432,6 +471,7 @@ it("should call the install reusing as auth the selected docker credentials", as
     "",
     ["repo-1"],
     [],
+    false,
     false,
     undefined,
   );
@@ -514,6 +554,12 @@ describe("when the repository info is already populated", () => {
       const repo = { metadata: { name: "foo" }, spec: { tlsInsecureSkipVerify: true } } as any;
       const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
       expect(wrapper.find("#kubeapps-repo-skip-tls")).toBeChecked();
+    });
+
+    it("should parse the existing pass credentials config", () => {
+      const repo = { metadata: { name: "foo" }, spec: { passCredentials: true } } as any;
+      const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
+      expect(wrapper.find("#kubeapps-repo-pass-credentials")).toBeChecked();
     });
 
     it("should parse a bearer token", () => {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -30,6 +30,7 @@ interface IAppRepoFormProps {
     registrySecrets: string[],
     ociRepositories: string[],
     skipTLS: boolean,
+    passCredentials: boolean,
     filter?: IAppRepositoryFilter,
   ) => Promise<boolean>;
   onAfterInstall?: () => void;
@@ -65,6 +66,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
   const [type, setType] = useState(TYPE_HELM);
   const [ociRepositories, setOCIRepositories] = useState("");
   const [skipTLS, setSkipTLS] = useState(!!repo?.spec?.tlsInsecureSkipVerify);
+  const [passCredentials, setPassCredentials] = useState(!!repo?.spec?.passCredentials);
   const [filterNames, setFilterNames] = useState("");
   const [filterRegex, setFilterRegex] = useState(false);
   const [filterExclude, setFilterExclude] = useState(false);
@@ -105,6 +107,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
       );
       setOCIRepositories(repo.spec?.ociRepositories?.join(", ") || "");
       setSkipTLS(!!repo.spec?.tlsInsecureSkipVerify);
+      setPassCredentials(!!repo.spec?.passCredentials);
       if (repo.spec?.filterRule?.jq) {
         const { names, regex, exclude } = toParams(repo.spec.filterRule);
         setFilterRegex(regex);
@@ -187,6 +190,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
           customCA,
           ociRepoList,
           skipTLS,
+          passCredentials,
         ),
       );
       setValidated(currentlyValidated);
@@ -208,6 +212,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
         selectedImagePullSecret.length ? [selectedImagePullSecret] : [],
         ociRepoList,
         skipTLS,
+        passCredentials,
         filter,
       );
       if (success && onAfterInstall) {
@@ -261,6 +266,10 @@ export function AppRepoForm(props: IAppRepoFormProps) {
   };
   const handleSkipTLSChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSkipTLS(!skipTLS);
+    setValidated(undefined);
+  };
+  const handlePassCredentialsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassCredentials(!passCredentials);
     setValidated(undefined);
   };
   const handleFilterNames = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -546,6 +555,17 @@ export function AppRepoForm(props: IAppRepoFormProps) {
             type="checkbox"
             checked={skipTLS}
             onChange={handleSkipTLSChange}
+          />
+        </CdsCheckbox>
+        <CdsCheckbox className="ca-skip-tls">
+          <label className="clr-control-label">
+            Pass Credentials to 3rd party URLs (Icon and Tarball files)
+          </label>
+          <input
+            id="kubeapps-repo-pass-credentials"
+            type="checkbox"
+            checked={passCredentials}
+            onChange={handlePassCredentialsChange}
           />
         </CdsCheckbox>
 

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -38,6 +38,7 @@ export class AppRepository {
     registrySecrets: string[],
     ociRepositories: string[],
     skipTLS: boolean,
+    passCredentials: boolean,
     filter?: IAppRepositoryFilter,
   ) {
     const { data } = await axiosWithAuth.put<ICreateAppRepositoryResponse>(
@@ -55,6 +56,7 @@ export class AppRepository {
           registrySecrets,
           ociRepositories,
           tlsInsecureSkipVerify: skipTLS,
+          passCredentials: passCredentials,
           filter,
         },
       },
@@ -86,6 +88,7 @@ export class AppRepository {
     registrySecrets: string[],
     ociRepositories: string[],
     skipTLS: boolean,
+    passCredentials: boolean,
     filter?: IAppRepositoryFilter,
   ) {
     const { data } = await axiosWithAuth.post<ICreateAppRepositoryResponse>(
@@ -103,6 +106,7 @@ export class AppRepository {
           registrySecrets,
           ociRepositories,
           tlsInsecureSkipVerify: skipTLS,
+          passCredentials: passCredentials,
           filterRule: filter,
         },
       },
@@ -120,6 +124,7 @@ export class AppRepository {
     customCA: string,
     ociRepositories: string[],
     skipTLS: boolean,
+    passCredentials: boolean,
   ) {
     const { data } = await axiosWithAuth.post<any>(
       url.backend.apprepositories.validate(cluster, namespace),
@@ -132,6 +137,7 @@ export class AppRepository {
           customCA,
           ociRepositories,
           tlsInsecureSkipVerify: skipTLS,
+          passCredentials: passCredentials,
         },
       },
     );

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -458,6 +458,7 @@ export type IAppRepository = IK8sObject<
     ociRepositories?: string[];
     tlsInsecureSkipVerify?: boolean;
     filterRule?: IAppRepositoryFilter;
+    passCredentials?: boolean;
   },
   undefined
 >;

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -417,6 +417,7 @@ type appRepositoryRequestDetails struct {
 	TLSInsecureSkipVerify bool                    `json:"tlsInsecureSkipVerify"`
 	FilterRule            v1alpha1.FilterRuleSpec `json:"filterRule"`
 	Description           string                  `json:"description"`
+	PassCredentials       bool                    `json:"passCredentials"`
 }
 
 // ErrGlobalRepositoryWithSecrets defines the error returned when an attempt is
@@ -851,6 +852,7 @@ func appRepositoryForRequest(appRepoRequest *appRepositoryRequest) *v1alpha1.App
 			TLSInsecureSkipVerify: appRepo.TLSInsecureSkipVerify,
 			FilterRule:            appRepo.FilterRule,
 			Description:           appRepo.Description,
+			PassCredentials:       appRepo.PassCredentials,
 		},
 	}
 }


### PR DESCRIPTION
### Description of the change

This PR adds a similar change as the Helm folks did in https://github.com/helm/helm/commit/179f90151d5ecb4aa3d35ada35e82b5c1e791752

Now, the credentials will be passed to an external URL if: 1) a user adds `pass-credentials` to the repo OR 2) the domain in the chart index.yaml file matches the icon/tarball domain.

### Benefits

Not passing credentials to external domains (such as icons and tarballs)

### Possible drawbacks

If users don't explicitly decide to allow passing the credentials, in scenarios when the index.yaml URL doesn't match the icon/tarball URL domain, the credentials won't be passed through anymore.

### Applicable issues

- fixes #2136

### Additional information

![image](https://user-images.githubusercontent.com/11535726/123844343-344d0180-d913-11eb-9d58-948ff1855d83.png)

More testing is required, I feel the mock clients we use here are not enough to make sure we are doing it right.