### PR TITLE
Remove GKE on master in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ workflows:
       - sync_chart_from_bitnami:
           <<: *build_on_master
       - GKE_1_17_MASTER:
-          <<: *build_on_master
+          <<: *build_on_tag
           requires:
             - test_go
             - test_dashboard
@@ -131,7 +131,7 @@ workflows:
             - build_pinniped_proxy
             - sync_chart_from_bitnami
       - GKE_1_17_LATEST_RELEASE:
-          <<: *build_on_master
+          <<: *build_on_tag
           requires:
             - test_go
             - test_dashboard
@@ -140,7 +140,7 @@ workflows:
             - build_pinniped_proxy
             - sync_chart_from_bitnami
       - GKE_1_18_MASTER:
-          <<: *build_on_master
+          <<: *build_on_tag
           requires:
             - test_go
             - test_dashboard
@@ -149,7 +149,7 @@ workflows:
             - build_pinniped_proxy
             - sync_chart_from_bitnami
       - GKE_1_18_LATEST_RELEASE:
-          <<: *build_on_master
+          <<: *build_on_tag
           requires:
             - test_go
             - test_dashboard
@@ -161,10 +161,6 @@ workflows:
           <<: *build_on_master
           requires:
             - local_e2e_tests
-            - GKE_1_17_MASTER
-            - GKE_1_17_LATEST_RELEASE
-            - GKE_1_18_MASTER
-            - GKE_1_18_LATEST_RELEASE
       - sync_chart_to_bitnami:
           <<: *build_on_tag
           requires:
@@ -271,7 +267,7 @@ install_cluster: &install_cluster
         kubectl --context kind-kubeapps-ci --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci apply -f ./docs/user/manifests/ingress-nginx-kind-with-large-proxy-buffers.yaml &&
         sleep 5 &&
         kubectl --context kind-kubeapps-ci --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=120s &&
-        
+
         kubectl --context kind-kubeapps-ci --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci delete rolebinding kubeapps-user -n  kubeapps-user-namespace &&
         kubectl --context kind-kubeapps-ci --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci create rolebinding kubeapps-view-secret-oidc --role view-secrets --user oidc:kubeapps-user@example.com &&
         kubectl --context kind-kubeapps-ci --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci create clusterrolebinding kubeapps-view-oidc  --clusterrole=view --user oidc:kubeapps-user@example.com &&
@@ -305,7 +301,7 @@ export_cluster_variables: &export_cluster_variables
 
       # If running kubectl without args, use the default "kubeapps-ci" cluster
       cp ${HOME}/.kube/kind-config-kubeapps-ci ${HOME}/.kube/config
-      kubectl config set-context kind-kubeapps-ci 
+      kubectl config set-context kind-kubeapps-ci
 
       # If the default IP the proper one, the multicluster setup will fail
       if [ "$DEFAULT_DEX_IP" != "$DEX_IP" ]; then echo "Default IP does not match with current IP used in Kind"; exit 1; fi
@@ -427,7 +423,7 @@ install_multicluster_deps: &install_multicluster_deps
 
       # Install openldap
       kubectl create namespace ldap
-      helm install ldap stable/openldap --namespace ldap 
+      helm install ldap stable/openldap --namespace ldap
 
       # Create certs
       kubectl -n dex create secret tls dex-web-server-tls --key ./devel/dex.key --cert ./devel/dex.crt


### PR DESCRIPTION
### Description of the change

This PR simply disables the GKE testing each time we push to master. Instead, it will only run when tagging a new release.

### Benefits

No more (so frequent) CI errors.

### Possible drawbacks

Code takes more time to be tested in GKE, but with the multicluster env in Kind we are spinning up, I think is enough. 

### Applicable issues

N/A

### Additional information

N/A
