### PR TITLE
Update to support k8s 1.21 requiring dex update.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,6 +422,7 @@ install_multicluster_deps: &install_multicluster_deps
       helm install dex dex/dex --version 0.5.0 --namespace dex --values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
 
       # Install openldap
+      helm repo add stable https://charts.helm.sh/stable
       kubectl create namespace ldap
       helm install ldap stable/openldap --namespace ldap
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,11 +415,11 @@ install_multicluster_deps: &install_multicluster_deps
     name: "Install multicluster deps"
     command: |
       sed -i -e "s/172.18.0.2/$DEFAULT_DEX_IP/g;s/localhost/kubeapps-ci.kubeapps/g" ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
-      helm repo add stable https://charts.helm.sh/stable
+      helm repo add dex https://charts.dexidp.io
 
       # Install dex
       kubectl create namespace dex
-      helm install dex stable/dex --namespace dex --values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
+      helm install dex dex/dex --version 0.5.0 --namespace dex --values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
 
       # Install openldap
       kubectl create namespace ldap

--- a/docs/user/manifests/kubeapps-local-dev-dex-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-dex-values.yaml
@@ -1,4 +1,5 @@
-https: true
+https:
+  enabled: true
 certs:
   web:
     create: false
@@ -10,6 +11,9 @@ config:
   web:
     tlsCert: /etc/dex/tls/https/server/tls.crt
     tlsKey: /etc/dex/tls/https/server/tls.key
+  enablePasswordDB: true
+  storage:
+    type: memory
   # Instead of reading from an external storage, use this list of clients.
   staticClients:
     # The default client is in this setup the client used by Kubeapps'
@@ -93,6 +97,18 @@ config:
 
           # The group name should be the "cn" value.
           nameAttr: cn
-grpc: false
+grpc:
+  enabled: false
 service:
   type: NodePort
+  ports:
+    https:
+      nodePort: 32000
+volumes:
+  - name: https-tls
+    secret:
+      defaultMode: 420
+      secretName: dex-web-server-tls
+volumeMounts:
+  - mountPath: /etc/dex/tls/https/server
+    name: https-tls

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -59,9 +59,9 @@ module.exports = {
         timeout: 10000,
       });
       await page.click("#submit-login");
-      await expect(page).toClick("button", {
-        text: "Grant Access",
-      });
+      // Additionally click on the new "Grant Access" confirmation.
+      await page.waitForNavigation({ waitUntil: "domcontentloaded" });
+      await expect(page).toClick('button.dex-btn[type="submit"]');
       await page.waitForSelector(".kubeapps-header-content", {
         visible: true,
         timeout: 10000,

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -60,7 +60,11 @@ module.exports = {
       });
       await page.click("#submit-login");
       // Additionally click on the new "Grant Access" confirmation.
-      await page.waitForNavigation({ waitUntil: "domcontentloaded" });
+      await page.waitForSelector('.dex-container button[type="submit"]', {
+        text: "Grant Access",
+        visible: true,
+        timeout: 10000,
+      });
       await expect(page).toMatchElement('.dex-container button[type="submit"]', {
         text: "Grant Access",
       });

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -59,6 +59,10 @@ module.exports = {
         timeout: 10000,
       });
       await page.click("#submit-login");
+      await page.waitForNavigation({ waitUntil: "domcontentloaded" });
+      await expect(page).toClick("button", {
+        text: "Grant Access",
+      });
       await page.waitForSelector(".kubeapps-header-content", {
         visible: true,
         timeout: 10000,

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -59,7 +59,6 @@ module.exports = {
         timeout: 10000,
       });
       await page.click("#submit-login");
-      await page.waitForNavigation({ waitUntil: "domcontentloaded" });
       await expect(page).toClick("button", {
         text: "Grant Access",
       });

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -60,10 +60,12 @@ module.exports = {
       });
       await page.click("#submit-login");
       // Additionally click on the new "Grant Access" confirmation.
+      await page.waitForNavigation({ waitUntil: "domcontentloaded" });
       await expect(page).toMatchElement('.dex-container button[type="submit"]', {
         text: "Grant Access",
       });
       await expect(page).toClick('.dex-container button[type="submit"]');
+      await page.waitForNavigation({ waitUntil: "domcontentloaded" });
       await page.waitForSelector(".kubeapps-header-content", {
         visible: true,
         timeout: 10000,

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -60,8 +60,10 @@ module.exports = {
       });
       await page.click("#submit-login");
       // Additionally click on the new "Grant Access" confirmation.
-      await page.waitForNavigation({ waitUntil: "domcontentloaded" });
-      await expect(page).toClick('button.dex-btn[type="submit"]');
+      await expect(page).toMatchElement('.dex-container button[type="submit"]', {
+        text: "Grant Access",
+      });
+      await expect(page).toClick('.dex-container button[type="submit"]');
       await page.waitForSelector(".kubeapps-header-content", {
         visible: true,
         timeout: 10000,

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -9,8 +9,8 @@ deploy-dex: devel/dex.crt devel/dex.key
 	kubectl --kubeconfig=${CLUSTER_CONFIG} -n dex create secret tls dex-web-server-tls \
 		--key ./devel/dex.key \
 		--cert ./devel/dex.crt
-	helm --kubeconfig=${CLUSTER_CONFIG} repo add stable https://charts.helm.sh/stable
-	helm --kubeconfig=${CLUSTER_CONFIG} install dex stable/dex --namespace dex  --values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
+	helm --kubeconfig=${CLUSTER_CONFIG} repo add dex https://charts.dexidp.io
+	helm --kubeconfig=${CLUSTER_CONFIG} install dex dex/dex --version 0.5.0 --namespace dex  --values ./docs/user/manifests/kubeapps-local-dev-dex-values.yaml
 
 deploy-openldap:
 	kubectl --kubeconfig=${CLUSTER_CONFIG} create namespace ldap


### PR DESCRIPTION
### Description of the change

I updated my local kind installation (to v0.11.1, so supporting k8s 1.21) only to find that it breaks the dev env.

The reason is a change in 1.21 which results in the version of dex we were using crash-looping.

Since we were using the deprecated (and no longer updated) stable repo for dex, I updated to the current dex chart repo and got things working with the latest version of that chart instead.

### Benefits

Dev environment works with k8s 1.21.

Updated dex version (only visible difference is that it now lets the user choose to grant the email scope).


### Possible drawbacks

None that I can think of.

