### PR TITLE
bumped kube version

### DIFF
--- a/cmd/pinniped-proxy/Cargo.lock
+++ b/cmd/pinniped-proxy/Cargo.lock
@@ -27,12 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
-name = "array_tool"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f8cb5d814eb646a863c4f24978cff2880c4be96ad8cde2c0f0678732902e271"
-
-[[package]]
 name = "async-stream"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
@@ -596,12 +590,10 @@ dependencies = [
 
 [[package]]
 name = "jsonpath_lib"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61352ec23883402b7d30b3313c16cbabefb8907361c4eb669d990cbb87ceee5a"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
 dependencies = [
- "array_tool",
- "env_logger",
  "log",
  "serde",
  "serde_json",
@@ -609,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc1f973542059e6d5a6d63de6a9539d0ec784f82b2327f3c1915d33200bc6a4"
+checksum = "fbff78f6da26dde0d74188966d23fc763431d730d0f766ecf7699209f8fc243c"
 dependencies = [
  "base64",
  "bytes",
@@ -623,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.55.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a7370e62dacd8f672231c59001ddf00b090648c81b3cde2600bfbfab7518fe"
+checksum = "8152fba26129a09bf30179092753b399760a305a218b8bc558f9a2087b5c1d70"
 dependencies = [
  "base64",
  "bytes",
@@ -634,6 +626,7 @@ dependencies = [
  "either",
  "futures",
  "http",
+ "http-body",
  "hyper",
  "hyper-timeout",
  "hyper-tls",
@@ -646,36 +639,34 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "static_assertions",
  "thiserror",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tracing",
- "url",
 ]
 
 [[package]]
 name = "kube-core"
-version = "0.55.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a12871b580beae491ae6adeed43f261d85c3fb2bf97d53ab9cf9c1c9ffb32e5"
+checksum = "36b767df01404bb99fb75ac2ceded28ce34c30fdcffbb4346e2c44d30756bfba"
 dependencies = [
+ "form_urlencoded",
  "http",
  "k8s-openapi",
- "once_cell",
  "serde",
  "serde_json",
  "thiserror",
- "url",
 ]
 
 [[package]]
 name = "kube-derive"
-version = "0.55.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875af6c219be177d6c5cca8c82f026b6c338bffbefcfebd3ed454d78ed74b9f4"
+checksum = "b6d0e5489859d9430689f64e69cacc9bf8cb68556f436c73a6a308d4e256b7a0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -686,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.55.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975f4b3d7742d74ae5c15d3b460b68dea35ee622219e6ea1bc95f71e344ac061"
+checksum = "f8358421de932e06d0521700fc8ecfc7058c95509e0770d2da88be78cd737c07"
 dependencies = [
  "dashmap",
  "derivative",
@@ -983,6 +974,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "http",
  "hyper",
  "hyper-tls",
  "k8s-openapi",
@@ -1394,12 +1386,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1611,23 @@ dependencies = [
  "pin-project 1.0.7",
  "tokio",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58e177fa381489c0eb101ed27fb4233ba5cbe548226f439dd22853f9383bc26"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project 1.0.7",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -15,15 +15,15 @@ anyhow = "1.0"
 base64 = "0.13"
 hyper = { version = "0.14", features = ["server"] }
 hyper-tls = "0.5"
-kube = { version = "0.55.0" }
+kube = { version = "0.57.0" }
 # We explicitly import kube-derive without the schema option to avoid
 # requiring the jsonschema for CRDs until
 # https://github.com/Arnavion/k8s-openapi/issues/86
 # is sorted. AFAICT, the openapi json schema is only required when creating a
 # CRD (which we're not).
-kube-derive = { version = "0.55.0", default-features = false}
-kube-runtime = "0.55.0"
-k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_17"] }
+kube-derive = { version = "0.57.0", default-features = false}
+kube-runtime = "0.57.0"
+k8s-openapi = { version = "0.12.0", default-features = false, features = ["v1_20"] }
 log = "0.4"
 native-tls = "0.2"
 openssl = "0.10"
@@ -36,6 +36,7 @@ thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 tokio-native-tls = "0.3"
 url = "2.2"
+http = "0.2.4"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/cmd/pinniped-proxy/src/pinniped.rs
+++ b/cmd/pinniped-proxy/src/pinniped.rs
@@ -386,7 +386,7 @@ mod tests {
                     e.is::<http::uri::InvalidUri>(),
                     "got: {:#?}, want: {}",
                     e,
-                    http::uri::InvalidUri::InvalidUriChar
+                    http::uri::InvalidUri.InvalidUriChar
                 );
                 Ok(())
             }

--- a/cmd/pinniped-proxy/src/pinniped.rs
+++ b/cmd/pinniped-proxy/src/pinniped.rs
@@ -383,10 +383,10 @@ mod tests {
             Ok(_) => anyhow::bail!("expected error"),
             Err(e) => {
                 assert!(
-                    e.is::<url::ParseError>(),
+                    e.is::<http::uri::InvalidUri>(),
                     "got: {:#?}, want: {}",
                     e,
-                    url::ParseError::InvalidDomainCharacter
+                    http::uri::InvalidUri::InvalidUriChar
                 );
                 Ok(())
             }

--- a/cmd/pinniped-proxy/src/pinniped.rs
+++ b/cmd/pinniped-proxy/src/pinniped.rs
@@ -14,7 +14,7 @@ use openssl::{pkcs12::Pkcs12, pkey::PKey, x509::X509};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use thiserror::Error;
-use url::Url;
+use http::Uri;
 
 const DEFAULT_PINNIPED_API_SUFFIX: &str = "DEFAULT_PINNIPED_API_SUFFIX";
 const DEFAULT_PINNIPED_NAMESPACE: &str = "DEFAULT_PINNIPED_NAMESPACE";
@@ -224,8 +224,8 @@ fn get_client_config(
     pinniped_namespace: String,
 ) -> Result<kube::Client> {
     let mut config =
-        Config::new(Url::parse(k8s_api_server_url).context("Failed parsing url for exchange")?);
-    config.default_ns = pinniped_namespace.clone();
+        Config::new(k8s_api_server_url.parse::<Uri>().context("Failed parsing url for exchange")?);
+    config.default_namespace = pinniped_namespace.clone();
     let x509 = X509::from_pem(k8s_api_ca_cert_data).context("error creating x509 from pem")?;
     let der = x509.to_der().context("error creating der from x509")?;
     config.root_cert = Some(vec![der]);

--- a/cmd/pinniped-proxy/src/pinniped.rs
+++ b/cmd/pinniped-proxy/src/pinniped.rs
@@ -386,7 +386,7 @@ mod tests {
                     e.is::<http::uri::InvalidUri>(),
                     "got: {:#?}, want: {}",
                     e,
-                    http::uri::InvalidUri.InvalidUriChar
+                    "InvalidUri.InvalidUriChar"
                 );
                 Ok(())
             }


### PR DESCRIPTION
### Description of the change

upgraded kube crate from version 0.55.0 to 0.57.0.
refactored code for backward incompatible changes

### Benefits

upgraded to new version to use dynamic kube objects

### Possible drawbacks

none

### Applicable issues

issue #2695: Allow configuring pinniped-proxy with per-cluster namespace and suffix

### Additional information
