### PR TITLE
CI - Fix rollback test

### DIFF
--- a/integration/use-cases/08-rollback.js
+++ b/integration/use-cases/08-rollback.js
@@ -25,7 +25,9 @@ test("Upgrades an application", async () => {
 
   // Try to rollback when the app hasn't been upgraded
   await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).toMatchElement("cds-modal-content p", { text: "The application has not been upgraded, it's not possible to rollback." });
+  await expect(page).toMatchElement("cds-modal-content p", {
+    text: "The application has not been upgraded, it's not possible to rollback.",
+  });
   await expect(page).toClick("cds-button", { text: "Cancel" });
 
   // Upgrade the app to get another revision
@@ -40,29 +42,32 @@ test("Upgrades an application", async () => {
   await new Promise(r => setTimeout(r, 500));
 
   await expect(page).toClick("li", { text: "Changes" });
-  await expect(page).toMatch("replicaCount: 2", { timeout: 60000 });
+  await expect(page).toMatch("replicaCount: 2");
   await expect(page).toMatchElement("input[type='number']", { value: 2 });
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   // Rollback to the previous revision (default selected value)
-  await page.waitForTimeout(1000)
+  await page.waitForTimeout(1000);
+  await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
   await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).toMatch("(current: 2)", { timeout: 60000 });
+  await expect(page).not.toMatch("Loading");
+  await expect(page).toMatch("(current: 2)");
   await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
 
-
   // Check revision and rollback to a revision (manual selected value)
-  await page.waitForTimeout(1000)
+  await page.waitForTimeout(1000);
   await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).toMatch("(current: 3)", { timeout: 60000 });
+  await expect(page).not.toMatch("Loading");
+  await expect(page).toMatch("(current: 3)");
 
   await expect(page).toSelect("cds-select > select", "1");
   await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
 
-  // Check revision
-  await page.waitForTimeout(1000)
+  // Check revisions
+  await page.waitForTimeout(1000);
+  await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
   await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).toMatch("(current: 4)", { timeout: 60000 });
-
+  await expect(page).not.toMatch("Loading");
+  await expect(page).toMatch("(current: 4)");
 });

--- a/integration/use-cases/08-rollback.js
+++ b/integration/use-cases/08-rollback.js
@@ -40,22 +40,22 @@ test("Upgrades an application", async () => {
   await new Promise(r => setTimeout(r, 500));
 
   await expect(page).toClick("li", { text: "Changes" });
-  await expect(page).toMatch("replicaCount: 2");
+  await expect(page).toMatch("replicaCount: 2", { timeout: 60000 });
   await expect(page).toMatchElement("input[type='number']", { value: 2 });
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   // Rollback to the previous revision (default selected value)
+  await page.waitForTimeout(1000)
   await expect(page).toClick("cds-button", { text: "Rollback" });
-
-  await expect(page).toMatch("(current: 2)");
+  await expect(page).toMatch("(current: 2)", { timeout: 60000 });
   await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
 
 
   // Check revision and rollback to a revision (manual selected value)
   await page.waitForTimeout(1000)
   await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).toMatch("(current: 3)");
+  await expect(page).toMatch("(current: 3)", { timeout: 60000 });
 
   await expect(page).toSelect("cds-select > select", "1");
   await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
@@ -63,6 +63,6 @@ test("Upgrades an application", async () => {
   // Check revision
   await page.waitForTimeout(1000)
   await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).toMatch("(current: 4)");
+  await expect(page).toMatch("(current: 4)", { timeout: 60000 });
 
 });

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -398,7 +398,7 @@ edit_token="$(kubectl get -n kubeapps secret "$(kubectl get -n kubeapps servicea
 
 ## Run tests
 info "Running Integration tests..."
-if ! kubectl exec -it "$pod" -- /bin/sh -c "INTEGRATION_ENTRYPOINT=http://kubeapps-ci.kubeapps USE_MULTICLUSTER_OIDC_ENV=${USE_MULTICLUSTER_OIDC_ENV} ADMIN_TOKEN=${admin_token} VIEW_TOKEN=${view_token} EDIT_TOKEN=${edit_token} yarn start ${ignoreFlag}"; then
+if ! kubectl exec -it "$pod" -- /bin/sh -c "INTEGRATION_RETRY_ATTEMPTS=3 INTEGRATION_ENTRYPOINT=http://kubeapps-ci.kubeapps USE_MULTICLUSTER_OIDC_ENV=${USE_MULTICLUSTER_OIDC_ENV} ADMIN_TOKEN=${admin_token} VIEW_TOKEN=${view_token} EDIT_TOKEN=${edit_token} yarn start ${ignoreFlag}"; then
   ## Integration tests failed, get report screenshot
   warn "PODS status on failure"
   kubectl cp "${pod}:/app/reports" ./reports


### PR DESCRIPTION
### Description of the change

In the rollback test, we were performing the rollback action prior to check if the app was fully deployed. It caused some inconsistencies; especially, the rollback dialog showed "loading, please wait". Wherefore the expected text never appeared.

This PR is for checking the app is fully deployed and the rollback dialog is loaded before checking the revision version.

Every time the tests passed... it was like planet conjunction :P

### Benefits

The CI (should) pass again.

### Possible drawbacks

N/A

### Applicable issues

N/A
### Additional information

N/A
