### PR TITLE
Update stale bot frequency

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 90
+daysUntilStale: 15
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 3
 # Issues with these labels will never be considered stale
 exemptLabels:
   - priority/unbreak-now
@@ -9,8 +9,9 @@ exemptLabels:
   - priority/medium
   - kind/bug
   - kind/feature
+  - kind/refactor
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had

--- a/docs/developer/issue-triage-process.md
+++ b/docs/developer/issue-triage-process.md
@@ -29,9 +29,9 @@ Besides this manual triage process, there are two automatic process lead by the 
 
 - Automatically move new and reopened issues to the **Inbox** column to start the triage process (due to eventual project-bot outages, once a month we should manually search for issues with "no:project" assigned).
 - Automatically **dependabot** and **Snyk** are labelling PRs depending on the target language.
-- Automatically **stalebot** is checking inactive issues to label them as 'stale'. An issue becomes stale after 60 days of inactivity and the bot will close it after 7 days of inactivity for stale issues. To be considered:
+- Automatically **stalebot** is checking inactive issues to label them as 'stale'. An issue becomes stale after 15 days of inactivity and the bot will close it after 3 days of inactivity for stale issues. To be considered:
   - Issues labeled as 'priority/unbreak-now' → 'priority/high' → 'priority/medium' will never be labeled as 'stale'.
-  - Issues labeled as 'kind/feature' or 'kind/bug' will never be labeled as 'stale'
+  - Issues labeled as 'kind/feature', 'kind/bug' or 'kind/refactor' will never be labeled as 'stale'
   - Only issues labeled as 'priority/low' or 'awaiting-more-evidence' could be considered stale (and those without any priority label).
   - The label to use when marking an issue as stale is 'stale'.
 


### PR DESCRIPTION
### Description of the change

Update the stale bot to increase the frequency of issues marked as stale to 15 days (the standard Kubeapps iteration cycle). The issue triage documentation is also updated to be aligned to these changes.

### Benefits

These changes will contribute to keep a cleaner board without outdated issues. It is also the goal to foster Kubeapps maintainers and contributors to provide more frequent feedback/confirmation to open issues.

### Possible drawbacks

Increase the revision of issues marked as stale.

### Applicable issues

  - fixes #3088 

### Additional information

N/A