### PR TITLE
Update so plugins are passed a rest.Config getter rather than a client getter

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/go-redis/redis/v8"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +50,7 @@ type ResourceWatcherCache struct {
 // and/or caching-rleated code is moved into a separate package?
 type cacheConfig struct {
 	gvr          schema.GroupVersionResource
-	clientGetter server.KubernetesClientGetter
+	clientGetter clientGetter
 	// 'onAdd' and 'onModify' hooks are called when a new or modified object comes about and
 	// allows the plug-in to return information about WHETHER OR NOT and WHAT is to be stored
 	// in the cache for a given k8s object (passed in as a untyped/unstructured map)
@@ -160,7 +159,7 @@ func (c *ResourceWatcherCache) startResourceWatcher() {
 func (c *ResourceWatcherCache) newResourceWatcherChan() (<-chan watch.Event, error) {
 	ctx := context.Background()
 
-	_, dynamicClient, err := c.config.clientGetter(ctx)
+	dynamicClient, err := c.config.clientGetter(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "unable to get client due to: %v", err)
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
@@ -26,7 +26,7 @@ import (
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesClientGetter) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesConfigGetter) (interface{}, error) {
 	log.Infof("+fluxv2 RegisterWithGRPCServer")
 	svr, err := NewServer(clientGetter)
 	if err != nil {

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
@@ -26,9 +26,9 @@ import (
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesConfigGetter) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter) (interface{}, error) {
 	log.Infof("+fluxv2 RegisterWithGRPCServer")
-	svr, err := NewServer(clientGetter)
+	svr, err := NewServer(configGetter)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
@@ -36,8 +36,8 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesConfigGetter) (interface{}, error) {
-	svr := NewServer(clientGetter)
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter) (interface{}, error) {
+	svr := NewServer(configGetter)
 	v1alpha1.RegisterHelmPackagesServiceServer(s, svr)
 	return svr, nil
 }

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
@@ -36,7 +36,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesClientGetter) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesConfigGetter) (interface{}, error) {
 	svr := NewServer(clientGetter)
 	v1alpha1.RegisterHelmPackagesServiceServer(s, svr)
 	return svr, nil

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/kubeapps/kubeapps/pkg/dbutils"
 	"google.golang.org/grpc/codes"
@@ -66,7 +65,7 @@ func TestGetClient(t *testing.T) {
 	if err != nil {
 		log.Fatalf("%s", err)
 	}
-	clientGetter := func(context.Context) (kubernetes.Interface, dynamic.Interface, error) {
+	testClientGetter := func(context.Context) (kubernetes.Interface, dynamic.Interface, error) {
 		return typfake.NewSimpleClientset(), dynfake.NewSimpleDynamicClientWithCustomListKinds(
 			runtime.NewScheme(),
 			map[schema.GroupVersionResource]string{
@@ -78,7 +77,7 @@ func TestGetClient(t *testing.T) {
 	testCases := []struct {
 		name              string
 		manager           utils.AssetManager
-		clientGetter      server.KubernetesClientGetter
+		clientGetter      clientGetter
 		statusCodeClient  codes.Code
 		statusCodeManager codes.Code
 	}{
@@ -92,7 +91,7 @@ func TestGetClient(t *testing.T) {
 		{
 			name:              "it returns internal error status when no manager configured",
 			manager:           nil,
-			clientGetter:      clientGetter,
+			clientGetter:      testClientGetter,
 			statusCodeClient:  codes.OK,
 			statusCodeManager: codes.Internal,
 		},
@@ -115,7 +114,7 @@ func TestGetClient(t *testing.T) {
 		{
 			name:         "it returns client without error when configured correctly",
 			manager:      manager,
-			clientGetter: clientGetter,
+			clientGetter: testClientGetter,
 		},
 	}
 

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
@@ -36,7 +36,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesClientGetter) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesConfigGetter) (interface{}, error) {
 	svr := NewServer(clientGetter)
 	v1alpha1.RegisterKappControllerPackagesServiceServer(s, svr)
 	return svr, nil

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
@@ -36,8 +36,8 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, clientGetter server.KubernetesConfigGetter) (interface{}, error) {
-	svr := NewServer(clientGetter)
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter) (interface{}, error) {
+	svr := NewServer(configGetter)
 	v1alpha1.RegisterKappControllerPackagesServiceServer(s, svr)
 	return svr, nil
 }

--- a/cmd/kubeapps-apis/server/plugins.go
+++ b/cmd/kubeapps-apis/server/plugins.go
@@ -111,7 +111,7 @@ func (s *pluginsServer) GetConfiguredPlugins(ctx context.Context, in *plugins.Ge
 func (s *pluginsServer) registerPlugins(pluginPaths []string, grpcReg grpc.ServiceRegistrar, gwArgs gwHandlerArgs, serveOpts ServeOptions) ([]*plugins.Plugin, error) {
 	pluginDetails := []*plugins.Plugin{}
 
-	clientGetter, err := createConfigGetter(serveOpts)
+	configGetter, err := createConfigGetter(serveOpts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a ClientGetter: %w", err)
 	}
@@ -129,7 +129,7 @@ func (s *pluginsServer) registerPlugins(pluginPaths []string, grpcReg grpc.Servi
 			pluginDetails = append(pluginDetails, pluginDetail)
 		}
 
-		if err = s.registerGRPC(p, pluginDetail, grpcReg, clientGetter); err != nil {
+		if err = s.registerGRPC(p, pluginDetail, grpcReg, configGetter); err != nil {
 			return nil, err
 		}
 

--- a/cmd/kubeapps-apis/server/plugins.go
+++ b/cmd/kubeapps-apis/server/plugins.go
@@ -33,8 +33,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	log "k8s.io/klog/v2"
@@ -48,8 +46,8 @@ const (
 	clustersCAFilesPrefix   = "/etc/additional-clusters-cafiles"
 )
 
-// KubernetesClientGetter is a function type used by plugins to get a k8s client
-type KubernetesClientGetter func(context.Context) (kubernetes.Interface, dynamic.Interface, error)
+// KubernetesConfigGetter is a function type used by plugins to get a k8s config
+type KubernetesConfigGetter func(context.Context) (*rest.Config, error)
 
 // pkgsPluginWithServer stores the plugin detail together with its implementation.
 type pkgsPluginWithServer struct {
@@ -113,7 +111,7 @@ func (s *pluginsServer) GetConfiguredPlugins(ctx context.Context, in *plugins.Ge
 func (s *pluginsServer) registerPlugins(pluginPaths []string, grpcReg grpc.ServiceRegistrar, gwArgs gwHandlerArgs, serveOpts ServeOptions) ([]*plugins.Plugin, error) {
 	pluginDetails := []*plugins.Plugin{}
 
-	clientGetter, err := createClientGetter(serveOpts)
+	clientGetter, err := createConfigGetter(serveOpts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a ClientGetter: %w", err)
 	}
@@ -145,16 +143,16 @@ func (s *pluginsServer) registerPlugins(pluginPaths []string, grpcReg grpc.Servi
 }
 
 // registerGRPC finds and calls the required function for registering the plugin for the GRPC server.
-func (s *pluginsServer) registerGRPC(p *plugin.Plugin, pluginDetail *plugins.Plugin, registrar grpc.ServiceRegistrar, clientGetter KubernetesClientGetter) error {
+func (s *pluginsServer) registerGRPC(p *plugin.Plugin, pluginDetail *plugins.Plugin, registrar grpc.ServiceRegistrar, clientGetter KubernetesConfigGetter) error {
 	grpcRegFn, err := p.Lookup(grpcRegisterFunction)
 	if err != nil {
 		return fmt.Errorf("unable to lookup %q for %v: %w", grpcRegisterFunction, pluginDetail, err)
 	}
-	type grpcRegisterFunctionType = func(grpc.ServiceRegistrar, KubernetesClientGetter) (interface{}, error)
+	type grpcRegisterFunctionType = func(grpc.ServiceRegistrar, KubernetesConfigGetter) (interface{}, error)
 
 	grpcFn, ok := grpcRegFn.(grpcRegisterFunctionType)
 	if !ok {
-		var dummyFn grpcRegisterFunctionType = func(grpc.ServiceRegistrar, KubernetesClientGetter) (interface{}, error) { return nil, nil }
+		var dummyFn grpcRegisterFunctionType = func(grpc.ServiceRegistrar, KubernetesConfigGetter) (interface{}, error) { return nil, nil }
 		return fmt.Errorf("unable to use %q in plugin %v due to mismatched signature.\nwant: %T\ngot: %T", grpcRegisterFunction, pluginDetail, dummyFn, grpcRegFn)
 	}
 
@@ -258,10 +256,10 @@ func listSOFiles(fsys fs.FS, pluginDirs []string) ([]string, error) {
 	return matches, nil
 }
 
-// createClientGetter returns a function closure for creating the k8s client to interact with the cluster.
+// createConfigGetter returns a function closure for creating the k8s config to interact with the cluster.
 // The returned function utilizes the user credential present in the request context.
 // The plugins just have to call this function passing the context in order to retrieve the configured k8s client
-func createClientGetter(serveOpts ServeOptions) (KubernetesClientGetter, error) {
+func createConfigGetter(serveOpts ServeOptions) (KubernetesConfigGetter, error) {
 	var restConfig *rest.Config
 	var clustersConfig kube.ClustersConfig
 	var err error
@@ -298,20 +296,20 @@ func createClientGetter(serveOpts ServeOptions) (KubernetesClientGetter, error) 
 
 	// return the closure fuction that takes the context, but preserving the required scope,
 	// 'inClusterConfig' and 'config'
-	return createClientGetterWithParams(restConfig, serveOpts, clustersConfig)
+	return createConfigGetterWithParams(restConfig, serveOpts, clustersConfig)
 }
 
 // createClientGetter takes the required params and returns the closure fuction.
 // it's splitted for testing this fn separately
-func createClientGetterWithParams(inClusterConfig *rest.Config, serveOpts ServeOptions, clustersConfig kube.ClustersConfig) (KubernetesClientGetter, error) {
+func createConfigGetterWithParams(inClusterConfig *rest.Config, serveOpts ServeOptions, clustersConfig kube.ClustersConfig) (KubernetesConfigGetter, error) {
 	// return the closure fuction that takes the context, but preserving the required scope,
 	// 'inClusterConfig' and 'config'
-	return func(ctx context.Context) (kubernetes.Interface, dynamic.Interface, error) {
+	return func(ctx context.Context) (*rest.Config, error) {
 		log.Infof("+clientGetter.GetClient")
 		var err error
 		token, err := extractToken(ctx)
 		if err != nil {
-			return nil, nil, status.Errorf(codes.Unauthenticated, "invalid authorization metadata: %v", err)
+			return nil, status.Errorf(codes.Unauthenticated, "invalid authorization metadata: %v", err)
 		}
 
 		var config *rest.Config
@@ -320,21 +318,13 @@ func createClientGetterWithParams(inClusterConfig *rest.Config, serveOpts ServeO
 			// we should pass the cluster name instead
 			config, err = kube.NewClusterConfig(inClusterConfig, token, clustersConfig.KubeappsClusterName, clustersConfig)
 			if err != nil {
-				return nil, nil, fmt.Errorf("unable to get clusterConfig: %w", err)
+				return nil, fmt.Errorf("unable to get clusterConfig: %w", err)
 			}
 		} else {
 			// Just using the created SA, no user account is used
 			config = inClusterConfig
 		}
-		dynamicClient, err := dynamic.NewForConfig(config)
-		if err != nil {
-			return nil, nil, fmt.Errorf("unable to create dynamic client: %w", err)
-		}
-		typedClient, err := kubernetes.NewForConfig(config)
-		if err != nil {
-			return nil, nil, fmt.Errorf("unable to create typed client: %w", err)
-		}
-		return typedClient, dynamicClient, nil
+		return config, nil
 	}, nil
 }
 

--- a/cmd/kubeapps-apis/server/plugins_test.go
+++ b/cmd/kubeapps-apis/server/plugins_test.go
@@ -364,12 +364,12 @@ func TestCreateClientGetterWithParams(t *testing.T) {
 					},
 				},
 			}
-			clientGetter, err := createClientGetterWithParams(inClusterConfig, serveOpts, config)
+			configGetter, err := createConfigGetterWithParams(inClusterConfig, serveOpts, config)
 			if err != nil {
-				t.Fatalf("in %s: fail creating the clientGetter:  %+v", tc.name, err)
+				t.Fatalf("in %s: fail creating the configGetter:  %+v", tc.name, err)
 			}
 
-			typedClient, dynamicClient, err := clientGetter(ctx)
+			restConfig, err := configGetter(ctx)
 			if tc.expectedErrMsg != nil && err != nil {
 				if got, want := err.Error(), tc.expectedErrMsg.Error(); !cmp.Equal(want, got) {
 					t.Errorf("in %s: mismatch (-want +got):\n%s", tc.name, cmp.Diff(want, got))
@@ -379,11 +379,8 @@ func TestCreateClientGetterWithParams(t *testing.T) {
 			}
 
 			if tc.shouldCreate {
-				if dynamicClient == nil {
-					t.Errorf("got: nil, want: dynamic.Interface")
-				}
-				if typedClient == nil {
-					t.Errorf("got: nil, want: kubernetes.Interface")
+				if restConfig == nil {
+					t.Errorf("got: nil, want: rest.Config")
 				}
 			}
 		})


### PR DESCRIPTION
### Description of the change

Originally we passed plugins a client getter that return a dynamic
client. We then found that the helm plugin additionally needs a typed
client, so updated the client getter to return both. For work that I'm
currently doing instantiating a helm API action configuration, I also
need the plugin to have access to a genericclioptions.RESTClientGetter.

Rather than updating the existing client getter to return yet another
type, and given that it's a single line to create a client from the rest
config, I'm instead updating so that plugins are initialised with an
initialized rest.Config getter so that they can create any client they
need while still not needing to know any details of the config (eg.
pinniped setup or similar).

### Benefits

I can continue with the helm work, using the config to create a RESTClientGetter for the Helm API.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref #3146

### Additional information

Since neither kapp_controller nor fluxv2 plugins use the typed client, I updated those to only create the client that they use (the dynamic one).

cc @gfichtenholt JFYI - this shouldn't affect your branch, unless you've also updated how the kubernetes clients are created, but if there's a conflict, I'm happy to merge this after your PR and deal with the conflicts.
