### PR TITLE
Enable or disable change context button based on clusters and namespaces

### DIFF
--- a/dashboard/src/components/Header/ContextSelector.test.tsx
+++ b/dashboard/src/components/Header/ContextSelector.test.tsx
@@ -165,6 +165,21 @@ it("disables the create button if not allowed", () => {
   expect(wrapper.find(".flat-btn").first()).toBeDisabled();
 });
 
+it("disables the change context button if namespace is not loaded yet", () => {
+  const clusters = {
+    currentCluster: "foo",
+    clusters: {
+      foo: {
+        currentNamespace: "default",
+        namespaces: [],
+        canCreateNS: false,
+      },
+    },
+  } as IClustersState;
+  const wrapper = mountWrapper(getStore({ clusters }), <ContextSelector />);
+  expect(wrapper.find(CdsButton).filterWhere(b => b.text() === "Change Context")).toBeDisabled();
+});
+
 it("changes the location with the new namespace", () => {
   const push = jest.fn();
   spyOnUseHistory = jest.spyOn(ReactRouter, "useHistory").mockReturnValue({ push } as any);

--- a/dashboard/src/components/Header/ContextSelector.tsx
+++ b/dashboard/src/components/Header/ContextSelector.tsx
@@ -27,6 +27,7 @@ function ContextSelector() {
   const canCreateNS = currentCluster.canCreateNS;
   const error = currentCluster.error;
   const [open, setOpen] = useState(false);
+  const [enableChangeContext, setEnableChangeContext] = useState(false);
   const [cluster, setStateCluster] = useState(clusters.currentCluster);
   const [namespace, setStateNamespace] = useState(namespaceSelected);
   const [newNSModalIsOpen, setNewNSModalIsOpen] = useState(false);
@@ -48,6 +49,7 @@ function ContextSelector() {
 
   useEffect(() => {
     setStateNamespace(clusters.clusters[cluster].currentNamespace);
+    setEnableChangeContext(clusters.clusters[cluster].namespaces.length === 0);
   }, [clusters.clusters, cluster]);
 
   const toggleOpen = () => setOpen(!open);
@@ -204,7 +206,12 @@ function ContextSelector() {
             </div>
           </div>
           <div className="dropdown-menu-padding">
-            <CdsButton status="primary" size="sm" onClick={changeContext}>
+            <CdsButton
+              status="primary"
+              size="sm"
+              onClick={changeContext}
+              disabled={enableChangeContext}
+            >
               Change Context
             </CdsButton>
           </div>


### PR DESCRIPTION
### Description of the change

Adds a condition to enable or disable change context button based on current clusters and namespaces.

### Benefits

Improves user experience by not allowing to switch context while no namespace is selected.

### Possible drawbacks

None.

### Applicable issues

Fixes #2723.

### Additional information

https://user-images.githubusercontent.com/43246350/126552562-ffbe026f-b57c-406d-acde-6c8708d8ed44.mp4

Still working to implement a test.



