### PR TITLE
Fix merge of my PR which wasn't updated after renames

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -1541,7 +1541,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 			},
 			expectedStatusCode: codes.OK,
 			expectedResponse: &corev1.GetInstalledPackageSummariesResponse{
-				InstalledPackagesSummaries: []*corev1.InstalledPackageSummary{
+				InstalledPackageSummaries: []*corev1.InstalledPackageSummary{
 					{
 						InstalledPackageRef: &corev1.InstalledPackageReference{
 							Context: &corev1.Context{
@@ -1570,7 +1570,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 			defer cleanup()
 
 			if tc.expectedStatusCode == codes.OK {
-				populateAssetDB(t, mock, tc.expectedResponse.InstalledPackagesSummaries)
+				populateAssetDB(t, mock, tc.expectedResponse.InstalledPackageSummaries)
 			}
 
 			response, err := server.GetInstalledPackageSummaries(context.Background(), tc.request)


### PR DESCRIPTION
### Description of the change

Antonio recently landed changes for more consistent naming, and I landed my PR which added new tests using the old names and didn't merge the latest changes on master before landing. So the code itself was updated correctly, but the new tests that I wrote kept the incorrect naming.

### Benefits

CI passing again on master.

### Possible drawbacks

None

### Additional information

I'll rubber-stamp this one to get CI passing again.
