### PR TITLE
Update to enable individual plugins for apis server

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -11,9 +11,14 @@ dependencies:
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
     version: 10.x.x
+  # Currently redis is only used for an in-progress plugin for flux support.
+  # Our upstream bitnami/kubeapps chart should not include redis as a
+  # dependency yet, and in development we can set redis.enabled if developing
+  # other plugins only.
   - name: redis
     repository: https://charts.bitnami.com/bitnami
     version: 14.x.x
+    condition: redis.enabled
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 home: https://kubeapps.com
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -71,8 +71,10 @@ spec:
           command:
             - /kubeapps-apis
           args:
+            {{- range .Values.kubeappsapis.enabledPlugins }}
             - --plugin-dir
-            - /plugins/
+            - /plugins/{{ . }}
+            {{- end }}
             {{- if .Values.clusters }}
             - --clusters-config-path=/config/clusters.conf
             {{- end }}
@@ -86,8 +88,8 @@ spec:
             - name: PORT
               value: {{ .Values.kubeappsapis.containerPort | quote }}
             # REDIS-* vars are required by the plugins for caching functionality
-            # TODO (gfichtenolt) this as required by the kubeapps apis service (which will 
-            # longer-term pass something to the plugins so that the plugins won't need to 
+            # TODO (gfichtenolt) this as required by the kubeapps apis service (which will
+            # longer-term pass something to the plugins so that the plugins won't need to
             # know these details). Currently they're used directly by the flux plugin
             - name: REDIS_ADDR
               value: kubeapps-redis-master.{{ .Release.Namespace }}.svc.cluster.local:6379

--- a/chart/kubeapps/templates/kubeappsapis/rbac.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/rbac.yaml
@@ -20,6 +20,11 @@ rules:
       - "source.toolkit.fluxcd.io"
     resources: ['*']
     verbs: ['*']
+  # So that our dev user is seen as having access to a namespace.
+  # We'll need to add rbac for our dev user to install later as well.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ['get']
 {{- if .Values.kubeappsapis.unsafeUseDemoSA }}
 # Dev-only ClusterRoleBinding to the ServiceAccount
 ---

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -49,9 +49,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM bitnami/minideb:buster
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kubeapps/kubeapps/kubeapps-apis /kubeapps-apis
-COPY --from=builder /kapp-controller-packages-v1alpha1-plugin.so /plugins/
-COPY --from=builder /fluxv2-packages-v1alpha1-plugin.so /plugins/
-COPY --from=builder /helm-packages-v1alpha1-plugin.so /plugins/
+COPY --from=builder /kapp-controller-packages-v1alpha1-plugin.so /plugins/kapp-controller/
+COPY --from=builder /fluxv2-packages-v1alpha1-plugin.so /plugins/fluxv2/
+COPY --from=builder /helm-packages-v1alpha1-plugin.so /plugins/helm/
 
 EXPOSE 50051
 USER 1001

--- a/docs/developer/manifests/values.kubeappsapis.yaml
+++ b/docs/developer/manifests/values.kubeappsapis.yaml
@@ -11,6 +11,9 @@ featureFlags:
 kubeappsapis:
   ## @param kubeappsapis.unsafeUseDemoSA If true, replace the user's credentials by a full-granted demo service account. Just intented for development purposes.
   unsafeUseDemoSA: false
+  enabledPlugins:
+    - helm
+    - fluxv2
   ## Bitnami Kubeapps-APIs image
   ## ref: https://hub.docker.com/r/bitnami/kubeapps-apis/tags/
   ## @param kubeappsapis.image.registry Kubeapps-APIs image registry
@@ -206,7 +209,17 @@ kubeappsapis:
 ## Redis server to satisfy the applications caching requirements
 ##
 redis:
-  ## @param redis.redisPassword Password 
+  ## @param redis.redisPassword Password
   ## ref: https://github.com/bitnami/bitnami-docker-redis/blob/master/README.md#setting-the-server-password-on-first-run
   ##
   redisPassword: ""
+  ## @param redis.enabled Enable the redis deployment when deploying Kubeapps APIs.
+  ## We currently have the situation that Redis is required for the fluxv2 plugin only.
+  ## Until such a point that we're releasing with the fluxv2 plugin enabled, or the
+  ## plugin cache support has been generalised so all plugins use Redis, we'll need
+  ## to manually enable this in dev while ensuring it is false for releases (as it
+  ## is a conditional dependency in the Chart.yaml).
+  enabled: true
+  # In dev, just like postgres we don't need replicas.
+  replica:
+    replicaCount: 0

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -31,6 +31,7 @@ deploy-dependencies: deploy-dex deploy-openldap devel/localhost-cert.pem
 		--from-literal=postgresql-postgres-password=dev-only-fake-password \
 		--from-literal=postgresql-password=dev-only-fake-password
 
+
 deploy-dev-kubeapps:
 	helm --kubeconfig=${CLUSTER_CONFIG} upgrade --install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \

--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -31,7 +31,6 @@ deploy-dependencies: deploy-dex deploy-openldap devel/localhost-cert.pem
 		--from-literal=postgresql-postgres-password=dev-only-fake-password \
 		--from-literal=postgresql-password=dev-only-fake-password
 
-
 deploy-dev-kubeapps:
 	helm --kubeconfig=${CLUSTER_CONFIG} upgrade --install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \
 		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \


### PR DESCRIPTION
### Description of the change

I noticed that currently we were always loading all plugins with no option to enable individual ones.

Given that we're planning to release initially with only the helm plugin enabled, this change updates to allow enabling specific plugins, defaulting to the helm one.

I've also updated the dependencies in the Chart.yaml, so that we don't accidentally update the upstream chart with the redis dependency.

Finally, I've set the replicaCount for redis in dev to zero (similar to what we do for postgres). Let me know if this is an issue Greg.

### Benefits

Upstream changes to our chart (whether by us or the content team) should include only the helm plugin for now.

### Possible drawbacks

None

### Additional information

I'll annotate in line for anything I missed here.
