### PR TITLE
Remove unnecessary and incorrect check on maintainers.

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -526,11 +526,9 @@ func isValidChart(chart *models.Chart) (bool, error) {
 			}
 		}
 	}
-	if chart.Maintainers != nil || len(chart.ChartVersions) != 0 {
-		for _, maintainer := range chart.Maintainers {
-			if maintainer.Name == "" {
-				return false, status.Errorf(codes.Internal, "required field .Maintainers[i].Name not found on helm chart: %v", chart)
-			}
+	for _, maintainer := range chart.Maintainers {
+		if maintainer.Name == "" {
+			return false, status.Errorf(codes.Internal, "required field .Maintainers[i].Name not found on helm chart: %v", chart)
 		}
 	}
 	return true, nil


### PR DESCRIPTION
### Description of the change

Dimitri pointed out that the check on these seemed odd (why check ChartVersions at all?).

There's actually no need for checking whether chart.Maintainers is nil or not since nil is the zero value for arrays, a range of it results in nothing to iterate.

The existing tests in TestIsValidChart demo this already (examples with nil maintainers).

I'm not yet sure about sharing code between plugins, so for now haven't dealt with that (but more than happy if you want to have a go Dimitri).

### Benefits

Removes confusing code :)

### Possible drawbacks

None.
