### PR TITLE
feat(dashboard): Add default theme value

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -178,6 +178,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `dashboard.customStyle`                           | Custom CSS injected to the Dashboard to customize Kubeapps look and feel                  | `""`                 |
 | `dashboard.customComponents`                      | Custom Form components injected into the BasicDeploymentForm                              | `""`                 |
 | `dashboard.customLocale`                          | Custom translations injected to the Dashboard to customize the strings used in Kubeapps   | `""`                 |
+| `dashboard.defaultTheme`                          | Default theme used in the Dashboard if the user has not selected any theme yet.           | `""`                 |
 | `dashboard.replicaCount`                          | Number of Dashboard replicas to deploy                                                    | `2`                  |
 | `dashboard.extraEnvVars`                          | Array with extra environment variables to add to the Dashboard container                  | `[]`                 |
 | `dashboard.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for the Dashboard container          | `nil`                |

--- a/chart/kubeapps/templates/dashboard/configmap.yaml
+++ b/chart/kubeapps/templates/dashboard/configmap.yaml
@@ -76,5 +76,5 @@ data:
       "authProxySkipLoginPage": {{ .Values.authProxy.skipKubeappsLoginPage }},
       "featureFlags": {{ .Values.featureFlags | toJson }},
       "clusters": {{ template "kubeapps.clusterNames" . }},
-      "defaultTheme": "{{ .Values.dashboard.defaultTheme }}"
+      "theme": "{{ .Values.dashboard.defaultTheme }}"
     }

--- a/chart/kubeapps/templates/dashboard/configmap.yaml
+++ b/chart/kubeapps/templates/dashboard/configmap.yaml
@@ -76,5 +76,5 @@ data:
       "authProxySkipLoginPage": {{ .Values.authProxy.skipKubeappsLoginPage }},
       "featureFlags": {{ .Values.featureFlags | toJson }},
       "clusters": {{ template "kubeapps.clusterNames" . }},
-      "theme": "{{ .Values.dashboard.theme }}"
+      "defaultTheme": "{{ .Values.dashboard.defaultTheme }}"
     }

--- a/chart/kubeapps/templates/dashboard/configmap.yaml
+++ b/chart/kubeapps/templates/dashboard/configmap.yaml
@@ -75,5 +75,6 @@ data:
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},
       "authProxySkipLoginPage": {{ .Values.authProxy.skipKubeappsLoginPage }},
       "featureFlags": {{ .Values.featureFlags | toJson }},
-      "clusters": {{ template "kubeapps.clusterNames" . }}
+      "clusters": {{ template "kubeapps.clusterNames" . }},
+      "theme": "{{ .Values.dashboard.theme }}"
     }

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -445,8 +445,10 @@ dashboard:
   ##   "login-oidc": "Login with my company SSO"
   ##
   customLocale: ""
-  ## @param dashboard.defaultTheme will be used as the default theme for the dashboard instead of window.matchMedia
+  ## @param dashboard.defaultTheme Default theme used in the Dashboard if the user has not selected any theme yet.
   ## enum: [ "light", "dark" ]
+  ## e.g:
+  ## defaultTheme: dark
   ##
   defaultTheme: ""
   ## @param dashboard.replicaCount Number of Dashboard replicas to deploy

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -445,6 +445,10 @@ dashboard:
   ##   "login-oidc": "Login with my company SSO"
   ##
   customLocale: ""
+  ## @param dashboard.defaultTheme will be used as the default theme for the dashboard instead of window.matchMedia
+  ## enum: [ "light", "dark" ]
+  ##
+  defaultTheme: ""
   ## @param dashboard.replicaCount Number of Dashboard replicas to deploy
   ##
   replicaCount: 2

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -6,5 +6,6 @@
   "authProxySkipLoginPage": false,
   "oauthLoginURI": "/oauth2/start",
   "oauthLogoutURI": "/oauth2/sign_out",
-  "clusters": ["default"]
+  "clusters": ["default"],
+  "theme": ""
 }

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -7,5 +7,5 @@
   "oauthLoginURI": "/oauth2/start",
   "oauthLogoutURI": "/oauth2/sign_out",
   "clusters": ["default"],
-  "theme": ""
+  "defaultTheme": ""
 }

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -7,5 +7,5 @@
   "oauthLoginURI": "/oauth2/start",
   "oauthLogoutURI": "/oauth2/sign_out",
   "clusters": ["default"],
-  "defaultTheme": ""
+  "theme": "light"
 }

--- a/dashboard/src/actions/config.ts
+++ b/dashboard/src/actions/config.ts
@@ -28,9 +28,6 @@ export function getConfig(): ThunkAction<Promise<void>, IStoreState, null, Confi
     dispatch(requestConfig());
     try {
       const config = await Config.getConfig();
-      if (config.theme && Object.values(SupportedThemes).includes(config.theme)) {
-        Config.setTheme(config.theme);
-      }
       dispatch(receiveConfig(config));
     } catch (e) {
       dispatch(errorConfig(e));

--- a/dashboard/src/actions/config.ts
+++ b/dashboard/src/actions/config.ts
@@ -28,6 +28,9 @@ export function getConfig(): ThunkAction<Promise<void>, IStoreState, null, Confi
     dispatch(requestConfig());
     try {
       const config = await Config.getConfig();
+      if (config.theme && Object.values(SupportedThemes).includes(config.theme)) {
+        Config.setTheme(config.theme);
+      }
       dispatch(receiveConfig(config));
     } catch (e) {
       dispatch(errorConfig(e));


### PR DESCRIPTION
Signed-off-by: Anthony Rizzo <36711320+aanthonyrizzo@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
This PR adds the ability to overwrite the initial default theme for Kubeapps via a config value.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Allows for more control for theming and UX

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
If this value is set. Anytime a user reloads or refreshes, the theme is changed back to the default value, even if the user sets a different one. We can potentially add another value to local storage called `user_theme`, which is set by the theme toggle switch. And add logic there so if that value is present, ignore the config.theme value.

<!-- Describe any known limitations with your change -->

### Applicable issues
Fixes #3176 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
