### PR TITLE
Add chart files to response for AvailablePackageDetail

### DIFF
--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -87,6 +87,7 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.kubeappsapis.containerPort | quote }}
+            {{- if .Values.redis.enabled }}
             # REDIS-* vars are required by the plugins for caching functionality
             # TODO (gfichtenolt) this as required by the kubeapps apis service (which will
             # longer-term pass something to the plugins so that the plugins won't need to
@@ -100,6 +101,7 @@ spec:
                   name: {{ include "kubeapps.redis.secretName" . }}
             - name: REDIS_DB
               value: "0"
+            {{- end }}
             # TODO(agamez): pass this configuration using a separated config file
             # These env vars are currently (and temporarily) required by the 'helm' plugin
             - name: POD_NAMESPACE

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -414,9 +415,9 @@ func makeChart(chart_name, repo_name, namespace string, chart_versions []string)
 		versions = append(versions, models.ChartVersion{
 			Version:    v,
 			AppVersion: DefaultAppVersion,
-			Readme:     "chart readme",
-			Values:     "chart values",
-			Schema:     "chart schema",
+			Readme:     "not-used",
+			Values:     "not-used",
+			Schema:     "not-used",
 		})
 	}
 	ch.ChartVersions = versions
@@ -778,12 +779,18 @@ func TestAvailablePackageDetailFromChart(t *testing.T) {
 	testCases := []struct {
 		name       string
 		chart      *models.Chart
+		chartFiles *models.ChartFiles
 		expected   *corev1.AvailablePackageDetail
 		statusCode codes.Code
 	}{
 		{
 			name:  "it returns AvailablePackageDetail if the chart is correct",
 			chart: makeChart("foo", "repo-1", "my-ns", []string{"3.0.0"}),
+			chartFiles: &models.ChartFiles{
+				Readme: "chart readme",
+				Values: "chart values",
+				Schema: "chart schema",
+			},
 			expected: &corev1.AvailablePackageDetail{
 				Name:             "foo",
 				DisplayName:      "foo",
@@ -819,7 +826,7 @@ func TestAvailablePackageDetailFromChart(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			availablePackageDetail, err := AvailablePackageDetailFromChart(tc.chart)
+			availablePackageDetail, err := AvailablePackageDetailFromChart(tc.chart, tc.chartFiles)
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
@@ -837,13 +844,12 @@ func TestAvailablePackageDetailFromChart(t *testing.T) {
 
 func TestGetAvailablePackageDetail(t *testing.T) {
 	testCases := []struct {
-		name             string
-		charts           []*models.Chart
-		requestedVersion string
-		expectedPackage  *corev1.AvailablePackageDetail
-		statusCode       codes.Code
-		request          *corev1.GetAvailablePackageDetailRequest
-		authorized       bool
+		name            string
+		charts          []*models.Chart
+		expectedPackage *corev1.AvailablePackageDetail
+		statusCode      codes.Code
+		request         *corev1.GetAvailablePackageDetailRequest
+		authorized      bool
 	}{
 		{
 			name:       "it returns an availablePackageDetail from the database (latest version)",
@@ -851,7 +857,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 			request: &corev1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: &corev1.AvailablePackageReference{
 					Context:    &corev1.Context{Namespace: "my-ns"},
-					Identifier: "foo/bar",
+					Identifier: "repo-1%2Ffoo",
 				},
 			},
 			charts: []*models.Chart{makeChart("foo", "repo-1", "my-ns", []string{"3.0.0"})},
@@ -884,9 +890,9 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 					Context:    &corev1.Context{Namespace: "my-ns"},
 					Identifier: "foo/bar",
 				},
+				PkgVersion: "1.0.0",
 			},
-			requestedVersion: "1.0.0",
-			charts:           []*models.Chart{makeChart("foo", "repo-1", "my-ns", []string{"3.0.0", "2.0.0", "1.0.0"})},
+			charts: []*models.Chart{makeChart("foo", "repo-1", "my-ns", []string{"3.0.0", "2.0.0", "1.0.0"})},
 			expectedPackage: &corev1.AvailablePackageDetail{
 				Name:             "foo",
 				DisplayName:      "foo",
@@ -929,11 +935,11 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 					Context:    &corev1.Context{Namespace: "my-ns"},
 					Identifier: "foo/bar",
 				},
+				PkgVersion: "9.9.9",
 			},
-			requestedVersion: "9.9.9",
-			charts:           []*models.Chart{{Name: "foo"}},
-			expectedPackage:  &corev1.AvailablePackageDetail{},
-			statusCode:       codes.Internal,
+			charts:          []*models.Chart{{Name: "foo"}},
+			expectedPackage: &corev1.AvailablePackageDetail{},
+			statusCode:      codes.Internal,
 		},
 		{
 			name:       "it returns an unauthenticated status if the user doesn't have permissions",
@@ -964,20 +970,32 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				}
 				rows.AddRow(string(chartJSON))
 			}
-			if tc.statusCode != codes.Unauthenticated {
+			if tc.statusCode == codes.OK {
 				// Checking if the WHERE condition is properly applied
-				mock.ExpectQuery("SELECT info FROM").
-					WithArgs(tc.request.AvailablePackageRef.Context.Namespace, tc.request.AvailablePackageRef.Identifier).
+				chartIDUnescaped, err := url.QueryUnescape(tc.request.AvailablePackageRef.Identifier)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				mock.ExpectQuery("SELECT info FROM charts").
+					WithArgs(tc.request.AvailablePackageRef.Context.Namespace, chartIDUnescaped).
 					WillReturnRows(rows)
+				fileID := fileIDForChart(chartIDUnescaped, tc.expectedPackage.PkgVersion)
+				fileJSON, err := json.Marshal(models.ChartFiles{
+					Readme: tc.expectedPackage.Readme,
+					Values: tc.expectedPackage.DefaultValues,
+					Schema: tc.expectedPackage.ValuesSchema,
+				})
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				fileRows := sqlmock.NewRows([]string{"info"})
+				fileRows.AddRow(string(fileJSON))
+				mock.ExpectQuery("SELECT info FROM files").
+					WithArgs(tc.request.GetAvailablePackageRef().GetContext().GetNamespace(), fileID).
+					WillReturnRows(fileRows)
 			}
-			req := &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
-					Identifier: "foo/bar",
-				},
-				PkgVersion: tc.requestedVersion,
-			}
-			availablePackageDetails, err := server.GetAvailablePackageDetail(context.Background(), req)
+
+			availablePackageDetails, err := server.GetAvailablePackageDetail(context.Background(), tc.request)
 
 			if got, want := status.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)


### PR DESCRIPTION
### Description of the change

As Greg pointed out, the existing code was using what appear to be no-longer-used fields on the model.

This PR updates to request the chart files from the DB and use those instead.

I'll follow-up with a PR to remove the code which is no longer being used.

IRL:
```
grpcurl -plaintext -d '{"available_package_ref": {"context": {"namespace": "kubeapps"},"identifier": "bitnami/wordpress"}}' localhost:8080 kubeappsapis.plugins.helm.packages.v1alpha1.HelmPackagesService.GetAvailablePackageDetail
{
  "availablePackageDetail": {
    "availablePackageRef": {
      "context": {
        "namespace": "kubeapps"
      },
      "identifier": "bitnami/wordpress",
      "plugin": {
        "name": "helm.packages",
        "version": "v1alpha1"
      }
    },
    "name": "wordpress",
    "pkgVersion": "11.1.5",
    "appVersion": "5.7.2",
    "iconUrl": "https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png",
    "displayName": "wordpress",
    "shortDescription": "Web publishing platform for building blogs and websites.",
    "readme": "# WordPress\n\n[WordPress](https://wordpress.org/) is one of the most versatile open source content management systems on the market. A publishing platform for building blogs and websites.\n\n## TL;DR\n\n```console\n$ helm repo add bitnami https://charts.bitnami.com/bitnami\n$ helm install my-release bitnami/wordpress\n```\n\n## Introduction\n\nThis chart bootstraps a [WordPress](https://github.com/bitnami/bitnami-docker-wordpress) deployment on a [Kubernetes](http://kubernetes.io) 
...
```

### Benefits

We actually see Readme and other data required for the details.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3146

Other info:

- Fixed the tests to ensure they're sending url-encoded repos
- Fixed the chart to not expect a redis password if redis isn't being used.