### PR TITLE
Add missing files under "skip-auth-regex"

### DIFF
--- a/chart/kubeapps/templates/frontend/deployment.yaml
+++ b/chart/kubeapps/templates/frontend/deployment.yaml
@@ -123,8 +123,11 @@ spec:
             - --skip-auth-regex=^\/config\.json$
             - --skip-auth-regex=^\/manifest\.json$
             - --skip-auth-regex=^\/custom_style\.css$
+            - --skip-auth-regex=^\/clr-ui.min\.css$
+            - --skip-auth-regex=^\/clr-ui-dark.min\.css$
             - --skip-auth-regex=^\/custom_locale\.json$
             - --skip-auth-regex=^\/favicon.*\.png$
+            - --skip-auth-regex=^\/favicon.*\.ico$
             - --skip-auth-regex=^\/static\/
             - --skip-auth-regex=^\/$
             - --scope={{ .Values.authProxy.scope }}


### PR DESCRIPTION
### Description of the change

We noticed there were some missing files under the `--skip-auth-regex` flag. This issue should be preventing the dark mode to work properly in unauthenticated calls. 

` .... GET - "/clr-ui-dark.min.css" HTTP/1.1 "....  403 .....`

### Benefits

No more 403 errors before authenticated.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
