### PR TITLE
Don't set theme in local storage unless user sets.

### DIFF
--- a/dashboard/src/reducers/config.ts
+++ b/dashboard/src/reducers/config.ts
@@ -31,7 +31,6 @@ const configReducer = (state: IConfigState = initialState, action: ConfigAction)
         ...action.payload,
       };
     case getType(actions.config.receiveTheme):
-      Config.setTheme(action.payload);
       return {
         ...state,
         theme: action.payload,


### PR DESCRIPTION
### Description of the change

In #2573 a couple of CSS issues were fixed, one of which was to update the config reducer so that when a `receiveTheme` action is triggered:

- it calls setTheme(), explicitly setting the theme in the local config, and
- it updates the redux state to include the new theme value.

As a result of this, even if a user doesn't explicitly choose a theme, as soon as `getConfig()` is called, the local storage is set with a choice the user did not make.

I suspect (but am not 100%), that we don't need to be calling `setTheme()` to set the local storage in this case.

I've built an image from this and tested it, and it appears to function as expected, with the local storage only being set if I, the user, explicitly choose a theme.

@antgamdia Can you build and verify that this doesn't re-introduce any of the issues you were fixing in the related issue #2572? I cannot see any of them resurfacing, and I see the `cds-theme` set correctly both before and after an explicit selection is made.

### Benefits

It'll enable @aanthonyrizzo to continue thinking about a solution in #3191, with the assumption that the theme is only ever set in the local storage if the user has explicitly chosen a theme.

### Possible drawbacks

None that I can see, but let's see what Antonio knows about the original issues.

### Applicable issues

  - ref #2572 #3176

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
