### PR TITLE
Improve theme switcher mechanism

### DIFF
--- a/dashboard/src/actions/config.test.tsx
+++ b/dashboard/src/actions/config.test.tsx
@@ -57,7 +57,7 @@ describe("setTheme", () => {
     const expectedActions = [
       {
         payload: SupportedThemes.dark,
-        type: getType(actions.config.setThemeState),
+        type: getType(actions.config.receiveTheme),
       },
     ];
 

--- a/dashboard/src/actions/config.test.tsx
+++ b/dashboard/src/actions/config.test.tsx
@@ -51,9 +51,9 @@ describe("getTheme", () => {
   });
 });
 
-describe("setTheme", () => {
+describe("setUserTheme", () => {
   it("dispatches request config and its returned value", async () => {
-    Config.setTheme = jest.fn();
+    Config.setUserTheme = jest.fn();
     const expectedActions = [
       {
         payload: SupportedThemes.dark,
@@ -61,7 +61,7 @@ describe("setTheme", () => {
       },
     ];
 
-    await store.dispatch(actions.config.setTheme(SupportedThemes.dark));
+    await store.dispatch(actions.config.setUserTheme(SupportedThemes.dark));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/config.ts
+++ b/dashboard/src/actions/config.ts
@@ -47,13 +47,13 @@ export function getTheme(): ThunkAction<Promise<void>, IStoreState, null, Config
   };
 }
 
-// setTheme receives a theme and and stores it
+// setUserTheme receives a theme and and stores it
 // in both the redux state and the user's localstorage
-export function setTheme(
+export function setUserTheme(
   theme: SupportedThemes,
 ): ThunkAction<Promise<void>, IStoreState, null, ConfigAction> {
   return async dispatch => {
-    Config.setTheme(theme);
+    Config.setUserTheme(theme);
     dispatch(receiveTheme(theme));
   };
 }

--- a/dashboard/src/components/HeadManager/HeadManager.tsx
+++ b/dashboard/src/components/HeadManager/HeadManager.tsx
@@ -53,7 +53,7 @@ export default function HeadManager({ children }: IHeadManagerProps) {
         <link rel="stylesheet" type="text/css" href="./custom_style.css" />
 
         {/*  Set the clarity-ui css style */}
-        <link rel="stylesheet" type="text/css" href={getThemeFile(theme)} />
+        <link rel="stylesheet" type="text/css" href={getThemeFile(SupportedThemes[theme])} />
 
         <meta name="theme-color" content="#304250" />
         <meta

--- a/dashboard/src/components/Header/Menu.test.tsx
+++ b/dashboard/src/components/Header/Menu.test.tsx
@@ -72,10 +72,10 @@ describe("theme switcher toggle", () => {
   });
 
   it("calls setTheme with the new theme", () => {
-    actions.config.setTheme = jest.fn();
+    actions.config.setUserTheme = jest.fn();
     const wrapper = mountWrapper(defaultStore, <Menu {...defaultProps} />);
     const toggle = wrapper.find("cds-toggle input");
     toggle.simulate("change");
-    expect(actions.config.setTheme).toHaveBeenCalled();
+    expect(actions.config.setUserTheme).toHaveBeenCalled();
   });
 });

--- a/dashboard/src/components/Header/Menu.tsx
+++ b/dashboard/src/components/Header/Menu.tsx
@@ -46,7 +46,7 @@ function Menu({ clusters, appVersion, logout }: IContextSelectorProps) {
 
   const toggleTheme = () => {
     const newTheme = theme === SupportedThemes.dark ? SupportedThemes.light : SupportedThemes.dark;
-    dispatch(actions.config.setTheme(newTheme));
+    dispatch(actions.config.setUserTheme(newTheme));
   };
 
   useEffect(() => {

--- a/dashboard/src/reducers/config.ts
+++ b/dashboard/src/reducers/config.ts
@@ -1,7 +1,7 @@
 import { getType } from "typesafe-actions";
 import actions from "../actions";
 import { ConfigAction } from "../actions/config";
-import Config, { IConfig } from "../shared/Config";
+import { IConfig, SupportedThemes } from "../shared/Config";
 
 export interface IConfigState extends IConfig {
   loaded: boolean;
@@ -17,7 +17,7 @@ export const initialState: IConfigState = {
   oauthLogoutURI: "",
   authProxySkipLoginPage: false,
   clusters: [],
-  theme: Config.getTheme(),
+  theme: SupportedThemes.light,
 };
 
 const configReducer = (state: IConfigState = initialState, action: ConfigAction): IConfigState => {
@@ -31,12 +31,6 @@ const configReducer = (state: IConfigState = initialState, action: ConfigAction)
         ...action.payload,
       };
     case getType(actions.config.receiveTheme):
-      Config.setTheme(action.payload);
-      return {
-        ...state,
-        theme: action.payload,
-      };
-    case getType(actions.config.setThemeState):
       return {
         ...state,
         theme: action.payload,

--- a/dashboard/src/shared/Config.test.ts
+++ b/dashboard/src/shared/Config.test.ts
@@ -55,7 +55,7 @@ describe("Themes", () => {
   });
 
   it("returns the system theme", () => {
-    let defaultJSONTheme = { ...defaultJSON, theme: SupportedThemes.dark };
+    const defaultJSONTheme = { ...defaultJSON, theme: SupportedThemes.dark };
     expect(Config.getTheme(defaultJSONTheme)).toBe(SupportedThemes.dark);
   });
 
@@ -74,7 +74,7 @@ describe("Themes", () => {
     jest.spyOn(window.localStorage.__proto__, "getItem").mockReturnValue(SupportedThemes.dark);
 
     // System preference = light
-    let defaultJSONTheme = { ...defaultJSON, theme: SupportedThemes.light };
+    const defaultJSONTheme = { ...defaultJSON, theme: SupportedThemes.light };
 
     // Browser preference = dark
     Object.defineProperty(window, "matchMedia", {
@@ -88,7 +88,7 @@ describe("Themes", () => {
 
   it("returns the theme according to the preference (system>browser>fallback)", () => {
     // System preference = light
-    let defaultJSONTheme = { ...defaultJSON, theme: SupportedThemes.light };
+    const defaultJSONTheme = { ...defaultJSON, theme: SupportedThemes.light };
 
     // Browser preference = dark
     Object.defineProperty(window, "matchMedia", {
@@ -102,7 +102,7 @@ describe("Themes", () => {
 
   it("returns the theme according to the preference (browser>fallback)", () => {
     // System preference = N/A
-    let defaultJSONTheme = { ...defaultJSON, theme: "" };
+    const defaultJSONTheme = { ...defaultJSON, theme: "" };
 
     // Browser preference = dark
     Object.defineProperty(window, "matchMedia", {
@@ -116,7 +116,7 @@ describe("Themes", () => {
 
   it("returns the theme according to the preference (fallback)", () => {
     // System preference = N/A
-    let defaultJSONTheme = { ...defaultJSON, theme: "" };
+    const defaultJSONTheme = { ...defaultJSON, theme: "" };
 
     expect(Config.getTheme(defaultJSONTheme)).toBe(SupportedThemes.light);
   });

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -26,6 +26,7 @@ export default class Config {
     return data;
   }
 
+  // getTheme retrieves the different theme preferences and calculates which one is chosen
   public static getTheme(config: IConfig): SupportedThemes {
     // Define a ballback theme in case of errors
     const fallbackTheme = SupportedThemes.light;
@@ -35,8 +36,8 @@ export default class Config {
 
     // Retrieve the user theme preference
     const userTheme =
-      localStorage.getItem("theme") != null
-        ? SupportedThemes[localStorage.getItem("theme") as string]
+      localStorage.getItem("user-theme") != null
+        ? SupportedThemes[localStorage.getItem("user-theme") as string]
         : undefined;
 
     // Retrieve the browser theme preference
@@ -51,9 +52,17 @@ export default class Config {
     return chosenTheme;
   }
 
+  // setTheme performs a hot change of the current theme modifying the DOM
+  // it's a separate function for testing
   public static setTheme(theme: SupportedThemes) {
     document.body.setAttribute("cds-theme", theme);
-    localStorage.setItem("theme", theme);
+  }
+
+  // setUserTheme changes the current theme and also stores the user's preference in the localStorage
+  // it's a separate function for testing
+  public static setUserTheme(theme: SupportedThemes) {
+    this.setTheme(theme);
+    localStorage.setItem("user-theme", theme);
   }
 
   private static APIEndpoint = "config.json";

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -48,11 +48,6 @@ export default class Config {
     // calculates the chose theme based upon this prelation order: user>system>browser>fallback
     const chosenTheme = userTheme ?? systemTheme ?? browserTheme ?? fallbackTheme;
 
-    console.log(`1 userTheme: ${userTheme}`);
-    console.log(`2 systemTheme: ${systemTheme}`);
-    console.log(`3 browserTheme: ${browserTheme}`);
-    console.log(`== chosenTheme: ${chosenTheme}`);
-
     return chosenTheme;
   }
 

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -16,7 +16,7 @@ export interface IConfig {
   authProxySkipLoginPage: boolean;
   error?: Error;
   clusters: string[];
-  theme: SupportedThemes;
+  theme: string;
 }
 
 export default class Config {
@@ -26,15 +26,34 @@ export default class Config {
     return data;
   }
 
-  public static getTheme() {
-    let theme = localStorage.getItem("theme");
-    if (!theme) {
-      theme =
-        window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
-          ? SupportedThemes.dark
-          : SupportedThemes.light;
-    }
-    return (theme as SupportedThemes) || SupportedThemes.light;
+  public static getTheme(config: IConfig): SupportedThemes {
+    // Define a ballback theme in case of errors
+    const fallbackTheme = SupportedThemes.light;
+
+    // Retrieve the system theme preference (configurable via Values.dashboard.defaultTheme)
+    const systemTheme = config.theme != null ? SupportedThemes[config.theme] : undefined;
+
+    // Retrieve the user theme preference
+    const userTheme =
+      localStorage.getItem("theme") != null
+        ? SupportedThemes[localStorage.getItem("theme") as string]
+        : undefined;
+
+    // Retrieve the browser theme preference
+    const browserTheme =
+      window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? SupportedThemes.dark
+        : SupportedThemes.light;
+
+    // calculates the chose theme based upon this prelation order: user>system>browser>fallback
+    const chosenTheme = userTheme ?? systemTheme ?? browserTheme ?? fallbackTheme;
+
+    console.log(`1 userTheme: ${userTheme}`);
+    console.log(`2 systemTheme: ${systemTheme}`);
+    console.log(`3 browserTheme: ${browserTheme}`);
+    console.log(`== chosenTheme: ${chosenTheme}`);
+
+    return chosenTheme;
   }
 
   public static setTheme(theme: SupportedThemes) {


### PR DESCRIPTION
### Description of the change

After #3205 and #3191, we noticed we were overriding the theme config. It was the result of small improvements towards the dark mode and bug fixes along the way.
This PR is the first step at having a clearer logic on which theme preference takes precedence over another.

Currently: `user (via toggle)>system (via values.yaml)>browser (via browser config)>fallback (hardcoded light theme)`

### Benefits

It (should) paves the way to create other config parameters like "allowChangingTheme" or similar.

### Possible drawbacks

I've checked and I don't foresee any error... but UI can always fail OSI L8 actors are involved :P 

### Applicable issues

  - fixes #3176

### Additional information

I've used the changes from #3191 as my base branch, all the credits should go for @aanthonyrizzo. I'm thinking of merging that PR and then this one? cc @absoludity 

Here is a demo:

https://user-images.githubusercontent.com/11535726/127175624-2252d77a-541b-46a5-8fb5-c4aed5f4ddd6.mp4

