### PR TITLE
Add some logging when creating a screenshot.

### DIFF
--- a/integration/jest.environment.js
+++ b/integration/jest.environment.js
@@ -25,7 +25,7 @@ class ScreenshotOnFailureEnvironment extends PuppeteerEnvironment {
     try {
       // Check the server is up before running the test suite
       console.log(
-        `Waiting ${endpoint} to be ready before running the tests 
+        `Waiting ${endpoint} to be ready before running the tests
         (${waitTimeout / 1000}s)`,
       );
       await waitOn({

--- a/integration/use-cases/02-create-private-registry.js
+++ b/integration/use-cases/02-create-private-registry.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const utils = require("./lib/utils");
+const testName = "02-create-private-registry";
 
 test("Creates a private registry", async () => {
   var token =
@@ -64,7 +65,7 @@ test("Creates a private registry", async () => {
 
   await utils.retryAndRefresh(page, 3, async () => {
     await expect(page).toMatch("apache");
-  });
+  }, testName);
 
   await expect(page).toMatchElement("a", { text: "apache", timeout: 60000 });
   await expect(page).toClick("a", { text: "apache" });

--- a/integration/use-cases/03-create-registry.js
+++ b/integration/use-cases/03-create-registry.js
@@ -1,4 +1,5 @@
 const utils = require("./lib/utils");
+const testName = "03-create-registry";
 
 test("Creates a registry", async () => {
   await utils.login(
@@ -28,9 +29,9 @@ test("Creates a registry", async () => {
     // TODO(andresmgot): In theory, there is no need to refresh but sometimes the repo
     // does not appear
     await expect(page).toClick("a", { text: "my-repo" });
-  });
+  }, testName);
 
   await utils.retryAndRefresh(page, 3, async () => {
     await expect(page).toMatch("gitlab-runner");
-  });
+  }, testName);
 });

--- a/integration/use-cases/06-operator-deployment.js
+++ b/integration/use-cases/06-operator-deployment.js
@@ -1,5 +1,7 @@
 const utils = require("./lib/utils");
 
+const testName = "06-operator-deployment";
+
 // The operator may take some minutes to be created
 jest.setTimeout(360000);
 
@@ -20,7 +22,7 @@ test("Deploys an Operator", async () => {
   await utils.retryAndRefresh(page, 3, async () => {
     // Sometimes this fails with: TypeError: Cannot read property 'click' of null
     await expect(page).toClick("cds-button", { text: "Deploy" });
-  });
+  }, testName);
 
   const isAlreadyDeployed = await page.evaluate(
     () => document.querySelector("cds-button[disabled]") !== null,
@@ -33,7 +35,7 @@ test("Deploys an Operator", async () => {
     await utils.retryAndRefresh(page, 4, async () => {
       // The CSV takes a bit to get populated
       await expect(page).toMatch("Installed");
-    });
+    }, testName);
   } else {
     console.log("Warning: the operator has already been deployed");
   }
@@ -51,12 +53,12 @@ test("Deploys an Operator", async () => {
     await expect(page).toMatch("Prometheus");
 
     await expect(page).toClick(".info-card-header", { text: "Prometheus" });
-  });
+  }, testName);
 
   await utils.retryAndRefresh(page, 2, async () => {
     // Found the error "prometheuses.monitoring.coreos.com not found in the definition of prometheusoperator"
     await expect(page).toMatch("Deploy");
-  });
+  }, testName);
 
   await utils.retryAndRefresh(
     page,
@@ -64,22 +66,20 @@ test("Deploys an Operator", async () => {
     async () => {
       await expect(page).toClick("cds-button", { text: "Deploy" });
       await expect(page).toMatch("Installation Values");
-    },
-    "operator-view",
-  );
+    }, testName);
 
   // Update
   await expect(page).toClick("cds-button", { text: "Update" });
 
   await utils.retryAndRefresh(page, 2, async () => {
     await expect(page).toMatch("creationTimestamp");
-  });
+  }, testName);
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   await utils.retryAndRefresh(page, 2, async () => {
     await expect(page).toMatch("Installation Values");
-  });
+  }, testName);
 
   // Delete
   await expect(page).toClick("cds-button", { text: "Delete" });

--- a/integration/use-cases/07-upgrade.js
+++ b/integration/use-cases/07-upgrade.js
@@ -1,4 +1,5 @@
 const utils = require("./lib/utils");
+const testName = "07-upgrade";
 
 test("Upgrades an application", async () => {
   await utils.login(
@@ -26,7 +27,7 @@ test("Upgrades an application", async () => {
     const chartVersionValue = await chartVersionElementContent.jsonValue();
     latestChartVersion = chartVersionValue.split(" ")[0];
     expect(latestChartVersion).not.toBe("");
-  });
+  }, testName);
 
   await expect(page).toSelect('select[name="chart-versions"]', "7.3.2");
 
@@ -34,7 +35,7 @@ test("Upgrades an application", async () => {
 
   await utils.retryAndRefresh(page, 3, async () => {
     await expect(page).toMatch("7.3.2");
-  });
+  }, testName);
 
   await expect(page).toMatchElement("input[type='number']");
   // Increase the number of replicas
@@ -62,7 +63,7 @@ test("Upgrades an application", async () => {
   // Verify that the form contains the old version
   await utils.retryAndRefresh(page, 3, async () => {
     await expect(page).toMatch("7.3.2");
-  });
+  }, testName);
 
   await expect(page).toMatchElement("input[type='number']", { value: 2 });
 
@@ -78,7 +79,7 @@ test("Upgrades an application", async () => {
     const chartVersionElementContent = await chartVersionElement.getProperty("value");
     const chartVersionValue = await chartVersionElementContent.jsonValue();
     expect(chartVersionValue).toEqual(latestChartVersion);
-  });
+  }, testName);
 
   await expect(page).toMatchElement("input[type='number']", { value: 2 });
 

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -9,14 +9,15 @@ module.exports = {
         await toCheck();
         break;
       } catch (e) {
-        if (testName) {
-          await page.screenshot({
-            path: path.join(
-              __dirname,
-              `../../${screenshotsFolder}/${testName}-${retries - retriesLeft}.png`,
-            ),
-          });
-        }
+        testName = testName || "unknown";
+        let screenshotFilename = `../../${screenshotsFolder}/${testName}-${retries - retriesLeft}.png`;
+        console.log(`Saving screenshot to ${screenshotFilename}`);
+        await page.screenshot({
+          path: path.join(
+            __dirname,
+            screenshotFilename
+          ),
+        });
         if (retriesLeft === 1) {
           // Unable to get it done
           throw e;
@@ -38,6 +39,14 @@ module.exports = {
   },
   login: async (page, isOIDC, uri, token, username, password) => {
     await page.goto(getUrl(uri));
+    let screenshotFilename = `../../${screenshotsFolder}/login-at-test-start.png`;
+    console.log(`Saving screenshot to ${screenshotFilename}`);
+    await page.screenshot({
+      path: path.join(
+        __dirname,
+        screenshotFilename
+      ),
+    });
     if (isOIDC === "true") {
       await page.waitForNavigation({ waitUntil: "domcontentloaded" });
       await expect(page).toClick("cds-button", {

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -39,14 +39,6 @@ module.exports = {
   },
   login: async (page, isOIDC, uri, token, username, password) => {
     await page.goto(getUrl(uri));
-    let screenshotFilename = `../../${screenshotsFolder}/login-at-test-start.png`;
-    console.log(`Saving screenshot to ${screenshotFilename}`);
-    await page.screenshot({
-      path: path.join(
-        __dirname,
-        screenshotFilename
-      ),
-    });
     if (isOIDC === "true") {
       await page.waitForNavigation({ waitUntil: "domcontentloaded" });
       await expect(page).toClick("cds-button", {


### PR DESCRIPTION
Also ensure a screenshot is created when logging in so the directory is
non-empty.

Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

While trying to find out why CI isn't saving screenshots as artifacts anymore, I checked a build from a few months ago, and there I see the following in the Uploading Artifacts step log:
```
Uploading /home/circleci/project/integration/reports to integration/reports
Uploading /home/circleci/project/integration/reports/.notempty: SKIPPED, file is empty
Uploading /home/circleci/project/integration/reports/screenshots/upgrades-an-application.png (20 kB): DONE
```

whereas today, we see only the first two lines, implying that circle ci thinks there's nothing to upload.

This PR just adds some logging so we can test whether the directory we think we're writing to is actually the one we're expecting to write to.

### Benefits

Hopefully shed light on what's happening with screenshots.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  Just trying to help Antonio with the CI issues for the UX integration.

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
