### PR TITLE
Fix test which depended on map key order.

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"sort"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -793,7 +794,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						},
 					},
 				},
-				Categories: []string{"foo", "bar"},
+				Categories: []string{"bar", "foo"},
 			},
 			statusCode: codes.OK,
 		},
@@ -824,8 +825,14 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				for _, chart := range tc.charts {
 					dict[chart.Category] = dict[chart.Category] + 1
 				}
-				for category, count := range dict {
-					catrows.AddRow(category, count)
+				// Ensure we've got a fixed order for the results.
+				categories := []string{}
+				for category := range dict {
+					categories = append(categories, category)
+				}
+				sort.Strings(categories)
+				for _, category := range categories {
+					catrows.AddRow(category, dict[category])
 				}
 
 				mock.ExpectQuery("SELECT (info ->> 'category')*").


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

I had a test failure on a [CI run for another branch which failed](https://app.circleci.com/pipelines/github/kubeapps/kubeapps/3783/workflows/802eef40-a668-4f0a-a15a-5ebd95b07d10/jobs/54013) with:

```
--- FAIL: TestGetAvailablePackageSummaries (0.00s)
    --- FAIL: TestGetAvailablePackageSummaries/it_returns_the_proper_chart_categories (0.00s)
        server_test.go:855: mismatch (-want +got):
              &v1alpha1.GetAvailablePackageSummariesResponse{
              	... // 3 ignored fields
              	AvailablePackageSummaries: {&{AvailablePackageRef: &{Context: &{Namespace: "my-ns"}, Identifier: "repo-1/chart-1", Plugin: &{Name: "helm.packages", Version: "v1alpha1"}}, Name: "chart-1", LatestPkgVersion: "3.0.0", LatestAppVersion: "1.2.6", ...}, &{AvailablePackageRef: &{Context: &{Namespace: "my-ns"}, Identifier: "repo-1/chart-2", Plugin: &{Name: "helm.packages", Version: "v1alpha1"}}, Name: "chart-2", LatestPkgVersion: "2.0.0", LatestAppVersion: "1.2.6", ...}, &{AvailablePackageRef: &{Context: &{Namespace: "my-ns"}, Identifier: "repo-1/chart-3", Plugin: &{Name: "helm.packages", Version: "v1alpha1"}}, Name: "chart-3", LatestPkgVersion: "1.0.0", LatestAppVersion: "1.2.6", ...}},
              	NextPageToken:             "",
              	Categories: []string{
            - 		"foo",
            + 		"bar",
            - 		"bar",
            + 		"foo",
              	},
              }
```

Turned out the test was pulling keys from a map and assuming order. This fixes that :)

### Benefits

Avoid occasional test failures.

### Possible drawbacks

None

