### PR TITLE
[kubeappsapis] Ignore FilterOptions for the namespace categories

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -201,8 +201,8 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	}
 
 	// This plugin will include, as part of the GetAvailablePackageSummariesResponse,
-	// a "Categories" field containing only the distinct category names considering the FilterOptions
-	chartCategories, err := s.manager.GetAllChartCategories(cq)
+	// a "Categories" field containing only the distinct category names considering just the namespace
+	chartCategories, err := s.manager.GetAllChartCategories(utils.ChartQuery{Namespace: namespace})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Unable to fetch chart categories: %v", err)
 	}


### PR DESCRIPTION
### Description of the change

This PR removes the FilterOptions when returning all the distinct categories in a namespace, as per https://github.com/kubeapps/kubeapps/pull/3210#issuecomment-889540304

### Benefits

Fetching the charts will also fetch the categories (no duplicated requests) [in the new API]

### Possible drawbacks

N/A


### Applicable issues

N/A

### Additional information

N/A

