### PR TITLE
fix(chart): Skip README when it cannot be found

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -179,6 +179,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `dashboard.customAppViews`                        | Package names to signal a custom app view                                                  | `[]`                 |
 | `dashboard.customComponents`                      | Custom Form components injected into the BasicDeploymentForm                               | `""`                 |
 | `dashboard.remoteComponentsUrl`                   | Remote URL that can be used to load custom components vs loading from the local filesystem | `""`                 |
+| `dashboard.skipAvailablePackageDetails`           | Skip package details when they are not available                                           | `false`              |
 | `dashboard.customLocale`                          | Custom translations injected to the Dashboard to customize the strings used in Kubeapps    | `""`                 |
 | `dashboard.defaultTheme`                          | Default theme used in the Dashboard if the user has not selected any theme yet.            | `""`                 |
 | `dashboard.replicaCount`                          | Number of Dashboard replicas to deploy                                                     | `2`                  |

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -453,6 +453,9 @@ dashboard:
   ## @param dashboard.remoteComponentsUrl Remote URL that can be used to load custom components vs loading from the local filesystem
   ##
   remoteComponentsUrl: ""
+  ## @param dashboard.skipAvailablePackageDetails Skip package details when they are not available
+  ##
+  skipAvailablePackageDetails: false
   ## @param dashboard.customLocale Custom translations injected to the Dashboard to customize the strings used in Kubeapps
   ## ref: https://github.com/kubeapps/kubeapps/blob/master/docs/developer/translate-kubeapps.md
   ## e.g:

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -9,5 +9,6 @@
   "clusters": ["default"],
   "theme": "light",
   "remoteComponentsUrl": "",
-  "customAppViews": []
+  "customAppViews": [],
+  "skipAvailablePackageDetails": false
 }

--- a/dashboard/src/components/ChartView/ChartView.test.tsx
+++ b/dashboard/src/components/ChartView/ChartView.test.tsx
@@ -15,6 +15,7 @@ import { IConfigState } from "reducers/config";
 import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 import { IChartState } from "../../shared/types";
 import AvailablePackageMaintainers from "./AvailablePackageMaintainers";
+import ChartReadme from "./ChartReadme";
 import ChartView from "./ChartView";
 
 const defaultProps = {
@@ -248,6 +249,39 @@ it("renders the home link when set", () => {
       </a>,
     ),
   ).toBe(true);
+});
+
+describe("when package details are not available", () => {
+  it("redirects when skipAvailablePackageDetails is set to true", () => {
+    const wrapper = mountWrapper(
+      getStore({
+        ...defaultState,
+        charts: { selected: { readme: "" } },
+        config: { skipAvailablePackageDetails: true },
+      }),
+      <Router history={history}>
+        <Route path={routePath}>
+          <ChartView />
+        </Route>
+      </Router>,
+    );
+    expect(wrapper.text()).not.toContain("Fetching application README...");
+  });
+
+  it("does not redirect when skipAvailablePackageDetails is set to false", () => {
+    const wrapper = mountWrapper(
+      getStore({
+        ...defaultState,
+        config: { skipAvailablePackageDetails: false },
+      }),
+      <Router history={history}>
+        <Route path={routePath}>
+          <ChartView />
+        </Route>
+      </Router>,
+    );
+    expect(wrapper.containsMatchingElement(<ChartReadme />)).toBe(true);
+  });
 });
 
 describe("ChartMaintainers githubIDAsNames prop value", () => {

--- a/dashboard/src/components/ChartView/ChartView.tsx
+++ b/dashboard/src/components/ChartView/ChartView.tsx
@@ -103,7 +103,7 @@ export default function ChartView() {
     return <LoadingWrapper loaded={false} />;
   }
 
-  // If the chart does not have a README, redirect to deployment form
+  // If package does not have a README, redirect to deployment form
   if (!readme && config.skipAvailablePackageDetails) {
     return (
       <ReactRouter.Redirect

--- a/dashboard/src/components/ChartView/ChartView.tsx
+++ b/dashboard/src/components/ChartView/ChartView.tsx
@@ -103,6 +103,22 @@ export default function ChartView() {
     return <LoadingWrapper loaded={false} />;
   }
 
+  // If the chart does not have a README, redirect to deployment form
+  if (!readme && config.skipAvailablePackageDetails) {
+    return (
+      <ReactRouter.Redirect
+        to={app.apps.new(
+          cluster,
+          namespace,
+          availablePackageDetail,
+          pkgVersion!,
+          kubeappsNamespace,
+          pluginObj,
+        )}
+      />
+    );
+  }
+
   return (
     <section>
       <div>

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -132,7 +132,6 @@ export default function DeploymentForm() {
   };
 
   const selectVersion = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    console.log(e.target.value);
     dispatch(
       push(
         url.app.apps.new(

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -85,10 +85,10 @@ export default function DeploymentForm() {
           plugin: pluginObj,
           identifier: packageId,
         } as AvailablePackageReference,
-        chartVersion,
+        chartVersion || versions[0]?.pkgVersion,
       ),
     );
-  }, [chartCluster, chartNamespace, packageId, chartVersion, dispatch, pluginObj]);
+  }, [chartCluster, chartNamespace, packageId, chartVersion, dispatch, pluginObj, versions]);
 
   const handleValuesChange = (value: string) => {
     setAppValues(value);
@@ -132,6 +132,7 @@ export default function DeploymentForm() {
   };
 
   const selectVersion = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    console.log(e.target.value);
     dispatch(
       push(
         url.app.apps.new(

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -39,6 +39,7 @@ const makeStore = (
     theme: SupportedThemes.light,
     remoteComponentsUrl: "",
     customAppViews: [],
+    skipAvailablePackageDetails: false,
   };
   const clusters: IClustersState = {
     currentCluster: "default",

--- a/dashboard/src/containers/RoutesContainer/Routes.tsx
+++ b/dashboard/src/containers/RoutesContainer/Routes.tsx
@@ -29,7 +29,11 @@ const privateRoutes = {
   "/c/:cluster/ns/:namespace/apps/:pluginName/:pluginVersion/:releaseName/upgrade": AppUpgrade,
   "/c/:cluster/ns/:namespace/apps/new/:repo/:pluginName/:pluginVersion/:id/versions/:version":
     DeploymentForm,
+  "/c/:cluster/ns/:namespace/apps/new/:repo/:pluginName/:pluginVersion/:id/versions/":
+    DeploymentForm,
   "/c/:cluster/ns/:namespace/apps/new-from-:global(global)/:repo/:pluginName/:pluginVersion/:id/versions/:version":
+    DeploymentForm,
+  "/c/:cluster/ns/:namespace/apps/new-from-:global(global)/:repo/:pluginName/:pluginVersion/:id/versions/":
     DeploymentForm,
   "/c/:cluster/ns/:namespace/catalog": Catalog,
   "/c/:cluster/ns/:namespace/catalog/:repo": Catalog,

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -449,6 +449,7 @@ describe("clusterReducer", () => {
       theme: "light",
       remoteComponentsUrl: "",
       customAppViews: [],
+      skipAvailablePackageDetails: false,
     } as IConfig;
     it("re-writes the clusters to match the config.clusters state", () => {
       expect(

--- a/dashboard/src/reducers/config.ts
+++ b/dashboard/src/reducers/config.ts
@@ -20,6 +20,7 @@ export const initialState: IConfigState = {
   theme: SupportedThemes.light,
   remoteComponentsUrl: "",
   customAppViews: [],
+  skipAvailablePackageDetails: false,
 };
 
 const configReducer = (state: IConfigState = initialState, action: ConfigAction): IConfigState => {

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -181,6 +181,7 @@ describe("Auth", () => {
         theme: SupportedThemes.light,
         remoteComponentsUrl: "",
         customAppViews: [],
+        skipAvailablePackageDetails: false,
       });
 
       expect(mockedAssign).toBeCalledWith(oauthLogoutURI);
@@ -200,6 +201,7 @@ describe("Auth", () => {
         theme: SupportedThemes.light,
         remoteComponentsUrl: "",
         customAppViews: [],
+        skipAvailablePackageDetails: false,
       });
 
       expect(mockedAssign).toBeCalledWith("/oauth2/sign_out");

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -25,6 +25,7 @@ export interface IConfig {
   theme: string;
   remoteComponentsUrl: string;
   customAppViews: ICustomAppViewIdentifier[];
+  skipAvailablePackageDetails: boolean;
 }
 
 export default class Config {


### PR DESCRIPTION
Signed-off-by: Anthony Rizzo <36711320+aanthonyrizzo@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
<!-- Describe the scope of your change - i.e. what the change does. -->
This PR adds a logical statement to redirect and not render the `<ChartReadme />` when there is a README error. Since I only want to redirect when the file is not found, I check the error as such `.includes("not found")`. I cant see why having this as the default behavior would cause issues but this can easily be controlled w/ a config variable if we wanted.

### Benefits
<!-- What benefits will be realized by the code change? -->
This change will circumvent the no README error and direct the user to the deployment form

### Possible drawbacks
<!-- Describe any known limitations with your change -->
I don't see any but I could be wrong

### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
Fixes #3226 
