### PR TITLE
feat(form): Allow remote loading for form components

### DIFF
--- a/chart/kubeapps/templates/dashboard/configmap.yaml
+++ b/chart/kubeapps/templates/dashboard/configmap.yaml
@@ -76,5 +76,6 @@ data:
       "authProxySkipLoginPage": {{ .Values.authProxy.skipKubeappsLoginPage }},
       "featureFlags": {{ .Values.featureFlags | toJson }},
       "clusters": {{ template "kubeapps.clusterNames" . }},
-      "theme": "{{ .Values.dashboard.defaultTheme }}"
+      "theme": "{{ .Values.dashboard.defaultTheme }}",
+      "remoteComponentsUrl": "{{ .Values.dashboard.remoteComponentsUrl }}"
     }

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -437,6 +437,9 @@ dashboard:
   ## ref: https://github.com/kubeapps/kubeapps/blob/master/docs/developer/custom-form-component-support.md
   ##
   customComponents: ""
+  ## @param dashboard.remoteComponentsUrl Remote URL that can be used to load custom components vs loading from the local filesystem
+  ##
+  remoteComponentsUrl: ""
   ## @param dashboard.customLocale Custom translations injected to the Dashboard to customize the strings used in Kubeapps
   ## ref: https://github.com/kubeapps/kubeapps/blob/master/docs/developer/translate-kubeapps.md
   ## e.g:

--- a/dashboard/public/config.json
+++ b/dashboard/public/config.json
@@ -7,5 +7,6 @@
   "oauthLoginURI": "/oauth2/start",
   "oauthLogoutURI": "/oauth2/sign_out",
   "clusters": ["default"],
-  "theme": "light"
+  "theme": "light",
+  "remoteComponentsUrl": ""
 }

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from "enzyme";
+import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 import { IBasicFormParam } from "shared/types";
 import { CustomComponent } from "../../../RemoteComponent";
 import CustomFormComponentLoader from "./CustomFormParam";
@@ -17,6 +17,10 @@ const defaultProps = {
   handleBasicFormParamChange: jest.fn(),
 };
 
+const defaultState = {
+  config: { remoteComponentsUrl: "" },
+};
+
 // Mocking the window so that the injected components are imported correctly
 const location = window.location;
 beforeAll((): void => {
@@ -32,11 +36,36 @@ afterAll((): void => {
 });
 
 it("should render a custom form component", () => {
-  const wrapper = mount(<CustomFormComponentLoader {...defaultProps} />);
+  const wrapper = mountWrapper(
+    getStore(defaultState),
+    <CustomFormComponentLoader {...defaultProps} />,
+  );
   expect(wrapper.find(CustomFormComponentLoader)).toExist();
 });
 
 it("should render the remote component", () => {
-  const wrapper = mount(<CustomFormComponentLoader {...defaultProps} />);
+  const wrapper = mountWrapper(
+    getStore(defaultState),
+    <CustomFormComponentLoader {...defaultProps} />,
+  );
   expect(wrapper.find(CustomComponent)).toExist();
+});
+
+it("should render the remote component with the default URL", () => {
+  const wrapper = mountWrapper(
+    getStore(defaultState),
+    <CustomFormComponentLoader {...defaultProps} />,
+  );
+  expect(wrapper.find(CustomComponent)).toExist();
+  expect(wrapper.find(CustomComponent).prop("url")).toContain("custom_components.js");
+});
+
+it("should render the remote component with the URL if set in the config", () => {
+  const wrapper = mountWrapper(
+    getStore({
+      config: { remoteComponentsUrl: "www.thiswebsite.com" },
+    }),
+    <CustomFormComponentLoader {...defaultProps} />,
+  );
+  expect(wrapper.find(CustomComponent).prop("url")).toBe("www.thiswebsite.com");
 });

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
-import { IBasicFormParam } from "shared/types";
+import { IBasicFormParam, IStoreState } from "shared/types";
 import { CustomComponent } from "../../../RemoteComponent";
-
+import { useSelector } from "react-redux";
 export interface ICustomParamProps {
   param: IBasicFormParam;
   handleBasicFormParamChange: (
@@ -14,7 +14,14 @@ export default function CustomFormComponentLoader({
   handleBasicFormParamChange,
 }: ICustomParamProps) {
   // Fetches the custom-component bundle served by the dashboard nginx
-  const url = `${window.location.origin}/custom_components.js`;
+
+  const {
+    config: { remoteComponentsUrl },
+  } = useSelector((state: IStoreState) => state);
+
+  const url = remoteComponentsUrl
+    ? remoteComponentsUrl
+    : `${window.location.origin}/custom_components.js`;
 
   return useMemo(
     () => (

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -38,6 +38,7 @@ const makeStore = (
     clusters: [],
     authProxySkipLoginPage: false,
     theme: SupportedThemes.light,
+    remoteComponentsUrl: "",
   };
   const clusters: IClustersState = {
     currentCluster: "default",

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -448,6 +448,7 @@ describe("clusterReducer", () => {
       clusters: ["additionalCluster1", "additionalCluster2"],
       authProxySkipLoginPage: false,
       theme: "light",
+      remoteComponentsUrl: "",
     } as IConfig;
     it("re-writes the clusters to match the config.clusters state", () => {
       expect(

--- a/dashboard/src/reducers/config.ts
+++ b/dashboard/src/reducers/config.ts
@@ -18,6 +18,7 @@ export const initialState: IConfigState = {
   authProxySkipLoginPage: false,
   clusters: [],
   theme: SupportedThemes.light,
+  remoteComponentsUrl: "",
 };
 
 const configReducer = (state: IConfigState = initialState, action: ConfigAction): IConfigState => {

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -179,6 +179,7 @@ describe("Auth", () => {
         clusters: [],
         authProxySkipLoginPage: false,
         theme: SupportedThemes.light,
+        remoteComponentsUrl: "",
       });
 
       expect(mockedAssign).toBeCalledWith(oauthLogoutURI);
@@ -196,6 +197,7 @@ describe("Auth", () => {
         clusters: [],
         authProxySkipLoginPage: false,
         theme: SupportedThemes.light,
+        remoteComponentsUrl: "",
       });
 
       expect(mockedAssign).toBeCalledWith("/oauth2/sign_out");

--- a/dashboard/src/shared/Config.ts
+++ b/dashboard/src/shared/Config.ts
@@ -17,6 +17,7 @@ export interface IConfig {
   error?: Error;
   clusters: string[];
   theme: string;
+  remoteComponentsUrl: string;
 }
 
 export default class Config {

--- a/docs/developer/custom-form-component-support.md
+++ b/docs/developer/custom-form-component-support.md
@@ -17,6 +17,7 @@ This is an extension to the [basic form support](https://github.com/kubeapps/kub
    ```
 
    Note: The file can be located anywhere on your file system or even a remote source!
+  Alternatively we provide remote loading by setting the `remoteComponentsUrl` value to the URL that is serving your bundle. If this is not set, the configmap will be the default loader.
 
 3. Once the deployment is complete you will need a values json that will signal to Kubeapps that we want to render a custom component and not one fo the provided ones. To do that you will need a `values.json.schema` that has a `customComponent` key, more info [here](https://github.com/kubeapps/kubeapps/blob/master/docs/developer/custom-form-component-support.md#render-a-custom-component).
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
<!-- Describe the scope of your change - i.e. what the change does. -->
This PR adds the ability for developers to load their custom components from a remote URL as an alternative to loading from the configmap. This is an optional value that can be set for the custom components feature. If the value is not set the `<CustomComponent />` will be pulled from the `custom_components.js` file.

### Benefits
<!-- What benefits will be realized by the code change? -->
- No longer worry about 1 MiB max configmap size
- Allows for easier version control of the form components (should that be needed)

### Possible drawbacks
<!-- Describe any known limitations with your change -->
- Bundle will have to be served from a remote host and will be the responsibility of the developer