### PR TITLE
docs: add namespace flag for retrieve token example

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -38,7 +38,7 @@ To retrieve the token,
 ### On Linux/macOS:
 
 ```bash
-kubectl get secret $(kubectl get serviceaccount kubeapps-operator -o jsonpath='{range .secrets[*]}{.name}{"\n"}{end}' | grep kubeapps-operator-token) -o jsonpath='{.data.token}' -o go-template='{{.data.token | base64decode}}' && echo
+kubectl get --namespace default secret $(kubectl get --namespace default serviceaccount kubeapps-operator -o jsonpath='{range .secrets[*]}{.name}{"\n"}{end}' | grep kubeapps-operator-token) -o jsonpath='{.data.token}' -o go-template='{{.data.token | base64decode}}' && echo
 ```
 
 ### On Windows:
@@ -48,12 +48,12 @@ Create a file called `GetDashToken.cmd` with the following lines in it:
 ```bat
 @ECHO OFF
 REM Get the Service Account
-kubectl get serviceaccount kubeapps-operator -o jsonpath={.secrets[].name} > s.txt
+kubectl get --namespace default serviceaccount kubeapps-operator -o jsonpath={.secrets[].name} > s.txt
 SET /p ks=<s.txt
 DEL s.txt
 
 REM Get the Base64 encoded token
-kubectl get secret %ks% -o jsonpath={.data.token} > b64.txt
+kubectl get --namespace default secret %ks% -o jsonpath={.data.token} > b64.txt
 
 REM Decode The Token
 DEL token.txt


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Updates "Getting Started" docs retrieve token example to use `--namespace default` flag. 

### Benefits

When creating a serviceaccount in previous section, it's also done with `--namespace default` flag in case user is not in the `default` namespace context. By adding the namespace flag, users in different context can copy and paste the shell example otherwise they'll receive this error:
```shell
» kubectl get serviceaccount kubeapps-operator -o jsonpath='{range .secrets[*]}{.name}{"\n"}{end}' | grep kubeapps-operator-token                                                                                                          
Error from server (NotFound): serviceaccounts "kubeapps-operator" not found

```

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

n/a

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
