### PR TITLE
Add GetInstalledPackageDetail implementation.

### DIFF
--- a/script/deploy-dev.mk
+++ b/script/deploy-dev.mk
@@ -37,6 +37,17 @@ deploy-dev-kubeapps:
 		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
 		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml
 
+deploy-dev-kubeapps-with-apis:
+	helm --kubeconfig=${CLUSTER_CONFIG} upgrade --install kubeapps ./chart/kubeapps --namespace kubeapps --create-namespace \
+		--values ./docs/user/manifests/kubeapps-local-dev-values.yaml \
+		--values ./docs/user/manifests/kubeapps-local-dev-auth-proxy-values.yaml \
+		--values ./docs/user/manifests/kubeapps-local-dev-additional-kind-cluster.yaml \
+		--values ./docs/developer/manifests/values.kubeappsapis.yaml \
+		--set kubeappsapis.unsafeUseDemoSA=true \
+		--set redis.enabled=false \
+		--set kubeappsapis.image.tag=latest
+
+
 deploy-dev: deploy-dependencies deploy-dev-kubeapps
 	@echo "\nYou can now simply open your browser at https://localhost/ to access Kubeapps!"
 	@echo "When logging in, you will be redirected to dex (with a self-signed cert) and can login with email as either of"


### PR DESCRIPTION
### Description of the change

Adds implementation for GetInstalledPackageDetail.

The response includes the release values, notes and a ref to the available package for further details about the available package:
```
# Get the summaries first to find an installed package ref:
$ grpcurl -plaintext localhost:8080 kubeappsapis.plugins.helm.packages.v1alpha1.HelmPackagesService.GetInstalledPackageSummaries                                                                                               {
  "installedPackageSummaries": [
    ...
    {
      "installedPackageRef": {
        "context": {
          "namespace": "default"
        },
        "identifier": "test-apache"
      },
      "name": "test-apache",
      "pkgVersionReference": {
        "version": "8.5.8"
      },
      "currentPkgVersion": "8.5.8",
      "currentAppVersion": "2.4.48",
      "iconUrl": "https://bitnami.com/assets/stacks/apache/img/apache-stack-220x234.png",
      "pkgDisplayName": "apache",
      "shortDescription": "Chart for Apache HTTP Server",
      "latestPkgVersion": "8.6.0",
      "status": {
        "ready": true,
        "reason": "STATUS_REASON_INSTALLED",
        "userReason": "deployed"
      }
    }
  ]
}

# Now grab the detail:
$ grpcurl -plaintext -d '{"installed_package_ref": {"context": {"namespace": "default"}, "identifier": "test-apache"}}' localhost:8080  kubeappsapis.plugins.helm.packages.v1alpha1.HelmPackagesService.GetInstalledPackageDetail
{
  "installedPackageDetail": {
    "installedPackageRef": {
      "context": {
        "namespace": "default"
      },
      "identifier": "test-apache"
    },
    "pkgVersionReference": {
      "version": "8.5.8"
    },
    "name": "test-apache",
    "currentPkgVersion": "8.5.8",
    "valuesApplied": "{\"affinity\":{},\"cloneHtdocsFromGit\":{\"enabled\":false,\"extraVolumeMounts\":[],\"interval\":60,\"resources\":{}},\"commonAnnotations\":{},\"commonLabels\":{},\"extraDeploy\":[],\"extraEnvVars\":[],\"extraVolumeMounts\":[],\"extraVolumes\":[],\"git\":{\"pullPolicy\":\"IfNotPresent\",\"registry\":\"docker.io\",\"repository\":\"bitnami/git\",\"tag\":\"2.32.0-debian-10-r26\"},\"hostAliases\":[{\"hostnames\":[\"status.localhost\"],\"ip\":\"127.0.0.1\"}],\"image\":{\"debug\":false,\"pullPolicy\":\"IfNotPresent\",\"registry\":\"docker.io\",\"repository\":\"bitnami/apache\",\"tag\":\"2.4.48-debian-10-r28\"},\"ingress\":{\"annotations\":{},\"apiVersion\":null,\"certManager\":false,\"enabled\":false,\"hostname\":\"example.local\",\"path\":\"/\",\"pathType\":\"ImplementationSpecific\",\"secrets\":null,\"tls\":[{\"hosts\":[\"example.local\"],\"secretName\":\"example.local-tls\"}]},\"initContainers\":{},\"kubeVersion\":null,\"livenessProbe\":{\"enabled\":true,\"failureThreshold\":6,\"initialDelaySeconds\":180,\"path\":\"/\",\"periodSeconds\":20,\"port\":\"http\",\"successThreshold\":1,\"timeoutSeconds\":5},\"metrics\":{\"enabled\":false,\"image\":{\"pullPolicy\":\"IfNotPresent\",\"registry\":\"docker.io\",\"repository\":\"bitnami/apache-exporter\",\"tag\":\"0.9.0-debian-10-r25\"},\"podAnnotations\":{\"prometheus.io/port\":\"9117\",\"prometheus.io/scrape\":\"true\"},\"resources\":{\"limits\":{},\"requests\":{}}},\"nodeAffinityPreset\":{\"key\":\"\",\"type\":\"\",\"values\":[]},\"nodeSelector\":{},\"podAffinityPreset\":\"\",\"podAnnotations\":{},\"podAntiAffinityPreset\":\"soft\",\"podLabels\":{},\"readinessProbe\":{\"enabled\":true,\"failureThreshold\":6,\"initialDelaySeconds\":30,\"path\":\"/\",\"periodSeconds\":10,\"port\":\"http\",\"successThreshold\":1,\"timeoutSeconds\":5},\"replicaCount\":1,\"resources\":{\"limits\":{},\"requests\":{}},\"service\":{\"annotations\":{},\"externalTrafficPolicy\":\"Cluster\",\"httpsPort\":443,\"nodePorts\":{\"http\":\"\",\"https\":\"\"},\"port\":80,\"type\":\"LoadBalancer\"},\"sidecars\":{},\"tolerations\":[]}",
    "status": {
      "ready": true,
      "reason": "STATUS_REASON_INSTALLED",
      "userReason": "deployed"
    },
    "postInstallationNotes": "\n** Please be patient while the chart is being deployed **\n\n1. Get the Apache URL by running:\n\n** Please ensure an external IP is associated to the test-apache service before proceeding **\n** Watch the status using: kubectl get svc --namespace default -w test-apache **\n\n  export SERVICE_IP=$(kubectl get svc --namespace default test-apache --template \"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}\")\n  echo URL            : http://$SERVICE_IP/\n\n\nWARNING: You did not provide a custom web application. Apache will be deployed with a default page. Check the README section \"Deploying your custom web application\" in https://github.com/bitnami/charts/blob/master/bitnami/apache/README.md#deploying-your-custom-web-application.\n\n\n",
    "availablePackageRef": {
      "context": {
        "namespace": "kubeapps"
      },
      "identifier": "bitnami/apache",
      "plugin": {
        "name": "helm.packages",
        "version": "v1alpha1"
      }
    }
  }
}

```

We'll need to enable querying the k8s resources for an installed package separately, rather than including those details in this response. So the related UX calls will still use the old API until we do so.

### Benefits

One step closer.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref #3146

### Additional information

