### PR TITLE
Update server.KubernetesConfigGetter to support cluster arg

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -52,7 +52,10 @@ func NewServer(configGetter server.KubernetesConfigGetter) (*Server, error) {
 		if configGetter == nil {
 			return nil, status.Errorf(codes.Internal, "configGetter arg required")
 		}
-		config, err := configGetter(ctx)
+		// The Flux plugin currently supports interactions with the default (kubeapps)
+		// cluster only:
+		cluster := ""
+		config, err := configGetter(ctx, cluster)
 		if err != nil {
 			return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get config : %v", err))
 		}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -91,7 +91,8 @@ func NewServer(configGetter server.KubernetesConfigGetter) *Server {
 			if configGetter == nil {
 				return nil, nil, status.Errorf(codes.Internal, "configGetter arg required")
 			}
-			config, err := configGetter(ctx)
+			// Not yet sending cluster.
+			config, err := configGetter(ctx, "")
 			if err != nil {
 				return nil, nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get config : %v", err))
 			}
@@ -109,7 +110,7 @@ func NewServer(configGetter server.KubernetesConfigGetter) *Server {
 			if configGetter == nil {
 				return nil, status.Errorf(codes.Internal, "configGetter arg required")
 			}
-			config, err := configGetter(ctx)
+			config, err := configGetter(ctx, "")
 			if err != nil {
 				return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get config : %v", err))
 			}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -77,7 +77,10 @@ func NewServer(configGetter server.KubernetesConfigGetter) *Server {
 			if configGetter == nil {
 				return nil, status.Errorf(codes.Internal, "configGetter arg required")
 			}
-			config, err := configGetter(ctx)
+			// The Kapp Controller plugin currently supports interactions with
+			// the default (kubeapps) cluster only:
+			cluster := ""
+			config, err := configGetter(ctx, cluster)
 			if err != nil {
 				return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get config : %v", err))
 			}

--- a/cmd/kubeapps-apis/server/plugins.go
+++ b/cmd/kubeapps-apis/server/plugins.go
@@ -310,9 +310,9 @@ func createConfigGetterWithParams(inClusterConfig *rest.Config, serveOpts ServeO
 
 		var config *rest.Config
 
-		// TODO(minelson): Enable existing plugins to pass an empty cluster name
-		// to get the kubeapps cluster for now, until we support (or otherwise
-		// decide) multicluster configuration of all plugins.
+		// Enable existing plugins to pass an empty cluster name to get the
+		// kubeapps cluster for now, until we support (or otherwise decide)
+		// multicluster configuration of all plugins.
 		if cluster == "" {
 			cluster = clustersConfig.KubeappsClusterName
 		}


### PR DESCRIPTION
### Description of the change

Updates the KubernetesConfigGetter function alias to accept the cluster as an arg.

It uses this to return a config for the specified cluster, but defaults to the current behaviour of the cluster on which Kubeapps is running.

Tests that the correct config is created depending on the clusterConfig.

### Benefits

This is step 1 in being able to match the existing cluster support but with the new APIs server (for Helm).

### Possible drawbacks


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref #3278

### Additional information

The following PR will add support for the Helm plugin to reply sanely for requests to other clusters, while leaving the other plugins using the default behaviour for now.
