### PR TITLE
Support multi-cluster with helm plugin

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
@@ -21,6 +21,7 @@ import (
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 	log "k8s.io/klog/v2"
 )
 
@@ -37,7 +38,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter, clustersConfig kube.ClustersConfig) (interface{}, error) {
 	log.Infof("+fluxv2 RegisterWithGRPCServer")
 	svr, err := NewServer(configGetter)
 	if err != nil {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
@@ -21,6 +21,7 @@ import (
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 )
 
 // Set the pluginDetail once during a module init function so the single struct
@@ -36,9 +37,8 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter) (interface{}, error) {
-	// TODO
-	svr := NewServer(configGetter, "default")
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter, clustersConfig kube.ClustersConfig) (interface{}, error) {
+	svr := NewServer(configGetter, clustersConfig.KubeappsClusterName)
 	v1alpha1.RegisterHelmPackagesServiceServer(s, svr)
 	return svr, nil
 }

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
@@ -37,7 +37,8 @@ func init() {
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
 func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter) (interface{}, error) {
-	svr := NewServer(configGetter)
+	// TODO
+	svr := NewServer(configGetter, "default")
 	v1alpha1.RegisterHelmPackagesServiceServer(s, svr)
 	return svr, nil
 }

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -575,6 +575,9 @@ func isValidChart(chart *models.Chart) (bool, error) {
 func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *corev1.GetInstalledPackageSummariesRequest) (*corev1.GetInstalledPackageSummariesResponse, error) {
 	namespace := request.GetContext().GetNamespace()
 	cluster := request.GetContext().GetCluster()
+	if cluster == "" {
+		cluster = s.globalPackagingCluster
+	}
 	actionConfig, err := s.actionConfigGetter(ctx, cluster, namespace)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
@@ -600,6 +603,7 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 	installedPkgSummaries := make([]*corev1.InstalledPackageSummary, len(releases))
 	for i, r := range releases {
 		installedPkgSummaries[i] = installedPkgSummaryFromRelease(r)
+		installedPkgSummaries[i].InstalledPackageRef.Context.Cluster = cluster
 	}
 
 	// Fill in the latest package version for each.

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -57,6 +57,7 @@ import (
 
 const (
 	globalPackagingNamespace = "kubeapps"
+	globalPackagingCluster   = "default"
 	DefaultAppVersion        = "1.2.6"
 	DefaultChartDescription  = "default chart description"
 	DefaultChartIconURL      = "https://example.com/chart.svg"
@@ -79,7 +80,7 @@ func TestGetClient(t *testing.T) {
 	if err != nil {
 		log.Fatalf("%s", err)
 	}
-	testClientGetter := func(context.Context) (kubernetes.Interface, dynamic.Interface, error) {
+	testClientGetter := func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
 		return typfake.NewSimpleClientset(), dynfake.NewSimpleDynamicClientWithCustomListKinds(
 			runtime.NewScheme(),
 			map[schema.GroupVersionResource]string{
@@ -119,7 +120,7 @@ func TestGetClient(t *testing.T) {
 		{
 			name:    "it returns failed-precondition when configGetter itself errors",
 			manager: manager,
-			clientGetter: func(context.Context) (kubernetes.Interface, dynamic.Interface, error) {
+			clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
 				return nil, nil, fmt.Errorf("Bang!")
 			},
 			statusCodeClient:  codes.FailedPrecondition,
@@ -136,7 +137,7 @@ func TestGetClient(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := Server{clientGetter: tc.clientGetter, manager: tc.manager}
 
-			typedClient, dynamicClient, errClient := s.GetClients(context.Background())
+			typedClient, dynamicClient, errClient := s.GetClients(context.Background(), "")
 
 			if got, want := status.Code(errClient), tc.statusCodeClient; got != want {
 				t.Errorf("got: %+v, want: %+v", got, want)
@@ -473,7 +474,7 @@ func makeServer(t *testing.T, authorized bool, actionConfig *action.Configuratio
 			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: authorized},
 		}, nil
 	})
-	clientGetter := func(context.Context) (kubernetes.Interface, dynamic.Interface, error) {
+	clientGetter := func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
 		return clientSet, dynamicClient, nil
 	}
 
@@ -484,7 +485,8 @@ func makeServer(t *testing.T, authorized bool, actionConfig *action.Configuratio
 		clientGetter:             clientGetter,
 		manager:                  manager,
 		globalPackagingNamespace: globalPackagingNamespace,
-		actionConfigGetter: func(context.Context, string) (*action.Configuration, error) {
+		globalPackagingCluster:   globalPackagingCluster,
+		actionConfigGetter: func(context.Context, string, string) (*action.Configuration, error) {
 			return actionConfig, nil
 		},
 	}, mock, cleanup
@@ -492,14 +494,14 @@ func makeServer(t *testing.T, authorized bool, actionConfig *action.Configuratio
 
 func TestGetAvailablePackageSummaries(t *testing.T) {
 	testCases := []struct {
-		name               string
-		charts             []*models.Chart
-		expectDBQuery      bool
-		statusCode         codes.Code
-		request            *corev1.GetAvailablePackageSummariesRequest
-		expectedResponse   *corev1.GetAvailablePackageSummariesResponse
-		authorized         bool
-		expectedCategories []*models.ChartCategory
+		name                   string
+		charts                 []*models.Chart
+		expectDBQueryNamespace string
+		statusCode             codes.Code
+		request                *corev1.GetAvailablePackageSummariesRequest
+		expectedResponse       *corev1.GetAvailablePackageSummariesResponse
+		authorized             bool
+		expectedCategories     []*models.ChartCategory
 	}{
 		{
 			name:       "it returns a set of availablePackageSummary from the database (global ns)",
@@ -510,10 +512,11 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					Namespace: globalPackagingNamespace,
 				},
 			},
-			expectDBQuery: true,
+			expectDBQueryNamespace: globalPackagingNamespace,
 			charts: []*models.Chart{
 				makeChart("chart-1", "repo-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
 				makeChart("chart-2", "repo-1", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
+				makeChart("chart-3-global", "repo-1", globalPackagingNamespace, []string{"2.0.0"}, DefaultChartCategory),
 			},
 			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
 				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
@@ -526,7 +529,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
 						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Namespace: "my-ns"},
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-1",
 							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
@@ -540,8 +543,22 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
 						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Namespace: "my-ns"},
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-2",
+							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+						},
+					},
+					{
+						Name:             "chart-3-global",
+						DisplayName:      "chart-3-global",
+						LatestPkgVersion: "2.0.0",
+						LatestAppVersion: DefaultAppVersion,
+						IconUrl:          DefaultChartIconURL,
+						Categories:       []string{DefaultChartCategory},
+						ShortDescription: DefaultChartDescription,
+						AvailablePackageRef: &corev1.AvailablePackageReference{
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: globalPackagingNamespace},
+							Identifier: "repo-1/chart-3-global",
 							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
@@ -555,11 +572,10 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			authorized: true,
 			request: &corev1.GetAvailablePackageSummariesRequest{
 				Context: &corev1.Context{
-					Cluster:   "",
 					Namespace: "my-ns",
 				},
 			},
-			expectDBQuery: true,
+			expectDBQueryNamespace: "my-ns",
 			charts: []*models.Chart{
 				makeChart("chart-1", "repo-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
 				makeChart("chart-2", "repo-1", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
@@ -575,7 +591,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
 						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Namespace: "my-ns"},
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-1",
 							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
@@ -589,7 +605,56 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
 						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Namespace: "my-ns"},
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+							Identifier: "repo-1/chart-2",
+							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+						},
+					},
+				},
+				Categories: []string{"cat1"},
+			},
+			statusCode: codes.OK,
+		},
+		{
+			name:       "it returns a set of the global availablePackageSummary from the database (not the specific ns on other cluster)",
+			authorized: true,
+			request: &corev1.GetAvailablePackageSummariesRequest{
+				Context: &corev1.Context{
+					Cluster:   "other",
+					Namespace: "my-ns",
+				},
+			},
+			expectDBQueryNamespace: globalPackagingNamespace,
+			charts: []*models.Chart{
+				makeChart("chart-1", "repo-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
+				makeChart("chart-2", "repo-1", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
+			},
+			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
+					{
+						Name:             "chart-1",
+						DisplayName:      "chart-1",
+						LatestPkgVersion: "3.0.0",
+						LatestAppVersion: DefaultAppVersion,
+						IconUrl:          DefaultChartIconURL,
+						Categories:       []string{DefaultChartCategory},
+						ShortDescription: DefaultChartDescription,
+						AvailablePackageRef: &corev1.AvailablePackageReference{
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+							Identifier: "repo-1/chart-1",
+							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+						},
+					},
+					{
+						Name:             "chart-2",
+						DisplayName:      "chart-2",
+						LatestPkgVersion: "2.0.0",
+						LatestAppVersion: DefaultAppVersion,
+						IconUrl:          DefaultChartIconURL,
+						Categories:       []string{DefaultChartCategory},
+						ShortDescription: DefaultChartDescription,
+						AvailablePackageRef: &corev1.AvailablePackageReference{
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-2",
 							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
@@ -607,9 +672,8 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					Namespace: "",
 				},
 			},
-			expectDBQuery: false,
-			charts:        []*models.Chart{},
-			statusCode:    codes.Unimplemented,
+			charts:     []*models.Chart{},
+			statusCode: codes.Unimplemented,
 		},
 		{
 			name:       "it returns an internal error status if response does not contain version",
@@ -620,9 +684,9 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					Namespace: globalPackagingNamespace,
 				},
 			},
-			expectDBQuery: true,
-			charts:        []*models.Chart{makeChart("chart-1", "repo-1", "my-ns", []string{}, DefaultChartCategory)},
-			statusCode:    codes.Internal,
+			expectDBQueryNamespace: globalPackagingNamespace,
+			charts:                 []*models.Chart{makeChart("chart-1", "repo-1", "my-ns", []string{}, DefaultChartCategory)},
+			statusCode:             codes.Internal,
 		},
 		{
 			name:       "it returns an unauthenticated status if the user doesn't have permissions",
@@ -632,9 +696,8 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					Namespace: "my-ns",
 				},
 			},
-			expectDBQuery: false,
-			charts:        []*models.Chart{{Name: "foo"}},
-			statusCode:    codes.Unauthenticated,
+			charts:     []*models.Chart{{Name: "foo"}},
+			statusCode: codes.Unauthenticated,
 		},
 		{
 			name:       "it returns only the requested page of results and includes the next page token",
@@ -649,7 +712,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					PageSize:  1,
 				},
 			},
-			expectDBQuery: true,
+			expectDBQueryNamespace: globalPackagingNamespace,
 			charts: []*models.Chart{
 				makeChart("chart-1", "repo-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
 				makeChart("chart-2", "repo-1", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
@@ -666,7 +729,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						ShortDescription: DefaultChartDescription,
 						Categories:       []string{DefaultChartCategory},
 						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Namespace: "my-ns"},
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-2",
 							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
@@ -691,7 +754,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					PageSize:  2,
 				},
 			},
-			expectDBQuery: true,
+			expectDBQueryNamespace: globalPackagingNamespace,
 			charts: []*models.Chart{
 				makeChart("chart-1", "repo-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
 				makeChart("chart-2", "repo-1", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
@@ -708,7 +771,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
 						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Namespace: "my-ns"},
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-3",
 							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
@@ -731,8 +794,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					PageSize:  2,
 				},
 			},
-			expectDBQuery: false,
-			statusCode:    codes.InvalidArgument,
+			statusCode: codes.InvalidArgument,
 		},
 		{
 			name:       "it returns the proper chart categories",
@@ -743,7 +805,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					Namespace: "my-ns",
 				},
 			},
-			expectDBQuery: true,
+			expectDBQueryNamespace: "my-ns",
 			charts: []*models.Chart{
 				makeChart("chart-1", "repo-1", "my-ns", []string{"3.0.0"}, "foo"),
 				makeChart("chart-2", "repo-1", "my-ns", []string{"2.0.0"}, "bar"),
@@ -760,7 +822,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Categories:       []string{"foo"},
 						ShortDescription: DefaultChartDescription,
 						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Namespace: "my-ns"},
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-1",
 							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
@@ -774,7 +836,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Categories:       []string{"bar"},
 						ShortDescription: DefaultChartDescription,
 						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Namespace: "my-ns"},
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-2",
 							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
@@ -788,7 +850,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 						Categories:       []string{"bar"},
 						ShortDescription: DefaultChartDescription,
 						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Namespace: "my-ns"},
+							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-3",
 							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
@@ -814,7 +876,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				rows.AddRow(row)
 			}
 
-			if tc.expectDBQuery {
+			if tc.expectDBQueryNamespace != "" {
 				// Checking if the WHERE condtion is properly applied
 
 				// Check returned categories
@@ -836,11 +898,11 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				}
 
 				mock.ExpectQuery("SELECT (info ->> 'category')*").
-					WithArgs(tc.request.Context.Namespace, server.globalPackagingNamespace).
+					WithArgs(tc.expectDBQueryNamespace, server.globalPackagingNamespace).
 					WillReturnRows(catrows)
 
 				mock.ExpectQuery("SELECT info FROM").
-					WithArgs(tc.request.Context.Namespace, server.globalPackagingNamespace).
+					WithArgs(tc.expectDBQueryNamespace, server.globalPackagingNamespace).
 					WillReturnRows(rows)
 
 				if tc.request.GetPaginationOptions().GetPageSize() > 0 {
@@ -1010,6 +1072,29 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 			statusCode: codes.OK,
 		},
 		{
+			name:       "it returns an invalid arg error status if no context is provided",
+			authorized: true,
+			request: &corev1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &corev1.AvailablePackageReference{
+					Identifier: "foo/bar",
+				},
+			},
+			charts:     []*models.Chart{{Name: "foo"}},
+			statusCode: codes.InvalidArgument,
+		},
+		{
+			name:       "it returns an invalid arg error status if cluster is not the global/kubeapps one",
+			authorized: true,
+			request: &corev1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &corev1.AvailablePackageReference{
+					Context:    &corev1.Context{Cluster: "other-cluster", Namespace: "my-ns"},
+					Identifier: "foo/bar",
+				},
+			},
+			charts:     []*models.Chart{{Name: "foo"}},
+			statusCode: codes.InvalidArgument,
+		},
+		{
 			name:       "it returns an internal error status if the chart is invalid",
 			authorized: true,
 			request: &corev1.GetAvailablePackageDetailRequest{
@@ -1141,6 +1226,16 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 					Context: &corev1.Context{
 						Namespace: "kubeapps",
 					},
+				},
+			},
+			expectedStatusCode: codes.InvalidArgument,
+		},
+		{
+			name: "it returns invalid argument if called with a cluster other than the global/kubeapps one",
+			request: &corev1.GetAvailablePackageVersionsRequest{
+				AvailablePackageRef: &corev1.AvailablePackageReference{
+					Context:    &corev1.Context{Cluster: "other-cluster", Namespace: "kubeapps"},
+					Identifier: "bitnami/apache",
 				},
 			},
 			expectedStatusCode: codes.InvalidArgument,

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -1512,6 +1512,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					{
 						InstalledPackageRef: &corev1.InstalledPackageReference{
 							Context: &corev1.Context{
+								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-1",
 							},
 							Identifier: "my-release-1",
@@ -1533,6 +1534,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					{
 						InstalledPackageRef: &corev1.InstalledPackageReference{
 							Context: &corev1.Context{
+								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-1",
 							},
 							Identifier: "my-release-3",
@@ -1585,6 +1587,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					{
 						InstalledPackageRef: &corev1.InstalledPackageReference{
 							Context: &corev1.Context{
+								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-1",
 							},
 							Identifier: "my-release-1",
@@ -1606,6 +1609,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					{
 						InstalledPackageRef: &corev1.InstalledPackageReference{
 							Context: &corev1.Context{
+								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-2",
 							},
 							Identifier: "my-release-2",
@@ -1627,6 +1631,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					{
 						InstalledPackageRef: &corev1.InstalledPackageReference{
 							Context: &corev1.Context{
+								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-3",
 							},
 							Identifier: "my-release-3",
@@ -1682,6 +1687,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					{
 						InstalledPackageRef: &corev1.InstalledPackageReference{
 							Context: &corev1.Context{
+								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-1",
 							},
 							Identifier: "my-release-1",
@@ -1703,6 +1709,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					{
 						InstalledPackageRef: &corev1.InstalledPackageReference{
 							Context: &corev1.Context{
+								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-2",
 							},
 							Identifier: "my-release-2",
@@ -1760,6 +1767,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					{
 						InstalledPackageRef: &corev1.InstalledPackageReference{
 							Context: &corev1.Context{
+								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-3",
 							},
 							Identifier: "my-release-3",
@@ -1801,6 +1809,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					{
 						InstalledPackageRef: &corev1.InstalledPackageReference{
 							Context: &corev1.Context{
+								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-1",
 							},
 							Identifier: "my-release-1",

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
@@ -21,6 +21,7 @@ import (
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
+	"github.com/kubeapps/kubeapps/pkg/kube"
 )
 
 // Set the pluginDetail once during a module init function so the single struct
@@ -36,7 +37,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter, clustersConfig kube.ClustersConfig) (interface{}, error) {
 	svr := NewServer(configGetter)
 	v1alpha1.RegisterKappControllerPackagesServiceServer(s, svr)
 	return svr, nil

--- a/cmd/kubeapps-apis/server/plugins.go
+++ b/cmd/kubeapps-apis/server/plugins.go
@@ -67,6 +67,9 @@ type pluginsServer struct {
 	// TODO: Update the plugins server to be able to register different versions
 	// of core plugins.
 	packagesPlugins []*pkgsPluginWithServer
+
+	// The parsed config for clusters in a multi-cluster setup.
+	clustersConfig kube.ClustersConfig
 }
 
 func NewPluginsServer(serveOpts ServeOptions, registrar grpc.ServiceRegistrar, gwArgs gwHandlerArgs) (*pluginsServer, error) {
@@ -79,6 +82,13 @@ func NewPluginsServer(serveOpts ServeOptions, registrar grpc.ServiceRegistrar, g
 	}
 
 	ps := &pluginsServer{}
+
+	// get the parsed kube.ClustersConfig from the serveOpts
+	clustersConfig, err := getClustersConfigFromServeOpts(serveOpts)
+	if err != nil {
+		return nil, err
+	}
+	ps.clustersConfig = clustersConfig
 
 	pluginDetails, err := ps.registerPlugins(pluginPaths, registrar, gwArgs, serveOpts)
 	if err != nil {
@@ -111,7 +121,7 @@ func (s *pluginsServer) GetConfiguredPlugins(ctx context.Context, in *plugins.Ge
 func (s *pluginsServer) registerPlugins(pluginPaths []string, grpcReg grpc.ServiceRegistrar, gwArgs gwHandlerArgs, serveOpts ServeOptions) ([]*plugins.Plugin, error) {
 	pluginDetails := []*plugins.Plugin{}
 
-	configGetter, err := createConfigGetter(serveOpts)
+	configGetter, err := createConfigGetter(serveOpts, s.clustersConfig)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a ClientGetter: %w", err)
 	}
@@ -148,15 +158,17 @@ func (s *pluginsServer) registerGRPC(p *plugin.Plugin, pluginDetail *plugins.Plu
 	if err != nil {
 		return fmt.Errorf("unable to lookup %q for %v: %w", grpcRegisterFunction, pluginDetail, err)
 	}
-	type grpcRegisterFunctionType = func(grpc.ServiceRegistrar, KubernetesConfigGetter) (interface{}, error)
+	type grpcRegisterFunctionType = func(grpc.ServiceRegistrar, KubernetesConfigGetter, kube.ClustersConfig) (interface{}, error)
 
 	grpcFn, ok := grpcRegFn.(grpcRegisterFunctionType)
 	if !ok {
-		var dummyFn grpcRegisterFunctionType = func(grpc.ServiceRegistrar, KubernetesConfigGetter) (interface{}, error) { return nil, nil }
+		var dummyFn grpcRegisterFunctionType = func(grpc.ServiceRegistrar, KubernetesConfigGetter, kube.ClustersConfig) (interface{}, error) {
+			return nil, nil
+		}
 		return fmt.Errorf("unable to use %q in plugin %v due to mismatched signature.\nwant: %T\ngot: %T", grpcRegisterFunction, pluginDetail, dummyFn, grpcRegFn)
 	}
 
-	server, err := grpcFn(registrar, clientGetter)
+	server, err := grpcFn(registrar, clientGetter, s.clustersConfig)
 	if err != nil {
 		return fmt.Errorf("plug-in %q failed to register due to: %v", pluginDetail, err)
 	} else if server == nil {
@@ -259,9 +271,8 @@ func listSOFiles(fsys fs.FS, pluginDirs []string) ([]string, error) {
 // createConfigGetter returns a function closure for creating the k8s config to interact with the cluster.
 // The returned function utilizes the user credential present in the request context.
 // The plugins just have to call this function passing the context in order to retrieve the configured k8s client
-func createConfigGetter(serveOpts ServeOptions) (KubernetesConfigGetter, error) {
+func createConfigGetter(serveOpts ServeOptions, clustersConfig kube.ClustersConfig) (KubernetesConfigGetter, error) {
 	var restConfig *rest.Config
-	var clustersConfig kube.ClustersConfig
 	var err error
 
 	if serveOpts.UnsafeLocalDevKubeconfig {
@@ -282,12 +293,6 @@ func createConfigGetter(serveOpts ServeOptions) (KubernetesConfigGetter, error) 
 		if err != nil {
 			return nil, fmt.Errorf("unable to get inClusterConfig: %w", err)
 		}
-	}
-
-	// get the parsed kube.ClustersConfig from the serveOpts
-	clustersConfig, err = getClustersConfigFromServeOpts(serveOpts)
-	if err != nil {
-		return nil, err
 	}
 
 	// return the closure fuction that takes the context, but preserving the required scope,


### PR DESCRIPTION
### Description of the change

This PR updates the GRPC registration function for plugins so that it receives the clusters configuration. This enables plugins to make decisions based on the clusters configuration, which is required for the Helm plugin as it behaves slightly differently for the cluster on which Kubeapps is installed.
Even though the Helm plugin only requires the kubeapps cluster name, I've passed the complete config for generality... perhaps we should just pass the kubeapps cluster name for now (though that makes assumptions about other plugins later needs).

It then updates the Helm plugin so that:

 * Requests for packages available in a namespace of other clusters only ever returns the global available packages (ie. those from the kubeapps namespace on the kubeapps cluster), and
 * Requests for installed packages on a cluster (or namespace of a cluster) use the config for that cluster.

Example, after installing apache on the second cluster:

```
grpcurl -H "$auth_header" -plaintext -d '{"context": {"cluster": "second-cluster", "namespace": "default"}}' localhost:8080 kubeappsapis.plugins.helm.packages.v1alpha1.HelmPackagesService.GetInstalledPackageSummaries
{
  "installedPackageSummaries": [
    {
      "installedPackageRef": {
        "context": {
          "cluster": "second-cluster",
          "namespace": "default"
        },
        "identifier": "apache-second-cluster"
      },
      "name": "apache-second-cluster",
      "pkgVersionReference": {
        "version": "8.6.0"
      },
      "currentPkgVersion": "8.6.0",
      "currentAppVersion": "2.4.48",
      "iconUrl": "https://bitnami.com/assets/stacks/apache/img/apache-stack-220x234.png",
      "pkgDisplayName": "apache",
      "shortDescription": "Chart for Apache HTTP Server",
      "latestPkgVersion": "8.6.0",
      "status": {
        "ready": true,
        "reason": "STATUS_REASON_INSTALLED",
        "userReason": "deployed"
      }
    }
  ]
}

```

### Benefits

We can continue to support the existing multicluster functionality when using the new API.

### Possible drawbacks


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3278

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
