### PR TITLE
replicated fix previously made for create to upgrade as well

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -233,7 +233,8 @@ func upgradeRelease(cfg Config, w http.ResponseWriter, req *http.Request, params
 		returnErrMessage(err, w)
 		return
 	}
-	appRepo, caCertSecret, authSecret, err := chart.GetAppRepoAndRelatedSecrets(chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, cfg.KubeHandler, cfg.Token, cfg.Cluster, cfg.Options.KubeappsNamespace, cfg.Options.ClustersConfig.KubeappsClusterName)
+	// TODO: currently app repositories are only supported on the cluster on which Kubeapps is installed. #1982
+	appRepo, caCertSecret, authSecret, err := chart.GetAppRepoAndRelatedSecrets(chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, cfg.KubeHandler, cfg.Token, cfg.Options.ClustersConfig.KubeappsClusterName, cfg.Options.KubeappsNamespace, cfg.Options.ClustersConfig.KubeappsClusterName)
 	if err != nil {
 		returnErrMessage(fmt.Errorf("unable to get app repository %q: %v", chartDetails.AppRepositoryResourceName, err), w)
 		return


### PR DESCRIPTION
### Description of the change

The Create operation was fixed in a previous commit to allow creation of apps on a remote cluster from a global repository.
The fix was not applied to the Upgrade operation and as such upgrading an app deployed on a remote cluster was failing.

The change is applying the same fix made for Create onto Upgrade as well.

### Benefits

Upgrade of remote applications will not be possible.

### Possible drawbacks

none

### Applicable issues

Issue 3213

### Additional information

N/A