### PR TITLE
Add roadmap to Kubeapps documentation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,36 @@
+## **Kubeapps Project Roadmap**
+
+###
+
+**About this document**
+
+This document provides a link to the[ Kubeapps Project issues](https://github.com/kubeapps/kubeapps/issues) list that serves as the up to date description of items that are in the Kubeapps release pipeline. This should serve as a reference point for Kubeapps users and contributors to understand where the project is heading, and help determine if a contribution could be conflicting with a longer term plan.
+
+###
+
+**How to help?**
+
+Discussion on the roadmap can take place in threads under [Issues](https://github.com/kubeapps/kubeapps/issues). Please open and comment on an issue if you want to provide suggestions and feedback to an item in the roadmap. Please review the roadmap to avoid potential duplicated effort.
+
+###
+
+**How to add an item to the roadmap?**
+
+Please open an issue to track any initiative on the roadmap of Kubeapps (usually driven by new feature requests). We will work with and rely on our community to focus our efforts to improve Kubeapps.
+
+###
+
+**Current Roadmap**
+
+The following table includes the current roadmap for Kubeapps. If you have any questions or would like to contribute to Kubeapps, please contact by Slack on the [#Kubeapps channel](https://kubernetes.slack.com/messages/kubeapps) to discuss with our team. If you don't know where to start, we are always looking for contributors that will help us reduce technical, automation, and documentation debt. Please take the timelines & dates as proposals and goals. Priorities and requirements change based on community feedback, roadblocks encountered, community contributions, etc. If you depend on a specific item, we encourage you to contact by Slack, or help us deliver that feature by contributing to Kubeapps.
+
+Last Updated: August 2021
+Theme|Description|Timeline|
+|--|--|--|
+|Pluggable architecture |Kubeapps moves forward to define a plugin interface for further package support |Aug 2021|
+|Kubeapps API service |Description |Aug 2021|
+|UI integration for pluggable API|The UI interacts with a single service (Kubeapps APIs) for all packaging functionality|Aug 2021|
+|direct-helm plugin |The direct-Helm plugin aims at just replacing the current logic (mostly implemented by the assetsvc) to the plugin. |Aug 2021|
+|flux plugin |Description |Sep 2021|
+|kapp-controller plugin |Description |Exploring/Ongoing|
+|Improve our CI/CD systems |Description |Exploring/Ongoing|


### PR DESCRIPTION
Signed-off-by: Pepe Baena <ppbaena@gmail.com>

### Description of the change

New file to publish Kubeapps roadmap and next features to the community.

### Benefits

This should serve as a reference point for Kubeapps users and contributors to understand where the project is heading, and help determine if a contribution could be conflicting with a longer term plan.

### Possible drawbacks

If any, that we publish our planning what increases the commitment with deadlines.

### Applicable issues

  - fixes #3285 

### Additional information

N/A
