### PR TITLE
fix upgrade for charts where the optional app version not specified

### DIFF
--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -172,8 +172,7 @@ export function getAppWithUpdateInfo(
         app.chart &&
         app.chart.metadata &&
         app.chart.metadata.name &&
-        app.chart.metadata.version &&
-        app.chart.metadata.appVersion
+        app.chart.metadata.version
       ) {
         dispatch(
           getAppUpdateInfo(
@@ -182,7 +181,7 @@ export function getAppWithUpdateInfo(
             app.name,
             app.chart.metadata.name,
             app.chart.metadata.version,
-            app.chart.metadata.appVersion,
+            app.chart.metadata.appVersion ? app.chart.metadata.appVersion : "",
           ),
         );
       }

--- a/dashboard/src/shared/Chart.ts
+++ b/dashboard/src/shared/Chart.ts
@@ -78,7 +78,9 @@ export default class Chart {
   ) {
     const url = `${URL.api.charts.base(cluster, namespace)}/charts?name=${encodeURIComponent(
       name,
-    )}&version=${encodeURIComponent(version)}&appversion=${appVersion}`;
+    )}&version=${encodeURIComponent(version)}&appversion=${encodeURIComponent(
+      appVersion ? appVersion : "",
+    )}`;
     const { data } = await axiosWithAuth.get<{ data: IChart[] }>(url);
     return data.data;
   }


### PR DESCRIPTION
### Description of the change

The change is to fix upgrade of apps when the charts does not provide an app version (optional field).
One change is to ensure that "undefined" is not sent as a filter value when querying the list of matching charts.
The other change is to remove the app version as a condition to render the AppUpgrade component.


### Benefits

Upgrade of apps with charts with no app version is now possible.

### Possible drawbacks

none

### Applicable issues

- fixes  #3253

### Additional information

This is the simplest change. The UI will most likely change once the new APIs are integrated.