### PR TITLE
Update the InstalledPackageReference.Identifier for Helm.

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -677,7 +677,7 @@ func installedPkgSummaryFromRelease(r *release.Release) *corev1.InstalledPackage
 			Context: &corev1.Context{
 				Namespace: r.Namespace,
 			},
-			Identifier: r.Name,
+			Identifier: fmt.Sprintf("%s/%d", r.Name, r.Version),
 		},
 		Name: r.Name,
 		PkgVersionReference: &corev1.VersionReference{
@@ -703,9 +703,24 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.
 		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
 	}
 
+	// If the identifier is just the release name, default to fetching the latest release
+	// version (Helm will do this if the release version is 0), otherwise fetch the specific
+	// release version from the identifier.
+	identifierParts := strings.Split(identifier, "/")
+	releaseName := identifierParts[0]
+	releaseVersion := 0
+	if len(identifierParts) == 2 {
+		version, err := strconv.ParseUint(identifierParts[1], 10, 0)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "Unable to parse helm release version in %q", identifier)
+		}
+		releaseVersion = int(version)
+	}
+
 	// First grab the release.
 	getcmd := action.NewGet(actionConfig)
-	release, err := getcmd.Run(identifier)
+	getcmd.Version = releaseVersion
+	release, err := getcmd.Run(releaseName)
 	if err != nil {
 		if err == driver.ErrReleaseNotFound {
 			return nil, status.Errorf(codes.NotFound, "Unable to find Helm release %q in namespace %q: %+v", identifier, namespace, err)
@@ -716,7 +731,8 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.
 
 	// Grab the released values.
 	valuescmd := action.NewGetValues(actionConfig)
-	values, err := valuescmd.Run(identifier)
+	valuescmd.Version = releaseVersion
+	values, err := valuescmd.Run(releaseName)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Unable to get Helm release values: %v", err)
 	}
@@ -760,6 +776,13 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.
 }
 
 func installedPkgDetailFromRelease(r *release.Release, ref *corev1.InstalledPackageReference) *corev1.InstalledPackageDetail {
+	// If the request reference did not specify a helm release version, we will
+	// have fetched the most recent and want to ensure it is set for the
+	// returned detail.
+	parts := strings.Split(ref.GetIdentifier(), "/")
+	if len(parts) == 1 {
+		ref.Identifier = fmt.Sprintf("%s/%d", ref.GetIdentifier(), r.Version)
+	}
 	return &corev1.InstalledPackageDetail{
 		InstalledPackageRef: ref,
 		Name:                r.Name,


### PR DESCRIPTION
Updates the identifier to include the release version.

Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

As noted in the [missing fields comment](https://github.com/kubeapps/kubeapps/issues/3165#issuecomment-882943900), the dashboard needs to be able to present release versions for the rollback action.

Initially we thought we'd need to update the `InstalledPackageDetail` with a list of rollback versions, but this doesn't translate well to any other packaging systems (Flux allows rolling back, but not to a specific release version, just the previous one, so doesn't expose any release version, kapp_controller doesn't appear to have any concept of release revisions/versions yet).

After realising that the current dashboard simply [generates the list of rollback targets based on the current revision](https://github.com/kubeapps/kubeapps/blob/master/dashboard/src/components/AppView/AppControls/RollbackButton/RollbackDialog.tsx#L39-L42), we just need to ensure that the helm rollback action knows the current release version. And given that it's likely we'll follow suite and later update to simply allow rolling back (without specifying which release version, but just rolling back to the most recent successful one as flux does), I don't want to add it unnecessarily to the `InstalledPackageDetail`.

So, instead, this PR updates the `InstalledPackageReference` so that the plugin-specific identifier can include the release version. This is a good idea regardless since otherwise the helm plugin has no way to fetch anything other than the latest release version.

A query with an identifier without the release version will return the latest release version (with the correct identifier).

### Benefits

Two-fold:

* The dashboard can for now pull out the helm release version (though longer-term I'd suggest we support rolling back to the latest successful release version so the dashboard does not need this info at all),
* The helm plugin can now be used to fetch different release versions of a release.


### Possible drawbacks

I didn't want to change the proto here, so you'll notice in the tests that when I fetch a previous release version (that has been superseded), the status says unknown. We may want to add a more specific enum for superseded.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref #3165

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
