### PR TITLE
Ts types fix

### DIFF
--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -112,7 +112,7 @@ function getAppUpdateInfo(
   currentVersion: string,
   appVersion: string,
 ): ThunkAction<Promise<void>, IStoreState, null, AppsAction> {
-  return async (dispatch) => {
+  return async dispatch => {
     dispatch(requestAppUpdateInfo());
     try {
       const chartsInfo = await Chart.listWithFilters(
@@ -262,7 +262,7 @@ export function deployChart(
   values?: string,
   schema?: JSONSchemaType<any>,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppsAction> {
-  return async (dispatch) => {
+  return async dispatch => {
     dispatch(requestDeployApp());
     try {
       if (values && schema) {
@@ -302,7 +302,7 @@ export function upgradeApp(
   values?: string,
   schema?: JSONSchemaType<any>,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppsAction> {
-  return async (dispatch) => {
+  return async dispatch => {
     dispatch(requestUpgradeApp());
     try {
       if (values && schema) {
@@ -332,7 +332,7 @@ export function rollbackApp(
   releaseName: string,
   revision: number,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppsAction> {
-  return async (dispatch) => {
+  return async dispatch => {
     dispatch(requestRollbackApp());
     try {
       await App.rollback(cluster, namespace, releaseName, revision);

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -97,7 +97,7 @@ export function getApp(
       const app = await App.getRelease(cluster, namespace, releaseName);
       dispatch(selectApp(app));
       return app;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorApp(new FetchError(e.message)));
       return;
     }
@@ -112,7 +112,7 @@ function getAppUpdateInfo(
   currentVersion: string,
   appVersion: string,
 ): ThunkAction<Promise<void>, IStoreState, null, AppsAction> {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     dispatch(requestAppUpdateInfo());
     try {
       const chartsInfo = await Chart.listWithFilters(
@@ -146,7 +146,7 @@ function getAppUpdateInfo(
         };
       }
       dispatch(receiveAppUpdateInfo({ releaseName, updateInfo }));
-    } catch (e) {
+    } catch (e: any) {
       const updateInfo: IChartUpdateInfo = {
         error: e,
         upToDate: false,
@@ -185,7 +185,7 @@ export function getAppWithUpdateInfo(
           ),
         );
       }
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorApp(new FetchError(e.message)));
     }
   };
@@ -203,7 +203,7 @@ export function deleteApp(
       await App.delete(cluster, namespace, releaseName, purge);
       dispatch(receiveDeleteApp());
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorApp(new DeleteError(e.message)));
       return false;
     }
@@ -221,7 +221,7 @@ export function fetchApps(
       const apps = await App.listApps(cluster, ns);
       dispatch(receiveAppList(apps));
       return apps;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorApp(new FetchError(e.message)));
       return [];
     }
@@ -247,7 +247,7 @@ export function fetchAppsWithUpdateInfo(
           ),
         ),
       );
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorApp(new FetchError(e.message)));
     }
   };
@@ -262,7 +262,7 @@ export function deployChart(
   values?: string,
   schema?: JSONSchemaType<any>,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppsAction> {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     dispatch(requestDeployApp());
     try {
       if (values && schema) {
@@ -286,7 +286,7 @@ export function deployChart(
       );
       dispatch(receiveDeployApp());
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorApp(new CreateError(e.message)));
       return false;
     }
@@ -302,7 +302,7 @@ export function upgradeApp(
   values?: string,
   schema?: JSONSchemaType<any>,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppsAction> {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     dispatch(requestUpgradeApp());
     try {
       if (values && schema) {
@@ -319,7 +319,7 @@ export function upgradeApp(
       await App.upgrade(cluster, namespace, releaseName, chartNamespace, chartVersion, values);
       dispatch(receiveUpgradeApp());
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorApp(new UpgradeError(e.message)));
       return false;
     }
@@ -332,14 +332,14 @@ export function rollbackApp(
   releaseName: string,
   revision: number,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppsAction> {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     dispatch(requestRollbackApp());
     try {
       await App.rollback(cluster, namespace, releaseName, revision);
       dispatch(receiveRollbackApp());
       dispatch(getAppWithUpdateInfo(cluster, namespace, releaseName));
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorApp(new RollbackError(e.message)));
       return false;
     }

--- a/dashboard/src/actions/auth.ts
+++ b/dashboard/src/actions/auth.ts
@@ -41,7 +41,7 @@ export function authenticate(
       if (oidc) {
         dispatch(setSessionExpired(false));
       }
-    } catch (e) {
+    } catch (e: any) {
       dispatch(authenticationError(e.toString()));
     }
   };

--- a/dashboard/src/actions/catalog.ts
+++ b/dashboard/src/actions/catalog.ts
@@ -83,7 +83,7 @@ export function provision(
         filteredParams,
       );
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCatalog(e, "create"));
       return false;
     }
@@ -110,7 +110,7 @@ export function addBinding(
         filteredParams,
       );
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCatalog(e, "create"));
       return false;
     }
@@ -128,7 +128,7 @@ export function removeBinding(
     try {
       await ServiceBinding.delete(currentCluster, namespace, name);
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCatalog(e, "delete"));
       return false;
     }
@@ -145,7 +145,7 @@ export function deprovision(
     try {
       await ServiceCatalog.deprovisionInstance(currentCluster, instance);
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCatalog(e, "deprovision"));
       return false;
     }
@@ -161,7 +161,7 @@ export function sync(
     } = getState();
     try {
       await ServiceCatalog.syncBroker(kubeappsCluster, broker);
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCatalog(e, "update"));
     }
   };
@@ -178,7 +178,7 @@ export function getBindings(
     try {
       const bindingsWithSecrets = await ServiceBinding.list(kubeappsCluster, ns);
       dispatch(receiveBindingsWithSecrets(bindingsWithSecrets));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCatalog(e, "fetch"));
     }
   };
@@ -193,7 +193,7 @@ export function getBrokers(): ThunkAction<Promise<void>, IStoreState, null, Serv
     try {
       const brokers = await ServiceCatalog.getServiceBrokers(currentCluster);
       dispatch(receiveBrokers(brokers));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCatalog(e, "fetch"));
     }
   };
@@ -208,7 +208,7 @@ export function getClasses(): ThunkAction<Promise<void>, IStoreState, null, Serv
     try {
       const classes = await ServiceCatalog.getServiceClasses(currentCluster);
       dispatch(receiveClasses(classes));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCatalog(e, "fetch"));
     }
   };
@@ -225,7 +225,7 @@ export function getInstances(
     try {
       const instances = await ServiceInstance.list(currentCluster, ns);
       dispatch(receiveInstances(instances));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCatalog(e, "fetch"));
     }
   };
@@ -240,7 +240,7 @@ export function getPlans(): ThunkAction<Promise<void>, IStoreState, null, Servic
     try {
       const plans = await ServiceCatalog.getServicePlans(currentCluster);
       dispatch(receivePlans(plans));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCatalog(e, "fetch"));
     }
   };

--- a/dashboard/src/actions/charts.ts
+++ b/dashboard/src/actions/charts.ts
@@ -111,7 +111,7 @@ export function fetchCharts(
           totalPages: response.meta.totalPages,
         }),
       );
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorChart(new FetchError(e.message)));
     }
   };
@@ -128,7 +128,7 @@ export function fetchChartCategories(
       if (categories) {
         dispatch(receiveChartCategories(categories));
       }
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorChartCatetories(new FetchError(e.message)));
     }
   };
@@ -147,7 +147,7 @@ export function fetchChartVersions(
         dispatch(receiveChartVersions(versions));
       }
       return versions;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorChart(new FetchError(e.message)));
       return [];
     }
@@ -162,7 +162,7 @@ async function getChart(cluster: string, namespace: string, id: string, version:
     try {
       values = await Chart.getValues(cluster, namespace, id, version);
       schema = await Chart.getSchema(cluster, namespace, id, version);
-    } catch (e) {
+    } catch (e: any) {
       if (e.constructor !== NotFoundError) {
         throw e;
       }
@@ -184,7 +184,7 @@ export function getChartVersion(
       if (chartVersion) {
         dispatch(selectChartVersion(chartVersion, values, schema));
       }
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorChart(new FetchError(e.message)));
     }
   };
@@ -203,7 +203,7 @@ export function getDeployedChartVersion(
       if (chartVersion) {
         dispatch(receiveDeployedChartVersion(chartVersion, values, schema));
       }
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorChart(new FetchError(e.message)));
     }
   };
@@ -245,7 +245,7 @@ export function getChartReadme(
     try {
       const readme = await Chart.getReadme(cluster, namespace, id, version);
       dispatch(selectReadme(readme));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorReadme(e.toString()));
     }
   };

--- a/dashboard/src/actions/config.ts
+++ b/dashboard/src/actions/config.ts
@@ -25,7 +25,7 @@ export function getConfig(): ThunkAction<Promise<void>, IStoreState, null, Confi
     try {
       const config = await Config.getConfig();
       dispatch(receiveConfig(config));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorConfig(e));
     }
   };
@@ -40,7 +40,7 @@ export function getTheme(): ThunkAction<Promise<void>, IStoreState, null, Config
       const theme = Config.getTheme(config);
       Config.setTheme(theme);
       dispatch(receiveTheme(theme));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorConfig(e));
     }
   };

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -77,7 +77,7 @@ export function getResourceKinds(
       const groups = await Kube.getAPIGroups(cluster);
       const kinds = await Kube.getResourceKinds(cluster, groups);
       dispatch(receiveResourceKinds(kinds));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(receiveKindsError(e));
     }
   };
@@ -108,7 +108,7 @@ export function getResource(
     try {
       const r = await ref.getResource();
       dispatch(receiveResource({ key, resource: r as IResource }));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(receiveResourceError({ key, error: e }));
     }
   };

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -69,7 +69,7 @@ export function fetchNamespaces(
       }
       dispatch(receiveNamespaces(cluster, namespaceStrings));
       return namespaceStrings;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorNamespaces(cluster, e, "list"));
       return [];
     }
@@ -86,7 +86,7 @@ export function createNamespace(
       dispatch(postNamespace(cluster, ns));
       dispatch(fetchNamespaces(cluster));
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorNamespaces(cluster, e, "create"));
       return false;
     }
@@ -103,7 +103,7 @@ export function getNamespace(
       const namespace = await Namespace.get(cluster, ns);
       dispatch(receiveNamespace(cluster, namespace));
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorNamespaces(cluster, e, "get"));
       return false;
     }
@@ -127,7 +127,7 @@ export function canCreate(
     try {
       const allowed = await Kube.canI(cluster, "", "namespaces", "create", "");
       dispatch(setAllowCreate(cluster, allowed));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorNamespaces(cluster, e, "get"));
     }
   };

--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -151,7 +151,7 @@ export function checkOLMInstalled(
         dispatch(OLMInstalled());
       }
       return installed;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorOLMCheck(e));
       return false;
     }
@@ -168,7 +168,7 @@ export function getOperators(
       const operators = await Operators.getOperators(cluster, namespace);
       const sortedOp = operators.sort((o1, o2) => (o1.metadata.name > o2.metadata.name ? 1 : -1));
       dispatch(receiveOperators(sortedOp));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorOperators(e));
     }
   };
@@ -184,7 +184,7 @@ export function getOperator(
     try {
       const operator = await Operators.getOperator(cluster, namespace, operatorName);
       dispatch(receiveOperator(operator));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorOperators(e));
     }
   };
@@ -201,7 +201,7 @@ export function getCSVs(
       const sortedCSVs = csvs.sort((o1, o2) => (o1.metadata.name > o2.metadata.name ? 1 : -1));
       dispatch(receiveCSVs(sortedCSVs));
       return sortedCSVs;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCSVs(e));
       return [];
     }
@@ -219,7 +219,7 @@ export function getCSV(
       const csv = await Operators.getCSV(cluster, namespace, name);
       dispatch(receiveCSV(csv));
       return csv;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorCSVs(e));
       return;
     }
@@ -239,7 +239,7 @@ export function createResource(
       const r = await Operators.createResource(cluster, namespace, apiVersion, resource, body);
       dispatch(resourceCreated(r));
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorResourceCreate(e));
       return false;
     }
@@ -264,7 +264,7 @@ export function deleteResource(
       );
       dispatch(resourceDeleted());
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorResourceDelete(e));
       return false;
     }
@@ -292,7 +292,7 @@ export function updateResource(
       );
       dispatch(resourceUpdated(r));
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorResourceUpdate(e));
       return false;
     }
@@ -326,7 +326,7 @@ export function getResources(
             plural,
           );
           resources = resources.concat(csvResources.items);
-        } catch (e) {
+        } catch (e: any) {
           dispatch(errorCustomResource(e));
         }
       });
@@ -361,7 +361,7 @@ export function getResource(
             resourceName,
           );
           dispatch(receiveCustomResource(resource));
-        } catch (e) {
+        } catch (e: any) {
           dispatch(errorCustomResource(e));
         }
       } else {
@@ -398,7 +398,7 @@ export function createOperator(
       );
       dispatch(operatorCreated(r));
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorOperatorCreate(e));
       return false;
     }
@@ -421,7 +421,7 @@ export function listSubscriptions(
       }
       dispatch(receiveSubscriptions(items));
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorSubscriptionList(e));
       return false;
     }

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -151,7 +151,7 @@ export const resyncRepo = (
 export const resyncAllRepos = (
   repos: IAppRepositoryKey[],
 ): ThunkAction<Promise<void>, IStoreState, null, AppReposAction> => {
-  return async (dispatch) => {
+  return async dispatch => {
     repos.forEach(repo => {
       dispatch(resyncRepo(repo.name, repo.namespace));
     });

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -125,7 +125,7 @@ export const deleteRepo = (
     try {
       await AppRepository.delete(currentCluster, namespace, name);
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorRepos(e, "delete"));
       return false;
     }
@@ -142,7 +142,7 @@ export const resyncRepo = (
     } = getState();
     try {
       await AppRepository.resync(currentCluster, namespace, name);
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorRepos(e, "update"));
     }
   };
@@ -151,7 +151,7 @@ export const resyncRepo = (
 export const resyncAllRepos = (
   repos: IAppRepositoryKey[],
 ): ThunkAction<Promise<void>, IStoreState, null, AppReposAction> => {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     repos.forEach(repo => {
       dispatch(resyncRepo(repo.name, repo.namespace));
     });
@@ -169,7 +169,7 @@ export const fetchRepoSecret = (
     try {
       const secret = await Secret.get(currentCluster, namespace, name);
       dispatch(receiveReposSecret(secret));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorRepos(e, "fetch"));
     }
   };
@@ -198,7 +198,7 @@ export const fetchRepos = (
         totalRepos = uniqBy(totalRepos.concat(globalRepos.items), "metadata.uid");
         dispatch(receiveRepos(totalRepos));
       }
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorRepos(e, "fetch"));
     }
   };
@@ -255,7 +255,7 @@ export const installRepo = (
       dispatch(addedRepo(data.appRepository));
 
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorRepos(e, "create"));
       return false;
     }
@@ -320,7 +320,7 @@ export const updateRepo = (
         }
       }
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorRepos(e, "update"));
       return false;
     }
@@ -363,7 +363,7 @@ export const validateRepo = (
         dispatch(errorRepos(new Error(JSON.stringify(data)), "validate"));
         return false;
       }
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorRepos(e, "validate"));
       return false;
     }
@@ -376,14 +376,14 @@ export function checkChart(
   repo: string,
   chartName: string,
 ): ThunkAction<Promise<boolean>, IStoreState, null, AppReposAction> {
-  return async (dispatch, getState) => {
+  return async dispatch => {
     dispatch(requestRepo());
     const appRepository = await AppRepository.get(cluster, repoNamespace, repo);
     try {
       await Chart.fetchChartVersions(cluster, repoNamespace, `${repo}/${chartName}`);
       dispatch(receiveRepo(appRepository));
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(
         errorChart(new NotFoundError(`Chart ${chartName} not found in the repository ${repo}.`)),
       );
@@ -410,7 +410,7 @@ export function fetchImagePullSecrets(
         "type=kubernetes.io/dockerconfigjson",
       );
       dispatch(receiveImagePullSecrets(secrets.items));
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorRepos(e, "fetch"));
     }
   };
@@ -440,7 +440,7 @@ export function createDockerRegistrySecret(
       );
       dispatch(createImagePullSecret(secret));
       return true;
-    } catch (e) {
+    } catch (e: any) {
       dispatch(errorRepos(e, "fetch"));
       return false;
     }

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -263,21 +263,21 @@ export function AppRepoForm(props: IAppRepoFormProps) {
     setOCIRepositories(e.target.value);
     setValidated(undefined);
   };
-  const handleSkipTLSChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSkipTLSChange = (_e: React.ChangeEvent<HTMLInputElement>) => {
     setSkipTLS(!skipTLS);
     setValidated(undefined);
   };
-  const handlePassCredentialsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handlePassCredentialsChange = (_e: React.ChangeEvent<HTMLInputElement>) => {
     setPassCredentials(!passCredentials);
     setValidated(undefined);
   };
   const handleFilterNames = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setFilterNames(e.target.value);
   };
-  const handleFilterRegex = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFilterRegex = (_e: React.ChangeEvent<HTMLInputElement>) => {
     setFilterRegex(!filterRegex);
   };
-  const handleFilterExclude = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFilterExclude = (_e: React.ChangeEvent<HTMLInputElement>) => {
     setFilterExclude(!filterExclude);
   };
 
@@ -292,7 +292,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
       if (parsedMessage.code && parsedMessage.message) {
         message = `Code: ${parsedMessage.code}. Message: ${parsedMessage.message}`;
       }
-    } catch (e) {
+    } catch (e: any) {
       // Not a json message
     }
     return message;

--- a/dashboard/src/components/FilterGroup/FilterGroup.test.tsx
+++ b/dashboard/src/components/FilterGroup/FilterGroup.test.tsx
@@ -18,7 +18,7 @@ it("renders a multicheckbox", () => {
 
 it("calls onChange function", () => {
   const currentFilters: string[] = [];
-  const onAddFilter = jest.fn((n, f) => currentFilters.push(f));
+  const onAddFilter = jest.fn((_n, f) => currentFilters.push(f));
   const onRemoveFilter = jest.fn();
   const wrapper = mountWrapper(
     defaultStore,

--- a/dashboard/src/components/LoginForm/LoginForm.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.test.tsx
@@ -156,7 +156,7 @@ describe("oauth login form", () => {
     const props2 = {
       ...props,
       checkCookieAuthentication: jest.fn().mockReturnValue({
-        then: jest.fn(f => false),
+        then: jest.fn(() => false),
       }),
     };
     const wrapper = mountWrapper(defaultStore, <LoginForm {...props2} />);

--- a/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
+++ b/dashboard/src/components/OperatorInstanceForm/OperatorInstanceForm.tsx
@@ -166,7 +166,6 @@ export default function DeploymentFormBody({
             <p>{crd?.description}</p>
             <OperatorInstanceFormBody
               isFetching={isFetching}
-              namespace={namespace}
               handleDeploy={handleDeploy}
               defaultValues={defaultValues}
             />

--- a/dashboard/src/components/OperatorInstanceFormBody/OperatorInstanceFormBody.test.tsx
+++ b/dashboard/src/components/OperatorInstanceFormBody/OperatorInstanceFormBody.test.tsx
@@ -8,7 +8,6 @@ import OperatorInstanceFormBody, { IOperatorInstanceFormProps } from "./Operator
 
 const defaultProps: IOperatorInstanceFormProps = {
   isFetching: false,
-  namespace: "kubeapps",
   handleDeploy: jest.fn(),
   defaultValues: "",
 };

--- a/dashboard/src/components/OperatorInstanceFormBody/OperatorInstanceFormBody.tsx
+++ b/dashboard/src/components/OperatorInstanceFormBody/OperatorInstanceFormBody.tsx
@@ -13,7 +13,6 @@ import LoadingWrapper from "../LoadingWrapper";
 
 export interface IOperatorInstanceFormProps {
   isFetching: boolean;
-  namespace: string;
   handleDeploy: (resource: IResource) => void;
   defaultValues: string;
   deployedValues?: string;
@@ -29,7 +28,6 @@ export interface IOperatorInstanceFormBodyState {
 function DeploymentFormBody({
   defaultValues,
   isFetching,
-  namespace,
   handleDeploy,
   deployedValues,
 }: IOperatorInstanceFormProps) {
@@ -59,7 +57,7 @@ function DeploymentFormBody({
     let resource: any = {};
     try {
       resource = yaml.load(values);
-    } catch (e) {
+    } catch (e: any) {
       setParseError(new Error(`Unable to parse the given YAML. Got: ${e.message}`));
       return;
     }

--- a/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.tsx
+++ b/dashboard/src/components/OperatorInstanceUpdateForm/OperatorInstanceUpdateForm.tsx
@@ -114,7 +114,6 @@ function OperatorInstanceUpdateForm({
             <p>{crd?.description}</p>
             <OperatorInstanceFormBody
               isFetching={isFetching}
-              namespace={namespace}
               handleDeploy={handleDeploy}
               defaultValues={defaultValues}
               deployedValues={currentValues}

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.tsx
@@ -12,7 +12,7 @@ interface IAccessURLTableContainerProps {
   ingressRefs: ResourceRef[];
 }
 
-function mapStateToProps({ kube, config }: IStoreState, props: IAccessURLTableContainerProps) {
+function mapStateToProps({ kube }: IStoreState, props: IAccessURLTableContainerProps) {
   // Extract the Services and Ingresses form the Redux state using the keys for
   // each ResourceRef.
   return {

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.ts
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.ts
@@ -15,7 +15,7 @@ interface IApplicationStatusContainerProps {
   info?: hapi.release.IInfo;
 }
 
-function mapStateToProps({ kube, config }: IStoreState, props: IApplicationStatusContainerProps) {
+function mapStateToProps({ kube }: IStoreState, props: IApplicationStatusContainerProps) {
   const { deployRefs, statefulsetRefs, daemonsetRefs, info } = props;
   return {
     deployments: filterByResourceRefs(deployRefs, kube.items),

--- a/dashboard/src/containers/ErrorBoundaryContainer/ErrorBoundaryContainer.ts
+++ b/dashboard/src/containers/ErrorBoundaryContainer/ErrorBoundaryContainer.ts
@@ -7,7 +7,7 @@ interface IErrorBoundaryProps {
 }
 
 function mapStateToProps(
-  { clusters: { currentCluster, clusters }, config }: IStoreState,
+  { clusters: { currentCluster, clusters } }: IStoreState,
   { children }: IErrorBoundaryProps,
 ) {
   const cluster = clusters[currentCluster];

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -16,7 +16,6 @@ const makeStore = (
   authenticating: boolean,
   oidcAuthenticated: boolean,
   authenticationError: string,
-  _defaultNamespace: string,
   authProxyEnabled: boolean,
   oauthLoginURI: string,
 ) => {
@@ -70,7 +69,6 @@ describe("LoginFormContainer props", () => {
       true,
       true,
       "It's a trap",
-      "",
       authProxyEnabled,
       "/myoauth/start",
     );
@@ -92,7 +90,6 @@ describe("LoginFormContainer props", () => {
       true,
       true,
       "It's a trap",
-      "",
       authProxyEnabled,
       "/myoauth/start",
     );

--- a/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
+++ b/dashboard/src/containers/LoginFormContainer/LoginFormContainer.test.tsx
@@ -16,7 +16,7 @@ const makeStore = (
   authenticating: boolean,
   oidcAuthenticated: boolean,
   authenticationError: string,
-  defaultNamespace: string,
+  _defaultNamespace: string,
   authProxyEnabled: boolean,
   oauthLoginURI: string,
 ) => {

--- a/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
+++ b/dashboard/src/containers/OperatorInstanceViewContainer/OperatorInstanceViewContainer.tsx
@@ -16,7 +16,7 @@ interface IRouteProps {
   };
 }
 function mapStateToProps(
-  { apps, clusters: { currentCluster, clusters }, config, operators }: IStoreState,
+  { clusters: { currentCluster, clusters }, config, operators }: IStoreState,
   { match: { params } }: IRouteProps,
 ) {
   return {

--- a/dashboard/src/containers/RoutesContainer/RoutesContainer.tsx
+++ b/dashboard/src/containers/RoutesContainer/RoutesContainer.tsx
@@ -3,7 +3,7 @@ import { withRouter } from "react-router";
 import { IStoreState } from "shared/types";
 import Routes from "./Routes";
 
-function mapStateToProps({ auth, clusters: { currentCluster, clusters }, config }: IStoreState) {
+function mapStateToProps({ auth, clusters: { currentCluster, clusters } }: IStoreState) {
   return {
     cluster: currentCluster,
     currentNamespace: clusters[currentCluster].currentNamespace,

--- a/dashboard/src/reducers/apps.test.ts
+++ b/dashboard/src/reducers/apps.test.ts
@@ -22,7 +22,7 @@ describe("appsReducer", () => {
 
   describe("reducer actions", () => {
     it("sets isFetching when requesting an app", () => {
-      [true, false].forEach(e => {
+      [true, false].forEach(_e => {
         expect(
           appsReducer(undefined, {
             type: actionTypes.requestApps as any,

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -53,7 +53,7 @@ describe("Auth", () => {
         let err = null;
         try {
           await Auth.validateToken("default", "foo");
-        } catch (e) {
+        } catch (e: any) {
           err = e;
         } finally {
           expect(err).toEqual(testCase.expectedError);

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -61,7 +61,7 @@ export class Auth {
       await Axios.get(url.api.k8s.base(cluster) + "/", {
         headers: { Authorization: `Bearer ${token}` },
       });
-    } catch (e) {
+    } catch (e: any) {
       const res = e.response as AxiosResponse;
       if (res.status === 401) {
         throw new Error("invalid token");
@@ -110,7 +110,7 @@ export class Auth {
   public static async isAuthenticatedWithCookie(cluster: string): Promise<boolean> {
     try {
       await Axios.get(url.api.k8s.base(cluster) + "/");
-    } catch (e) {
+    } catch (e: any) {
       const response = e.response as AxiosResponse;
       // The only error response which can possibly mean we did authenticate is
       // a 403 from the k8s api server (ie. we got through to k8s api server

--- a/dashboard/src/shared/AxiosInstance.ts
+++ b/dashboard/src/shared/AxiosInstance.ts
@@ -91,7 +91,7 @@ export function addErrorHandling(axiosInstance: AxiosInstance, store: Store<ISto
                   .join("; ")}`,
               ),
             );
-          } catch (e) {
+          } catch (e: any) {
             // Subcase 4:
             //   A non-parseable 403 error.
             //   Do not require reauthentication and display error (ie. edge cases of proxy auth)

--- a/dashboard/src/shared/ClusterServiceClass.ts
+++ b/dashboard/src/shared/ClusterServiceClass.ts
@@ -43,7 +43,7 @@ export class ClusterServiceClass {
     return data;
   }
 
-  public static async list(cluster: string, namespace?: string): Promise<IClusterServiceClass[]> {
+  public static async list(cluster: string): Promise<IClusterServiceClass[]> {
     const instances = await ServiceCatalog.getItems<IClusterServiceClass>(
       cluster,
       "serviceinstances",

--- a/dashboard/src/shared/Config.test.ts
+++ b/dashboard/src/shared/Config.test.ts
@@ -62,7 +62,7 @@ describe("Themes", () => {
   it("returns the default browser theme", () => {
     Object.defineProperty(window, "matchMedia", {
       writable: true,
-      value: jest.fn().mockImplementation(query => ({
+      value: jest.fn().mockImplementation(() => ({
         matches: true,
       })),
     });
@@ -79,7 +79,7 @@ describe("Themes", () => {
     // Browser preference = dark
     Object.defineProperty(window, "matchMedia", {
       writable: true,
-      value: jest.fn().mockImplementation(query => ({
+      value: jest.fn().mockImplementation(() => ({
         matches: true,
       })),
     });
@@ -93,7 +93,7 @@ describe("Themes", () => {
     // Browser preference = dark
     Object.defineProperty(window, "matchMedia", {
       writable: true,
-      value: jest.fn().mockImplementation(query => ({
+      value: jest.fn().mockImplementation(() => ({
         matches: true,
       })),
     });
@@ -107,7 +107,7 @@ describe("Themes", () => {
     // Browser preference = dark
     Object.defineProperty(window, "matchMedia", {
       writable: true,
-      value: jest.fn().mockImplementation(query => ({
+      value: jest.fn().mockImplementation(() => ({
         matches: true,
       })),
     });

--- a/dashboard/src/shared/I18n.ts
+++ b/dashboard/src/shared/I18n.ts
@@ -37,7 +37,7 @@ export default class I18n {
         throw new Error("Empty custom locale");
       }
       return { locale: lang, messages: customMessages };
-    } catch (err) {
+    } catch (e: any) {
       if (lang && ISupportedLangs[lang]) {
         return this.getConfig(lang);
       } else {

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -144,7 +144,7 @@ export class Kube {
         namespace,
       });
       return data?.allowed ? data.allowed : false;
-    } catch (err) {
+    } catch (e: any) {
       return false;
     }
   }

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -32,8 +32,8 @@ export default class Namespace {
         url.api.k8s.namespace(cluster, namespace),
       );
       return data;
-    } catch (err) {
-      switch (err.constructor) {
+    } catch (e: any) {
+      switch (e.constructor) {
         case ForbiddenError:
           throw new ForbiddenError(
             `You don't have sufficient permissions to use the namespace ${namespace}`,
@@ -41,7 +41,7 @@ export default class Namespace {
         case NotFoundError:
           throw new NotFoundError(`Namespace ${namespace} not found. Create it before using it.`);
         default:
-          throw err;
+          throw e;
       }
     }
   }
@@ -55,7 +55,7 @@ function parseStoredNS() {
   let parsedNS = {};
   try {
     parsedNS = JSON.parse(ns);
-  } catch (e) {
+  } catch (e: any) {
     // The stored value should be a json object, if not, ignore it
   }
   return parsedNS;

--- a/dashboard/src/shared/ServiceBinding.ts
+++ b/dashboard/src/shared/ServiceBinding.ts
@@ -103,7 +103,7 @@ export class ServiceBinding {
           .then(response => {
             return { binding, secret: response.data };
           })
-          .catch(err => {
+          .catch(() => {
             // return with undefined secrets
             return { binding };
           });

--- a/dashboard/src/shared/ServiceCatalog.ts
+++ b/dashboard/src/shared/ServiceCatalog.ts
@@ -34,7 +34,7 @@ export class ServiceCatalog {
       },
       {
         headers: { "Content-Type": "application/merge-patch+json" },
-        validateStatus: statusCode => true,
+        validateStatus: () => true,
       },
     );
     return data;
@@ -44,7 +44,7 @@ export class ServiceCatalog {
     try {
       const { status } = await axiosWithAuth.get(this.endpoint(cluster));
       return status === 200;
-    } catch (err) {
+    } catch (e: any) {
       return false;
     }
   }

--- a/dashboard/src/shared/jq.ts
+++ b/dashboard/src/shared/jq.ts
@@ -14,7 +14,7 @@ export function toFilterRule(
       acc[`$var${i}`] = n;
       return acc;
     }, {});
-    const jq = namesArray.map((v, i) => `.name == $var${i}`).join(" or ");
+    const jq = namesArray.map((_v, i) => `.name == $var${i}`).join(" or ");
     filter = { jq, variables };
   }
   if (exclude) {

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,30 +1,48 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
-    "outDir": "build/dist",
-    "module": "esnext",
-    "target": "es6",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "sourceMap": true,
-    "allowJs": true,
-    "jsx": "react-jsx",
-    "moduleResolution": "node",
-    "rootDir": "src",
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "strict": true,
-    "noFallthroughCasesInSwitch": true
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+    /* Language and Environment */
+    "jsx": "react-jsx", /* Specify what JSX code is generated. */
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ], /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "es6", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    /* Modules */
+    "baseUrl": "src", /* Specify the base directory to resolve non-relative module names. */
+    "module": "esnext", /* Specify what module code is generated. */
+    "moduleResolution": "node", /* Specify how TypeScript looks up a file from a given module specifier. */
+    "resolveJsonModule": true, /* Enable importing .json files */
+    "rootDir": "src", /* Specify the root folder within your source files. */
+    /* JavaScript Support */
+    "allowJs": true, /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    /* Emit */
+    "noEmit": true, /* Disable emitting files from a compilation. */
+    "outDir": "build/dist", /* Specify an output folder for all emitted files. */
+    "removeComments": true, /* Disable emitting comments. */
+    "sourceMap": true, /* Create source map files for emitted JavaScript files. */
+    /* Interop Constraints */
+    "allowSyntheticDefaultImports": true, /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
+    "isolatedModules": true, /* Ensure that each file can be safely transpiled without relying on other imports. */
+    /* Type Checking */
+    "noFallthroughCasesInSwitch": true, /* Enable error reporting for fallthrough cases in switch statements. */
+    "noImplicitAny": true, /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    "noImplicitReturns": true, /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    "noImplicitThis": true, /* Enable error reporting when `this` is given the type `any`. */
+    // "noPropertyAccessFromIndexSignature": true, /* Enforces using indexed accessors for keys declared using an indexed type */
+    "noUnusedLocals": true, /* Enable error reporting when a local variables aren't read. */
+    "noUnusedParameters": true, /* Raise an error when a function parameter isn't read */
+    "strict": true, /* Enable all strict type-checking options. */
+    "strictBindCallApply": true, /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    "strictFunctionTypes": true, /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    "strictNullChecks": true, /* When type checking, take into account `null` and `undefined`. */
+    "strictPropertyInitialization": true, /* Check for class properties that are declared but not set in the constructor. */
+    /* Completeness */
+    "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+    "suppressImplicitAnyIndexErrors": true /* Suppresses reporting the error about implicit anys when indexing into objects */
   },
   "exclude": [
     "node_modules",
@@ -35,5 +53,7 @@
     "webpack",
     "jest"
   ],
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
### Description of the change

As #3313 bumps the ts version up, it defaults the errors in `catch` statements to `unkown` instead of `any`. This PR is to explicitly use `any`.
However, I've removed a bunch of unused fields also noted by the typescript checker.
Besides, I've migrated the `tsconfig` file to the one that is autogenerated, as it includes some inline comments, useful to quickly know what's doing each option.

### Benefits

No ts errors that are preventing us from merging #3313

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A