### PR TITLE
Match ES version in ts and eslint config

### DIFF
--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -8,7 +8,7 @@
       "dom.iterable",
       "esnext"
     ], /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "target": "es6", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2020", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     /* Modules */
     "baseUrl": "src", /* Specify the base directory to resolve non-relative module names. */
     "module": "esnext", /* Specify what module code is generated. */


### PR DESCRIPTION
### Description of the change

`eslint` is using ES2020, but tsconfig was still in ES6. This PR is to make both versions match.

### Benefits

No ES versions mismatches.

### Possible drawbacks

Don't foresee any, but let CI confirm.

### Applicable issues

N/A

### Additional information

N/A
