### PR TITLE
Fix development ingress to be valid with ingress-nginx 1.0.0

### DIFF
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -23,3 +23,7 @@ ingress:
   - hosts:
     - localhost
     secretName: localhost-tls
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    # Required for ingress-nginx 1.0.0 for a valid ingress.
+    kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
### Description of the change


Tried to setup a dev env and it was not working because the ingress-nginx controller was claiming that the kubeaps ingress was invalid.

Turned out to be related to the update to use 1.0.0 of the ingress-nginx controller in our dev env, which requires the class to be set for the ingress to pass validation.

### Benefits

Dev env works again.

### Possible drawbacks


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
