### PR TITLE
Don't cache clients that are created (without auth) when app loads.

### DIFF
--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -6,7 +6,7 @@ import { KubeappsGrpcClient } from "./KubeappsGrpcClient";
 export const KUBEOPS_ROOT_URL = "api/kubeops/v1";
 export class App {
   // TODO(agamez): move to the core 'PackagesServiceClientImpl' when pagination is ready there
-  private static client = new KubeappsGrpcClient().getHelmPackagesServiceClientImpl();
+  private static client = () => new KubeappsGrpcClient().getHelmPackagesServiceClientImpl();
 
   public static async GetInstalledPackageSummaries(
     cluster: string,
@@ -14,7 +14,7 @@ export class App {
     page?: number,
     size?: number,
   ) {
-    return await this.client.GetInstalledPackageSummaries({
+    return await this.client().GetInstalledPackageSummaries({
       context: { cluster: cluster, namespace: namespace },
       paginationOptions: { pageSize: size || 0, pageToken: page?.toString() || "0" },
     });
@@ -25,7 +25,7 @@ export class App {
     namespace: string,
     releaseName: string,
   ) {
-    return await this.client.GetInstalledPackageDetail({
+    return await this.client().GetInstalledPackageDetail({
       installedPackageRef: {
         identifier: releaseName,
         context: { cluster: cluster, namespace: namespace },

--- a/dashboard/src/shared/Chart.ts
+++ b/dashboard/src/shared/Chart.ts
@@ -7,7 +7,7 @@ import { KubeappsGrpcClient } from "./KubeappsGrpcClient";
 
 export default class Chart {
   // TODO(agamez): move to the core 'PackagesServiceClientImpl' when pagination is ready there
-  private static client = new KubeappsGrpcClient().getHelmPackagesServiceClientImpl();
+  private static client = () => new KubeappsGrpcClient().getHelmPackagesServiceClientImpl();
 
   public static async getAvailablePackageSummaries(
     cluster: string,
@@ -17,7 +17,7 @@ export default class Chart {
     size: number,
     query?: string,
   ): Promise<GetAvailablePackageSummariesResponse> {
-    return await this.client.GetAvailablePackageSummaries({
+    return await this.client().GetAvailablePackageSummaries({
       context: { cluster: cluster, namespace: namespace },
       filterOptions: {
         query: query,
@@ -32,7 +32,7 @@ export default class Chart {
     namespace: string,
     id: string,
   ): Promise<GetAvailablePackageVersionsResponse> {
-    return await this.client.GetAvailablePackageVersions({
+    return await this.client().GetAvailablePackageVersions({
       availablePackageRef: {
         context: { cluster: cluster, namespace: namespace },
         identifier: id,
@@ -46,7 +46,7 @@ export default class Chart {
     id: string,
     version?: string,
   ): Promise<GetAvailablePackageDetailResponse> {
-    return await this.client.GetAvailablePackageDetail({
+    return await this.client().GetAvailablePackageDetail({
       pkgVersion: version,
       availablePackageRef: {
         context: { cluster: cluster, namespace: namespace },

--- a/dashboard/src/shared/KubeappsGrpcClient.ts
+++ b/dashboard/src/shared/KubeappsGrpcClient.ts
@@ -14,15 +14,6 @@ export class KubeappsGrpcClient {
   private grpcWebImpl!: GrpcWebImpl;
   private transport: grpc.TransportFactory;
 
-  // core apis
-  private packagesServiceClientImpl!: PackagesServiceClientImpl;
-  private pluginsServiceClientImpl!: PluginsServiceClientImpl;
-
-  // plugins package apis
-  private helmPackagesServiceClientImpl!: HelmPackagesServiceClientImpl;
-  private kappControllerPackagesServiceClientImpl!: KappControllerPackagesServiceClientImpl;
-  private fluxv2PackagesServiceClientImpl!: FluxV2PackagesServiceClientImpl;
-
   constructor(transport?: grpc.TransportFactory) {
     this.transport = transport ?? grpc.CrossBrowserHttpTransport({});
   }
@@ -49,33 +40,25 @@ export class KubeappsGrpcClient {
 
   // Core APIs
   public getPackagesServiceClientImpl() {
-    return this.packagesServiceClientImpl || new PackagesServiceClientImpl(this.getGrpcClient());
+    return new PackagesServiceClientImpl(this.getGrpcClient());
   }
 
   public getPluginsServiceClientImpl() {
-    return this.pluginsServiceClientImpl || new PluginsServiceClientImpl(this.getGrpcClient());
+    return new PluginsServiceClientImpl(this.getGrpcClient());
   }
 
   // Plugins (packages) APIs
   // TODO(agamez): ideally, these clients should be loaded automatically from a list of configured plugins
   public getHelmPackagesServiceClientImpl() {
-    return (
-      this.helmPackagesServiceClientImpl || new HelmPackagesServiceClientImpl(this.getGrpcClient())
-    );
+    return new HelmPackagesServiceClientImpl(this.getGrpcClient());
   }
 
   public getKappControllerPackagesServiceClientImpl() {
-    return (
-      this.kappControllerPackagesServiceClientImpl ||
-      new KappControllerPackagesServiceClientImpl(this.getGrpcClient())
-    );
+    return new KappControllerPackagesServiceClientImpl(this.getGrpcClient());
   }
 
   public getFluxv2PackagesServiceClientImpl() {
-    return (
-      this.fluxv2PackagesServiceClientImpl ||
-      new FluxV2PackagesServiceClientImpl(this.getGrpcClient())
-    );
+    return new FluxV2PackagesServiceClientImpl(this.getGrpcClient());
   }
 }
 


### PR DESCRIPTION
### Description of the change

One of the most difficult (yet satisfying to find the solution) bugs I've debugged in a long time :P

Our CI for the release was failing only for tests on GKE, but it turned out to be just because the GKE tests are the only ones which use token authentication.

Reproducing the issue locally was tricky at first, because it seemed to go away if you refresh the page (which explained some of the screenshots taken on CI which had errors at first, but passed on refresh).

The issue turned out to be that we were initializing the grpc clients when the app loads. Since there is no auth token present in local storage when the app loads and you're unauthenticated, the clients do not have any authentication metadata. If you re-load after authenticating, no issue. If you're configured with OIDC, this issue is not present since the metadata is added by auth-proxy for requests in-flight.

### Benefits

Tests pass when using token auth. Bug fixed when using token auth. Note that it would also mean that if you authed with one token with high privs, refreshed to have things working, logged out and logged in with a low-priv token, you'd still have a client initialized with the high prived token.

### Possible drawbacks

microseconds slower? Not sure.

### Applicable issues


### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
