### PR TITLE
Fixes #3347 by not assuming semver for app version.

### DIFF
--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -67,7 +67,7 @@ it("should add a tooltip with the chart update available", () => {
   expect(tooltip.text()).toBe("A new package version is available: 1.1.0");
 });
 
-it("should add a second label with the app update available", () => {
+it("should add a tooltip with the app update available", () => {
   const props = {
     ...defaultProps,
     app: {
@@ -79,6 +79,21 @@ it("should add a second label with the app update available", () => {
   const wrapper = mountWrapper(defaultStore, <AppListItem {...props} />);
   const tooltip = wrapper.find(Tooltip);
   expect(tooltip.text()).toBe("A new app version is available: 1.1.0");
+});
+
+it("should add a tooltip with the app update available without requiring semver versioning", () => {
+  // The AppVersion is not always required to be semver2, certainly not in Helm's Chart.yaml.
+  const props = {
+    ...defaultProps,
+    app: {
+      ...defaultProps.app,
+      latestVersion: { appVersion: "latest-crack", pkgVersion: "1.1.0" } as PackageAppVersion,
+      currentVersion: { appVersion: "1.0.0", pkgVersion: "1.0.0" } as PackageAppVersion,
+    },
+  } as IAppListItemProps;
+  const wrapper = mountWrapper(defaultStore, <AppListItem {...props} />);
+  const tooltip = wrapper.find(Tooltip);
+  expect(tooltip.text()).toBe("A new app version is available: latest-crack");
 });
 
 it("doesn't include a double v prefix", () => {

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -21,7 +21,7 @@ function AppListItem(props: IAppListItemProps) {
   if (
     app.latestVersion?.appVersion &&
     app.currentVersion?.appVersion &&
-    semver.gt(app.latestVersion?.appVersion, app.currentVersion?.appVersion)
+    app.currentVersion?.appVersion !== app.latestVersion?.appVersion
   ) {
     tooltipContent = (
       <>

--- a/dashboard/src/components/AppView/ChartInfo/ChartInfo.test.tsx
+++ b/dashboard/src/components/AppView/ChartInfo/ChartInfo.test.tsx
@@ -67,7 +67,7 @@ context("ChartUpdateInfo: when information about updates is available", () => {
       ...defaultProps.app,
       latestVersion: {
         pkgVersion: "1.0.1",
-        appVersion: "0.0.1",
+        appVersion: "10.0.0",
       },
     } as InstalledPackageDetail;
     const wrapper = mountWrapper(
@@ -76,7 +76,7 @@ context("ChartUpdateInfo: when information about updates is available", () => {
     );
     expect(wrapper.find(Alert).text()).toContain("A new package version is available: 1.0.1");
   });
-  it("renders an new version found message if the app latest version is newer", () => {
+  it("renders an new version found message if the app latest version is different", () => {
     const appWithUpdates = {
       ...defaultProps.app,
       latestVersion: {
@@ -89,5 +89,19 @@ context("ChartUpdateInfo: when information about updates is available", () => {
       <ChartInfo {...defaultProps} app={appWithUpdates} />,
     );
     expect(wrapper.find(Alert).text()).toContain("A new app version is available: 10.1.0");
+  });
+  it("renders an new version found message if the app latest version is different without being semver", () => {
+    const appWithUpdates = {
+      ...defaultProps.app,
+      latestVersion: {
+        pkgVersion: "1.0.1",
+        appVersion: "latest",
+      },
+    } as InstalledPackageDetail;
+    const wrapper = mountWrapper(
+      defaultStore,
+      <ChartInfo {...defaultProps} app={appWithUpdates} />,
+    );
+    expect(wrapper.find(Alert).text()).toContain("A new app version is available: latest");
   });
 });

--- a/dashboard/src/components/AppView/ChartInfo/ChartUpdateInfo.tsx
+++ b/dashboard/src/components/AppView/ChartInfo/ChartUpdateInfo.tsx
@@ -16,7 +16,7 @@ export default function ChartUpdateInfo({ app, cluster }: IChartInfoProps) {
   if (
     app.latestVersion?.appVersion &&
     app.currentVersion?.appVersion &&
-    semver.gt(app.latestVersion?.appVersion, app.currentVersion?.appVersion)
+    app.currentVersion?.appVersion !== app.latestVersion?.appVersion
   ) {
     // There is a new application version
     alertContent = (


### PR DESCRIPTION
### Description of the change

As per the [Helm docs for the Chart.yaml](https://helm.sh/docs/topics/charts/#the-chartyaml-file), the appVersion field is not required to be semver at all.

I wonder whether we should assume this for package version as well. For Helm it's safe, but we can't base our decisions on Helm. Furthermore, it's already enough that the backend has indicated that the latest version is different to the current version, so I can't see why we need the semver check here in the frontend even for the package version.

Let me know and I'll update to remove it there also.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3347

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
