### PR TITLE
Add a rename for auto chart sync

### DIFF
--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -64,6 +64,10 @@ replaceImage_latestToProduction() {
         targetImageEscaped="bitnami\/kubeapps-apis"
     fi
 
+    if [ $repoName == "bitnami-docker-kubeapps-kubeapps-apis" ]; then
+        repoName="bitnami-docker-kubeapps-apis"
+    fi
+
     echo "Replacing ${service}"...
 
     local curl_opts=()


### PR DESCRIPTION
I assumed I already sent this PR, but while pruning my branches it seems I didn't.

### Description of the change

This PR fixes an unnoticed rename we should perform to be able to push local chart changes to bitnami/charts again.

### Benefits

No more manual workarounds (last time I had to ssh into the circleci machine to trigger the PR :P )

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A