### PR TITLE
Update chart.RegistrySecretsPerDomain to depend on kube clientset only.

### DIFF
--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -52,12 +52,13 @@ type Options struct {
 // Config represents data needed by each handler to be able to create Helm 3 actions.
 // It cannot be created without a bearer token, so a new one must be created upon each HTTP request.
 type Config struct {
-	ActionConfig *action.Configuration
-	Options      Options
-	KubeHandler  kube.AuthHandler
-	Resolver     handlerutil.ResolverFactory
-	Cluster      string
-	Token        string
+	ActionConfig  *action.Configuration
+	Options       Options
+	KubeHandler   kube.AuthHandler
+	Resolver      handlerutil.ResolverFactory
+	Cluster       string
+	Token         string
+	userClientSet kubernetes.Interface
 }
 
 // WithHandlerConfig takes a dependentHandler and creates a regular (WithParams) handler that,
@@ -109,12 +110,13 @@ func WithHandlerConfig(storageForDriver agent.StorageForDriver, options Options)
 			}
 
 			cfg := Config{
-				Options:      options,
-				ActionConfig: actionConfig,
-				KubeHandler:  kubeHandler,
-				Cluster:      cluster,
-				Token:        token,
-				Resolver:     &handlerutil.ClientResolver{},
+				Options:       options,
+				ActionConfig:  actionConfig,
+				KubeHandler:   kubeHandler,
+				Cluster:       cluster,
+				Token:         token,
+				Resolver:      &handlerutil.ClientResolver{},
+				userClientSet: userKubeClient,
 			}
 			f(cfg, w, req, params)
 		}
@@ -199,7 +201,7 @@ func CreateRelease(cfg Config, w http.ResponseWriter, req *http.Request, params 
 	releaseName := chartDetails.ReleaseName
 	namespace := params[namespaceParam]
 	valuesString := chartDetails.Values
-	registrySecrets, err := chartUtils.RegistrySecretsPerDomain(appRepo.Spec.DockerRegistrySecrets, cfg.Cluster, appRepo.Namespace, cfg.Token, cfg.KubeHandler)
+	registrySecrets, err := chartUtils.RegistrySecretsPerDomain(req.Context(), appRepo.Spec.DockerRegistrySecrets, appRepo.Namespace, cfg.userClientSet)
 	if err != nil {
 		returnErrMessage(err, w)
 		return
@@ -245,7 +247,7 @@ func upgradeRelease(cfg Config, w http.ResponseWriter, req *http.Request, params
 		caCertSecret, authSecret,
 		cfg.Resolver.New(appRepo.Spec.Type, cfg.Options.UserAgent),
 	)
-	registrySecrets, err := chartUtils.RegistrySecretsPerDomain(appRepo.Spec.DockerRegistrySecrets, cfg.Cluster, appRepo.Namespace, cfg.Token, cfg.KubeHandler)
+	registrySecrets, err := chartUtils.RegistrySecretsPerDomain(req.Context(), appRepo.Spec.DockerRegistrySecrets, appRepo.Namespace, cfg.userClientSet)
 	if err != nil {
 		returnErrMessage(err, w)
 		return


### PR DESCRIPTION
### Description of the change

This is a spin-off change for supporting CreateInstalledPackage via the new kubeapps apis. I don't want the new kubeapps-apis to need to deal with the `kube.handler` abstraction, since our plugins don't even see the user token, nor should they need to know about them.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

The RegistrySecretsPerDomain function depends on less code.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

None known.

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - ref #3146

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
