### PR TITLE
Avoid using semver for check pkg updates

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -52,7 +52,6 @@
     "redux-thunk": "^2.3.0",
     "remark-gfm": "^2.0.0",
     "seamless-immutable": "^7.1.4",
-    "semver": "^7.3.5",
     "swagger-ui-react": "^3.52.0",
     "typesafe-actions": "^5.1.0",
     "yaml": "^1.10.2"
@@ -114,7 +113,6 @@
     "@types/react-router-hash-link": "^2.4.1",
     "@types/react-transition-group": "^4.4.2",
     "@types/redux-mock-store": "^1.0.3",
-    "@types/semver": "^7.3.8",
     "@types/swagger-ui-react": "^3.35.2",
     "enzyme": "^3.11.0",
     "eslint-config-prettier": "^8.3.0",

--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -96,6 +96,20 @@ it("should add a tooltip with the app update available without requiring semver 
   expect(tooltip.text()).toBe("A new app version is available: latest-crack");
 });
 
+it("should add a tooltip with the pkg update available without requiring semver versioning", () => {
+  const props = {
+    ...defaultProps,
+    app: {
+      ...defaultProps.app,
+      latestVersion: { appVersion: "1.0.0", pkgVersion: "latest" } as PackageAppVersion,
+      currentVersion: { appVersion: "1.0.0", pkgVersion: "1.0.0" } as PackageAppVersion,
+    },
+  } as IAppListItemProps;
+  const wrapper = mountWrapper(defaultStore, <AppListItem {...props} />);
+  const tooltip = wrapper.find(Tooltip);
+  expect(tooltip.text()).toBe("A new package version is available: latest");
+});
+
 it("doesn't include a double v prefix", () => {
   const props = {
     ...defaultProps,

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -1,6 +1,5 @@
 import Tooltip from "components/js/Tooltip";
 import { InstalledPackageSummary } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
-import * as semver from "semver";
 import helmIcon from "../../icons/helm.svg";
 import placeholder from "../../placeholder.png";
 import * as url from "../../shared/url";
@@ -31,7 +30,7 @@ function AppListItem(props: IAppListItemProps) {
   } else if (
     app.latestVersion?.pkgVersion &&
     app.currentVersion?.pkgVersion &&
-    semver.gt(app.latestVersion?.pkgVersion, app.currentVersion?.pkgVersion)
+    app.latestVersion?.pkgVersion !== app.currentVersion?.pkgVersion
   ) {
     tooltipContent = (
       <>

--- a/dashboard/src/components/AppView/ChartInfo/ChartInfo.test.tsx
+++ b/dashboard/src/components/AppView/ChartInfo/ChartInfo.test.tsx
@@ -104,4 +104,18 @@ context("ChartUpdateInfo: when information about updates is available", () => {
     );
     expect(wrapper.find(Alert).text()).toContain("A new app version is available: latest");
   });
+  it("renders an new version found message if the pkg latest version is different without being semver", () => {
+    const appWithUpdates = {
+      ...defaultProps.app,
+      latestVersion: {
+        pkgVersion: "latest",
+        appVersion: "10.0.0",
+      },
+    } as InstalledPackageDetail;
+    const wrapper = mountWrapper(
+      defaultStore,
+      <ChartInfo {...defaultProps} app={appWithUpdates} />,
+    );
+    expect(wrapper.find(Alert).text()).toContain("A new package version is available: latest");
+  });
 });

--- a/dashboard/src/components/AppView/ChartInfo/ChartUpdateInfo.tsx
+++ b/dashboard/src/components/AppView/ChartInfo/ChartUpdateInfo.tsx
@@ -2,7 +2,6 @@ import { CdsIcon } from "@cds/react/icon";
 import Alert from "components/js/Alert";
 import { InstalledPackageDetail } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { Link } from "react-router-dom";
-import * as semver from "semver";
 import { app as appURL } from "shared/url";
 
 interface IChartInfoProps {
@@ -27,7 +26,7 @@ export default function ChartUpdateInfo({ app, cluster }: IChartInfoProps) {
   } else if (
     app.latestVersion?.pkgVersion &&
     app.currentVersion?.pkgVersion &&
-    semver.gt(app.latestVersion?.pkgVersion, app.currentVersion?.pkgVersion)
+    app.latestVersion?.pkgVersion !== app.currentVersion?.pkgVersion
   ) {
     // There is a new package version
     alertContent = (

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -2458,11 +2458,6 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/semver@^7.3.8":
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
-  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
-
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"


### PR DESCRIPTION
### Description of the change

Follow-up PR from #3348. This PR is removing the `semver` for checking package updates. We should not assume every package is being semantically versionated


### Benefits

We will support any pkg versionning.

### Possible drawbacks

From now on, it is the backend package plugin that is currently in charge of returning the latest version.

### Applicable issues

N/A

### Additional information

N/A