### PR TITLE
Ensure relative path is used for kubeappsapis so any subpath is included.

### DIFF
--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -181,5 +181,5 @@ export const api = {
       `api/v1/clusters/${cluster}/namespaces/${namespace}/operator/${name}/logo`,
   },
 
-  kubeappsapis: "/apis",
+  kubeappsapis: "apis",
 };


### PR DESCRIPTION
### Description of the change

Updates the kubeappsapis URL in the dashboard to be relative like all other endpoints.

See the related #3368  for details (and the related slack conversation). Herve found that if you use a subpath, then requests are not sent to the backend apis server. This can itself be reproduced in the local dev env with the diff on the issue repro steps, and is fixed by the one-line change here (to use a relative URL path).

Whether or not there is still an issue in Herve's environment once the paths are corrected in the dashboard remains to be seen.

### Benefits

Kubeapps can be deployed on a subpath again.

### Possible drawbacks

None that I can see.

### Applicable issues

  - ref #3368 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
