### PR TITLE
Kubeapps-APIs implementation of helm create installed pkg 

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/create_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/create_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright © 2021 VMware
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreateInstalledPackage(t *testing.T) {
+	testCases := []struct {
+		name               string
+		request            *corev1.CreateInstalledPackageRequest
+		expectedResponse   *corev1.CreateInstalledPackageResponse
+		expectedStatusCode codes.Code
+	}{
+		{
+			name: "creates the installed package",
+			request: &corev1.CreateInstalledPackageRequest{
+				AvailablePackageRef: &corev1.AvailablePackageReference{
+					Context: &corev1.Context{
+						Namespace: globalPackagingNamespace,
+					},
+					Identifier: "bitnami/apache",
+				},
+				TargetContext: &corev1.Context{
+					Namespace: "default",
+				},
+				Name: "my-apache",
+				PkgVersionReference: &corev1.VersionReference{
+					Version: "1.18.3",
+				},
+			},
+			expectedResponse: &corev1.CreateInstalledPackageResponse{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Namespace: "default",
+					},
+					Identifier: "my-apache",
+				},
+			},
+			expectedStatusCode: codes.OK,
+		},
+		{
+			name: "returns invalid if available package ref invalid",
+			request: &corev1.CreateInstalledPackageRequest{
+				AvailablePackageRef: &corev1.AvailablePackageReference{
+					Context: &corev1.Context{
+						Namespace: globalPackagingNamespace,
+					},
+					Identifier: "not-a-valid-identifier",
+				},
+			},
+			expectedStatusCode: codes.InvalidArgument,
+		},
+	}
+
+	ignoredUnexported := cmpopts.IgnoreUnexported(
+		corev1.CreateInstalledPackageResponse{},
+		corev1.InstalledPackageReference{},
+	)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server, _, cleanup := makeServer(t, true, nil, &v1alpha1.AppRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bitnami",
+					Namespace: globalPackagingNamespace,
+				},
+			})
+			defer cleanup()
+
+			response, err := server.CreateInstalledPackage(context.Background(), tc.request)
+
+			if got, want := status.Code(err), tc.expectedStatusCode; got != want {
+				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
+			}
+
+			if got, want := response, tc.expectedResponse; !cmp.Equal(got, want, ignoredUnexported) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported))
+			}
+		})
+	}
+}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -23,13 +23,16 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/kubeapps/common/datastore"
+	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
 	helmv1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"github.com/kubeapps/kubeapps/pkg/agent"
+	"github.com/kubeapps/kubeapps/pkg/chart"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
+	"github.com/kubeapps/kubeapps/pkg/handlerutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -38,7 +41,10 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	corek8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	log "k8s.io/klog/v2"
@@ -311,7 +317,7 @@ func AvailablePackageSummaryFromChart(chart *models.Chart) (*corev1.AvailablePac
 func getUnescapedChartID(chartID string) (string, error) {
 	unescapedChartID, err := url.QueryUnescape(chartID)
 	if err != nil {
-		return "", status.Errorf(codes.Internal, "Unable to decode chart ID chart: %v", chartID)
+		return "", status.Errorf(codes.InvalidArgument, "Unable to decode chart ID chart: %v", chartID)
 	}
 	// TODO(agamez): support ID with multiple slashes, eg: aaa/bbb/ccc
 	chartIDParts := strings.Split(unescapedChartID, "/")
@@ -796,4 +802,142 @@ func installedPkgDetailFromRelease(r *release.Release, ref *corev1.InstalledPack
 		},
 		CustomDetail: customDetailHelm,
 	}, nil
+}
+
+func splitChartIdentifier(chartID string) (repoName, chartName string, err error) {
+	// getUnescapedChartID also ensures that there are two parts (ie. repo/chart-name only)
+	unescapedChartID, err := getUnescapedChartID(chartID)
+	if err != nil {
+		return "", "", err
+	}
+	chartIDParts := strings.Split(unescapedChartID, "/")
+	return chartIDParts[0], chartIDParts[1], nil
+}
+
+// CreateInstalledPackage creates an installed package.
+func (s *Server) CreateInstalledPackage(ctx context.Context, request *corev1.CreateInstalledPackageRequest) (*corev1.CreateInstalledPackageResponse, error) {
+	// Get the AppRepository for the available package.
+	// TODO: currently app repositories are only supported on the cluster on
+	// which Kubeapps is installed. #1982
+	chartID := request.GetAvailablePackageRef().GetIdentifier()
+	repoNamespace := request.GetAvailablePackageRef().GetContext().GetNamespace()
+	repoName, chartName, err := splitChartIdentifier(chartID)
+	chartVersion := request.GetPkgVersionReference().GetVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	log.Errorf("Got here 1")
+	// Most of the existing code that we want to reuse is based on having a typed AppRepository.
+	appRepo, caCertSecret, authSecret, err := s.getAppRepoAndRelatedSecrets(ctx, repoName, repoNamespace)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Unable to fetch app repo %q from namespace %q: %v", repoName, repoNamespace, err)
+	}
+
+	log.Errorf("Got here 2. appRepo: %+v, caCertSecret: %+v, authSecret: %+v", appRepo, caCertSecret, authSecret)
+	// Grab the chart itself
+	ch, err := handlerutil.GetChart(
+		&chart.Details{
+			AppRepositoryResourceName:      appRepo.Name,
+			AppRepositoryResourceNamespace: appRepo.Namespace,
+			ChartName:                      chartName,
+			Version:                        chartVersion,
+		},
+		appRepo,
+		caCertSecret, authSecret,
+		// TODO(minelson): add a useragent comment to kubeapps APIs and ensure it is passed
+		// through to be used here.
+		(&handlerutil.ClientResolver{}).New(appRepo.Spec.Type, "kubeapps-apis/devel"),
+	)
+
+	log.Errorf("Got here 3. chart is: %+v", ch)
+	// Create an action config for the target namespace.
+	namespace := request.GetTargetContext().GetNamespace()
+	cluster := request.GetTargetContext().GetCluster()
+	if cluster == "" {
+		cluster = s.globalPackagingCluster
+	}
+	actionConfig, err := s.actionConfigGetter(ctx, cluster, namespace)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
+	}
+
+	log.Errorf("Got here 4")
+	// We currently get app repositories on the kubeapps cluster only.
+	typedClient, _, err := s.GetClients(ctx, s.globalPackagingCluster)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Unable to create kubernetes clientset: %v", err)
+	}
+	registrySecrets, err := chart.RegistrySecretsPerDomain(ctx, appRepo.Spec.DockerRegistrySecrets, appRepo.Namespace, typedClient)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Unable to fetch registry secrets from the namespace %q: %v", appRepo.Namespace, err)
+	}
+	log.Errorf("Got here 5")
+
+	release, err := agent.CreateRelease(actionConfig, request.GetName(), namespace, request.GetValues(), ch, registrySecrets)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Unable to create helm release %q in the namespace %q: %v", request.GetName(), appRepo.Namespace, err)
+	}
+
+	log.Errorf("Got here 6")
+	return &corev1.CreateInstalledPackageResponse{
+		InstalledPackageRef: &corev1.InstalledPackageReference{
+			Context: &corev1.Context{
+				Cluster:   cluster,
+				Namespace: release.Namespace,
+			},
+			Identifier: release.Name,
+		},
+	}, nil
+}
+
+// GetAppRepoAndRelatedSecrets retrieves the given repo from its namespace
+// Depending on the repo namespace and the
+func (s *Server) getAppRepoAndRelatedSecrets(ctx context.Context, appRepoName, appRepoNamespace string) (*appRepov1.AppRepository, *corek8sv1.Secret, *corek8sv1.Secret, error) {
+
+	// We currently get app repositories on the kubeapps cluster only.
+	typedClient, dynClient, err := s.GetClients(ctx, s.globalPackagingCluster)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Using the dynamic client to get the AppRepository rather than updating the interface
+	// returned by the client getter, then converting the result back to a typed AppRepository
+	// since our existing code that we're re-using expects one.
+	gvr := schema.GroupVersionResource{
+		Group:    "kubeapps.com",
+		Version:  "v1alpha1",
+		Resource: "apprepositories",
+	}
+	appRepoUnstructured, err := dynClient.Resource(gvr).Namespace(appRepoNamespace).Get(ctx, appRepoName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to get app repository %s/%s: %v", appRepoNamespace, appRepoName, err)
+	}
+
+	var appRepo appRepov1.AppRepository
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(appRepoUnstructured.UnstructuredContent(), &appRepo)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to convert unstructured AppRepository for %s/%s to a structured AppRepository: %v", appRepoNamespace, appRepoName, err)
+	}
+
+	auth := appRepo.Spec.Auth
+	var caCertSecret *corek8sv1.Secret
+	if auth.CustomCA != nil {
+		secretName := auth.CustomCA.SecretKeyRef.Name
+		caCertSecret, err = typedClient.CoreV1().Secrets(appRepoNamespace).Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("unable to read secret %q: %v", auth.CustomCA.SecretKeyRef.Name, err)
+		}
+	}
+
+	var authSecret *corek8sv1.Secret
+	if auth.Header != nil {
+		secretName := auth.Header.SecretKeyRef.Name
+		authSecret, err = typedClient.CoreV1().Secrets(appRepoNamespace).Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("unable to read secret %q: %v", secretName, err)
+		}
+	}
+
+	return &appRepo, caCertSecret, authSecret, nil
 }

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -592,6 +592,8 @@ func isValidChart(chart *models.Chart) (bool, error) {
 func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *corev1.GetInstalledPackageSummariesRequest) (*corev1.GetInstalledPackageSummariesResponse, error) {
 	namespace := request.GetContext().GetNamespace()
 	cluster := request.GetContext().GetCluster()
+	contextMsg := fmt.Sprintf("(cluster=[%s], namespace=[%s])", cluster, namespace)
+	log.Infof("+helm GetInstalledPackageSummaries %s", contextMsg)
 	if cluster == "" {
 		cluster = s.globalPackagingCluster
 	}
@@ -710,6 +712,8 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.
 	namespace := request.GetInstalledPackageRef().GetContext().GetNamespace()
 	cluster := request.GetInstalledPackageRef().GetContext().GetCluster()
 	identifier := request.GetInstalledPackageRef().GetIdentifier()
+	contextMsg := fmt.Sprintf("(cluster=[%s], namespace=[%s])", cluster, namespace)
+	log.Infof("+helm GetInstalledPackageDetail %s, id: %q", contextMsg, identifier)
 	actionConfig, err := s.actionConfigGetter(ctx, cluster, namespace)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
@@ -818,6 +822,8 @@ func splitChartIdentifier(chartID string) (repoName, chartName string, err error
 
 // CreateInstalledPackage creates an installed package.
 func (s *Server) CreateInstalledPackage(ctx context.Context, request *corev1.CreateInstalledPackageRequest) (*corev1.CreateInstalledPackageResponse, error) {
+	contextMsg := fmt.Sprintf("(cluster=[%s], namespace=[%s])", request.GetTargetContext().GetCluster(), request.GetTargetContext().GetNamespace())
+	log.Infof("+helm CreateInstalledPackage %s", contextMsg)
 	// Get the AppRepository for the available package.
 	// TODO: currently app repositories are only supported on the cluster on
 	// which Kubeapps is installed. #1982

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/kubeapps/common/datastore"
+	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
@@ -469,13 +470,19 @@ func makeChartRowsJSON(t *testing.T, charts []*models.Chart, pageToken string, p
 }
 
 // makeServer returns a server backed with an sql mock and a cleanup function
-func makeServer(t *testing.T, authorized bool, actionConfig *action.Configuration) (*Server, sqlmock.Sqlmock, func()) {
+func makeServer(t *testing.T, authorized bool, actionConfig *action.Configuration, objects ...runtime.Object) (*Server, sqlmock.Sqlmock, func()) {
 	// Creating the dynamic client
+	scheme := runtime.NewScheme()
+	err := v1alpha1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
 	dynamicClient := dynfake.NewSimpleDynamicClientWithCustomListKinds(
-		runtime.NewScheme(),
+		scheme,
 		map[schema.GroupVersionResource]string{
 			{Group: "foo", Version: "bar", Resource: "baz"}: "PackageList",
 		},
+		objects...,
 	)
 
 	// Creating an authorized clientGetter

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	helmv1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/pkg/chart/fake"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/kubeapps/kubeapps/pkg/dbutils"
 	"google.golang.org/grpc/codes"
@@ -507,6 +508,7 @@ func makeServer(t *testing.T, authorized bool, actionConfig *action.Configuratio
 		actionConfigGetter: func(context.Context, string, string) (*action.Configuration, error) {
 			return actionConfig, nil
 		},
+		chartClientFactory: &fake.ChartClientFactory{},
 	}, mock, cleanup
 }
 


### PR DESCRIPTION
### Description of the change

Adds implementation for `CreateInstalledPackage` for the helm plugin.

```
$ grpcurl -plaintext -d '{"available_package_ref": {"context": {"namespace": "kubeapps"},"identifier": "bitnami/apache"}, "target_context": {"namespace": "default"}, "name": "apache-via-api"}' localhost:8080 kubeappsapis.plugins.helm.packages.v1alpha1.HelmPackagesService.CreateInstalledPackage
{
  "installedPackageRef": {
    "context": {
      "cluster": "default",
      "namespace": "default"
    },
    "identifier": "apache-via-api",
    "plugin": {
      "name": "helm.packages",
      "version": "v1alpha1"
    }
  }
}

$ k -n default get po
NAME                              READY   STATUS    RESTARTS   AGE
apache-via-api-6dbc85b48b-cdd56   0/1     Running   0          11s
```

### Benefits

One more piece we can switch over with the current helm support.

### Possible drawbacks

None that I'm aware of. We really should do some profiling of this function - similar to the non-kubeapps-apis version it takes a while to complete, mostly I assume because it's downloading the chart from the index, but perhaps there are other causes which we can get around (such as, it may be first downloading the index, even though we should have the URL).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Ref #3146

### Additional information

I'll follow with a PR to ensure we can set the user-agent appropriately so we don't lose stats again :)
