### PR TITLE
Chart: add support for basic authentication on initial apprepositories

### DIFF
--- a/chart/kubeapps/Chart.lock
+++ b/chart/kubeapps/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.8.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.9.4
+  version: 10.9.5
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 15.3.0
-digest: sha256:aeaec0be82187933fa9771b63d3c8bb6b82f33e0cbac6d548cfe182efda852f5
-generated: "2021-09-02T00:14:17.499728161Z"
+  version: 15.3.1
+digest: sha256:2d4b55776549e3f0ea0a32531734d311a825fed3a433ff1e3312fee1c2b04ae1
+generated: "2021-09-08T05:11:24.71302194+02:00"

--- a/chart/kubeapps/templates/apprepository/apprepositories-secret.yaml
+++ b/chart/kubeapps/templates/apprepository/apprepositories-secret.yaml
@@ -23,9 +23,9 @@ data:
   {{- end }}
   {{- $authorizationHeader := "" }}
   {{- if .authorizationHeader }}
-    {{- $authorizationHeader = .authorizationHeader | b64enc }}
+    {{- $authorizationHeader = .authorizationHeader }}
   {{- else if .basicAuth }}
-    {{- $authorizationHeader = printf "Basic %s" ((printf "%s:%s" .basicAuth.user .basicAuth.password) | b64enc) }}
+    {{- $authorizationHeader = printf "Basic %s" (printf "%s:%s" .basicAuth.user .basicAuth.password | b64enc) }}
   {{- end }}
   {{- if $authorizationHeader }}
   authorizationHeader: |-

--- a/chart/kubeapps/templates/apprepository/apprepositories-secret.yaml
+++ b/chart/kubeapps/templates/apprepository/apprepositories-secret.yaml
@@ -1,5 +1,5 @@
 {{- range .Values.apprepository.initialRepos }}
-{{- if or .caCert .authorizationHeader }}
+{{- if or .caCert .authorizationHeader .basicAuth }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,9 +21,15 @@ data:
   ca.crt: |-
     {{ .caCert | b64enc }}
   {{- end }}
+  {{- $authorizationHeader := "" }}
   {{- if .authorizationHeader }}
+    {{- $authorizationHeader = .authorizationHeader | b64enc }}
+  {{- else if .basicAuth }}
+    {{- $authorizationHeader = printf "Basic %s" ((printf "%s:%s" .basicAuth.user .basicAuth.password) | b64enc) }}
+  {{- end }}
+  {{- if $authorizationHeader }}
   authorizationHeader: |-
-    {{ .authorizationHeader | b64enc }}
+    {{ $authorizationHeader | b64enc }}
   {{- end }}
 ---
 {{/* credentials are required in the release namespace for syncer jobs */}}
@@ -45,9 +51,9 @@ data:
   ca.crt: |-
     {{ .caCert | b64enc }}
   {{- end }}
-  {{- if .authorizationHeader }}
+  {{- if $authorizationHeader }}
   authorizationHeader: |-
-    {{ .authorizationHeader | b64enc }}
+    {{ $authorizationHeader | b64enc }}
   {{- end }}
 ---
 {{- end }}

--- a/chart/kubeapps/templates/apprepository/apprepositories.yaml
+++ b/chart/kubeapps/templates/apprepository/apprepositories.yaml
@@ -45,7 +45,7 @@ spec:
       nodeSelector: {{- toYaml .nodeSelector | nindent 8 }}
       {{- end }}
   {{- end }}
-  {{- if or .caCert .authorizationHeader }}
+  {{- if or .caCert .authorizationHeader .basicAuth }}
   auth:
     {{- if .caCert }}
     customCA:
@@ -53,7 +53,7 @@ spec:
         key: ca.crt
         name: {{ printf "apprepo-%s-secrets" .name }}
     {{- end }}
-    {{- if .authorizationHeader }}
+    {{- if or .authorizationHeader .basicAuth }}
     header:
       secretKeyRef:
         key: authorizationHeader

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -706,8 +706,12 @@ apprepository:
   ##   url: https://chartmuseum.default:8080
   ##   nodeSelector:
   ##     somelabel: somevalue
-  ##   # Specify an Authorization Header if you are using an authentication method.
+  ##   # Specify an Authorization Header if you are using an authentication method:
   ##   authorizationHeader: "Bearer xrxNC..."
+  ##   # Specify the credentials if you are using a basic authentication method:
+  ##   basicAuth:
+  ##     user:
+  ##     password:
   ##   # If you're providing your own certificates, please use this to add the certificates as secrets.
   ##   # It should start with -----BEGIN CERTIFICATE----- or
   ##   # -----BEGIN RSA PRIVATE KEY-----

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -702,28 +702,28 @@ apprepository:
   ## @param apprepository.initialRepos [array] Initial chart repositories to configure
   ## e.g:
   ## initialRepos:
-  ## - name: chartmuseum
-  ##   url: https://chartmuseum.default:8080
-  ##   nodeSelector:
-  ##     somelabel: somevalue
-  ##   # Specify an Authorization Header if you are using an authentication method:
-  ##   authorizationHeader: "Bearer xrxNC..."
-  ##   # Specify the credentials if you are using a basic authentication method:
-  ##   basicAuth:
-  ##     user:
-  ##     password:
-  ##   # If you're providing your own certificates, please use this to add the certificates as secrets.
-  ##   # It should start with -----BEGIN CERTIFICATE----- or
-  ##   # -----BEGIN RSA PRIVATE KEY-----
-  ##   caCert:
-  ##   # Create this apprepository in a custom namespace
-  ##   namespace:
-  ##   # In case of an OCI registry, specify the type
-  ##   type: oci
-  ##   # And specify the list of repositories
-  ##   ociRepositories:
-  ##     - nginx
-  ##     - jenkins
+  ##   - name: chartmuseum
+  ##     url: https://chartmuseum.default:8080
+  ##     nodeSelector:
+  ##       somelabel: somevalue
+  ##     # Specify an Authorization Header if you are using an authentication method:
+  ##     authorizationHeader: "Bearer xrxNC..."
+  ##     # Specify the credentials if you are using a basic authentication method:
+  ##     basicAuth:
+  ##       user:
+  ##       password:
+  ##     # If you're providing your own certificates, please use this to add the certificates as secrets.
+  ##     # It should start with -----BEGIN CERTIFICATE----- or
+  ##     # -----BEGIN RSA PRIVATE KEY-----
+  ##     caCert:
+  ##     # Create this apprepository in a custom namespace
+  ##     namespace:
+  ##     # In case of an OCI registry, specify the type
+  ##     type: oci
+  ##     # And specify the list of repositories
+  ##     ociRepositories:
+  ##       - nginx
+  ##       - jenkins
   ##
   initialRepos:
     - name: bitnami


### PR DESCRIPTION
### Description of the change

This PR adds the ability to specify the credentials to connect to a repository, e.g.:
```bash
helm install kubeapps bitnami/kubeapps -n kubeapps --create-namespace \
  --set apprepository.initialRepos[0].name=local \
  --set apprepository.initialRepos[0].url=http://localhost \
  --set apprepository.initialRepos[0].basicAuth.user=<user> \
  --set apprepository.initialRepos[0].basicAuth.password=<password>
```