### PR TITLE
Add plugin-specific user-agent to kubeapps-apis helm plugin

### DIFF
--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /go/src/github.com/kubeapps/kubeapps
 COPY go.mod go.sum ./
 COPY pkg pkg
 COPY cmd cmd
+ARG VERSION="devel"
 
 ARG BUF_VERSION="0.52.0"
 RUN curl -sSL "https://github.com/bufbuild/buf/releases/download/v$BUF_VERSION/buf-Linux-x86_64" -o "/tmp/buf" && chmod +x "/tmp/buf"
@@ -42,6 +43,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build \
     -o /helm-packages-v1alpha1-plugin.so -buildmode=plugin \
+    -ldflags "-X main.version=$VERSION" \
     ./cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/*.go
 
 # Note: unlike the other docker images for go, we cannot use scratch as the plugins

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
@@ -26,7 +26,12 @@ import (
 
 // Set the pluginDetail once during a module init function so the single struct
 // can be used throughout the plugin.
-var pluginDetail plugins.Plugin
+var (
+	pluginDetail plugins.Plugin
+	// This version var is updated during the build (see the -ldflags option
+	// in the cmd/kubeapps-apis/Dockerfile)
+	version = "devel"
+)
 
 func init() {
 	pluginDetail = plugins.Plugin{

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -60,6 +60,7 @@ const (
 	MajorVersionsInSummary = 3
 	MinorVersionsInSummary = 3
 	PatchVersionsInSummary = 3
+	UserAgentPrefix        = "kubeapps-apis/plugins"
 )
 
 // Server implements the helm packages v1alpha1 interface.
@@ -841,6 +842,10 @@ func (s *Server) CreateInstalledPackage(ctx context.Context, request *corev1.Cre
 		return nil, status.Errorf(codes.Internal, "Unable to fetch app repo %q from namespace %q: %v", repoName, repoNamespace, err)
 	}
 
+	userAgentString := fmt.Sprintf("%s/%s/%s/%s", UserAgentPrefix, pluginDetail.Name, pluginDetail.Version, version)
+
+	log.Infof("+helm CreateInstalledPackage fetching chart %q with user-agent %q", chartID, userAgentString)
+
 	// Grab the chart itself
 	ch, err := handlerutil.GetChart(
 		&chart.Details{
@@ -851,9 +856,7 @@ func (s *Server) CreateInstalledPackage(ctx context.Context, request *corev1.Cre
 		},
 		appRepo,
 		caCertSecret, authSecret,
-		// TODO(minelson): add a useragent comment to kubeapps APIs and ensure it is passed
-		// through to be used here.
-		s.chartClientFactory.New(appRepo.Spec.Type, "kubeapps-apis/devel"),
+		s.chartClientFactory.New(appRepo.Spec.Type, userAgentString),
 	)
 
 	// Create an action config for the target namespace.


### PR DESCRIPTION
### Description of the change

Ensures that the user-agent is set when fetching the chart from the bitnami repository with with something that can be used to query access logs for all requests from the kubeapps-apis server or from specific plugins or specific versions and builds of specific plugins.

As an example, after building the image with:

```bash
$ IMAGE_TAG=dev4 VERSION=test-version-from-env make kubeapps/kubeapps-apis
```

and loading and running, I see the following in the logs when creating a new installed package:

```
I0908 03:50:27.512904       1 server.go:841] +helm CreateInstalledPackage fetching chart "bitnami/
apache" with user-agent "kubeapps-apis/plugins/helm.packages/v1alpha1/test-version-from-env"
I0908 03:50:28.960310       1 plugins.go:114] +core GetConfiguredPlugins
I0908 03:50:38.960270       1 plugins.go:114] +core GetConfiguredPlugins
2021/09/08 03:50:48 Downloading https://charts.bitnami.com/bitnami/apache-8.6.3.tgz ...
I0908 03:50:48.900042       1 plugins.go:309] +clientGetter.GetClient
```

### Benefits

We can track requests to the bitnami repository for charts using our new api server.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

  - Ref #3146 

### Additional information

Confirmed that more than 50% of the request time is actually fetching the index and then parsing it to get the specific chart URL in the index. We should instead be storing the URL for specific chart (versions) in the cache when syncing repositories, so that installing a chart doesn't first require fetching the index. This would halve this lengthy endpoint.
