### PR TITLE
Add missing dependencies for CI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,9 +116,12 @@ workflows:
           requires:
             - test_go
             - test_dashboard
+            - test_pinniped_proxy
+            - test_chart_render
             - build_go_images
             - build_dashboard
             - build_pinniped_proxy
+            - sync_chart_from_bitnami
       - sync_chart_from_bitnami:
           <<: *build_on_master
       - GKE_1_20_MASTER:
@@ -126,6 +129,8 @@ workflows:
           requires:
             - test_go
             - test_dashboard
+            - test_pinniped_proxy
+            - test_chart_render
             - build_go_images
             - build_dashboard
             - build_pinniped_proxy
@@ -135,6 +140,8 @@ workflows:
           requires:
             - test_go
             - test_dashboard
+            - test_pinniped_proxy
+            - test_chart_render
             - build_go_images
             - build_dashboard
             - build_pinniped_proxy
@@ -144,6 +151,8 @@ workflows:
           requires:
             - test_go
             - test_dashboard
+            - test_pinniped_proxy
+            - test_chart_render
             - build_go_images
             - build_dashboard
             - build_pinniped_proxy
@@ -153,6 +162,8 @@ workflows:
           requires:
             - test_go
             - test_dashboard
+            - test_pinniped_proxy
+            - test_chart_render
             - build_go_images
             - build_dashboard
             - build_pinniped_proxy
@@ -172,6 +183,7 @@ workflows:
       - release:
           <<: *build_on_tag
           requires:
+            - sync_chart_to_bitnami
             - local_e2e_tests
             - GKE_1_20_MASTER
             - GKE_1_20_LATEST_RELEASE


### PR DESCRIPTION
### Description of the change
After sketching up some diagrams, I noticed our CI has some steps wich aren't defined in the `requires` section. 

Example:
![image](https://user-images.githubusercontent.com/11535726/132515576-eefd5872-acea-40d6-985d-c7f61846d86d.png)

### Benefits

Not a real benefit, actually, but the dependencies that semantically makes sense are now defined as part of the CI config.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

It seems to me that we have to do something with the `GKE_1_XX_zzzzzz` steps. The tests there were also flaky during the past release.

I'm thinking about having a named commit that makes CirlceCI trigger this workflow, something like "prerelease" or "prepare release". This way, we can safely execute the GKE test... without tagging a commit (an action that  automatically triggers the bitnami pipeline)
