### PR TITLE
Fix text color issue in dark mode

### DIFF
--- a/dashboard/src/components/LoadingWrapper/LoadingWrapper.scss
+++ b/dashboard/src/components/LoadingWrapper/LoadingWrapper.scss
@@ -1,0 +1,3 @@
+.loadingText {
+  color: var(--cds-global-typography-color-400, #21333b);
+}

--- a/dashboard/src/components/LoadingWrapper/LoadingWrapper.tsx
+++ b/dashboard/src/components/LoadingWrapper/LoadingWrapper.tsx
@@ -1,4 +1,5 @@
 import { CdsProgressCircle } from "@cds/react/progress-circle";
+import "./LoadingWrapper.css";
 
 export interface ILoadingWrapperProps {
   loaded?: boolean;
@@ -13,7 +14,7 @@ function LoadingWrapper(props: ILoadingWrapperProps) {
     props.children
   ) : (
     <div className={props.className || ""}>
-      {props.loadingText && <div className="flex-h-center">{props.loadingText}</div>}
+      {props.loadingText && <div className="flex-h-center loadingText">{props.loadingText}</div>}
       <div className="flex-h-center margin-t-md">
         <CdsProgressCircle size={props.size || "xxl"} status="info" />
       </div>


### PR DESCRIPTION
### Description of the change

While using Kubeapps I noticed a minor issue in dark mode when rolling back an application, but it resulted to be an issue with the LoadingWrapper text, which wasn't getting the proper css color variable.

### Benefits

Proper text color: 

![image](https://user-images.githubusercontent.com/11535726/133116714-93ee6d43-6da0-4fd3-a208-5aedacae63e8.png)

### Possible drawbacks

N/A

### Applicable issues

N/A
### Additional information

N/A
