### PR TITLE
Pass asset-syncer img as an ENV var

### DIFF
--- a/chart/kubeapps/templates/apprepository/deployment.yaml
+++ b/chart/kubeapps/templates/apprepository/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - /apprepository-controller
           args:
             - --user-agent-comment=kubeapps/{{ .Chart.AppVersion }}
-            - --repo-sync-image={{ include "common.images.image" (dict "imageRoot" .Values.apprepository.syncImage "global" .Values.global) }}
+            - --repo-sync-image=$(REPO_SYNC_IMAGE)
             {{- if .Values.global }}
               {{- if.Values.global.imagePullSecrets }}
                 {{- range $key, $value := .Values.global.imagePullSecrets }}
@@ -89,6 +89,9 @@ spec:
             - --crontab={{ .Values.apprepository.crontab }}
             {{- end }}
             - --repos-per-namespace={{ .Values.apprepository.watchAllNamespaces }}
+          env:
+            - name: REPO_SYNC_IMAGE
+              value: {{ include "common.images.image" (dict "imageRoot" .Values.apprepository.syncImage "global" .Values.global) }}
           {{- if .Values.apprepository.resources }}
           resources: {{- toYaml .Values.apprepository.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Description of the change

This PR is just to pass the asset-syncer job image as an ENV var.

### Benefits

Kubeapps is closer to being built as a Carvel pkg.

### Possible drawbacks

N/A

### Applicable issues

  - fixes #3401

### Additional information

If accepted, then sync with the Content team to check if any further changes are required in their internal tooling.


