### PR TITLE
Add kubeappsapis img to the imagePullSecrets dict

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "kubeapps.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.frontend.image .Values.dashboard.image .Values.apprepository.image .Values.apprepository.syncImage .Values.assetsvc.image .Values.kubeops.image .Values.authProxy.image .Values.pinnipedProxy.image .Values.testImage) "global" .Values.global) }}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.frontend.image .Values.dashboard.image .Values.apprepository.image .Values.apprepository.syncImage .Values.assetsvc.image .Values.kubeops.image .Values.authProxy.image .Values.pinnipedProxy.image .Values.kubeappsapis.image .Values.testImage) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -227,4 +227,5 @@ Check if there are rolling tags in the images
 {{- include "common.warnings.rollingTag" .Values.kubeops.image }}
 {{- include "common.warnings.rollingTag" .Values.authProxy.image }}
 {{- include "common.warnings.rollingTag" .Values.pinnipedProxy.image }}
+{{- include "common.warnings.rollingTag" .Values.kubeappsapis.image }}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

Minor PR adding kubeappapis image to a couple of missing places in the chart.

### Benefits

If using pullsecrets for our chart images, they will also work for the kubeappsapis img

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
