### PR TITLE
Add versions - kubeappsapis

### DIFF
--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -23,14 +23,14 @@ RUN /tmp/buf lint ./cmd/kubeapps-apis
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build \
-    -ldflags "-X main.version=$VERSION" \
+    -ldflags "-X github.com/kubeapps/kubeapps/cmd/kubeapps-apis/cmd.version=$VERSION" \
     ./cmd/kubeapps-apis
 
 # Build 'kapp-controller' plugin, version 'v1alpha1'
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build \
-    -ldflags "-X main.version=$VERSION" \
+    -ldflags "-X github.com/kubeapps/kubeapps/cmd/kubeapps-apis/cmd.version=$VERSION" \
     -o /kapp-controller-packages-v1alpha1-plugin.so -buildmode=plugin \
     ./cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/*.go
 
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build \
-    -ldflags "-X main.version=$VERSION" \
+    -ldflags "-X github.com/kubeapps/kubeapps/cmd/kubeapps-apis/cmd.version=$VERSION" \
     -o /fluxv2-packages-v1alpha1-plugin.so -buildmode=plugin \
     ./cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/*.go
 
@@ -46,7 +46,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build \
-    -ldflags "-X main.version=$VERSION" \
+    -ldflags "-X github.com/kubeapps/kubeapps/cmd/kubeapps-apis/cmd.version=$VERSION" \
     -o /helm-packages-v1alpha1-plugin.so -buildmode=plugin \
     ./cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/*.go
 

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -22,12 +22,15 @@ RUN /tmp/buf lint ./cmd/kubeapps-apis
 # Build the main grpc server
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build ./cmd/kubeapps-apis
+    go build \
+    -ldflags "-X main.version=$VERSION" \
+    ./cmd/kubeapps-apis
 
 # Build 'kapp-controller' plugin, version 'v1alpha1'
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build \
+    -ldflags "-X main.version=$VERSION" \
     -o /kapp-controller-packages-v1alpha1-plugin.so -buildmode=plugin \
     ./cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/*.go
 
@@ -35,6 +38,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build \
+    -ldflags "-X main.version=$VERSION" \
     -o /fluxv2-packages-v1alpha1-plugin.so -buildmode=plugin \
     ./cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/*.go
 
@@ -42,8 +46,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build \
-    -o /helm-packages-v1alpha1-plugin.so -buildmode=plugin \
     -ldflags "-X main.version=$VERSION" \
+    -o /helm-packages-v1alpha1-plugin.so -buildmode=plugin \
     ./cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/*.go
 
 # Note: unlike the other docker images for go, we cannot use scratch as the plugins

--- a/cmd/kubeapps-apis/cmd/root.go
+++ b/cmd/kubeapps-apis/cmd/root.go
@@ -30,6 +30,9 @@ import (
 var (
 	cfgFile   string
 	serveOpts server.ServeOptions
+	// This version var is updated during the build
+	// see the -ldflags option in the Dockerfile
+	version = "devel"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -43,6 +46,7 @@ The api service serves both gRPC and HTTP requests for the configured APIs.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		server.Serve(serveOpts)
 	},
+	Version: "devel",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -53,6 +57,7 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+	rootCmd.SetVersionTemplate(version)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kubeapps-apis.yaml)")
 

--- a/cmd/kubeapps-apis/cmd/root_test.go
+++ b/cmd/kubeapps-apis/cmd/root_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 VMware. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
+)
+
+func TestParseFlagsCorrect(t *testing.T) {
+	var tests = []struct {
+		name string
+		args []string
+		conf server.ServeOptions
+	}{
+		{
+			"all arguments are captured",
+			[]string{
+				"--config", "file",
+				"--port", "901",
+				"--plugin-dir", "foo01",
+				"--clusters-config-path", "foo02",
+				"--pinniped-proxy-url", "foo03",
+				"--unsafe-use-demo-sa", "true",
+				"--unsafe-local-dev-kubeconfig", "true",
+			},
+			server.ServeOptions{
+				Port:                     901,
+				PluginDirs:               []string{"foo01"},
+				ClustersConfigPath:       "foo02",
+				PinnipedProxyURL:         "foo03",
+				UnsafeUseDemoSA:          true,
+				UnsafeLocalDevKubeconfig: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRootCmd()
+			b := bytes.NewBufferString("")
+			cmd.SetOut(b)
+			cmd.SetErr(b)
+			setFlags(cmd)
+			cmd.SetArgs(tt.args)
+			cmd.Execute()
+			if got, want := serveOpts, tt.conf; !cmp.Equal(want, got) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of the change

This PR adds the `--version` command to `kubeaps-apis`

### Benefits

Our binaries will properly display their version

### Possible drawbacks

N/A

### Applicable issues

- related #3429

### Additional information

```
DOCKER_BUILDKIT=1 docker build -t kubeapps/kubeapps-apis:dev --build-arg "VERSION=$(git rev-parse HEAD)" -f cmd/kubeapps-apis/Dockerfile .

docker run  docker.io/kubeapps/kubeapps-apis:dev ./kubeapps-apis --version
``` 