### PR TITLE
Add versions - kubeops

### DIFF
--- a/cmd/kubeops/Dockerfile
+++ b/cmd/kubeops/Dockerfile
@@ -10,7 +10,7 @@ ARG VERSION
 # https://github.com/golang/go/issues/27719#issuecomment-514747274
 RUN --mount=type=cache,target=/go/pkg/mod \
   --mount=type=cache,target=/root/.cache/go-build \
-  CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X main.version=$VERSION" ./cmd/kubeops
+  CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X github.com/kubeapps/kubeapps/cmd/kubeops/cmd.version=$VERSION" ./cmd/kubeops
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/cmd/kubeops/cmd/root.go
+++ b/cmd/kubeops/cmd/root.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2021 VMware. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kubeapps/kubeapps/cmd/kubeops/server"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	cfgFile   string
+	serveOpts server.ServeOptions
+	// This Version var is updated during the build
+	// see the -ldflags option in the cmd/kubeops/Dockerfile
+	version = "devzzzel"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "kubeops",
+	Short: "Kubeops is micro-service that creates an API endpoint for accessing the Helm API and Kubernetes resources.",
+	Long:  "Kubeops is micro-service that creates an API endpoint for accessing the Helm API and Kubernetes resources.",
+	Run: func(cmd *cobra.Command, args []string) {
+		server.Serve(serveOpts)
+	},
+	Version: "devel",
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	cobra.CheckErr(rootCmd.Execute())
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+	rootCmd.SetVersionTemplate(version)
+
+	rootCmd.Flags().StringVar(&serveOpts.AssetsvcURL, "assetsvc-url", "https://kubeapps-internal-assetsvc:8080", "URL to the internal assetsvc")
+	rootCmd.Flags().StringVar(&serveOpts.HelmDriverArg, "helm-driver", "", "which Helm driver type to use")
+	rootCmd.Flags().IntVar(&serveOpts.ListLimit, "list-max", 256, "maximum number of releases to fetch")
+	rootCmd.Flags().StringVar(&serveOpts.UserAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
+	// Default timeout from https://github.com/helm/helm/blob/b0b0accdfc84e154b3d48ec334cd5b4f9b345667/cmd/helm/install.go#L216
+	rootCmd.Flags().Int64Var(&serveOpts.Timeout, "timeout", 300, "Timeout to perform release operations (install, upgrade, rollback, delete)")
+	rootCmd.Flags().StringVar(&serveOpts.ClustersConfigPath, "clusters-config-path", "", "Configuration for clusters")
+	rootCmd.Flags().StringVar(&serveOpts.PinnipedProxyURL, "pinniped-proxy-url", "http://kubeapps-internal-pinniped-proxy.kubeapps:3333", "internal url to be used for requests to clusters configured for credential proxying via pinniped")
+	rootCmd.Flags().IntVar(&serveOpts.Burst, "burst", 15, "internal burst capacity")
+	rootCmd.Flags().Float32Var(&serveOpts.Qps, "qps", 10, "internal QPS rate")
+	rootCmd.Flags().StringVar(&serveOpts.NamespaceHeaderName, "namespace-header-name", "", "name of the header field, e.g. namespace-header-name=X-Consumer-Groups")
+	rootCmd.Flags().StringVar(&serveOpts.NamespaceHeaderPattern, "namespace-header-pattern", "", "regular expression that matches only single group, e.g. namespace-header-pattern=^namespace:([\\w]+):\\w+$, to match namespace:ns:read")
+
+	serveOpts.UserAgent = getUserAgent(version, serveOpts.UserAgentComment)
+
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		// Search config in home directory with name ".kubeops" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName(".kubeops")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+	}
+}
+
+// Returns the user agent to be used during calls to the chart repositories
+// Examples:
+// kubeops/devel
+// kubeops/2.3.4 (kubeapps v2.3.4-beta4)
+func getUserAgent(version, userAgentComment string) string {
+	ua := "kubeops/" + version
+	if userAgentComment != "" {
+		ua = fmt.Sprintf("%s (%s)", ua, userAgentComment)
+	}
+	return ua
+}

--- a/cmd/kubeops/cmd/root.go
+++ b/cmd/kubeops/cmd/root.go
@@ -30,7 +30,7 @@ var (
 	serveOpts server.ServeOptions
 	// This Version var is updated during the build
 	// see the -ldflags option in the cmd/kubeops/Dockerfile
-	version = "devzzzel"
+	version = "devel"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/kubeops/cmd/root.go
+++ b/cmd/kubeops/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubeapps/kubeapps/cmd/kubeops/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	log "k8s.io/klog/v2"
 )
 
 var (
@@ -34,14 +35,20 @@ var (
 )
 
 // rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "kubeops",
-	Short: "Kubeops is micro-service that creates an API endpoint for accessing the Helm API and Kubernetes resources.",
-	Long:  "Kubeops is micro-service that creates an API endpoint for accessing the Helm API and Kubernetes resources.",
-	Run: func(cmd *cobra.Command, args []string) {
-		server.Serve(serveOpts)
-	},
-	Version: "devel",
+var rootCmd *cobra.Command
+
+func newRootCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "kubeops",
+		Short: "Kubeops is a micro-service that creates an API endpoint for accessing the Helm API and Kubernetes resources.",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			log.Infof("kubeops has been configured with: %#v", serveOpts)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return server.Serve(serveOpts)
+		},
+		Version: "devel",
+	}
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -52,23 +59,25 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+	rootCmd = newRootCmd()
 	rootCmd.SetVersionTemplate(version)
-
-	rootCmd.Flags().StringVar(&serveOpts.AssetsvcURL, "assetsvc-url", "https://kubeapps-internal-assetsvc:8080", "URL to the internal assetsvc")
-	rootCmd.Flags().StringVar(&serveOpts.HelmDriverArg, "helm-driver", "", "which Helm driver type to use")
-	rootCmd.Flags().IntVar(&serveOpts.ListLimit, "list-max", 256, "maximum number of releases to fetch")
-	rootCmd.Flags().StringVar(&serveOpts.UserAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
-	// Default timeout from https://github.com/helm/helm/blob/b0b0accdfc84e154b3d48ec334cd5b4f9b345667/cmd/helm/install.go#L216
-	rootCmd.Flags().Int64Var(&serveOpts.Timeout, "timeout", 300, "Timeout to perform release operations (install, upgrade, rollback, delete)")
-	rootCmd.Flags().StringVar(&serveOpts.ClustersConfigPath, "clusters-config-path", "", "Configuration for clusters")
-	rootCmd.Flags().StringVar(&serveOpts.PinnipedProxyURL, "pinniped-proxy-url", "http://kubeapps-internal-pinniped-proxy.kubeapps:3333", "internal url to be used for requests to clusters configured for credential proxying via pinniped")
-	rootCmd.Flags().IntVar(&serveOpts.Burst, "burst", 15, "internal burst capacity")
-	rootCmd.Flags().Float32Var(&serveOpts.Qps, "qps", 10, "internal QPS rate")
-	rootCmd.Flags().StringVar(&serveOpts.NamespaceHeaderName, "namespace-header-name", "", "name of the header field, e.g. namespace-header-name=X-Consumer-Groups")
-	rootCmd.Flags().StringVar(&serveOpts.NamespaceHeaderPattern, "namespace-header-pattern", "", "regular expression that matches only single group, e.g. namespace-header-pattern=^namespace:([\\w]+):\\w+$, to match namespace:ns:read")
-
+	setFlags(rootCmd)
 	serveOpts.UserAgent = getUserAgent(version, serveOpts.UserAgentComment)
+}
 
+func setFlags(c *cobra.Command) {
+	c.Flags().StringVar(&serveOpts.AssetsvcURL, "assetsvc-url", "https://kubeapps-internal-assetsvc:8080", "URL to the internal assetsvc")
+	c.Flags().StringVar(&serveOpts.HelmDriverArg, "helm-driver", "", "which Helm driver type to use")
+	c.Flags().IntVar(&serveOpts.ListLimit, "list-max", 256, "maximum number of releases to fetch")
+	c.Flags().StringVar(&serveOpts.UserAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
+	// Default timeout from https://github.com/helm/helm/blob/9fafb4ad6811afb017cc464b630be2ff8390ac63/cmd/helm/install.go#L146
+	c.Flags().Int64Var(&serveOpts.Timeout, "timeout", 300, "Timeout to perform release operations (install, upgrade, rollback, delete)")
+	c.Flags().StringVar(&serveOpts.ClustersConfigPath, "clusters-config-path", "", "Configuration for clusters")
+	c.Flags().StringVar(&serveOpts.PinnipedProxyURL, "pinniped-proxy-url", "http://kubeapps-internal-pinniped-proxy.kubeapps:3333", "internal url to be used for requests to clusters configured for credential proxying via pinniped")
+	c.Flags().IntVar(&serveOpts.Burst, "burst", 15, "internal burst capacity")
+	c.Flags().Float32Var(&serveOpts.Qps, "qps", 10, "internal QPS rate")
+	c.Flags().StringVar(&serveOpts.NamespaceHeaderName, "namespace-header-name", "", "name of the header field, e.g. namespace-header-name=X-Consumer-Groups")
+	c.Flags().StringVar(&serveOpts.NamespaceHeaderPattern, "namespace-header-pattern", "", "regular expression that matches only single group, e.g. namespace-header-pattern=^namespace:([\\w]+):\\w+$, to match namespace:ns:read")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/kubeops/cmd/root_test.go
+++ b/cmd/kubeops/cmd/root_test.go
@@ -16,7 +16,69 @@ limitations under the License.
 
 package cmd
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kubeapps/kubeapps/cmd/kubeops/server"
+)
+
+func TestParseFlagsCorrect(t *testing.T) {
+	var tests = []struct {
+		name string
+		args []string
+		conf server.ServeOptions
+	}{
+		{
+			"all arguments are captured",
+			[]string{
+
+				"--assetsvc-url", "foo01",
+				"--helm-driver", "foo02",
+				"--list-max", "901",
+				"--user-agent-comment", "foo03",
+				"--timeout", "902",
+				"--clusters-config-path", "foo04",
+				"--pinniped-proxy-url", "foo05",
+				"--burst", "903",
+				"--qps", "904",
+				"--namespace-header-name", "foo06",
+				"--namespace-header-pattern", "foo07",
+			},
+			server.ServeOptions{
+				AssetsvcURL:            "foo01",
+				HelmDriverArg:          "foo02",
+				ListLimit:              901,
+				UserAgentComment:       "foo03",
+				Timeout:                902,
+				ClustersConfigPath:     "foo04",
+				PinnipedProxyURL:       "foo05",
+				Burst:                  903,
+				Qps:                    904,
+				NamespaceHeaderName:    "foo06",
+				NamespaceHeaderPattern: "foo07",
+				UserAgent:              "kubeops/devel (foo03)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRootCmd()
+			b := bytes.NewBufferString("")
+			cmd.SetOut(b)
+			cmd.SetErr(b)
+			setFlags(cmd)
+			cmd.SetArgs(tt.args)
+			cmd.Execute()
+			serveOpts.UserAgent = getUserAgent(version, serveOpts.UserAgentComment)
+			if got, want := serveOpts, tt.conf; !cmp.Equal(want, got) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}
 
 func TestGetUserAgent(t *testing.T) {
 	testCases := []struct {

--- a/cmd/kubeops/cmd/root_test.go
+++ b/cmd/kubeops/cmd/root_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 VMware.
+Copyright 2021 VMware. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package main
+
+package cmd
 
 import "testing"
 

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -1,201 +1,26 @@
+/*
+Copyright 2021 VMware. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
-import (
-	"context"
-	"fmt"
-	"net/http"
-	"net/http/httputil"
-	"net/url"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
+import "github.com/kubeapps/kubeapps/cmd/kubeops/cmd"
 
-	"github.com/gorilla/mux"
-	"github.com/heptiolabs/healthcheck"
-	"github.com/kubeapps/kubeapps/cmd/kubeops/internal/handler"
-	"github.com/kubeapps/kubeapps/pkg/agent"
-	"github.com/kubeapps/kubeapps/pkg/auth"
-	backendHandlers "github.com/kubeapps/kubeapps/pkg/http-handler"
-	"github.com/kubeapps/kubeapps/pkg/kube"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
-	"github.com/urfave/negroni"
-	"k8s.io/helm/pkg/helm/environment"
-)
-
-const clustersCAFilesPrefix = "/etc/additional-clusters-cafiles"
-
-var (
-	clustersConfigPath     string
-	assetsvcURL            string
-	helmDriverArg          string
-	listLimit              int
-	pinnipedProxyURL       string
-	burst                  int
-	qps                    float32
-	settings               environment.EnvSettings
-	timeout                int64
-	userAgentComment       string
-	namespaceHeaderName    string
-	namespaceHeaderPattern string
-	// This version var is updated during the build (see the -ldflags option
-	// in the cmd/kubeops/Dockerfile)
-	version = "devel"
-)
-
-func init() {
-	settings.AddFlags(pflag.CommandLine)
-	pflag.StringVar(&assetsvcURL, "assetsvc-url", "https://kubeapps-internal-assetsvc:8080", "URL to the internal assetsvc")
-	pflag.StringVar(&helmDriverArg, "helm-driver", "", "which Helm driver type to use")
-	pflag.IntVar(&listLimit, "list-max", 256, "maximum number of releases to fetch")
-	pflag.StringVar(&userAgentComment, "user-agent-comment", "", "UserAgent comment used during outbound requests")
-	// Default timeout from https://github.com/helm/helm/blob/b0b0accdfc84e154b3d48ec334cd5b4f9b345667/cmd/helm/install.go#L216
-	pflag.Int64Var(&timeout, "timeout", 300, "Timeout to perform release operations (install, upgrade, rollback, delete)")
-	pflag.StringVar(&clustersConfigPath, "clusters-config-path", "", "Configuration for clusters")
-	pflag.StringVar(&pinnipedProxyURL, "pinniped-proxy-url", "http://kubeapps-internal-pinniped-proxy.kubeapps:3333", "internal url to be used for requests to clusters configured for credential proxying via pinniped")
-	pflag.IntVar(&burst, "burst", 15, "internal burst capacity")
-	pflag.Float32Var(&qps, "qps", 10, "internal QPS rate")
-	pflag.StringVar(&namespaceHeaderName, "namespace-header-name", "", "name of the header field, e.g. namespace-header-name=X-Consumer-Groups")
-	pflag.StringVar(&namespaceHeaderPattern, "namespace-header-pattern", "", "regular expression that matches only single group, e.g. namespace-header-pattern=^namespace:([\\w]+):\\w+$, to match namespace:ns:read")
-}
+// This cobra command was initially generated together with the cmd/root with the command
+// cobra init --pkg-name github.com/kubeapps/kubeapps/cmd/kubeops
 
 func main() {
-	pflag.Parse()
-	settings.Init(pflag.CommandLine)
-
-	kubeappsNamespace := os.Getenv("POD_NAMESPACE")
-	if kubeappsNamespace == "" {
-		log.Fatal("POD_NAMESPACE should be defined")
-	}
-
-	// If there is no clusters config, we default to the previous behaviour of a "default" cluster.
-	clustersConfig := kube.ClustersConfig{KubeappsClusterName: "default"}
-	if clustersConfigPath != "" {
-		var err error
-		var cleanupCAFiles func()
-		clustersConfig, cleanupCAFiles, err = kube.ParseClusterConfig(clustersConfigPath, clustersCAFilesPrefix, pinnipedProxyURL)
-		if err != nil {
-			log.Fatalf("unable to parse additional clusters config: %+v", err)
-		}
-		defer cleanupCAFiles()
-	}
-
-	options := handler.Options{
-		ListLimit:              listLimit,
-		Timeout:                timeout,
-		KubeappsNamespace:      kubeappsNamespace,
-		ClustersConfig:         clustersConfig,
-		Burst:                  burst,
-		QPS:                    qps,
-		NamespaceHeaderName:    namespaceHeaderName,
-		NamespaceHeaderPattern: namespaceHeaderPattern,
-		UserAgent:              getUserAgent(version, userAgentComment),
-	}
-
-	storageForDriver := agent.StorageForSecrets
-	if helmDriverArg != "" {
-		var err error
-		storageForDriver, err = agent.ParseDriverType(helmDriverArg)
-		if err != nil {
-			panic(err)
-		}
-	}
-	withHandlerConfig := handler.WithHandlerConfig(storageForDriver, options)
-	r := mux.NewRouter()
-
-	// Healthcheck
-	// TODO: add app specific health and readiness checks as per https://github.com/heptiolabs/healthcheck
-	health := healthcheck.NewHandler()
-	r.Handle("/live", health)
-	r.Handle("/ready", health)
-
-	// Routes
-	// Auth not necessary here with Helm 3 because it's done by Kubernetes.
-	addRoute := handler.AddRouteWith(r.PathPrefix("/v1").Subrouter(), withHandlerConfig)
-	addRoute("GET", "/clusters/{cluster}/releases", handler.ListAllReleases)
-	addRoute("GET", "/clusters/{cluster}/namespaces/{namespace}/releases", handler.ListReleases)
-	addRoute("POST", "/clusters/{cluster}/namespaces/{namespace}/releases", handler.CreateRelease)
-	addRoute("GET", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.GetRelease)
-	addRoute("PUT", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.OperateRelease)
-	addRoute("DELETE", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
-
-	// Backend routes unrelated to kubeops functionality.
-	err := backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), namespaceHeaderName, namespaceHeaderPattern, options.Burst, options.QPS, clustersConfig)
-	if err != nil {
-		log.Fatalf("Unable to setup backend routes: %+v", err)
-	}
-
-	// assetsvc reverse proxy
-	// TODO(mnelson) remove this reverse proxy once the haproxy frontend
-	// proxies requests directly to the assetsvc. Move the authz to the
-	// assetsvc itself.
-	authGate := auth.AuthGate(clustersConfig, kubeappsNamespace)
-	parsedAssetsvcURL, err := url.Parse(assetsvcURL)
-	if err != nil {
-		log.Fatalf("Unable to parse the assetsvc URL: %v", err)
-	}
-	assetsvcProxy := httputil.NewSingleHostReverseProxy(parsedAssetsvcURL)
-	assetsvcPrefix := "/assetsvc"
-	assetsvcRouter := r.PathPrefix(assetsvcPrefix).Subrouter()
-	// Logos don't require authentication so bypass that step. Nor are they cluster-aware as they're
-	// embedded as links in the stored chart data.
-	assetsvcRouter.Methods("GET").Path("/v1/ns/{namespace}/assets/{repo}/{id}/logo").Handler(negroni.New(
-		negroni.Wrap(http.StripPrefix(assetsvcPrefix, assetsvcProxy)),
-	))
-	assetsvcRouter.PathPrefix("/v1/clusters/{cluster}/namespaces/{namespace}/").Handler(negroni.New(
-		authGate,
-		negroni.Wrap(http.StripPrefix(assetsvcPrefix, assetsvcProxy)),
-	))
-
-	n := negroni.Classic()
-	n.UseHandler(r)
-
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
-	addr := ":" + port
-
-	srv := &http.Server{
-		Addr:    addr,
-		Handler: n,
-	}
-
-	go func() {
-		log.WithFields(log.Fields{"addr": addr}).Info("Started Kubeops")
-		err := srv.ListenAndServe()
-		if err != nil {
-			log.Info(err)
-		}
-	}()
-
-	// Catch SIGINT and SIGTERM
-	// Set up channel on which to send signal notifications.
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	log.Debug("Set system to get notified on signals")
-	s := <-c
-	log.Infof("Received signal: %v. Waiting for existing requests to finish", s)
-	// Set a timeout value high enough to let k8s terminationGracePeriodSeconds to act
-	// accordingly and send a SIGKILL if needed
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3600)
-	defer cancel()
-	// Doesn't block if no connections, but will otherwise wait
-	// until the timeout deadline.
-	srv.Shutdown(ctx)
-	log.Info("All requests have been served. Exiting")
-	os.Exit(0)
-}
-
-// Returns the user agent to be used during calls to the chart repositories
-// Examples:
-// kubeops/devel
-// kubeops/2.3.4 (kubeapps v2.3.4-beta4)
-func getUserAgent(version, userAgentComment string) string {
-	ua := "kubeops/" + version
-	if userAgentComment != "" {
-		ua = fmt.Sprintf("%s (%s)", ua, userAgentComment)
-	}
-	return ua
+	cmd.Execute()
 }

--- a/cmd/kubeops/server/server.go
+++ b/cmd/kubeops/server/server.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2021 VMware. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/heptiolabs/healthcheck"
+	"github.com/kubeapps/kubeapps/cmd/kubeops/internal/handler"
+	"github.com/kubeapps/kubeapps/pkg/agent"
+	"github.com/kubeapps/kubeapps/pkg/auth"
+	backendHandlers "github.com/kubeapps/kubeapps/pkg/http-handler"
+	"github.com/kubeapps/kubeapps/pkg/kube"
+	"github.com/urfave/negroni"
+
+	log "k8s.io/klog/v2"
+)
+
+type ServeOptions struct {
+	AssetsvcURL            string
+	HelmDriverArg          string
+	ListLimit              int
+	UserAgentComment       string
+	Timeout                int64
+	ClustersConfigPath     string
+	PinnipedProxyURL       string
+	Burst                  int
+	Qps                    float32
+	NamespaceHeaderName    string
+	NamespaceHeaderPattern string
+	UserAgent              string
+}
+
+const clustersCAFilesPrefix = "/etc/additional-clusters-cafiles"
+
+// Serve is the root command that is run when no other sub-commands are present.
+// It runs the gRPC service, registering the configured plugins.
+func Serve(serveOpts ServeOptions) {
+
+	kubeappsNamespace := os.Getenv("POD_NAMESPACE")
+	if kubeappsNamespace == "" {
+		log.Fatal("POD_NAMESPACE should be defined")
+	}
+
+	// If there is no clusters config, we default to the previous behaviour of a "default" cluster.
+	clustersConfig := kube.ClustersConfig{KubeappsClusterName: "default"}
+	if serveOpts.ClustersConfigPath != "" {
+		var err error
+		var cleanupCAFiles func()
+		clustersConfig, cleanupCAFiles, err = kube.ParseClusterConfig(serveOpts.ClustersConfigPath, clustersCAFilesPrefix, serveOpts.PinnipedProxyURL)
+		if err != nil {
+			log.Fatalf("unable to parse additional clusters config: %+v", err)
+		}
+		defer cleanupCAFiles()
+	}
+
+	options := handler.Options{
+		ListLimit:              serveOpts.ListLimit,
+		Timeout:                serveOpts.Timeout,
+		KubeappsNamespace:      kubeappsNamespace,
+		ClustersConfig:         clustersConfig,
+		Burst:                  serveOpts.Burst,
+		QPS:                    serveOpts.Qps,
+		NamespaceHeaderName:    serveOpts.NamespaceHeaderName,
+		NamespaceHeaderPattern: serveOpts.NamespaceHeaderPattern,
+		UserAgent:              serveOpts.UserAgent,
+	}
+
+	storageForDriver := agent.StorageForSecrets
+	if serveOpts.HelmDriverArg != "" {
+		var err error
+		storageForDriver, err = agent.ParseDriverType(serveOpts.HelmDriverArg)
+		if err != nil {
+			panic(err)
+		}
+	}
+	withHandlerConfig := handler.WithHandlerConfig(storageForDriver, options)
+	r := mux.NewRouter()
+
+	// Healthcheck
+	// TODO: add app specific health and readiness checks as per https://github.com/heptiolabs/healthcheck
+	health := healthcheck.NewHandler()
+	r.Handle("/live", health)
+	r.Handle("/ready", health)
+
+	// Routes
+	// Auth not necessary here with Helm 3 because it's done by Kubernetes.
+	addRoute := handler.AddRouteWith(r.PathPrefix("/v1").Subrouter(), withHandlerConfig)
+	addRoute("GET", "/clusters/{cluster}/releases", handler.ListAllReleases)
+	addRoute("GET", "/clusters/{cluster}/namespaces/{namespace}/releases", handler.ListReleases)
+	addRoute("POST", "/clusters/{cluster}/namespaces/{namespace}/releases", handler.CreateRelease)
+	addRoute("GET", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.GetRelease)
+	addRoute("PUT", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.OperateRelease)
+	addRoute("DELETE", "/clusters/{cluster}/namespaces/{namespace}/releases/{releaseName}", handler.DeleteRelease)
+
+	// Backend routes unrelated to kubeops functionality.
+	err := backendHandlers.SetupDefaultRoutes(r.PathPrefix("/backend/v1").Subrouter(), serveOpts.NamespaceHeaderName, serveOpts.NamespaceHeaderPattern, serveOpts.Burst, serveOpts.Qps, clustersConfig)
+	if err != nil {
+		log.Fatalf("Unable to setup backend routes: %+v", err)
+	}
+
+	// assetsvc reverse proxy
+	// TODO(mnelson) remove this reverse proxy once the haproxy frontend
+	// proxies requests directly to the assetsvc. Move the authz to the
+	// assetsvc itself.
+	authGate := auth.AuthGate(clustersConfig, kubeappsNamespace)
+	parsedAssetsvcURL, err := url.Parse(serveOpts.AssetsvcURL)
+	if err != nil {
+		log.Fatalf("Unable to parse the assetsvc URL: %v", err)
+	}
+	assetsvcProxy := httputil.NewSingleHostReverseProxy(parsedAssetsvcURL)
+	assetsvcPrefix := "/assetsvc"
+	assetsvcRouter := r.PathPrefix(assetsvcPrefix).Subrouter()
+	// Logos don't require authentication so bypass that step. Nor are they cluster-aware as they're
+	// embedded as links in the stored chart data.
+	assetsvcRouter.Methods("GET").Path("/v1/ns/{namespace}/assets/{repo}/{id}/logo").Handler(negroni.New(
+		negroni.Wrap(http.StripPrefix(assetsvcPrefix, assetsvcProxy)),
+	))
+	assetsvcRouter.PathPrefix("/v1/clusters/{cluster}/namespaces/{namespace}/").Handler(negroni.New(
+		authGate,
+		negroni.Wrap(http.StripPrefix(assetsvcPrefix, assetsvcProxy)),
+	))
+
+	n := negroni.Classic()
+	n.UseHandler(r)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	addr := ":" + port
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: n,
+	}
+
+	go func() {
+		log.Infof("Started Kubeops, addr=%v", addr)
+		err := srv.ListenAndServe()
+		if err != nil {
+			log.Info(err)
+		}
+	}()
+
+	// Catch SIGINT and SIGTERM
+	// Set up channel on which to send signal notifications.
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	log.Infof("Set system to get notified on signals")
+	s := <-c
+	log.Infof("Received signal: %v. Waiting for existing requests to finish", s)
+	// Set a timeout value high enough to let k8s terminationGracePeriodSeconds to act
+	// accordingly and send a SIGKILL if needed
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3600)
+	defer cancel()
+	// Doesn't block if no connections, but will otherwise wait
+	// until the timeout deadline.
+	srv.Shutdown(ctx)
+	log.Info("All requests have been served. Exiting")
+	os.Exit(0)
+
+}


### PR DESCRIPTION
### Description of the change

This PR adds the `--version` command to `kubeops`

Besides, it also adapts the code to the latest cobra boilerplate, so that all of our binaries are similar.

### Benefits

Our binaries will properly display their version

### Possible drawbacks

N/A

### Applicable issues

- related #3429

### Additional information

Testing with:

```
DOCKER_BUILDKIT=1 docker build -t kubeapps/kubeops:dev --build-arg "VERSION=$(git rev-parse HEAD)" -f cmd/kubeops/Dockerfile .

docker run  docker.io/kubeapps/kubeops:dev ./kubeops --version
``` 

