### PR TITLE
 Add versions - assetsvc

### DIFF
--- a/cmd/assetsvc/Dockerfile
+++ b/cmd/assetsvc/Dockerfile
@@ -9,12 +9,11 @@ ARG VERSION
 # With the trick below, Go's build cache is kept between builds.
 # https://github.com/golang/go/issues/27719#issuecomment-514747274
 RUN --mount=type=cache,target=/go/pkg/mod \
-  --mount=type=cache,target=/root/.cache/go-build \
-  CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X main.version=$VERSION" ./cmd/assetsvc
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X github.com/kubeapps/kubeapps/cmd/assetsvc/cmd.version=$VERSION" ./cmd/assetsvc
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kubeapps/kubeapps/assetsvc /assetsvc
-EXPOSE 8080
 USER 1001
 CMD ["/assetsvc"]

--- a/cmd/assetsvc/cmd/root.go
+++ b/cmd/assetsvc/cmd/root.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 VMware. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kubeapps/kubeapps/cmd/assetsvc/server"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	log "k8s.io/klog/v2"
+)
+
+var (
+	cfgFile   string
+	serveOpts server.ServeOptions
+	// This Version var is updated during the build
+	// see the -ldflags option in the cmd/kubeops/Dockerfile
+	version = "devel"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd *cobra.Command
+
+func newRootCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "assetsvc",
+		Short: "assetsvc is a micro-service that creates an API endpoint for accessing the Helm API and Kubernetes resources.",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			log.Infof("assetsvc has been configured with: %#v", serveOpts)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return server.Serve(serveOpts)
+		},
+		Version: "devel",
+	}
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	cobra.CheckErr(rootCmd.Execute())
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+	rootCmd = newRootCmd()
+	rootCmd.SetVersionTemplate(version)
+	setFlags(rootCmd)
+
+	serveOpts.DbPassword = os.Getenv("DB_PASSWORD")
+	serveOpts.KubeappsNamespace = os.Getenv("POD_NAMESPACE")
+}
+
+func setFlags(c *cobra.Command) {
+	c.Flags().StringVar(&serveOpts.DbURL, "database-url", "localhost", "Database URL")
+	c.Flags().StringVar(&serveOpts.DbUsername, "database-user", "root", "Database user")
+	c.Flags().StringVar(&serveOpts.DbName, "database-name", "charts", "Database name")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		// Search config in home directory with name ".kubeops" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName(".kubeops")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 The Helm Authors
+Copyright 2021 VMware. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,84 +16,8 @@ limitations under the License.
 
 package main
 
-import (
-	"flag"
-	"net/http"
-	"os"
-
-	"github.com/gorilla/mux"
-	"github.com/heptiolabs/healthcheck"
-	"github.com/kubeapps/common/datastore"
-	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
-	log "github.com/sirupsen/logrus"
-	"github.com/urfave/negroni"
-)
-
-const pathPrefix = "/v1"
-
-// TODO(absoludity): Let's not use globals for storing state like this.
-var manager utils.AssetManager
-
-func setupRoutes() http.Handler {
-	r := mux.NewRouter()
-
-	// Healthcheck
-	health := healthcheck.NewHandler()
-	r.Handle("/live", health)
-	r.Handle("/ready", health)
-
-	// Routes
-	apiv1 := r.PathPrefix(pathPrefix).Subrouter()
-	// TODO: mnelson: Seems we could use path per endpoint handling empty params? Check.
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts").Handler(WithParams(listChartsWithFilters)) // accepts: name, version, appversion, repos, categories, q, page, size
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/categories").Handler(WithParams(getChartCategories))
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}").Handler(WithParams(listChartsWithFilters)) // accepts: name, version, appversion, repos, categories, q, page, size
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/categories").Handler(WithParams(getChartCategories))
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}").Handler(WithParams(getChart))
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}/versions").Handler(WithParams(listChartVersions))
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}/versions/{version}").Handler(WithParams(getChartVersion))
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/README.md").Handler(WithParams(getChartVersionReadme))
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/values.yaml").Handler(WithParams(getChartVersionValues))
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/values.schema.json").Handler(WithParams(getChartVersionSchema))
-	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/logo").Handler(WithParams(getChartIcon))
-
-	// Leave icon on the non-cluster aware as it is used from a link in the db data :/
-	apiv1.Methods("GET").Path("/ns/{namespace}/assets/{repo}/{chartName}/logo").Handler(WithParams(getChartIcon))
-
-	n := negroni.Classic()
-	n.UseHandler(r)
-	return n
-}
+import "github.com/kubeapps/kubeapps/cmd/assetsvc/cmd"
 
 func main() {
-	dbURL := flag.String("database-url", "localhost", "Database URL")
-	dbName := flag.String("database-name", "charts", "Database database")
-	dbUsername := flag.String("database-user", "", "Database user")
-	dbPassword := os.Getenv("DB_PASSWORD")
-	flag.Parse()
-
-	dbConfig := datastore.Config{URL: *dbURL, Database: *dbName, Username: *dbUsername, Password: dbPassword}
-
-	kubeappsNamespace := os.Getenv("POD_NAMESPACE")
-
-	var err error
-	manager, err = utils.NewManager("postgresql", dbConfig, kubeappsNamespace)
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = manager.Init()
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer manager.Close()
-
-	n := setupRoutes()
-
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
-	addr := ":" + port
-	log.WithFields(log.Fields{"addr": addr}).Info("Started assetsvc")
-	http.ListenAndServe(addr, n)
+	cmd.Execute()
 }

--- a/cmd/assetsvc/pkg/utils/postgres_db_test.go
+++ b/cmd/assetsvc/pkg/utils/postgres_db_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 Bitnami
+Copyright 2021 VMware. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ limitations under the License.
 // Run the local postgres with
 // docker run --publish 5432:5432 -e ALLOW_EMPTY_PASSWORD=yes bitnami/postgresql:11.13.0-debian-10-r0
 // in another terminal.
-package main
+package utils
 
 import (
 	"database/sql"
@@ -27,16 +27,15 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest"
 	"github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest/pgtest"
 	_ "github.com/lib/pq"
 )
 
-func getInitializedManager(t *testing.T) (*utils.PostgresAssetManager, func()) {
+func getInitializedManager(t *testing.T) (*PostgresAssetManager, func()) {
 	pam, cleanup := pgtest.GetInitializedManager(t)
-	return &utils.PostgresAssetManager{pam}, cleanup
+	return &PostgresAssetManager{pam}, cleanup
 }
 
 func TestGetChart(t *testing.T) {
@@ -135,7 +134,7 @@ func TestGetVersion(t *testing.T) {
 			chartId:          "chart-1",
 			namespace:        "namespace-1",
 			requestedVersion: "doesnt-exist",
-			expectedErr:      utils.ErrChartVersionNotFound,
+			expectedErr:      ErrChartVersionNotFound,
 		},
 		{
 			name: "it returns an error if the chart version does not exist in that namespace",
@@ -388,7 +387,7 @@ func TestGetPaginatedChartList(t *testing.T) {
 				}
 			}
 
-			charts, numPages, err := pam.GetPaginatedChartListWithFilters(utils.ChartQuery{Namespace: tc.namespace, Repos: []string{tc.repo}}, 1, 10)
+			charts, numPages, err := pam.GetPaginatedChartListWithFilters(ChartQuery{Namespace: tc.namespace, Repos: []string{tc.repo}}, 1, 10)
 
 			if got, want := err, tc.expectedErr; got != want {
 				t.Fatalf("In '"+tc.name+"': "+"got err: %+v, want: %+v", got, want)
@@ -510,7 +509,7 @@ func TestGetChartsWithFilters(t *testing.T) {
 				}
 			}
 
-			charts, _, err := pam.GetPaginatedChartListWithFilters(utils.ChartQuery{Namespace: tc.namespace, ChartName: tc.chartName, Version: tc.chartVersion, AppVersion: tc.appVersion}, 1, 0)
+			charts, _, err := pam.GetPaginatedChartListWithFilters(ChartQuery{Namespace: tc.namespace, ChartName: tc.chartName, Version: tc.chartVersion, AppVersion: tc.appVersion}, 1, 0)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}

--- a/cmd/assetsvc/pkg/utils/postgresql_utils.go
+++ b/cmd/assetsvc/pkg/utils/postgresql_utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018 Bitnami
+Copyright 2021 VMware. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/assetsvc/pkg/utils/postgresql_utils_test.go
+++ b/cmd/assetsvc/pkg/utils/postgresql_utils_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) Bitnami
+Copyright 2021 VMware. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/assetsvc/pkg/utils/utils.go
+++ b/cmd/assetsvc/pkg/utils/utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 Bitnami
+Copyright 2021 VMware. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/assetsvc/server/handler.go
+++ b/cmd/assetsvc/server/handler.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018 The Helm Authors
+Copyright 2021 VMware. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package server
 
 import (
 	"fmt"

--- a/cmd/assetsvc/server/handler_test.go
+++ b/cmd/assetsvc/server/handler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018 The Helm Authors
+Copyright 2021 VMware. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package server
 
 import (
 	"bytes"

--- a/cmd/assetsvc/server/server.go
+++ b/cmd/assetsvc/server/server.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2021 VMware. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/mux"
+	"github.com/heptiolabs/healthcheck"
+	"github.com/kubeapps/common/datastore"
+	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
+	"github.com/urfave/negroni"
+	log "k8s.io/klog/v2"
+)
+
+type ServeOptions struct {
+	Manager           utils.AssetManager
+	DbURL             string
+	DbName            string
+	DbUsername        string
+	DbPassword        string
+	KubeappsNamespace string
+}
+
+// TODO(absoludity): Let's not use globals for storing state like this.
+var manager utils.AssetManager
+
+const pathPrefix = "/v1"
+
+func setupRoutes() http.Handler {
+	r := mux.NewRouter()
+
+	// Healthcheck
+	health := healthcheck.NewHandler()
+	r.Handle("/live", health)
+	r.Handle("/ready", health)
+
+	// Routes
+	apiv1 := r.PathPrefix(pathPrefix).Subrouter()
+	// TODO: mnelson: Seems we could use path per endpoint handling empty params? Check.
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts").Handler(WithParams(listChartsWithFilters)) // accepts: name, version, appversion, repos, categories, q, page, size
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/categories").Handler(WithParams(getChartCategories))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}").Handler(WithParams(listChartsWithFilters)) // accepts: name, version, appversion, repos, categories, q, page, size
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/categories").Handler(WithParams(getChartCategories))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}").Handler(WithParams(getChart))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}/versions").Handler(WithParams(listChartVersions))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/charts/{repo}/{chartName}/versions/{version}").Handler(WithParams(getChartVersion))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/README.md").Handler(WithParams(getChartVersionReadme))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/values.yaml").Handler(WithParams(getChartVersionValues))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/versions/{version}/values.schema.json").Handler(WithParams(getChartVersionSchema))
+	apiv1.Methods("GET").Path("/clusters/{cluster}/namespaces/{namespace}/assets/{repo}/{chartName}/logo").Handler(WithParams(getChartIcon))
+
+	// Leave icon on the non-cluster aware as it is used from a link in the db data :/
+	apiv1.Methods("GET").Path("/ns/{namespace}/assets/{repo}/{chartName}/logo").Handler(WithParams(getChartIcon))
+
+	n := negroni.Classic()
+	n.UseHandler(r)
+	return n
+}
+
+func Serve(serveOpts ServeOptions) error {
+	dbConfig := datastore.Config{URL: *&serveOpts.DbURL, Database: *&serveOpts.DbName, Username: *&serveOpts.DbUsername, Password: serveOpts.DbPassword}
+
+	var err error
+	manager, err = utils.NewManager("postgresql", dbConfig, serveOpts.KubeappsNamespace)
+	if err != nil {
+		return fmt.Errorf("Error: %v", err)
+	}
+	err = manager.Init()
+	if err != nil {
+		return fmt.Errorf("Error: %v", err)
+	}
+	defer manager.Close()
+
+	n := setupRoutes()
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	addr := ":" + port
+	log.Infof("Started assetsvc, addr=%s", addr)
+	http.ListenAndServe(addr, n)
+	return nil
+}

--- a/cmd/assetsvc/server/server_test.go
+++ b/cmd/assetsvc/server/server_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 The Helm Authors
+Copyright 2021 VMware. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package server
 
 import (
 	"encoding/json"


### PR DESCRIPTION
### Description of the change

This PR adds the `--version` command to `assetsvc`

### Benefits

Our binaries will properly display their version

### Possible drawbacks

N/A

### Applicable issues

- related #3429

### Additional information

```
DOCKER_BUILDKIT=1 docker build -t kubeapps/assetsvc:dev --build-arg "VERSION=$(git rev-parse HEAD)" -f cmd/assetsvc/Dockerfile .

docker run  docker.io/kubeapps/assetsvc:dev ./assetsvc --version
``` 