### PR TITLE
Add retry and refresh for screenshot on 02-create-private-registry.

### DIFF
--- a/integration/use-cases/02-create-private-registry.js
+++ b/integration/use-cases/02-create-private-registry.js
@@ -157,6 +157,13 @@ test("Creates a private registry", async () => {
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
-  await expect(page).toMatch("Up to date", { timeout: 60000 });
-  await expect(page).toMatch("Ready");
+  await utils.retryAndRefresh(
+    page,
+    3,
+    async () => {
+      await expect(page).toMatch("Up to date", { timeout: 60000 });
+      await expect(page).toMatch("Ready");
+    },
+    testName,
+  );
 });


### PR DESCRIPTION
### Description of the change

Seeing failures often for this test right at the end and am keen to understand what's going on when it fails.

Just adding a retry and refresh so it captures a screenshot when failing more than anything.


### Benefits

We'll know more about the failure.

### Possible drawbacks

None.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
