### PR TITLE
Document pinnipedConfig in values.yaml. Minor fix in Pinniped docs

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1464,7 +1464,7 @@ allowNamespaceDiscovery: true
 ## - isKubeappsCluster is an optional parameter that allows defining the cluster in which Kubeapps is installed;
 ##   this param is useful when every cluster is using an apiServiceURL (e.g., when using the Pinniped Impersonation Proxy)
 ##   as the chart cannot infer the cluster on which Kubeapps is installed in that case.
-## - pinnipedConfig is an optional parameter that allows defining the cluster running Pinniped
+## - pinnipedConfig is an optional parameter that contains configuration options specific to a cluster running the pinniped concierge service.
 ## e.g.:
 ## clusters:
 ## - name: default
@@ -1475,7 +1475,8 @@ allowNamespaceDiscovery: true
 ##   certificateAuthorityData: LS0tLS1CRUdJ...
 ##   serviceToken: ...
 ##   isKubeappsCluster: true
-##   pinnipedConfig: true
+##   pinnipedConfig:
+##     enable: true
 
 ##
 clusters:

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1373,7 +1373,6 @@ authProxy:
 ## @section Pinniped Proxy parameters
 
 ## Pinniped Proxy configuration for converting user OIDC tokens to k8s client authorization certs
-## NOTE: This component is alpha functionality in Kubeapps until we complete testing and documentation.
 ##
 pinnipedProxy:
   ## @param pinnipedProxy.enabled Specifies whether Kubeapps should configure Pinniped Proxy
@@ -1465,6 +1464,7 @@ allowNamespaceDiscovery: true
 ## - isKubeappsCluster is an optional parameter that allows defining the cluster in which Kubeapps is installed;
 ##   this param is useful when every cluster is using an apiServiceURL (e.g., when using the Pinniped Impersonation Proxy)
 ##   as the chart cannot infer the cluster on which Kubeapps is installed in that case.
+## - pinnipedConfig is an optional parameter that allows defining the cluster running Pinniped
 ## e.g.:
 ## clusters:
 ## - name: default
@@ -1475,6 +1475,8 @@ allowNamespaceDiscovery: true
 ##   certificateAuthorityData: LS0tLS1CRUdJ...
 ##   serviceToken: ...
 ##   isKubeappsCluster: true
+##   pinnipedConfig: true
+
 ##
 clusters:
   - name: default

--- a/docs/user/using-an-OIDC-provider-with-pinniped.md
+++ b/docs/user/using-an-OIDC-provider-with-pinniped.md
@@ -10,11 +10,11 @@ Install Pinniped into a `pinniped-concierge` namespace on your cluster with:
 kubectl apply -f https://get.pinniped.dev/latest/install-pinniped-concierge.yaml
 ```
 
-**NOTE**: Due to a breaking change in [Pinniped 0.6.0](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.6.0), the minimum version supported by Kubeapps is 0.6.0. Furthermore, [custom API suffixes](https://pinniped.dev/posts/multiple-pinnipeds) (introduced in Pinniped 0.5.0) are not yet fully supported. If your platform uses this feature, please [drop us an issue](https://github.com/kubeapps/kubeapps/issues/new).
-
 ## Configure Pinniped to trust your OIDC identity provider
 
 Once Pinniped is running, you can add a `JWTAuthenticator` custom resource so that Pinniped knows to trust your OIDC identity provider.
+
+> You can find additional information in this [step-by-step guide](../step-by-step/kubeapps-on-tkg/step-1.md).
 
 ```yaml
 apiVersion: authentication.concierge.pinniped.dev/v1alpha1


### PR DESCRIPTION
### Description of the change

This minor PR just documents the `pinnipedConfig: true` values under the `clusters` section in our chart and removes a no longer useful warning about the required pinniped version.

### Benefits

Better docs

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
