### PR TITLE
Don't rely on randomness for test names.

### DIFF
--- a/integration/use-cases/01-add-multicluster-deployment.js
+++ b/integration/use-cases/01-add-multicluster-deployment.js
@@ -33,7 +33,7 @@ test("Deploys an application with the values by default", async () => {
   );
 
   await expect(page).toMatchElement("#releaseName", { text: "" });
-  await page.type("#releaseName", utils.getRandomName("my-app"));
+  await page.type("#releaseName", utils.getRandomName("my-app-01-deploy"));
 
   await utils.retryAndRefresh(
     page,

--- a/integration/use-cases/04-default-deployment.js
+++ b/integration/use-cases/04-default-deployment.js
@@ -18,7 +18,7 @@ test("Deploys an application with the values by default", async () => {
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   await expect(page).toMatchElement("#releaseName", { text: "" });
-  await page.type("#releaseName", utils.getRandomName("my-app"));
+  await page.type("#releaseName", utils.getRandomName("my-app-for-04-deploy"));
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 

--- a/integration/use-cases/05-missing-permissions.js
+++ b/integration/use-cases/05-missing-permissions.js
@@ -18,7 +18,7 @@ test("Fails to deploy an application due to missing permissions", async () => {
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   await expect(page).toMatchElement("#releaseName", { text: "" });
-  await page.type("#releaseName", utils.getRandomName("my-app"));
+  await page.type("#releaseName", utils.getRandomName("my-app-for-05-perms"));
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 

--- a/integration/use-cases/07-upgrade.js
+++ b/integration/use-cases/07-upgrade.js
@@ -84,7 +84,7 @@ test("Upgrades an application", async () => {
   await expect(page).toMatch("replicaCount: 2");
 
   await expect(page).toMatchElement("#releaseName", { text: "" });
-  await page.type("#releaseName", utils.getRandomName("my-app"));
+  await page.type("#releaseName", utils.getRandomName("my-app-for-07-upgrade"));
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 

--- a/integration/use-cases/lib/utils.js
+++ b/integration/use-cases/lib/utils.js
@@ -88,7 +88,7 @@ module.exports = {
     }
   },
   getRandomName: base => {
-    const randomNumber = Math.floor(Math.random() * Math.floor(100));
+    const randomNumber = Math.floor(Math.random() * Math.floor(10000));
     const name = base + "-" + randomNumber;
     return name;
   },


### PR DESCRIPTION
### Description of the change

Saw the following failure in CI:
![07-upgrade-0](https://user-images.githubusercontent.com/497518/134613159-01ebb58f-ff7f-41c9-b7b9-c0c2880cb5ea.png)


We should not be relying on random names to avoid conflict between the tests. Updates to use a release name based on the running test. I've left the random suffix so that if we ever have the same tests running concurrently in the same cluster for different Kubeapps versions, we won't immediately fail.

### Benefits

CI won't fail due to name clashes.

### Possible drawbacks

None.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
