### PR TITLE
Fix error messages in kubeappsapis

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -844,6 +844,9 @@ func (s *Server) CreateInstalledPackage(ctx context.Context, request *corev1.Cre
 		Version:                        request.GetPkgVersionReference().GetVersion(),
 	}
 	ch, registrySecrets, err := s.fetchChartWithRegistrySecrets(ctx, chartDetails, typedClient)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "Missing permissions %v", err)
+	}
 
 	// Create an action config for the target namespace.
 	actionConfig, err := s.actionConfigGetter(ctx, request.GetTargetContext())
@@ -913,6 +916,9 @@ func (s *Server) UpdateInstalledPackage(ctx context.Context, request *corev1.Upd
 		Version:                        request.GetPkgVersionReference().GetVersion(),
 	}
 	ch, registrySecrets, err := s.fetchChartWithRegistrySecrets(ctx, chartDetails, typedClient)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "Missing permissions %v", err)
+	}
 
 	// Create an action config for the installed pkg context.
 	actionConfig, err := s.actionConfigGetter(ctx, installedRef.GetContext())
@@ -1020,6 +1026,9 @@ func (s *Server) fetchChartWithRegistrySecrets(ctx context.Context, chartDetails
 		caCertSecret, authSecret,
 		s.chartClientFactory.New(appRepo.Spec.Type, userAgentString),
 	)
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "Unable to fetch the chart %s from the namespace %q: %v", chartDetails.ChartName, appRepo.Namespace, err)
+	}
 
 	registrySecrets, err := chartutils.RegistrySecretsPerDomain(ctx, appRepo.Spec.DockerRegistrySecrets, appRepo.Namespace, client)
 	if err != nil {

--- a/cmd/kubeapps-apis/server/packages.go
+++ b/cmd/kubeapps-apis/server/packages.go
@@ -139,7 +139,7 @@ func (s packagesServer) GetAvailablePackageDetail(ctx context.Context, request *
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.GetAvailablePackageDetail(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable get the GetAvailablePackageDetail from the plugin %v: %v", request.AvailablePackageRef.Plugin, err)
+		return nil, status.Errorf(status.Convert(err).Code(), "Unable get the to get the available package detail from the plugin %v: %v", request.AvailablePackageRef.Plugin, err)
 	}
 
 	// Validate the plugin response
@@ -209,7 +209,7 @@ func (s packagesServer) GetInstalledPackageDetail(ctx context.Context, request *
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.GetInstalledPackageDetail(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable get the GetInstalledPackageDetail from the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, status.Errorf(status.Convert(err).Code(), "Unable to get the installed package detail from the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	// Validate the plugin response
@@ -241,7 +241,7 @@ func (s packagesServer) GetAvailablePackageVersions(ctx context.Context, request
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.GetAvailablePackageVersions(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable get the GetAvailablePackageVersions from the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, status.Errorf(status.Convert(err).Code(), "Unable to get the available package versions from the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	// Validate the plugin response
@@ -273,7 +273,7 @@ func (s packagesServer) CreateInstalledPackage(ctx context.Context, request *pac
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.CreateInstalledPackage(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to  CreateInstalledPackage using the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, status.Errorf(status.Convert(err).Code(), "Unable to create the installed package using the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	// Validate the plugin response
@@ -302,12 +302,12 @@ func (s packagesServer) UpdateInstalledPackage(ctx context.Context, request *pac
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.UpdateInstalledPackage(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to  CreateInstalledPackage using the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, status.Errorf(status.Convert(err).Code(), "Unable to update the installed package using the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	// Validate the plugin response
 	if response.InstalledPackageRef == nil {
-		return nil, status.Errorf(codes.Internal, "Invalid CreateInstalledPackage response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, status.Errorf(codes.Internal, "Invalid UpdateInstalledPackage response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	return response, nil
@@ -331,7 +331,7 @@ func (s packagesServer) DeleteInstalledPackage(ctx context.Context, request *pac
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.DeleteInstalledPackage(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to  CreateInstalledPackage using the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, status.Errorf(status.Convert(err).Code(), "Unable to delete the installed package using the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	return response, nil


### PR DESCRIPTION
### Description of the change

As part of the https://github.com/kubeapps/kubeapps/pull/3479#issuecomment-929086192, once we're using the operations in the UI, we've noticed there were some unhandled errors. This PR is to fix it, as well as for replacing some wrong error messages. 

### Benefits

The CI tests will continue to pass again

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

Note this is a workaround until we properly handle the aggregated error messages (issue https://github.com/kubeapps/kubeapps/issues/3385).  Right now, the mgs are really ugly and not-user-friendly whatsoever :p

![image](https://user-images.githubusercontent.com/11535726/135081609-e9b1e5da-3fed-447d-84b5-0e71c254e29b.png)
