### PR TITLE
Remove `immutable` and `seamless-immutable` UI dependencies

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,7 +17,6 @@
     "fstream": "^1.0.12",
     "google-protobuf": "^3.18.0",
     "history": "^4.10.1",
-    "immutable": "^4.0.0-rc.15",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
@@ -50,7 +49,6 @@
     "redux-devtools-extension": "^2.13.9",
     "redux-thunk": "^2.3.0",
     "remark-gfm": "^2.0.0",
-    "seamless-immutable": "^7.1.4",
     "swagger-ui-react": "^3.52.3",
     "typesafe-actions": "^5.1.0",
     "yaml": "^1.10.2"

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -7343,7 +7343,7 @@ immutable@^3.8.1, immutable@^3.x.x:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
   integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
 
-"immutable@^3.8.1 || ^4.0.0-rc.1", immutable@^4.0.0-rc.15:
+"immutable@^3.8.1 || ^4.0.0-rc.1":
   version "4.0.0-rc.15"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.15.tgz#c30056f05eaaf5650fd15230586688fdd15c54bc"
   integrity sha512-v8+A3sNyaieoP9dHegl3tEYnIZa7vqNiSv0U6D7YddiZi34VjKy4GsIxrRHj2d8+CS3MeiVja5QyNe4JO/aEXA==
@@ -13314,7 +13314,7 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-seamless-immutable@^7.1.3, seamless-immutable@^7.1.4:
+seamless-immutable@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/seamless-immutable/-/seamless-immutable-7.1.4.tgz#6e9536def083ddc4dea0207d722e0e80d0f372f8"
   integrity sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==


### PR DESCRIPTION
### Description of the change

As part of the analysis done in https://github.com/kubeapps/kubeapps/issues/3480, this PR is to remove the `immutable` and `seamless-immutable` dependency as they appear to be old and unused in our current code.
Quick manual tests do not result in a failure, so let's double-check it while triggering the CI.

### Benefits

No more old/unused UI deps to maintain.

### Possible drawbacks

Perhaps it is being used by react-scripts and we haven't noticed? Unlikely but plausible, let's see what our CI thinks.

### Applicable issues

- related #3480

### Additional information

I'm creating a single PR for each change so that we can know with certainty which dep is failing.
