### PR TITLE
Remove `raf` UI dependency

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -26,7 +26,6 @@
     "prop-types": "^15.7.2",
     "protobufjs": "^6.11.2",
     "qs": "^6.10.1",
-    "raf": "^3.4.1",
     "react": "^17.0.2",
     "react-ace": "^9.4.4",
     "react-compound-slider": "^3.3.1",

--- a/dashboard/src/setupTests.ts
+++ b/dashboard/src/setupTests.ts
@@ -2,7 +2,6 @@ import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
 import Enzyme from "enzyme";
 import "jest-enzyme";
 import { WebSocket } from "mock-socket";
-import "raf/polyfill"; // polyfill for requestAnimationFrame
 
 Enzyme.configure({ adapter: new Adapter() });
 


### PR DESCRIPTION
### Description of the change

As part of the analysis done in https://github.com/kubeapps/kubeapps/issues/3480, this PR is to remove the `raf` dependency as it appears to be old and unused in our current code.
Quick manual tests do not result in a failure, so let's double-check it while triggering the CI.

### Benefits

No more old/unused UI deps to maintain.

### Possible drawbacks

Perhaps it is being used by react-scripts and we haven't noticed? Unlikely but plausible, let's see what our CI thinks.

### Applicable issues

- related #3480

### Additional information

I'm creating a single PR for each change so that we can know with certainty which dep is failing.
