### PR TITLE
Replace `normalize` with `modern-normalize` UI dependency

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,7 +22,7 @@
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
-    "normalize.css": "^8.0.1",
+    "modern-normalize": "^1.1.0",
     "prop-types": "^15.7.2",
     "protobufjs": "^6.11.2",
     "qs": "^6.10.1",

--- a/dashboard/src/index.scss
+++ b/dashboard/src/index.scss
@@ -1,4 +1,4 @@
-@import "~normalize.css/normalize.css";
+@import "~modern-normalize/modern-normalize.css";
 @import "~@cds/core/global.css"; // clarity core global styles
 @import "~@cds/core/styles/theme.dark.css"; // clarity core dark theme
 @import "~@cds/core/styles/module.shims.css"; // non-evergreen browser shims

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -10404,11 +10404,6 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-normalize.css@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
-  integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
-
 npm-run-all@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"


### PR DESCRIPTION
### Description of the change

As part of the analysis done in https://github.com/kubeapps/kubeapps/issues/3480, this PR is to replace the `normalize` dependency as it appears to be old and clarity moved to `modern-normalize`
Quick manual tests do not result in a failure, so let's double-check it while triggering the CI.

### Benefits

No more old/unused UI deps to maintain.

### Possible drawbacks

Perhaps it is being used by react-scripts and we haven't noticed? Unlikely but plausible, let's see what our CI thinks.

### Applicable issues

- related #3480

### Additional information

I'm creating a single PR for each change so that we can know with certainty which dep is failing.
