### PR TITLE
Add isLegacySchema to support both Kubeapps schema and openapi schema

### DIFF
--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Param.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/Param.tsx
@@ -162,7 +162,7 @@ export default function Param({
   } else {
     const label = param.title || param.path;
     let inputType = "string";
-    if (type === "integer") {
+    if (type === "integer" || type === "number") {
       inputType = "number";
     }
     if (

--- a/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.tsx
@@ -4,7 +4,12 @@ import Alert from "components/js/Alert";
 import Tabs from "components/Tabs";
 import { isEqual } from "lodash";
 import { useEffect, useState } from "react";
-import { parseValues, retrieveBasicFormParams, setValue } from "../../shared/schema";
+import {
+  isLegacySchema,
+  parseValues,
+  retrieveBasicFormParams,
+  setValue,
+} from "../../shared/schema";
 import { DeploymentEvent, IBasicFormParam, IChartState } from "../../shared/types";
 import { getValueFromEvent } from "../../shared/utils";
 import ConfirmDialog from "../ConfirmDialog/ConfirmDialog";
@@ -44,7 +49,7 @@ function DeploymentFormBody({
   const { availablePackageDetail, versions, schema, values, pkgVersion, error } = selected;
 
   useEffect(() => {
-    const params = retrieveBasicFormParams(appValues, schema);
+    const params = retrieveBasicFormParams(isLegacySchema(schema), appValues, schema);
     if (!isEqual(params, basicFormParameters)) {
       setBasicFormParameters(params);
     }
@@ -59,7 +64,7 @@ function DeploymentFormBody({
     setValuesModified();
   };
   const refreshBasicParameters = () => {
-    setBasicFormParameters(retrieveBasicFormParams(appValues, schema));
+    setBasicFormParameters(retrieveBasicFormParams(isLegacySchema(schema), appValues, schema));
   };
 
   const handleBasicFormParamChange = (param: IBasicFormParam) => {
@@ -94,7 +99,7 @@ function DeploymentFormBody({
   const restoreDefaultValues = () => {
     if (values) {
       setValues(values);
-      setBasicFormParameters(retrieveBasicFormParams(values, schema));
+      setBasicFormParameters(retrieveBasicFormParams(isLegacySchema(schema), values, schema));
     }
     setRestoreModalOpen(false);
   };

--- a/dashboard/src/shared/schema.test.ts
+++ b/dashboard/src/shared/schema.test.ts
@@ -5,6 +5,7 @@ describe("retrieveBasicFormParams", () => {
   [
     {
       description: "should retrieve a param",
+      isLegacySchema: true,
       values: "user: andres",
       schema: {
         properties: { user: { type: "string", form: true } },
@@ -18,6 +19,7 @@ describe("retrieveBasicFormParams", () => {
     },
     {
       description: "should retrieve a param without default value",
+      isLegacySchema: true,
       values: "user:",
       schema: {
         properties: { user: { type: "string", form: true } },
@@ -30,6 +32,7 @@ describe("retrieveBasicFormParams", () => {
     },
     {
       description: "should retrieve a param with default value in the schema",
+      isLegacySchema: true,
       values: "user:",
       schema: {
         properties: { user: { type: "string", form: true, default: "michael" } },
@@ -43,6 +46,7 @@ describe("retrieveBasicFormParams", () => {
     },
     {
       description: "values prevail over default values",
+      isLegacySchema: true,
       values: "user: foo",
       schema: {
         properties: { user: { type: "string", form: true, default: "bar" } },
@@ -56,6 +60,7 @@ describe("retrieveBasicFormParams", () => {
     },
     {
       description: "it should return params even if the values don't include it",
+      isLegacySchema: true,
       values: "foo: bar",
       schema: {
         properties: { user: { type: "string", form: true, default: "andres" } },
@@ -69,6 +74,7 @@ describe("retrieveBasicFormParams", () => {
     },
     {
       description: "should retrieve a nested param",
+      isLegacySchema: true,
       values: "credentials:\n  user: andres",
       schema: {
         properties: {
@@ -87,6 +93,7 @@ describe("retrieveBasicFormParams", () => {
     },
     {
       description: "should retrieve several params and ignore the ones not marked",
+      isLegacySchema: true,
       values: `
 # Application Credentials
 credentials:
@@ -135,6 +142,7 @@ service: ClusterIP
     },
     {
       description: "should retrieve a param with title and description",
+      isLegacySchema: true,
       values: "blogName: myBlog",
       schema: {
         properties: {
@@ -143,6 +151,7 @@ service: ClusterIP
             form: true,
             title: "Blog Name",
             description: "Title of the blog",
+            isLegacySchema: true,
           },
         },
       } as any,
@@ -153,11 +162,13 @@ service: ClusterIP
           value: "myBlog",
           title: "Blog Name",
           description: "Title of the blog",
+          isLegacySchema: true,
         } as IBasicFormParam,
       ],
     },
     {
       description: "should retrieve a param with children params",
+      isLegacySchema: true,
       values: `
 externalDatabase:
   name: "foo"
@@ -194,6 +205,7 @@ externalDatabase:
     },
     {
       description: "should retrieve a false param",
+      isLegacySchema: true,
       values: "foo: false",
       schema: {
         properties: {
@@ -204,6 +216,7 @@ externalDatabase:
     },
     {
       description: "should retrieve a param with enum values",
+      isLegacySchema: true,
       values: "databaseType: postgresql",
       schema: {
         properties: {
@@ -225,7 +238,7 @@ externalDatabase:
     },
   ].forEach(t => {
     it(t.description, () => {
-      expect(retrieveBasicFormParams(t.values, t.schema)).toMatchObject(t.result);
+      expect(retrieveBasicFormParams(t.isLegacySchema, t.values, t.schema)).toMatchObject(t.result);
     });
   });
 });


### PR DESCRIPTION
### Description of the change

As per the investigation in #3526, new charts using the [readme-generator](https://github.com/bitnami-labs/readme-generator-for-helm) tool will get an autogenerated version of the schema which is no longer compatible with the kubeapps forms.

This PR addresses (or workaround) this issue by just identifying which schema are we using (right now: "having $schema means the old one")  and decide the logic to render the form elements,
Whereas in the legacy mode only properties having `form: true` will be displayed, in a normal JSONSchema this prop does not exist, so the default behavior is showing every property (unless manually marked as `form: false`).

Note this is a really naive approach and perhaps other solutions might come up but: i) we need to discuss internally which is the roadmap and the horizon of changes ahead; ii) one of the first chart updates was Apache... which the one used in our e2e tests, wherefore they are failing since yesterday (even the main branch)

### Benefits

Ci will work again. Charts using plain jsonschemas will get a form in kubeapps for each of the properties it defines.

### Possible drawbacks

We might not want to display every property, but I don't know the proper way to add this `form:false`, `hidden, for want of a better word, to a canonic JSONSchema file while ensuring its validity (that is, ideally we would want this property to be added by the readme-generator tool just using an annotation).

### Applicable issues

- fixes #3526

### Additional information

As already said, we need to have an internal discussion on what do to in the future. Because... if JSONSchema is the way to go, perhaps we can delegate all the current logic to a 3rd party dep. Note that the loading and UI interaction times are becoming annoying as the number of fields increases.

Let's see if CI agrees and passes with these changes
