### PR TITLE
Improve upgradeView, reduce API calls

### DIFF
--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -46,6 +46,7 @@ function AppUpgrade() {
   const dispatch: ThunkDispatch<IStoreState, null, Action> = useDispatch();
   const { cluster, namespace, releaseName, pluginName, pluginVersion } =
     ReactRouter.useParams() as IRouteParams;
+
   const {
     apps: {
       selected: installedAppInstalledPackageDetail,
@@ -55,6 +56,8 @@ function AppUpgrade() {
     },
     charts: { isFetching: chartsIsFetching, selected: selectedPackage },
   } = useSelector((state: IStoreState) => state);
+
+  const isFetching = appsIsFetching || chartsIsFetching;
 
   const [pluginObj] = useState({ name: pluginName, version: pluginVersion } as Plugin);
 
@@ -73,10 +76,14 @@ function AppUpgrade() {
     return <Alert theme="danger">Unable to retrieve the current app: {error.message}</Alert>;
   }
 
-  if (appsIsFetching || !installedAppInstalledPackageDetail) {
+  if (isFetching || !installedAppInstalledPackageDetail) {
     return (
       <LoadingWrapper
-        loadingText={`Fetching ${installedAppInstalledPackageDetail?.installedPackageRef?.identifier}...`}
+        loadingText={`Fetching ${
+          installedAppInstalledPackageDetail
+            ? installedAppInstalledPackageDetail?.installedPackageRef?.identifier
+            : "package"
+        }...`}
         className="margin-t-xxl"
         loaded={false}
       />
@@ -85,13 +92,7 @@ function AppUpgrade() {
   if (installedAppAvailablePackageDetail && installedAppInstalledPackageDetail && selectedPackage) {
     return (
       <div>
-        <UpgradeForm
-          installedAppAvailablePackageDetail={installedAppAvailablePackageDetail}
-          installedAppInstalledPackageDetail={installedAppInstalledPackageDetail}
-          selected={selectedPackage}
-          chartsIsFetching={chartsIsFetching}
-          error={error}
-        />
+        <UpgradeForm />
       </div>
     );
   }

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -56,11 +56,9 @@ function AppUpgrade() {
     charts: { isFetching: chartsIsFetching, selected: selectedPackage },
   } = useSelector((state: IStoreState) => state);
 
-  const [pluginObj] = useState(
-    selectedPackage.availablePackageDetail?.availablePackageRef?.plugin ??
-      ({ name: pluginName, version: pluginVersion } as Plugin),
-  );
+  const [pluginObj] = useState({ name: pluginName, version: pluginVersion } as Plugin);
 
+  // Initial fetch using the params in the URL
   useEffect(() => {
     dispatch(
       actions.apps.getApp({
@@ -84,22 +82,14 @@ function AppUpgrade() {
       />
     );
   }
-  if (
-    installedAppInstalledPackageDetail?.currentVersion?.pkgVersion &&
-    installedAppInstalledPackageDetail?.availablePackageRef?.identifier &&
-    installedAppInstalledPackageDetail?.availablePackageRef?.context?.namespace &&
-    installedAppInstalledPackageDetail?.installedPackageRef?.identifier &&
-    installedAppInstalledPackageDetail?.installedPackageRef?.context?.cluster &&
-    installedAppInstalledPackageDetail?.installedPackageRef?.context?.namespace &&
-    installedAppInstalledPackageDetail?.availablePackageRef?.plugin
-  ) {
+  if (installedAppAvailablePackageDetail && installedAppInstalledPackageDetail && selectedPackage) {
     return (
       <div>
         <UpgradeForm
           installedAppAvailablePackageDetail={installedAppAvailablePackageDetail}
           installedAppInstalledPackageDetail={installedAppInstalledPackageDetail}
-          chartsIsFetching={chartsIsFetching}
           selected={selectedPackage}
+          chartsIsFetching={chartsIsFetching}
           error={error}
         />
       </div>

--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -54,13 +54,7 @@ function AppUpgrade() {
       selectedDetails: installedAppAvailablePackageDetail,
     },
     charts: { isFetching: chartsIsFetching, selected: selectedPackage },
-    repos: { repo },
   } = useSelector((state: IStoreState) => state);
-
-  // const repoName = repo?.metadata?.name || app?.availablePackageRef?.context?.namespace;
-  const repoNamespace =
-    repo?.metadata?.namespace ||
-    installedAppInstalledPackageDetail?.availablePackageRef?.context?.namespace;
 
   const [pluginObj] = useState(
     selectedPackage.availablePackageDetail?.availablePackageRef?.plugin ??
@@ -75,7 +69,7 @@ function AppUpgrade() {
         plugin: pluginObj,
       } as InstalledPackageReference),
     );
-  }, [dispatch, cluster, namespace, releaseName, pluginObj]);
+  }, [dispatch, cluster, namespace, pluginObj, releaseName]);
 
   if (error && error.constructor === FetchError) {
     return <Alert theme="danger">Unable to retrieve the current app: {error.message}</Alert>;
@@ -84,7 +78,7 @@ function AppUpgrade() {
   if (appsIsFetching || !installedAppInstalledPackageDetail) {
     return (
       <LoadingWrapper
-        loadingText={`Fetching ${releaseName}...`}
+        loadingText={`Fetching ${installedAppInstalledPackageDetail?.installedPackageRef?.identifier}...`}
         className="margin-t-xxl"
         loaded={false}
       />
@@ -93,28 +87,20 @@ function AppUpgrade() {
   if (
     installedAppInstalledPackageDetail?.currentVersion?.pkgVersion &&
     installedAppInstalledPackageDetail?.availablePackageRef?.identifier &&
-    repoNamespace
+    installedAppInstalledPackageDetail?.availablePackageRef?.context?.namespace &&
+    installedAppInstalledPackageDetail?.installedPackageRef?.identifier &&
+    installedAppInstalledPackageDetail?.installedPackageRef?.context?.cluster &&
+    installedAppInstalledPackageDetail?.installedPackageRef?.context?.namespace &&
+    installedAppInstalledPackageDetail?.availablePackageRef?.plugin
   ) {
     return (
       <div>
         <UpgradeForm
           installedAppAvailablePackageDetail={installedAppAvailablePackageDetail}
-          appCurrentVersion={installedAppInstalledPackageDetail.currentVersion.pkgVersion}
-          appCurrentValues={installedAppInstalledPackageDetail.valuesApplied}
-          packageId={installedAppInstalledPackageDetail.availablePackageRef.identifier}
+          installedAppInstalledPackageDetail={installedAppInstalledPackageDetail}
           chartsIsFetching={chartsIsFetching}
-          repoNamespace={repoNamespace}
-          namespace={namespace}
-          cluster={cluster}
-          releaseName={releaseName}
           selected={selectedPackage}
-          deployed={{
-            chartVersion: installedAppAvailablePackageDetail,
-            values: installedAppAvailablePackageDetail?.defaultValues,
-            schema: installedAppAvailablePackageDetail?.valuesSchema as any,
-          }}
           error={error}
-          plugin={pluginObj}
         />
       </div>
     );

--- a/dashboard/src/components/DeploymentFormBody/Differential.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/Differential.test.tsx
@@ -6,7 +6,7 @@ import Differential from "./Differential";
 it("should render a diff between two strings", () => {
   const wrapper = mountWrapper(
     defaultStore,
-    <Differential oldValues="foo" newValues="bar" emptyDiffText="empty" />,
+    <Differential oldValues="foo" newValues="bar" emptyDiffElement={<span>empty</span>} />,
   );
   expect(wrapper.find(ReactDiffViewer).props()).toMatchObject({ oldValue: "foo", newValue: "bar" });
 });
@@ -14,7 +14,11 @@ it("should render a diff between two strings", () => {
 it("should print the emptyDiffText if there are no changes", () => {
   const wrapper = mountWrapper(
     defaultStore,
-    <Differential oldValues="foo" newValues="foo" emptyDiffText="No differences!" />,
+    <Differential
+      oldValues="foo"
+      newValues="foo"
+      emptyDiffElement={<span>No differences!</span>}
+    />,
   );
   expect(wrapper.text()).toMatch("No differences!");
   expect(wrapper.text()).not.toMatch("foo");
@@ -23,7 +27,7 @@ it("should print the emptyDiffText if there are no changes", () => {
 it("sets light theme by default", () => {
   const wrapper = mountWrapper(
     defaultStore,
-    <Differential oldValues="foo" newValues="bar" emptyDiffText="empty" />,
+    <Differential oldValues="foo" newValues="bar" emptyDiffElement={<span>empty</span>} />,
   );
   expect(wrapper.find(ReactDiffViewer).prop("useDarkTheme")).toBe(false);
 });
@@ -31,7 +35,7 @@ it("sets light theme by default", () => {
 it("changes theme", () => {
   const wrapper = mountWrapper(
     getStore({ config: { theme: SupportedThemes.dark } }),
-    <Differential oldValues="foo" newValues="bar" emptyDiffText="empty" />,
+    <Differential oldValues="foo" newValues="bar" emptyDiffElement={<span>empty</span>} />,
   );
   expect(wrapper.find(ReactDiffViewer).prop("useDarkTheme")).toBe(true);
 });

--- a/dashboard/src/components/DeploymentFormBody/Differential.tsx
+++ b/dashboard/src/components/DeploymentFormBody/Differential.tsx
@@ -7,11 +7,11 @@ import "./Differential.css";
 export interface IDifferentialProps {
   oldValues: string;
   newValues: string;
-  emptyDiffText: string;
+  emptyDiffElement: JSX.Element;
 }
 
 function Differential(props: IDifferentialProps) {
-  const { oldValues, newValues, emptyDiffText } = props;
+  const { oldValues, newValues, emptyDiffElement } = props;
   const {
     config: { theme },
   } = useSelector((state: IStoreState) => state);
@@ -38,7 +38,7 @@ function Differential(props: IDifferentialProps) {
   return (
     <div className="diff deployment-form-tabs-data">
       {oldValues === newValues ? (
-        <span>{emptyDiffText}</span>
+        emptyDiffElement
       ) : (
         <ReactDiffViewer
           oldValue={oldValues}

--- a/dashboard/src/components/DeploymentFormBody/DifferentialSelector.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DifferentialSelector.tsx
@@ -15,17 +15,30 @@ export default function DifferentialSelector({
   appValues,
 }: IDifferentialSelectorProps) {
   let oldValues = "";
-  let emptyDiffText = "";
+  let emptyDiffElement = <></>;
   if (deploymentEvent === "upgrade") {
     // If there are already some deployed values (upgrade scenario)
     // We compare the values from the old release and the new one
     oldValues = deployedValues;
-    emptyDiffText = "The values for the new release are identical to the deployed version.";
+    emptyDiffElement = (
+      <span>
+        <p>
+          The values you have entered to upgrade this package with are identical to the currently
+          deployed ones.
+        </p>
+        <p>
+          If you want to restore the default values provided by the package, click on the{" "}
+          <i>Restore defaults</i> button below.
+        </p>
+      </span>
+    );
   } else {
     // If it's a new deployment, we show the different from the default
     // values for the selected version
     oldValues = defaultValues || "";
-    emptyDiffText = "No changes detected from the package defaults.";
+    emptyDiffElement = <span>No changes detected from the package defaults.</span>;
   }
-  return <Differential oldValues={oldValues} newValues={appValues} emptyDiffText={emptyDiffText} />;
+  return (
+    <Differential oldValues={oldValues} newValues={appValues} emptyDiffElement={emptyDiffElement} />
+  );
 }

--- a/dashboard/src/components/OperatorInstanceFormBody/OperatorInstanceFormBody.tsx
+++ b/dashboard/src/components/OperatorInstanceFormBody/OperatorInstanceFormBody.tsx
@@ -114,10 +114,12 @@ function DeploymentFormBody({
               <Differential
                 oldValues={deployedValues || defaultValues}
                 newValues={values}
-                emptyDiffText={
-                  deployedValues
-                    ? "No changes detected from deployed values"
-                    : "No changes detected from example defaults"
+                emptyDiffElement={
+                  deployedValues ? (
+                    <span>No changes detected from deployed values</span>
+                  ) : (
+                    <span>No changes detected from example defaults</span>
+                  )
                 }
                 key="differential-selector"
               />,

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -90,7 +90,7 @@ const defaultProps = {
   error: undefined,
   apps: { isFetching: false },
   charts: { isFetching: false },
-  selected: {
+  selectedPackage: {
     versions: [{ appVersion: "10.0.0", pkgVersion: "1.2.3" }],
     availablePackageDetail: { name: "test" } as AvailablePackageDetail,
   } as IChartState["selected"],
@@ -141,7 +141,7 @@ describe("it behaves like a loading component", () => {
     expect(
       mountWrapper(
         defaultStore,
-        <UpgradeForm {...defaultProps} selected={{ ...defaultProps.selected, versions: [] }} />,
+        <UpgradeForm {...defaultProps} selectedPackage={{ ...defaultProps.selectedPackage, versions: [] }} />,
       ).find(LoadingWrapper),
     ).toExist();
   });
@@ -152,7 +152,7 @@ describe("it behaves like a loading component", () => {
         defaultStore,
         <UpgradeForm
           {...defaultProps}
-          selected={{ ...defaultProps.selected, availablePackageDetail: undefined }}
+          selectedPackage={{ ...defaultProps.selectedPackage, availablePackageDetail: undefined }}
         />,
       ).find(LoadingWrapper),
     ).toExist();
@@ -189,7 +189,7 @@ it("fetches the current chart version even if there is already one in the state"
   Chart.getAvailablePackageDetail = getAvailablePackageDetail;
   mountWrapper(
     defaultStore,
-    <UpgradeForm {...defaultProps} selected={selected} deployed={deployed} />,
+    <UpgradeForm {...defaultProps} selectedPackage={selected} deployed={deployed} />,
   );
   expect(getAvailablePackageDetail).toHaveBeenCalledWith(
     {
@@ -213,7 +213,7 @@ describe("renders an error", () => {
     };
     const wrapper = mountWrapper(
       defaultStore,
-      <UpgradeForm {...defaultProps} selected={selected} />,
+      <UpgradeForm {...defaultProps} selectedPackage={selected} />,
     );
     expect(wrapper.find(Alert).exists()).toBe(true);
     expect(wrapper.find(Alert).html()).toContain("wrong format!");
@@ -312,7 +312,7 @@ describe("when receiving new props", () => {
         {...populatedProps}
         deployed={{ values: deployedValues }}
         appCurrentValues={currentValues}
-        selected={{
+        selectedPackage={{
           versions: [testVersion],
           availablePackageDetail: availablePkgDetails[1],
           values: defaultValues,
@@ -426,7 +426,7 @@ describe("when receiving new props", () => {
           {...populatedProps}
           appCurrentValues={t.deployedValues}
           deployed={deployed}
-          selected={newSelected}
+          selectedPackage={newSelected}
         />,
       );
       expect(wrapper.find(DeploymentFormBody).prop("appValues")).toEqual(t.result);

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -11,9 +11,7 @@ import { push } from "connected-react-router";
 import * as jsonpatch from "fast-json-patch";
 import {
   AvailablePackageDetail,
-  AvailablePackageReference,
   InstalledPackageDetail,
-  InstalledPackageReference,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import * as yaml from "js-yaml";
 import { useEffect, useState } from "react";
@@ -28,11 +26,11 @@ import LoadingWrapper from "../LoadingWrapper/LoadingWrapper";
 import "./UpgradeForm.css";
 
 export interface IUpgradeFormProps {
-  installedAppAvailablePackageDetail?: AvailablePackageDetail;
-  installedAppInstalledPackageDetail?: InstalledPackageDetail;
+  installedAppAvailablePackageDetail: AvailablePackageDetail;
+  installedAppInstalledPackageDetail: InstalledPackageDetail;
+  selected: IChartState["selected"];
   chartsIsFetching: boolean;
   error?: Error;
-  selected: IChartState["selected"];
 }
 
 function applyModifications(mods: jsonpatch.Operation[], values: string) {
@@ -81,16 +79,9 @@ function UpgradeForm({
 
   useEffect(() => {
     dispatch(
-      actions.charts.fetchChartVersions({
-        context: {
-          cluster: installedAppInstalledPackageDetail?.installedPackageRef?.context?.cluster,
-          namespace: installedAppInstalledPackageDetail?.availablePackageRef?.context?.namespace,
-        },
-        plugin: installedAppInstalledPackageDetail?.availablePackageRef?.plugin,
-        identifier: installedAppInstalledPackageDetail?.availablePackageRef?.identifier,
-      } as AvailablePackageReference),
+      actions.charts.fetchChartVersions(installedAppInstalledPackageDetail?.availablePackageRef),
     );
-  }, [dispatch, installedAppInstalledPackageDetail]);
+  }, [dispatch, installedAppInstalledPackageDetail?.availablePackageRef]);
 
   useEffect(() => {
     if (installedAppAvailablePackageDetail?.defaultValues && !modifications) {
@@ -152,14 +143,7 @@ function UpgradeForm({
   const selectVersion = (e: React.ChangeEvent<HTMLSelectElement>) => {
     dispatch(
       actions.charts.fetchChartVersion(
-        {
-          context: {
-            cluster: installedAppInstalledPackageDetail?.installedPackageRef?.context?.cluster,
-            namespace: installedAppInstalledPackageDetail?.availablePackageRef?.context?.namespace,
-          },
-          plugin: installedAppInstalledPackageDetail?.availablePackageRef?.plugin,
-          identifier: installedAppInstalledPackageDetail?.availablePackageRef?.identifier,
-        } as AvailablePackageReference,
+        installedAppInstalledPackageDetail?.availablePackageRef,
         e.currentTarget.value,
       ),
     );
@@ -171,15 +155,7 @@ function UpgradeForm({
     if (availablePackageDetail) {
       const deployedSuccess = await dispatch(
         actions.apps.upgradeApp(
-          {
-            context: {
-              cluster: installedAppInstalledPackageDetail?.installedPackageRef?.context?.cluster,
-              namespace:
-                installedAppInstalledPackageDetail?.installedPackageRef?.context?.namespace,
-            },
-            identifier: installedAppInstalledPackageDetail?.installedPackageRef?.identifier,
-            plugin: installedAppInstalledPackageDetail?.availablePackageRef?.plugin,
-          } as InstalledPackageReference,
+          installedAppInstalledPackageDetail?.installedPackageRef!,
           availablePackageDetail,
           installedAppInstalledPackageDetail?.availablePackageRef?.context?.namespace!,
           appValues,
@@ -188,19 +164,7 @@ function UpgradeForm({
       );
       setIsDeploying(false);
       if (deployedSuccess) {
-        dispatch(
-          push(
-            url.app.apps.get({
-              context: {
-                cluster: installedAppInstalledPackageDetail?.installedPackageRef?.context?.cluster,
-                namespace:
-                  installedAppInstalledPackageDetail?.installedPackageRef?.context?.namespace,
-              },
-              plugin: installedAppInstalledPackageDetail?.availablePackageRef?.plugin,
-              identifier: installedAppInstalledPackageDetail?.installedPackageRef?.identifier,
-            } as AvailablePackageReference),
-          ),
-        );
+        dispatch(push(url.app.apps.get(installedAppInstalledPackageDetail?.installedPackageRef)));
       }
     }
   };


### PR DESCRIPTION
### Description of the change

The UpgradeView has been causing some headaches recently in CI, also, we got some issues and PR related to this view. This PR is aimed at addressing some of the issues, starting from reducing the number of redundant API calls we were making.
I've simplified the objects used there and, from now on, the source of truth is the react state. 

The high-level logic is:

1. `AppUpgrade`: get the parameters from the URL and load the `installedApp_InstalledPackageDetail` and `installedApp_AvailablePackageDetail`.
2. `UpgradeForm`: 
    1. Fetch the list of versions for this installed package
    2. If first time, mark as "selected" the currently deployed version (this prevents the blinking dropdown causing our tests to fail).
    3. Subsequent times, mark as select just what the user chooses via dropdown


### Benefits

I hope the CI doesn't complain anymore about the failing upgrade.

### Possible drawbacks

Unnoticed or unintended changes that leads to some unexpected behavior. However, I'll try to unit-test and e2e-test it as much as possible.


### Applicable issues

- fixes #3538
- fixes #3536

### Additional information

Marking as a draft as test are still pending
(personal note) merge and consider also this PR: https://github.com/kubeapps/kubeapps/pull/3525/files

Due to the myriad of changes in ongoing PRs, this one is likely subject to be modified while we merge some of them, (renaming, buttons using new API, etc). Holding off in the meantime.
