### PR TITLE
Mutate chart name when pushing to charmusseum

### DIFF
--- a/integration/use-cases/01-add-multicluster-deployment.js
+++ b/integration/use-cases/01-add-multicluster-deployment.js
@@ -20,8 +20,8 @@ test("Deploys an application with the values by default", async () => {
 
   await expect(page).toClick("a", { text: "Catalog" });
 
-  await expect(page).toMatchElement("a", { text: "Apache HTTP Server", timeout: 60000 });
-  await expect(page).toClick("a", { text: "Apache HTTP Server" });
+  await expect(page).toMatchElement("a", { text: "foo apache chart for CI", timeout: 60000 });
+  await expect(page).toClick("a", { text: "foo apache chart for CI" });
 
   await utils.retryAndRefresh(
     page,

--- a/integration/use-cases/02-create-private-registry.js
+++ b/integration/use-cases/02-create-private-registry.js
@@ -67,11 +67,11 @@ test("Creates a private registry", async () => {
     page,
     3,
     async () => {
-      await expect(page).toMatchElement("a", { text: "Apache HTTP Server", timeout: 10000 });
+      await expect(page).toMatchElement("a", { text: "foo apache chart for CI", timeout: 10000 });
     },
     testName,
   );
-  await expect(page).toClick("a", { text: "Apache HTTP Server" });
+  await expect(page).toClick("a", { text: "foo apache chart for CI" });
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 

--- a/integration/use-cases/04-default-deployment.js
+++ b/integration/use-cases/04-default-deployment.js
@@ -12,8 +12,8 @@ test("Deploys an application with the values by default", async () => {
 
   await expect(page).toClick("a", { text: "Catalog" });
 
-  await expect(page).toMatchElement("a", { text: "Apache HTTP Server", timeout: 60000 });
-  await expect(page).toClick("a", { text: "Apache HTTP Server" });
+  await expect(page).toMatchElement("a", { text: "foo apache chart for CI", timeout: 60000 });
+  await expect(page).toClick("a", { text: "foo apache chart for CI" });
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 

--- a/integration/use-cases/07-upgrade.js
+++ b/integration/use-cases/07-upgrade.js
@@ -13,8 +13,8 @@ test("Upgrades an application", async () => {
     "password",
   );
 
-  await expect(page).toMatchElement("a", { text: "Apache HTTP Server", timeout: 60000 });
-  await expect(page).toClick("a", { text: "Apache HTTP Server" });
+  await expect(page).toMatchElement("a", { text: "foo apache chart for CI", timeout: 60000 });
+  await expect(page).toClick("a", { text: "foo apache chart for CI" });
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 

--- a/integration/use-cases/08-rollback.js
+++ b/integration/use-cases/08-rollback.js
@@ -12,8 +12,8 @@ test("Rolls back an application", async () => {
   );
 
   // Deploy the app
-  await expect(page).toMatchElement("a", { text: "Apache HTTP Server", timeout: 60000 });
-  await expect(page).toClick("a", { text: "Apache HTTP Server" });
+  await expect(page).toMatchElement("a", { text: "foo apache chart for CI", timeout: 60000 });
+  await expect(page).toClick("a", { text: "foo apache chart for CI" });
 
   await expect(page).toClick("cds-button", { text: "Deploy" });
 

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -280,7 +280,7 @@ if [[ -n "${TEST_UPGRADE}" ]]; then
   # To test the upgrade, first install the latest version published
   info "Installing latest Kubeapps chart available"
   installOrUpgradeKubeapps bitnami/kubeapps \
-    "--set" "apprepository.initialRepos=null"
+    "--set" "apprepository.initialRepos={}"
 
   info "Waiting for Kubeapps components to be ready (bitnami chart)..."
   k8s_wait_for_deployment kubeapps kubeapps-ci

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -193,6 +193,10 @@ installOrUpgradeKubeapps() {
     --set postgresql.replication.enabled=false
     --set postgresql.postgresqlPassword=password
     --set redis.auth.password=password
+    --set apprepository.initialRepos[0].name=bitnami
+    --set apprepository.initialRepos[0].url=http://chartmuseum-chartmuseum.kubeapps:8080
+    --set apprepository.initialRepos[0].basicAuth.user=admin
+    --set apprepository.initialRepos[0].basicAuth.password=password
     --wait)
 
   echo "${cmd[@]}"


### PR DESCRIPTION
### Description of the change

This PR is intended to mitigate https://github.com/kubeapps/kubeapps/issues/3339 by replacing the chart `chart` with `prefix-chart`. This way, we will get a valid chart from the bitnami repo (as we were doing), but it cannot be retrieved by looking up the bitnami catalog (since `prefix-chart` does not exist anywhere except for our chartmusseum instance).
Also, it changes the description to ensure we are selecting the mutated chart.

Besides, instead of using the "bitnami" repo, this PR also installs a "bitnami" repo, but points to the local chartmusseum (which holds the mutated charts).

### Benefits

I really hope this PR would fix the CI issues we're having, as well as protect us from further upstream changes...

### Possible drawbacks

Perhaps the e2e tests will have to be modified. Let's see what our beloved CI has to say first. Edit: it passed!

### Applicable issues

-  related #3531

### Additional information

N/A
