### PR TITLE
Replace helm stable with BAC in chart readme

### DIFF
--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -559,7 +559,7 @@ helm install kubeapps --namespace kubeapps -f custom-values.yaml bitnami/kubeapp
 
 ### Configuring Initial Repositories
 
-By default, Kubeapps will track the [community Helm charts](https://github.com/helm/charts). To change these defaults, override with your desired parameters the `apprepository.initialRepos` object present in the [values.yaml](values.yaml) file.
+By default, Kubeapps will track the [Bitnami Application Catalog](https://github.com/bitnami/charts). To change these defaults, override with your desired parameters the `apprepository.initialRepos` object present in the [values.yaml](values.yaml) file.
 
 ### Enabling Operators
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -2,7 +2,6 @@
   "name": "dashboard",
   "version": "0.1.0",
   "private": true,
-  "proxy": "https://localhost", 
   "homepage": "./",
   "dependencies": {
     "@cds/city": "^1.1.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -2,6 +2,7 @@
   "name": "dashboard",
   "version": "0.1.0",
   "private": true,
+  "proxy": "https://localhost", 
   "homepage": "./",
   "dependencies": {
     "@cds/city": "^1.1.0",


### PR DESCRIPTION
### Description of the change

Minor PR replacing an old reference to the Helm stable repo with the Bitnami Application Catalog.

### Benefits

Up to date docs.

### Possible drawbacks

N/A, but CI will complain anyway :(

### Applicable issues

N/A

### Additional information

N/A
