### PR TITLE
Duplicated - fix(upgrade): Fetch package from its installed cluster

### DIFF
--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -75,7 +75,10 @@ function AppUpgrade() {
     dispatch(
       actions.charts.getDeployedChartVersion(
         {
-          context: { cluster: cluster, namespace: repoNamespace ?? "" },
+          context: {
+            cluster: app?.availablePackageRef?.context?.cluster ?? cluster,
+            namespace: repoNamespace ?? "",
+          },
           identifier: app?.availablePackageRef?.identifier ?? "",
           plugin: app?.availablePackageRef?.plugin,
         } as AvailablePackageReference,

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -164,7 +164,10 @@ it("fetches the available versions", () => {
   Chart.getAvailablePackageVersions = getAvailablePackageVersions;
   mountWrapper(defaultStore, <UpgradeForm {...defaultProps} />);
   expect(getAvailablePackageVersions).toHaveBeenCalledWith({
-    context: { cluster: defaultProps.cluster, namespace: defaultProps.repoNamespace },
+    context: {
+      cluster: defaultProps.cluster,
+      namespace: defaultProps.repoNamespace,
+    },
     identifier: defaultProps.packageId,
     plugin: defaultProps.plugin,
   } as AvailablePackageReference);
@@ -193,7 +196,10 @@ it("fetches the current chart version even if there is already one in the state"
   );
   expect(getAvailablePackageDetail).toHaveBeenCalledWith(
     {
-      context: { cluster: defaultProps.cluster, namespace: defaultProps.repoNamespace },
+      context: {
+        cluster: availablePkgDetails[0].availablePackageRef?.context?.cluster,
+        namespace: defaultProps.repoNamespace,
+      },
       identifier: defaultProps.packageId,
       plugin: defaultProps.plugin,
     } as AvailablePackageReference,

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -81,6 +81,8 @@ function UpgradeForm({
 
   const { availablePackageDetail, versions, schema, values, pkgVersion } = selected;
 
+  const packageCluster = availablePackageDetail?.availablePackageRef?.context?.cluster;
+
   const {
     apps: { isFetching: appsFetching },
     charts: { isFetching: chartsFetching },
@@ -91,12 +93,15 @@ function UpgradeForm({
   useEffect(() => {
     dispatch(
       actions.charts.fetchChartVersions({
-        context: { cluster: cluster, namespace: repoNamespace },
+        context: {
+          cluster: packageCluster ?? cluster,
+          namespace: repoNamespace,
+        },
         plugin: pluginObj,
         identifier: packageId,
       } as AvailablePackageReference),
     );
-  }, [dispatch, cluster, repoNamespace, packageId, pluginObj]);
+  }, [dispatch, packageCluster, repoNamespace, packageId, cluster, pluginObj]);
 
   useEffect(() => {
     if (deployed.values && !modifications) {
@@ -122,7 +127,7 @@ function UpgradeForm({
     dispatch(
       actions.charts.fetchChartVersion(
         {
-          context: { cluster: cluster, namespace: repoNamespace },
+          context: { cluster: packageCluster, namespace: repoNamespace },
           plugin: pluginObj,
           identifier: packageId,
         } as AvailablePackageReference,
@@ -131,7 +136,7 @@ function UpgradeForm({
     );
   }, [
     dispatch,
-    cluster,
+    packageCluster,
     repoNamespace,
     packageId,
     deployed.chartVersion?.version?.pkgVersion,
@@ -160,7 +165,7 @@ function UpgradeForm({
     dispatch(
       actions.charts.fetchChartVersion(
         {
-          context: { cluster: cluster, namespace: repoNamespace },
+          context: { cluster: packageCluster, namespace: repoNamespace },
           plugin: pluginObj,
           identifier: packageId,
         } as AvailablePackageReference,


### PR DESCRIPTION
edit(antgamdia): duplicating PR from our branch to avoid some permission-related issues after the forked repo was migrated to another repository. If CI passes, this PR should be ready to be merged. -- all credits of this PR should go to .aanthonyrizzo

PR comments at https://github.com/kubeapps/kubeapps/pull/3525


### Description of the change
<!-- Describe the scope of your change - i.e. what the change does. -->
This PR addresses (what I think is a bug) regarding the fetching of Packages when upgrading.

#### Current behavior
When navigating to the upgrade form for deployments that are installed in the `"default"` cluster. The upgrade form fails to fetch the applicable package details if it is looking in the wrong cluster.
![image](https://user-images.githubusercontent.com/36711320/135318524-441b5375-c178-4fd7-82eb-df67cdd69737.png)

#### New behavior
When fetching the package details, we use the cluster that is defined in the `AvailablePackageDetail` property when fetching the package. This should lead to correct fetching behavior.

### Benefits
<!-- What benefits will be realized by the code change? -->
Global packages that are installed in the `""` cluster but are deployed in the `"default"` can now be upgraded.

### Possible drawbacks
<!-- Describe any known limitations with your change -->
I don't believe there are any.

### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
I did not create an issue since I was experimenting w/ solutions locally and seemed to have solved it.

### Additional information
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
I believe this is a relatively impactful bug that is present in https://github.com/kubeapps/kubeapps/commit/05775ff847dcd3bc320f898d9c5963caf4e00d57 and should be addressed before the next major release. I have not pinpointed the exact commit that broke this behavior.

.antgamdia .absoludity for visibility 