### PR TITLE
Add missing rolebinding for the CI user

### DIFF
--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -409,6 +409,7 @@ kubectl create clusterrolebinding kubeapps-view --clusterrole=view --serviceacco
 kubectl create serviceaccount kubeapps-edit -n kubeapps
 kubectl create rolebinding kubeapps-edit -n kubeapps --clusterrole=edit --serviceaccount kubeapps:kubeapps-edit
 kubectl create rolebinding kubeapps-edit -n default --clusterrole=edit --serviceaccount kubeapps:kubeapps-edit
+kubectl create rolebinding kubeapps-repositories-read -n kubeapps --clusterrole kubeapps:kubeapps:apprepositories-read --serviceaccount kubeapps:kubeapps-edit
 
 ## Give the cluster some time to avoid issues like
 ## https://circleci.com/gh/kubeapps/kubeapps/16102


### PR DESCRIPTION
### Description of the change

This minor PR just adds a missing rolebinding (granting read on apprepositories) to the CI SA token we use as "edit-token".

### Benefits

CI will work in GKE (well, not only GKE, but any CI workflow not using the OIDC login)

### Possible drawbacks

None, but I wonder if this change is also required for some users. Not sure, but I'll drop a line in the release notes, just in case.

### Applicable issues

N/A
### Additional information

Rubber-stamping as it has been tested at https://app.circleci.com/pipelines/github/kubeapps/kubeapps/4497/workflows/17a5635f-fcfc-48f6-a3ec-5da8bc778b65