### PR TITLE
Show http or https when deploying with LoadBalancer

### DIFF
--- a/chart/kubeapps/templates/NOTES.txt
+++ b/chart/kubeapps/templates/NOTES.txt
@@ -48,7 +48,7 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
        Watch the status by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
 
    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-   echo "Kubeapps URL: http://$SERVICE_IP:{{ .Values.frontend.service.port }}"
+   echo "Kubeapps URL: http{{ if eq ( .Values.frontend.service.port | toString ) "443" }}s{{ end }}://$SERVICE_IP:{{ .Values.frontend.service.port }}"
 
 {{- else if contains "ClusterIP" .Values.frontend.service.type }}
 


### PR DESCRIPTION
### Description of the change

I've noticed I had this uncommitted minor change: displaying httpS if the port is 443 in the installation notes. Even if it is a stop-gap solution (not every HTTP over TLS is under 443 port), it will cover a wide range of deployments using the std port.

### Benefits

Navigating to the generated link will no longer result in a 404 page if using a loadbalancer that only exposes the :443 socket (and no redirection has been configured)

### Possible drawbacks

A user defining a plain HTTP protocol listening at :443 will get the error page... but, it's their fault for using an IANA-reserved port :P

### Applicable issues

N/A

### Additional information

N/A
