### PR TITLE
Enable UX to request fluxv2 available packages

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
@@ -40,7 +40,7 @@ func init() {
 // returning the server implementation.
 func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter, clustersConfig kube.ClustersConfig) (interface{}, error) {
 	log.Infof("+fluxv2 RegisterWithGRPCServer")
-	svr, err := NewServer(configGetter)
+	svr, err := NewServer(configGetter, clustersConfig.KubeappsClusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo_test.go
@@ -51,7 +51,6 @@ type testSpecGetAvailablePackageSummaries struct {
 }
 
 func TestGetAvailablePackageSummaries(t *testing.T) {
-	const KubeappsCluster = "default"
 	testCases := []struct {
 		name              string
 		request           *corev1.GetAvailablePackageSummariesRequest

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server_test.go
@@ -35,6 +35,8 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
+const KubeappsCluster = "default"
+
 func TestBadClientGetter(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -255,7 +257,8 @@ func newServer(clientGetter clientGetter, actionConfig *action.Configuration, re
 		actionConfigGetter: func(context.Context, string) (*action.Configuration, error) {
 			return actionConfig, nil
 		},
-		cache: cache,
+		cache:           cache,
+		kubeappsCluster: KubeappsCluster,
 	}
 	return s, mock, nil
 }


### PR DESCRIPTION
### Description of the change

This will be the first in a list of PRs required to use the flux plugin from the UI (I'll add and link an issue to track them).

Running the Kubeapps UX with the fluxv2 plugin enabled results in:

![kubeapps-with-fluxv2-unimplemented](https://user-images.githubusercontent.com/497518/137844637-4da87477-809e-469b-a97c-4a5bc068fe5f.png)

This is because currently the plugin handles the case where the `request.Context.Cluster == ""` (ie. cluster isn't specified) only, in which case it correctly defaults to the cluster on which Kubeapps is installed. Since the UI will not know which requests plugins can handle (ie. which plugins support requests for different clusters etc.), it will always set the full context and rely on the plugin to respond with unimplemented or a valid response accordingly.

With this change, the response correctly comes back as empty rather than unimplemented (before I've added any flux `HelmRepositories`):

![kubeapps-with-fluxv2-empty](https://user-images.githubusercontent.com/497518/137845266-a36f524e-c108-4c5e-a568-ed14e1b1206c.png)

### Benefits

Don't see an error when browsing for available apps using the flux plugin.

### Possible drawbacks

Can't think of any.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
Ref: #3610 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
