### PR TITLE
Increase kubeops pod's memory

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -948,7 +948,7 @@ kubeops:
   resources:
     limits:
       cpu: 250m
-      memory: 256Mi
+      memory: 1Gi
     requests:
       cpu: 25m
       memory: 32Mi


### PR DESCRIPTION
### Description of the change

DRAFT PR: this is just a not-mergeable change increasing the memory of the kubeops pod. To see if it exhausts all the assigned memory or it is just the new go versions require more memory.

### Benefits

N/A

### Possible drawbacks

N/A

### Applicable issues

- related to https://github.com/kubeapps/kubeapps/pull/3632

### Additional information

N/A