### PR TITLE
Remove husky as a dependency

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -114,7 +114,6 @@
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-redos": "^1.2.0",
-    "husky": "^4.3.8",
     "jest-enzyme": "^7.1.2",
     "jest-plugin-context": "^2.9.0",
     "lint-staged": "^11.2.3",
@@ -146,11 +145,6 @@
     "transformIgnorePatterns": [
       "node_modules/(?!@cds|@clr|@lit|bail|ccount|character-entities|comma-separated-tokens|escape-string-regexp|is-plain-obj|lit|lodash-es|markdown-table|mdast-util-definitions|mdast-util-find-and-replace|mdast-util-from-markdown|mdast-util-gfm|mdast-util-gfm-autolink-literal|mdast-util-to-hast|mdast-util-to-markdown|mdast-util-to-string|micromark|micromark-core-commonmark|parse-entities|property-information|ramda|react-markdown|react-markdown|remark-gfm|remark-parse|remark-rehype|space-separated-tokens|trough|unified|unist-builder|unist-util-generated|unist-util-is|unist-util-position|unist-util-stringify-position|unist-util-visit|unist-util-visit-parents|util-find-and-replace|vfile|vfile-message|.*css)"
     ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "yarn run ts-compile-check && lint-staged"
-    }
   },
   "browserslist": {
     "production": [

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -7314,22 +7314,6 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-husky@^4.3.8:
-  version "4.3.8"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.8.tgz#31144060be963fd6850e5cc8f019a1dfe194296d"
-  integrity sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==
-  dependencies:
-    chalk "^4.0.0"
-    ci-info "^2.0.0"
-    compare-versions "^3.6.0"
-    cosmiconfig "^7.0.0"
-    find-versions "^4.0.0"
-    opencollective-postinstall "^2.0.2"
-    pkg-dir "^5.0.0"
-    please-upgrade-node "^3.2.0"
-    slash "^3.0.0"
-    which-pm-runs "^1.0.0"
-
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
See https://github.com/kubeapps/kubeapps/pull/3626

Neither I nor Antonio are using husky to check frontend lint pre-commit (we've moved this to the image so non-linted code won't pass CI, and devs can do what they want to check locally).

Signed-off-by: Michael Nelson <minelson@vmware.com>

