### PR TITLE
Update rust to 1.56 with edition2021

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
     default: "14"
   RUST_VERSION:
     type: string
-    default: "1.55.0"
+    default: "1.56.0"
   DOCKER_VERSION:
     type: string
     default: "20.10.7"

--- a/cmd/pinniped-proxy/.rustfmt.toml
+++ b/cmd/pinniped-proxy/.rustfmt.toml
@@ -1,2 +1,2 @@
 imports_layout = "Horizontal"
-edition = "2018"
+edition = "2021"

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pinniped-proxy"
 version = "0.0.0-devel"
 authors = ["Kubeapps team <tanzu-kubeapps-team@vmware.com>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cmd/pinniped-proxy/Dockerfile
+++ b/cmd/pinniped-proxy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1
 
-FROM rust:1.55.0 as builder
+FROM rust:1.56.0 as builder
 
 WORKDIR /pinniped-proxy
 ARG VERSION


### PR DESCRIPTION
### Description of the change

The new edition of Rust just went out and some of our crates are using it. This PR is to update the Rust edition as there are no breaking changes affecting us.

List of the features and changes: https://blog.rust-lang.org/2021/05/11/edition-2021.html

### Benefits

Crates using `edition2021` will be able to get upgraded.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A