### PR TITLE
Extract repo and branches to the CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,24 @@ parameters:
   CI_BOT_FORKED_CHARTS_DEPLOYKEY_FILENAME:
     type: "string"
     default: "id_rsa_59812a95a654a746e515f537b34f6cad"
+  CHARTS_REPO_ORIGINAL:
+    type: "string"
+    default: "bitnami/charts"
+  BRANCH_CHARTS_REPO_ORIGINAL:
+    type: "string"
+    default: "BRANCH"
+  CHARTS_REPO_FORKED:
+    type: "string"
+    default: "kubeapps-bot/charts"
+  BRANCH_CHARTS_REPO_FORKED:
+    type: "string"
+    default: "master"
+  KUBEAPPS_REPO:
+    type: "string"
+    default: "kubeapp/kubeapps"
+  BRANCH_KUBEAPPS_REPO:
+    type: "string"
+    default: "master"
 
 ## Build conditions
 # Build on any branch or tag
@@ -651,7 +669,7 @@ jobs:
           # This token is passed as a GITHUB_TOKEN env var via CircleCI
           name: Execute the create_release script
           command: |
-            ./script/create_release.sh ${CIRCLE_TAG}
+            ./script/create_release.sh ${CIRCLE_TAG} << pipeline.parameters.KUBEAPPS_REPO >>
   local_e2e_tests:
     machine: true
     environment:
@@ -720,7 +738,7 @@ jobs:
           # This token is passed as a GITHUB_TOKEN env var via CircleCI
           name: Execute the chart_sync script
           command: |
-            ./script/chart_sync.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >>
+            ./script/chart_sync.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >> << pipeline.parameters.CHARTS_REPO_ORIGINAL >> << pipeline.parameters.BRANCH_CHARTS_REPO_ORIGINAL >> << pipeline.parameters.CHARTS_REPO_FORKED >> << pipeline.parameters.BRANCH_CHARTS_REPO_FORKED >>
   sync_chart_from_bitnami:
     environment:
       <<: *common_envars
@@ -755,7 +773,7 @@ jobs:
           # This token is passed as a GITHUB_TOKEN env var via CircleCI
           name: Execute the check_upstream_chart script
           command: |
-            ./script/chart_upstream_checker.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >> << pipeline.parameters.CI_BOT_FORKED_CHARTS_DEPLOYKEY_FILENAME >>
+            ./script/chart_upstream_checker.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >> << pipeline.parameters.CI_BOT_FORKED_CHARTS_DEPLOYKEY_FILENAME >> << pipeline.parameters.CHARTS_REPO_ORIGINAL >> << pipeline.parameters.BRANCH_CHARTS_REPO_ORIGINAL >> << pipeline.parameters.CHARTS_REPO_FORKED >> << pipeline.parameters.BRANCH_CHARTS_REPO_FORKED >> << pipeline.parameters.KUBEAPPS_REPO >> << pipeline.parameters.BRANCH_KUBEAPPS_REPO >>
   push_images:
     docker:
       - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>

--- a/script/chart-template-test.sh
+++ b/script/chart-template-test.sh
@@ -20,10 +20,11 @@ set -o pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null && pwd)
 CHART_DIR=$ROOT_DIR/chart/kubeapps/
-helm dep up $CHART_DIR
+
+helm dep up "${CHART_DIR}"
 
 # test with the minium supported helm version
-helm template $CHART_DIR --debug
+helm template "${CHART_DIR}" --debug
 
 # test with the latest stable helm version
-helm-stable template $CHART_DIR --debug
+helm-stable template "${CHART_DIR}" --debug

--- a/script/chart_sync.sh
+++ b/script/chart_sync.sh
@@ -20,26 +20,35 @@ set -o pipefail
 
 source $(dirname $0)/chart_sync_utils.sh
 
-user=${1:?}
-email=${2:?}
-gpg=${3:?}
+USERNAME=${1:?Missing git username}
+EMAIL=${2:?Missing git email}
+GPG_KEY=${3:?Missing git gpg key}
+CHARTS_REPO_ORIGINAL=${4:?Missing base chart repository}
+BRANCH_CHARTS_REPO_ORIGINAL=${5:?Missing base chart repository branch}
+CHARTS_REPO_FORKED=${6:?Missing forked chart repository}
+BRANCH_CHARTS_REPO_FORKED=${7:?Missing forked chart repository branch}
 
-currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep -oP '(?<=^version: ).*')
-externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO_ORIGINAL}/master/${CHART_REPO_PATH}/Chart.yaml | grep -oP '(?<=^version: ).*')
+currentVersion=$(grep -oP '(?<=^version: ).*' <"${KUBEAPPS_CHART_DIR}/Chart.yaml")
+externalVersion=$(curl -s "https://raw.githubusercontent.com/${CHARTS_REPO_ORIGINAL}/${BRANCH_CHARTS_REPO_ORIGINAL}/${CHART_REPO_PATH}/Chart.yaml" | grep -oP '(?<=^version: ).*')
 semverCompare=$(semver compare "${currentVersion}" "${externalVersion}")
+
 # If current version is greater than the chart external version, then send a PR bumping up the version externally
 if [[ ${semverCompare} -gt 0 ]]; then
-    echo "Current chart version ("${currentVersion}") is greater than the chart external version ("${externalVersion}")"
-    tempDir=$(mktemp -u)/charts
-    mkdir -p $tempDir
-    git clone https://github.com/${CHARTS_REPO} $tempDir --depth 1 --no-single-branch
-    configUser $tempDir $user $email $gpg
-    configUser $PROJECT_DIR $user $email $gpg
-    latestVersion=$(latestReleaseTag $PROJECT_DIR)
-    updateRepoWithLocalChanges $tempDir $latestVersion
-    commitAndSendExternalPR $tempDir "kubeapps-bump-${currentVersion}" ${currentVersion}
+    echo "Current chart version (${currentVersion}) is greater than the chart external version (${externalVersion})"
+    TMP_DIR=$(mktemp -u)/charts
+    mkdir -p "${TMP_DIR}"
+
+    git clone "https://github.com/${CHARTS_REPO_FORKED}" "${TMP_DIR}" --depth 1 --no-single-branch
+    configUser "${TMP_DIR}" "${USERNAME}" "${EMAIL}" "${GPG_KEY}"
+    configUser "${PROJECT_DIR}" "${USERNAME}" "${EMAIL}" "${GPG_KEY}"
+
+    latestVersion=$(latestReleaseTag "${PROJECT_DIR}")
+    prBranchName="kubeapps-bump-${currentVersion}"
+
+    updateRepoWithLocalChanges "${TMP_DIR}" "${latestVersion}" "${CHARTS_REPO_ORIGINAL}" "${BRANCH_CHARTS_REPO_ORIGINAL}" "${BRANCH_CHARTS_REPO_FORKED}"
+    commitAndSendExternalPR "${TMP_DIR}" "${prBranchName}" "${currentVersion}" "${CHARTS_REPO_ORIGINAL}" "${BRANCH_CHARTS_REPO_ORIGINAL}"
 elif [[ ${semverCompare} -lt 0 ]]; then
-    echo "Skipping Chart sync. WARNING Current chart version ("${currentVersion}") is less than the chart external version ("${externalVersion}")"
+    echo "Skipping Chart sync. WARNING Current chart version (${currentVersion}) is less than the chart external version (${externalVersion})"
 else
-    echo "Skipping Chart sync. The chart version ("${currentVersion}") has not changed"
+    echo "Skipping Chart sync. The chart version (${currentVersion}) has not changed"
 fi

--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -18,36 +18,39 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Remote github repostories for:
-## the upstream chart repository fork (CHARTS_REPO)
-## the upstream chart original repository (CHARTS_REPO_ORIGINAL)
-## the development chart repository (KUBEAPPS_REPO)
-CHARTS_REPO_ORIGINAL="bitnami/charts"
-CHARTS_REPO="kubeapps-bot/charts"
-KUBEAPPS_REPO="kubeapps/kubeapps"
-
-CHART_REPO_PATH="bitnami/kubeapps"
 PROJECT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null && pwd)
+
+# Path of the Kubeapps chart in the charts repo.
+# For instance, given "https://github.com/bitnami/charts/tree/master/bitnami/kubeapps" it should be "bitnami/kubeapps"
+CHART_REPO_PATH="bitnami/kubeapps"
+
+# Path of the Kubeapps chart in the Kubeapps repo.
+# For instance, given "https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps", it should be "chart/kubeapps"
 KUBEAPPS_CHART_DIR="${PROJECT_DIR}/chart/kubeapps"
+
+# Paths of the templates files, note they are also used elsewhere
 PR_INTERNAL_TEMPLATE_FILE="${PROJECT_DIR}/script/tpl/PR_internal_chart_template.md"
 PR_EXTERNAL_TEMPLATE_FILE="${PROJECT_DIR}/script/tpl/PR_external_chart_template.md"
+RELEASE_NOTES_TEMPLATE_FILE="${PROJECT_DIR}/script/tpl/release_notes.md"
 
 # Returns the tag for the latest release
 latestReleaseTag() {
-    local targetRepo=${1:?}
-    git -C "${targetRepo}/.git" fetch --tags
-    git -C "${targetRepo}/.git" describe --tags $(git rev-list --tags --max-count=1)
+    local TARGET_REPO=${1:?}
+
+    git -C "${TARGET_REPO}/.git" fetch --tags
+    git -C "${TARGET_REPO}/.git" describe --tags "$(git rev-list --tags --max-count=1)"
 }
 
 configUser() {
-    local targetRepo=${1:?}
-    local user=${2:?}
-    local email=${3:?}
-    local gpg=${4:?}
-    cd $targetRepo
-    git config user.name "$user"
-    git config user.email "$email"
-    git config user.signingkey "$gpg"
+    local TARGET_REPO=${1:?}
+    local USERNAME=${2:?}
+    local EMAIL=${3:?}
+    local GPG_KEY=${4:?}
+
+    cd "${TARGET_REPO}"
+    git config user.name "${USERNAME}"
+    git config user.email "${EMAIL}"
+    git config user.signingkey "${GPG_KEY}"
     git config --global commit.gpgSign true
     git config --global tag.gpgSign true
     git config pull.rebase false
@@ -55,23 +58,24 @@ configUser() {
 }
 
 replaceImage_latestToProduction() {
-    local service=${1:?}
-    local file=${2:?}
-    local repoName="bitnami-docker-kubeapps-${service}"
-    local currentImageEscaped="kubeapps\/${service}"
-    local targetImageEscaped="bitnami\/kubeapps-${service}"
+    local SERVICE=${1:?}
+    local FILE=${2:?}
+
+    local repoName="bitnami-docker-kubeapps-${SERVICE}"
+    local currentImageEscaped="kubeapps\/${SERVICE}"
+    local targetImageEscaped="bitnami\/kubeapps-${SERVICE}"
 
     # Prevent a wrong image name "bitnami/kubeapps-kubeapps-apis"
     # with a manual rename to "bitnami/kubeapps-apis"
-    if [ $targetImageEscaped == "bitnami\/kubeapps-kubeapps-apis" ]; then
+    if [ "${targetImageEscaped}" == "bitnami\/kubeapps-kubeapps-apis" ]; then
         targetImageEscaped="bitnami\/kubeapps-apis"
     fi
 
-    if [ $repoName == "bitnami-docker-kubeapps-kubeapps-apis" ]; then
+    if [ "${repoName}" == "bitnami-docker-kubeapps-kubeapps-apis" ]; then
         repoName="bitnami-docker-kubeapps-apis"
     fi
 
-    echo "Replacing ${service}"...
+    echo "Replacing ${SERVICE}"...
 
     local curl_opts=()
     if [[ $GITHUB_TOKEN != "" ]]; then
@@ -89,53 +93,59 @@ replaceImage_latestToProduction() {
     # Replace image and tag from the values.yaml
     sed -i.bk -e '1h;2,$H;$!d;g' -re \
         's/repository: '${currentImageEscaped}'\n    tag: latest/repository: '${targetImageEscaped}'\n    tag: '${tag}'/g' \
-        ${file}
-    rm "${file}.bk"
+        "${FILE}"
+    rm "${FILE}.bk"
 }
 
 replaceImage_productionToLatest() {
-    local service=${1:?}
-    local file=${2:?}
-    local targetTag=${3:?}
-    local repoName="bitnami-docker-kubeapps-${service}"
-    local currentImageEscaped="bitnami\/kubeapps-${service}"
-    local targetImageEscaped="kubeapps\/${service}"
+    local SERVICE=${1:?}
+    local FILE=${2:?}
+
+    local repoName="bitnami-docker-kubeapps-${SERVICE}"
+    local currentImageEscaped="bitnami\/kubeapps-${SERVICE}"
+    local targetImageEscaped="kubeapps\/${SERVICE}"
 
     # Prevent a wrong image name "bitnami/kubeapps-kubeapps-apis"
     # with a manual rename to "bitnami/kubeapps-apis"
-    if [ $currentImageEscaped == "bitnami\/kubeapps-kubeapps-apis" ]; then
+    if [ "${currentImageEscaped}" == "bitnami\/kubeapps-kubeapps-apis" ]; then
         currentImageEscaped="bitnami\/kubeapps-apis"
     fi
 
-    echo "Replacing ${service}"...
+    echo "Replacing ${SERVICE}"...
 
     # Replace image and tag from the values.yaml
     sed -i.bk -e '1h;2,$H;$!d;g' -re \
         's/repository: '${currentImageEscaped}'\n    tag: \S*/repository: '${targetImageEscaped}'\n    tag: latest/g' \
-        ${file}
-    rm "${file}.bk"
+        "${FILE}"
+    rm "${FILE}.bk"
 }
 
 updateRepoWithLocalChanges() {
-    local targetRepo=${1:?}
-    local targetTag=${2:?}
-    local targetTagWithoutV=${targetTag#v}
-    local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
+    local TARGET_REPO=${1:?}
+    local TARGET_TAG=${2:?}
+    local CHARTS_REPO_ORIGINAL=${3:?}
+    local BRANCH_CHARTS_REPO_ORIGINAL=${4:?}
+    local BRANCH_CHARTS_REPO_FORKED=${5:?}
+
+    local targetTagWithoutV=${TARGET_TAG#v}
+    local targetChartPath="${TARGET_REPO}/${CHART_REPO_PATH}"
     local chartYaml="${targetChartPath}/Chart.yaml"
+
     if [ ! -f "${chartYaml}" ]; then
         echo "Wrong repo path. You should provide the root of the repository" >/dev/stderr
         return 1
     fi
     # Fetch latest upstream changes, and commit&push them to the forked charts repo
-    git -C "${targetRepo}" remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
-    git -C "${targetRepo}" pull upstream master
-    git -C "${targetRepo}" push origin master
+    git -C "${TARGET_REPO}" remote add upstream "https://github.com/${CHARTS_REPO_ORIGINAL}.git"
+    git -C "${TARGET_REPO}" pull upstream "${BRANCH_CHARTS_REPO_ORIGINAL}"
+    git -C "${TARGET_REPO}" push origin "${BRANCH_CHARTS_REPO_FORKED}"
     rm -rf "${targetChartPath}"
     cp -R "${KUBEAPPS_CHART_DIR}" "${targetChartPath}"
     # Update Chart.yaml with new version
     sed -i.bk 's/appVersion: DEVEL/appVersion: '"${targetTagWithoutV}"'/g' "${chartYaml}"
     rm "${targetChartPath}/Chart.yaml.bk"
     # Replace images for the latest available
+    # TODO: use the IMAGES_TO_PUSH var already set in the CI config
     replaceImage_latestToProduction dashboard "${targetChartPath}/values.yaml"
     replaceImage_latestToProduction apprepository-controller "${targetChartPath}/values.yaml"
     replaceImage_latestToProduction asset-syncer "${targetChartPath}/values.yaml"
@@ -146,24 +156,29 @@ updateRepoWithLocalChanges() {
 }
 
 updateRepoWithRemoteChanges() {
-    local targetRepo=${1:?}
-    local targetTag=${2:?}
-    local forkSSHKeyFilename=${3:?}
-    local targetTagWithoutV=${targetTag#v}
-    local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
+    local TARGET_REPO=${1:?}
+    local TARGET_TAG=${2:?}
+    local FORKED_SSH_KEY_FILENAME=${3:?}
+    local CHARTS_REPO_ORIGINAL=${4:?}
+    local BRANCH_CHARTS_REPO_ORIGINAL=${5:?}
+    local BRANCH_CHARTS_REPO_FORKED=${6:?}
+
+    local targetTagWithoutV=${TARGET_REPO#v}
+    local targetChartPath="${TARGET_REPO}/${CHART_REPO_PATH}"
     local remoteChartYaml="${targetChartPath}/Chart.yaml"
     local localChartYaml="${KUBEAPPS_CHART_DIR}/Chart.yaml"
+
     if [ ! -f "${remoteChartYaml}" ]; then
         echo "Wrong repo path. You should provide the root of the repository" >/dev/stderr
         return 1
     fi
     # Fetch latest upstream changes, and commit&push them to the forked charts repo
-    git -C "${targetRepo}" remote add upstream https://github.com/${CHARTS_REPO_ORIGINAL}.git
-    git -C "${targetRepo}" pull upstream master
+    git -C "${TARGET_REPO}" remote add upstream "https://github.com/${CHARTS_REPO_ORIGINAL}.git"
+    git -C "${TARGET_REPO}" pull upstream "${BRANCH_CHARTS_REPO_ORIGINAL}"
 
     # https://superuser.com/questions/232373/how-to-tell-git-which-private-key-to-use
-    git -C "${targetRepo}" config --local core.sshCommand "ssh -i ~/.ssh/${forkSSHKeyFilename} -F /dev/null"
-    git -C "${targetRepo}" push origin master
+    git -C "${TARGET_REPO}" config --local core.sshCommand "ssh -i ~/.ssh/${FORKED_SSH_KEY_FILENAME} -F /dev/null"
+    git -C "${TARGET_REPO}" push origin "${BRANCH_CHARTS_REPO_FORKED}"
 
     rm -rf "${KUBEAPPS_CHART_DIR}"
     cp -R "${targetChartPath}" "${KUBEAPPS_CHART_DIR}"
@@ -171,26 +186,31 @@ updateRepoWithRemoteChanges() {
     sed -i.bk "s/appVersion: "${targetTagWithoutV}"/appVersion: DEVEL/g" "${localChartYaml}"
     rm "${KUBEAPPS_CHART_DIR}/Chart.yaml.bk"
     # Replace images for the latest available
-    replaceImage_productionToLatest dashboard "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
-    replaceImage_productionToLatest apprepository-controller "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
-    replaceImage_productionToLatest asset-syncer "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
-    replaceImage_productionToLatest assetsvc "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
-    replaceImage_productionToLatest kubeops "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
-    replaceImage_productionToLatest pinniped-proxy "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
-    replaceImage_productionToLatest kubeapps-apis "${KUBEAPPS_CHART_DIR}/values.yaml" targetTag
+    # TODO: use the IMAGES_TO_PUSH var already set in the CI config
+    replaceImage_productionToLatest dashboard "${KUBEAPPS_CHART_DIR}/values.yaml"
+    replaceImage_productionToLatest apprepository-controller "${KUBEAPPS_CHART_DIR}/values.yaml"
+    replaceImage_productionToLatest asset-syncer "${KUBEAPPS_CHART_DIR}/values.yaml"
+    replaceImage_productionToLatest assetsvc "${KUBEAPPS_CHART_DIR}/values.yaml"
+    replaceImage_productionToLatest kubeops "${KUBEAPPS_CHART_DIR}/values.yaml"
+    replaceImage_productionToLatest pinniped-proxy "${KUBEAPPS_CHART_DIR}/values.yaml"
+    replaceImage_productionToLatest kubeapps-apis "${KUBEAPPS_CHART_DIR}/values.yaml"
 }
 
 commitAndSendExternalPR() {
-    local targetRepo=${1:?}
-    local targetBranch=${2:-"master"}
-    local chartVersion=${3:?}
-    local targetChartPath="${targetRepo}/${CHART_REPO_PATH}"
+    local TARGET_REPO=${1:?}
+    local TARGET_BRANCH=${2:?}
+    local CHART_VERSION=${3:?}
+    local CHARTS_REPO_ORIGINAL=${4:?}
+    local BRANCH_CHARTS_REPO_ORIGINAL=${5:?}
+
+    local targetChartPath="${TARGET_REPO}/${CHART_REPO_PATH}"
     local chartYaml="${targetChartPath}/Chart.yaml"
+
     if [ ! -f "${chartYaml}" ]; then
         echo "Wrong repo path. You should provide the root of the repository" >/dev/stderr
         return 1
     fi
-    cd $targetRepo
+    cd "${TARGET_REPO}"
     if [[ ! $(git diff-index HEAD) ]]; then
         echo "Not found any change to commit" >/dev/stderr
         cd -
@@ -198,23 +218,26 @@ commitAndSendExternalPR() {
     fi
     sed -i.bk -e "s/<USER>/$(git config user.name)/g" "${PR_EXTERNAL_TEMPLATE_FILE}"
     sed -i.bk -e "s/<EMAIL>/$(git config user.email)/g" "${PR_EXTERNAL_TEMPLATE_FILE}"
-    git checkout -b $targetBranch
+    git checkout -b "${TARGET_BRANCH}"
     git add --all .
-    git commit -m "kubeapps: bump chart version to $chartVersion"
+    git commit -m "kubeapps: bump chart version to ${CHART_VERSION}"
     # NOTE: This expects to have a loaded SSH key
-    if [[ $(git ls-remote origin $targetBranch | wc -l) -eq 0 ]]; then
-        git push -u origin $targetBranch
-        gh pr create -d -B master -R ${CHARTS_REPO_ORIGINAL} -F ${PR_EXTERNAL_TEMPLATE_FILE} --title "[bitnami/kubeapps] Bump chart version to $chartVersion"
+    if [[ $(git ls-remote origin "${TARGET_BRANCH}" | wc -l) -eq 0 ]]; then
+        git push -u origin "${TARGET_BRANCH}"
+        gh pr create -d -B "${BRANCH_CHARTS_REPO_ORIGINAL}" -R "${CHARTS_REPO_ORIGINAL}" -F "${PR_EXTERNAL_TEMPLATE_FILE}" --title "[bitnami/kubeapps] Bump chart version to ${CHART_VERSION}"
     else
-        echo "The remote branch '$targetBranch' already exists, please check if there is already an open PR at the repository '${CHARTS_REPO_ORIGINAL}'"
+        echo "The remote branch '${TARGET_BRANCH}' already exists, please check if there is already an open PR at the repository '${CHARTS_REPO_ORIGINAL}'"
     fi
     cd -
 }
 
 commitAndSendInternalPR() {
-    local targetRepo=${1:?}
-    local targetBranch=${2:-"master"}
-    local chartVersion=${3:?}
+    local TARGET_REPO=${1:?}
+    local TARGET_BRANCH=${2:?}
+    local CHART_VERSION=${3:?}
+    local KUBEAPPS_REPO=${4:?}
+    local BRANCH_KUBEAPPS_REPO=${5:?}
+
     local targetChartPath="${KUBEAPPS_CHART_DIR}/Chart.yaml"
     local localChartYaml="${KUBEAPPS_CHART_DIR}/Chart.yaml"
 
@@ -222,21 +245,21 @@ commitAndSendInternalPR() {
         echo "Wrong repo path. You should provide the root of the repository" >/dev/stderr
         return 1
     fi
-    cd $targetRepo
+    cd "${TARGET_REPO}"
     if [[ ! $(git diff-index HEAD) ]]; then
         echo "Not found any change to commit" >/dev/stderr
         cd -
         return 1
     fi
-    git checkout -b $targetBranch
+    git checkout -b "${TARGET_BRANCH}"
     git add --all .
-    git commit -m "bump chart version to $chartVersion"
+    git commit -m "bump chart version to ${CHART_VERSION}"
     # NOTE: This expects to have a loaded SSH key
-    if [[ $(git ls-remote origin $targetBranch | wc -l) -eq 0 ]]; then
-        git push -u origin $targetBranch
-        gh pr create -d -B master -R ${KUBEAPPS_REPO} -F ${PR_INTERNAL_TEMPLATE_FILE} --title "Sync chart with bitnami/kubeapps chart (version $chartVersion)"
+    if [[ $(git ls-remote origin "${TARGET_BRANCH}" | wc -l) -eq 0 ]]; then
+        git push -u origin "${TARGET_BRANCH}"
+        gh pr create -d -B "${BRANCH_KUBEAPPS_REPO}" -R "${KUBEAPPS_REPO}" -F "${PR_INTERNAL_TEMPLATE_FILE}" --title "Sync chart with bitnami/kubeapps chart (version ${CHART_VERSION})"
     else
-        echo "The remote branch '$targetBranch' already exists, please check if there is already an open PR at the repository '${KUBEAPPS_REPO}'"
+        echo "The remote branch '${TARGET_BRANCH}' already exists, please check if there is already an open PR at the repository '${KUBEAPPS_REPO}'"
     fi
     cd -
 }

--- a/script/chart_upstream_checker.sh
+++ b/script/chart_upstream_checker.sh
@@ -20,27 +20,38 @@ set -o pipefail
 
 source $(dirname $0)/chart_sync_utils.sh
 
-user=${1:?}
-email=${2:?}
-gpg=${3:?}
-forkSSHKeyFilename=${4:?}
+USERNAME=${1:?Missing git username}
+EMAIL=${2:?Missing git email}
+GPG_KEY=${3:?Missing git gpg key}
+FORKED_SSH_KEY_FILENAME=${4:?Missing forked ssh key filename}
+CHARTS_REPO_ORIGINAL=${5:?Missing base chart repository}
+BRANCH_CHARTS_REPO_ORIGINAL=${6:?Missing base chart repository}
+CHARTS_REPO_FORKED=${7:?Missing forked chart repository}
+BRANCH_CHARTS_REPO_FORKED=${8:?Missing forked chart repository}
+KUBEAPPS_REPO=${9:?Missing kubeapps repository}
+BRANCH_KUBEAPPS_REPO=${10:?Missing kubeapps repository branch}
 
-currentVersion=$(cat "${KUBEAPPS_CHART_DIR}/Chart.yaml" | grep -oP '(?<=^version: ).*')
-externalVersion=$(curl -s https://raw.githubusercontent.com/${CHARTS_REPO_ORIGINAL}/master/${CHART_REPO_PATH}/Chart.yaml | grep -oP '(?<=^version: ).*')
+currentVersion=$(grep -oP '(?<=^version: ).*' <"${KUBEAPPS_CHART_DIR}/Chart.yaml")
+externalVersion=$(curl -s "https://raw.githubusercontent.com/${CHARTS_REPO_ORIGINAL}/${BRANCH_CHARTS_REPO_ORIGINAL}/${CHART_REPO_PATH}/Chart.yaml" | grep -oP '(?<=^version: ).*')
 semverCompare=$(semver compare "${currentVersion}" "${externalVersion}")
+
 # If current version is less than the chart external version, then retrieve the changes and send an internal PR with them
 if [[ ${semverCompare} -lt 0 ]]; then
-    echo "Current chart version ("${currentVersion}") is less than the chart external version ("${externalVersion}")"
-    tempDir=$(mktemp -u)/charts
-    mkdir -p $tempDir
-    git clone https://github.com/${CHARTS_REPO} $tempDir --depth 1 --no-single-branch
-    configUser $tempDir $user $email $gpg
-    configUser $PROJECT_DIR $user $email $gpg
-    latestVersion=$(latestReleaseTag $PROJECT_DIR)
-    updateRepoWithRemoteChanges $tempDir $latestVersion $forkSSHKeyFilename
-    commitAndSendInternalPR ${PROJECT_DIR} "sync-chart-changes-${externalVersion}" ${externalVersion}
+    echo "Current chart version (${currentVersion}) is less than the chart external version (${externalVersion})"
+    TMP_DIR=$(mktemp -u)/charts
+    mkdir -p "${TMP_DIR}"
+
+    git clone "https://github.com/${CHARTS_REPO_FORKED}" "${TMP_DIR}" --depth 1 --no-single-branch
+    configUser "${TMP_DIR}" "${USERNAME}" "${EMAIL}" "${GPG_KEY}"
+    configUser "${PROJECT_DIR}" "${USERNAME}" "${EMAIL}" "${GPG_KEY}"
+
+    latestVersion=$(latestReleaseTag "${PROJECT_DIR}")
+    prBranchName="sync-chart-changes-${externalVersion}"
+
+    updateRepoWithRemoteChanges "${TMP_DIR}" "${latestVersion}" "${FORKED_SSH_KEY_FILENAME}" "${CHARTS_REPO_ORIGINAL}" "${BRANCH_CHARTS_REPO_ORIGINAL}" "${BRANCH_CHARTS_REPO_FORKED}"
+    commitAndSendInternalPR "${PROJECT_DIR}" "${prBranchName}" "${externalVersion}" "${KUBEAPPS_REPO}" "${BRANCH_KUBEAPPS_REPO}"
 elif [[ ${semverCompare} -gt 0 ]]; then
-    echo "Skipping Chart sync. WARNING Current chart version ("${currentVersion}") is greater than the chart external version ("${externalVersion}")"
+    echo "Skipping Chart sync. WARNING Current chart version (${currentVersion}) is greater than the chart external version (${externalVersion})"
 else
-    echo "Skipping Chart sync. The chart version ("${currentVersion}") has not changed"
+    echo "Skipping Chart sync. The chart version (${currentVersion}) has not changed"
 fi

--- a/script/create_release.sh
+++ b/script/create_release.sh
@@ -18,16 +18,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-PROJECT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null && pwd)
+source $(dirname $0)/chart_sync_utils.sh
 
-KUBEAPPS_REPO="kubeapps/kubeapps"
-RELEASE_NOTES_TEMPLATE_FILE="${PROJECT_DIR}/script/tpl/release_notes.md"
-
-TAG=${1:?}
+TAG=${1:?Missing tag}
+KUBEAPPS_REPO=${2:?Missing kubeapps repo}
 
 if [[ -z "${TAG}" ]]; then
   echo "A git tag is required for creating a release"
   exit 1
 fi
 
-gh release create -R ${KUBEAPPS_REPO} -d "${TAG}" -t "${TAG}" -F "${RELEASE_NOTES_TEMPLATE_FILE}"
+gh release create -R "${KUBEAPPS_REPO}" -d "${TAG}" -t "${TAG}" -F "${RELEASE_NOTES_TEMPLATE_FILE}"

--- a/script/start-gke-env.sh
+++ b/script/start-gke-env.sh
@@ -32,18 +32,18 @@ fi
 if [[ $(gcloud container clusters list --filter="name:${CLUSTER}") ]]; then
     if gcloud container clusters list --filter="name:${CLUSTER}" | grep "STOPPING"; then
         cnt=300
-        while gcloud container clusters list | grep $CLUSTER; do
+        while gcloud container clusters list | grep "${CLUSTER}"; do
             ((cnt = cnt - 1)) || (echo "Waited 5m but cluster is still being deleted" && exit 1)
             sleep 1
         done
     else
         echo "GKE cluster already exits. Deleting it"
-        gcloud container clusters delete $CLUSTER --zone $ZONE
+        gcloud container clusters delete "${CLUSTER}" --zone "${ZONE}"
     fi
 fi
 
-echo "Creating cluster $CLUSTER in $ZONE (v$BRANCH)"
-gcloud container clusters create --cluster-version=${BRANCH} --zone $ZONE $CLUSTER --num-nodes 2 --machine-type=n1-standard-2 --preemptible --labels=team=kubeapps
+echo "Creating cluster ${CLUSTER} in ${ZONE} (v$BRANCH)"
+gcloud container clusters create --cluster-version="${BRANCH}" --zone "${ZONE}" "${CLUSTER}" --num-nodes 2 --machine-type=n1-standard-2 --preemptible --labels=team=kubeapps
 echo "Waiting for the cluster to respond..."
 cnt=20
 until kubectl get pods >/dev/null 2>&1; do


### PR DESCRIPTION
### Description of the change

This is a follow-up PR derived from https://github.com/kubeapps/kubeapps/pull/3668#discussion_r737237742, where we noticed we were hardcoding the repo names. Also, I noticed the branches were also being hardcoded. Given that we would want to get rid of the `master` branch at some point, this PR makes this future change easier.

Furthermore, I've addressed a bunch of linter issues, basically `$var` to `"${var}"`

### Benefits

As above, any change of repo or branch will be easier.

### Possible drawbacks

I hope none, but I haven't tested it as it would require setting up my private repos properly again. We can either invest some time in verifying it works OR just let our CI know and then just send a hotfix. I'm ok with both.

### Applicable issues

- related https://github.com/kubeapps/kubeapps/issues/3566

### Additional information

N/A
