### PR TITLE
Reduce memory consumption `GetCharts`

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1657,7 +1657,7 @@ kubeappsapis:
   resources:
     limits:
       cpu: 250m
-      memory: 128Mi
+      memory: 256Mi
     requests:
       cpu: 25m
       memory: 32Mi

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1657,7 +1657,7 @@ kubeappsapis:
   resources:
     limits:
       cpu: 250m
-      memory: 512Mi
+      memory: 128Mi
     requests:
       cpu: 25m
       memory: 32Mi


### PR DESCRIPTION
### Description of the change

TBD: it's WIP: i'm using this PR to trigger the e2e tests easily.

now I've just replaced the cache key, instead of reading the whole repo content again and again, I use the contentLength as the key. This PR is to see if it results in an improvement.
Note that just using that length may cause some false positive cache hits and false negative cache misses. It is

Mem reduced from 512 to 128 to trigger more failures.

https://github.com/ReneKroon/ttlcache

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
