### PR TITLE
Ensure cluster is set when listing and fetching apps.

### DIFF
--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -46,7 +46,7 @@ describe("fetches applications", () => {
     shortDescription: "some description",
   };
   let listAppsMock: jest.Mock;
-  let installedPackageSummaries: InstalledPackageSummary[] = [validInstalledPackageSummary];
+  const installedPackageSummaries: InstalledPackageSummary[] = [validInstalledPackageSummary];
   beforeEach(() => {
     listAppsMock = jest.fn(
       () =>

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -1,6 +1,8 @@
 import {
   AvailablePackageDetail,
   InstalledPackageDetail,
+  InstalledPackageSummary,
+  GetInstalledPackageSummariesResponse,
   InstalledPackageReference,
   VersionReference,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
@@ -33,9 +35,22 @@ beforeEach(() => {
 });
 
 describe("fetches applications", () => {
+  const validInstalledPackageSummary: InstalledPackageSummary = {
+    installedPackageRef: {
+      context: { cluster: "second-cluster", namespace: "my-ns" },
+      identifier: "some-name",
+    },
+    iconUrl: "",
+    name: "foo",
+    pkgDisplayName: "foo",
+    shortDescription: "some description",
+  };
   let listAppsMock: jest.Mock;
+  let installedPackageSummaries: InstalledPackageSummary[] = [validInstalledPackageSummary];
   beforeEach(() => {
-    listAppsMock = jest.fn(() => []);
+    listAppsMock = jest.fn(() => ({
+      installedPackageSummaries,
+    } as GetInstalledPackageSummariesResponse));
     App.GetInstalledPackageSummaries = listAppsMock;
   });
   afterEach(() => {
@@ -51,17 +66,26 @@ describe("fetches applications", () => {
       },
       {
         type: getType(actions.apps.receiveAppList),
-        payload: undefined,
+        payload: [validInstalledPackageSummary],
         meta: undefined,
         error: undefined,
       },
     ];
-    await store.dispatch(actions.apps.fetchApps("default-cluster", "default"));
+    await store.dispatch(actions.apps.fetchApps("second-cluster", "default"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(listAppsMock.mock.calls[0]).toEqual(["default-cluster", "default"]);
+    expect(listAppsMock.mock.calls[0]).toEqual(["second-cluster", "default"]);
   });
-  it("fetches applications, ignore when no data", async () => {
-    App.GetInstalledPackageSummaries = jest.fn();
+  it("fetches applications, updating cluster since some plugins don't return it", async () => {
+    installedPackageSummaries = [{
+      ...validInstalledPackageSummary,
+      installedPackageRef: {
+        ...validInstalledPackageSummary.installedPackageRef!,
+        context: {
+          namespace: validInstalledPackageSummary.installedPackageRef!.context!.namespace,
+          cluster: "other",
+        },
+      },
+    }];
     const expectedActions = [
       {
         type: getType(actions.apps.listApps),
@@ -71,15 +95,14 @@ describe("fetches applications", () => {
       },
       {
         type: getType(actions.apps.receiveAppList),
-        payload: undefined,
+        payload: [validInstalledPackageSummary],
         meta: undefined,
         error: undefined,
       },
     ];
-    await store.dispatch(actions.apps.fetchApps("default-cluster", "default"));
-    App.GetInstalledPackageSummaries = listAppsMock;
+    await store.dispatch(actions.apps.fetchApps("second-cluster", "default"));
     expect(store.getActions()).toEqual(expectedActions);
-    expect(listAppsMock.mock.calls[0]).toBeUndefined();
+    expect(listAppsMock.mock.calls[0]).toEqual(["second-cluster", "default"]);
   });
 });
 

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -78,37 +78,6 @@ describe("fetches applications", () => {
     expect(store.getActions()).toEqual(expectedActions);
     expect(listAppsMock.mock.calls[0]).toEqual(["second-cluster", "default"]);
   });
-  it("fetches applications, updating cluster since some plugins don't return it", async () => {
-    installedPackageSummaries = [
-      {
-        ...validInstalledPackageSummary,
-        installedPackageRef: {
-          ...validInstalledPackageSummary.installedPackageRef!,
-          context: {
-            namespace: validInstalledPackageSummary.installedPackageRef!.context!.namespace,
-            cluster: "other",
-          },
-        },
-      },
-    ];
-    const expectedActions = [
-      {
-        type: getType(actions.apps.listApps),
-        payload: undefined,
-        meta: undefined,
-        error: undefined,
-      },
-      {
-        type: getType(actions.apps.receiveAppList),
-        payload: [validInstalledPackageSummary],
-        meta: undefined,
-        error: undefined,
-      },
-    ];
-    await store.dispatch(actions.apps.fetchApps("second-cluster", "default"));
-    expect(store.getActions()).toEqual(expectedActions);
-    expect(listAppsMock.mock.calls[0]).toEqual(["second-cluster", "default"]);
-  });
 });
 
 describe("delete applications", () => {

--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -48,9 +48,12 @@ describe("fetches applications", () => {
   let listAppsMock: jest.Mock;
   let installedPackageSummaries: InstalledPackageSummary[] = [validInstalledPackageSummary];
   beforeEach(() => {
-    listAppsMock = jest.fn(() => ({
-      installedPackageSummaries,
-    } as GetInstalledPackageSummariesResponse));
+    listAppsMock = jest.fn(
+      () =>
+        ({
+          installedPackageSummaries,
+        } as GetInstalledPackageSummariesResponse),
+    );
     App.GetInstalledPackageSummaries = listAppsMock;
   });
   afterEach(() => {
@@ -76,16 +79,18 @@ describe("fetches applications", () => {
     expect(listAppsMock.mock.calls[0]).toEqual(["second-cluster", "default"]);
   });
   it("fetches applications, updating cluster since some plugins don't return it", async () => {
-    installedPackageSummaries = [{
-      ...validInstalledPackageSummary,
-      installedPackageRef: {
-        ...validInstalledPackageSummary.installedPackageRef!,
-        context: {
-          namespace: validInstalledPackageSummary.installedPackageRef!.context!.namespace,
-          cluster: "other",
+    installedPackageSummaries = [
+      {
+        ...validInstalledPackageSummary,
+        installedPackageRef: {
+          ...validInstalledPackageSummary.installedPackageRef!,
+          context: {
+            namespace: validInstalledPackageSummary.installedPackageRef!.context!.namespace,
+            cluster: "other",
+          },
         },
       },
-    }];
+    ];
     const expectedActions = [
       {
         type: getType(actions.apps.listApps),

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -102,13 +102,6 @@ export function getApp(
       // Get the details of an installed package
       const { installedPackageDetail } = await App.GetInstalledPackageDetail(installedPackageRef);
 
-      // Not all plugins (flux) are cluster aware.
-      if (
-        installedPackageDetail &&
-        !installedPackageDetail?.installedPackageRef?.context?.cluster
-      ) {
-        installedPackageDetail.installedPackageRef = installedPackageRef;
-      }
       // For local packages with no references to any available packages (eg.a local package for development)
       // we aren't able to get the details, but still want to display the available data so far
       let availablePackageDetail;
@@ -164,14 +157,6 @@ export function fetchApps(
     try {
       const res = await App.GetInstalledPackageSummaries(cluster, namespace);
       installedPackageSummaries = res?.installedPackageSummaries;
-
-      // Some plugins are not cluster aware, so initialize the cluster.
-      // TODO(minelson) Let's just ensure all plugins send the cluster even if
-      // they don't support multicluster?
-      installedPackageSummaries = installedPackageSummaries.map(pkg => {
-        pkg.installedPackageRef!.context!.cluster = cluster;
-        return pkg;
-      });
 
       dispatch(receiveAppList(installedPackageSummaries));
       return installedPackageSummaries;


### PR DESCRIPTION
### Description of the change

There were two small issues stopping the display if installed apps when using the flux plugin:

1. We currently dispatch a request to fetch the manifest for a helm deployment, which needs replacing. For now I've just disabled this request unless it's for the helm plugin, allowing the UI to display basic info about a flux installed app.
The flux plugin returns apps without the cluster set in the context.

2. The flux plugin returns an empty "cluster" in the context, regardless of the request, which leaves the dashboard unable to create the URL. I've worked around this for now by initializing the context.cluster when fetching apps based on the request. But if @gfichtenholt is OK with it, it'd be cleaner for the flux endpoints to populate the cluster (it already has the info both in the request and the configured kubeapps cluster), even if it's not supporting other clusters.

### Benefits

We can install apps with the flux plugin via the UI: (but note issues below)
![apache-via-flux](https://user-images.githubusercontent.com/497518/139192314-6eba506e-3d5c-4068-86c3-803b0620b078.png)

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

- Ref #3610

### Additional information

There is currently a small UI issue when displaying the installed apps list/tile:

![app-list-view-flux](https://user-images.githubusercontent.com/497518/139192380-aab97905-22bb-488a-8178-7e5fd8915a7e.png)

which could be related to the longer error status, which is happening because although apache is installed and running:
```
k get po
NAME                                         READY   STATUS    RESTARTS   AGE
default-test-apache-74565b799f-7ztqj         1/1     Running   0          1h
```
it's failed the helm install and so flux shows reconciliation failed, as shown above and via the cli.
