### PR TITLE
Fix wrong branch parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ parameters:
     default: "bitnami/charts"
   BRANCH_CHARTS_REPO_ORIGINAL:
     type: "string"
-    default: "BRANCH"
+    default: "master"
   CHARTS_REPO_FORKED:
     type: "string"
     default: "kubeapps-bot/charts"


### PR DESCRIPTION
### Description of the change

Trivial PR fixing a wrong branch name after #3676 

### Benefits

Master builds will run again

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
