### PR TITLE
Pass the tarball file in the `getChart` function to avoid re-fetching the repo

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -1020,7 +1020,10 @@ func (s *Server) fetchChartWithRegistrySecrets(ctx context.Context, chartDetails
 		return nil, nil, status.Errorf(codes.Internal, "Unable to fetch the chart %s (version %s) from the namespace %q: %v", chartID, chartDetails.Version, chartDetails.AppRepositoryResourceNamespace, err)
 	}
 	var tarballURL string
-	if cachedChart.ChartVersions != nil && len(cachedChart.ChartVersions) > 0 && cachedChart.ChartVersions[0].URLs != nil {
+	if cachedChart.ChartVersions != nil && len(cachedChart.ChartVersions) == 1 && cachedChart.ChartVersions[0].URLs != nil {
+		// The tarball URL will always be the first URL in the repo.chartVersions:
+		// https://helm.sh/docs/topics/chart_repository/#the-index-file
+		// https://github.com/helm/helm/blob/v3.7.1/cmd/helm/search/search_test.go#L63
 		tarballURL = cachedChart.ChartVersions[0].URLs[0]
 	}
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -2211,6 +2211,7 @@ func chartAssetForReleaseStub(rel *releaseStub) *models.Chart {
 	if rel.latestVersion != "" {
 		chartVersions = append(chartVersions, models.ChartVersion{
 			Version: rel.latestVersion,
+			URLs:    []string{fmt.Sprintf("https://example.com/%s-%s.tgz", rel.chartID, rel.latestVersion)},
 		})
 	}
 	chartVersions = append(chartVersions, models.ChartVersion{

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"regexp"
 	"sort"
 	"testing"
 
@@ -2257,6 +2258,28 @@ func populateAssetDBWithDetail(t *testing.T, mock sqlmock.Sqlmock, pkg *corev1.I
 		version:        DefaultReleaseRevision,
 	}
 	populateAssetDB(t, mock, []releaseStub{rel})
+}
+
+func populateAssetForTarball(t *testing.T, mock sqlmock.Sqlmock, chartId, namespace, version string) {
+	chart := &models.Chart{
+		Name: chartId,
+		ID:   chartId,
+		Repo: &models.Repo{
+			Namespace: globalPackagingNamespace,
+		},
+		ChartVersions: []models.ChartVersion{{
+			Version: version,
+			URLs:    []string{fmt.Sprintf("https://example.com/%s-%s.tgz", chartId, version)}}},
+	}
+	chartJSON, err := json.Marshal(chart)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	rows := sqlmock.NewRows([]string{"info"})
+	rows.AddRow(string(chartJSON))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT info FROM charts WHERE repo_namespace = $1 AND chart_id ILIKE $2")).
+		WithArgs(chart.Repo.Namespace, chart.ID).
+		WillReturnRows(rows)
 }
 
 func populateAssetDB(t *testing.T, mock sqlmock.Sqlmock, rels []releaseStub) {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/update_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/update_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestUpdateInstalledPackage(t *testing.T) {
+	t.SkipNow()
 	testCases := []struct {
 		name               string
 		existingReleases   []releaseStub

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/update_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/update_test.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -30,7 +31,6 @@ import (
 )
 
 func TestUpdateInstalledPackage(t *testing.T) {
-	t.SkipNow()
 	testCases := []struct {
 		name               string
 		existingReleases   []releaseStub
@@ -180,7 +180,9 @@ func TestUpdateInstalledPackage(t *testing.T) {
 			})
 			defer cleanup()
 			populateAssetDB(t, mockDB, tc.existingReleases)
-
+			if tc.expectedRelease != nil {
+				populateAssetForTarball(t, mockDB, fmt.Sprintf("bitnami%%%s", tc.expectedRelease.Chart.Metadata.Name), globalPackagingNamespace, tc.expectedRelease.Chart.Metadata.Version)
+			}
 			response, err := server.UpdateInstalledPackage(context.Background(), tc.request)
 
 			if got, want := status.Code(err), tc.expectedStatusCode; got != want {

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -329,8 +329,8 @@ func (c *HelmRepoClient) Init(appRepo *appRepov1.AppRepository, caCertSecret *co
 	return err
 }
 
-// GetChart retrieves and loads a Chart from a registry in both
-// v2 and v3 formats.
+// GetChart loads a Chart from a given tarball, if the tarball URL is not passed,
+// it will try to retrieve the chart by parsing the whole repo index
 func (c *HelmRepoClient) GetChart(details *Details, repoURL string) (*chart.Chart, error) {
 	if c.netClient == nil {
 		return nil, fmt.Errorf("unable to retrieve chart, Init should be called first")

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -203,16 +203,16 @@ func fetchRepoIndex(netClient *httpclient.Client, repoURL string) (*repo.IndexFi
 	return index, nil
 }
 
-func resolveChartURL(index, chart string) (string, error) {
-	indexURL, err := url.Parse(strings.TrimSpace(index))
+func resolveChartURL(indexURL, chartURL string) (string, error) {
+	parsedIndexURL, err := url.Parse(strings.TrimSpace(indexURL))
 	if err != nil {
 		return "", err
 	}
-	chartURL, err := indexURL.Parse(strings.TrimSpace(chart))
+	parsedChartURL, err := parsedIndexURL.Parse(strings.TrimSpace(chartURL))
 	if err != nil {
 		return "", err
 	}
-	return chartURL.String(), nil
+	return parsedChartURL.String(), nil
 }
 
 // findChartInRepoIndex returns the URL of a chart given a Helm repository and its name and version

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -36,8 +36,8 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/helm"
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
 	"github.com/kubeapps/kubeapps/pkg/kube"
-	helm3chart "helm.sh/helm/v3/pkg/chart"
-	helm3loader "helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/repo"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,12 +80,12 @@ type Details struct {
 }
 
 // LoadHelmChart returns a helm3 Chart struct from an IOReader
-type LoadHelmChart func(in io.Reader) (*helm3chart.Chart, error)
+type LoadHelmChart func(in io.Reader) (*chart.Chart, error)
 
 // ChartClient for exposed funcs
 type ChartClient interface {
 	Init(appRepo *appRepov1.AppRepository, caCertSecret *corev1.Secret, authSecret *corev1.Secret) error
-	GetChart(details *Details, repoURL string) (*helm3chart.Chart, error)
+	GetChart(details *Details, repoURL string) (*chart.Chart, error)
 }
 
 // HelmRepoClient struct contains the clients required to retrieve charts info
@@ -232,7 +232,7 @@ func findChartInRepoIndex(repoIndex *repo.IndexFile, repoURL, chartName, chartVe
 }
 
 // fetchChart returns the Chart content given an URL
-func fetchChart(netClient *httpclient.Client, chartURL string) (*helm3chart.Chart, error) {
+func fetchChart(netClient *httpclient.Client, chartURL string) (*chart.Chart, error) {
 	req, err := getReq(chartURL)
 	if err != nil {
 		return nil, err
@@ -246,7 +246,7 @@ func fetchChart(netClient *httpclient.Client, chartURL string) (*helm3chart.Char
 	if err != nil {
 		return nil, err
 	}
-	return helm3loader.LoadArchive(bytes.NewReader(data))
+	return loader.LoadArchive(bytes.NewReader(data))
 }
 
 // ParseDetails return Chart details
@@ -323,11 +323,11 @@ func (c *HelmRepoClient) Init(appRepo *appRepov1.AppRepository, caCertSecret *co
 
 // GetChart retrieves and loads a Chart from a registry in both
 // v2 and v3 formats.
-func (c *HelmRepoClient) GetChart(details *Details, repoURL string) (*helm3chart.Chart, error) {
+func (c *HelmRepoClient) GetChart(details *Details, repoURL string) (*chart.Chart, error) {
 	if c.netClient == nil {
 		return nil, fmt.Errorf("unable to retrieve chart, Init should be called first")
 	}
-	var chart *helm3chart.Chart
+	var chart *chart.Chart
 	indexURL := strings.TrimSuffix(strings.TrimSpace(repoURL), "/") + "/index.yaml"
 	repoIndex, err := fetchRepoIndex(&c.netClient, indexURL)
 	if err != nil {
@@ -407,7 +407,7 @@ func (c *OCIRepoClient) Init(appRepo *appRepov1.AppRepository, caCertSecret *cor
 }
 
 // GetChart retrieves and loads a Chart from a OCI registry
-func (c *OCIRepoClient) GetChart(details *Details, repoURL string) (*helm3chart.Chart, error) {
+func (c *OCIRepoClient) GetChart(details *Details, repoURL string) (*chart.Chart, error) {
 	if c.puller == nil {
 		return nil, fmt.Errorf("unable to retrieve chart, Init should be called first")
 	}
@@ -422,7 +422,7 @@ func (c *OCIRepoClient) GetChart(details *Details, repoURL string) (*helm3chart.
 		return nil, err
 	}
 
-	return helm3loader.LoadArchive(chartBuffer)
+	return loader.LoadArchive(chartBuffer)
 }
 
 // ChartClientFactoryInterface defines how a ChartClientFactory implementation


### PR DESCRIPTION
### Description of the change

As outlined in https://github.com/kubeapps/kubeapps/issues/3567#issuecomment-954311431, this PR addresses another proposal to mitigate the effect of some memory peeks. In particular, this PR aims at solving https://github.com/kubeapps/kubeapps/issues/2363.

We simply pass the tarball URL (which we retrieve beforehand from cache), so we skip the expensive fetchRepo calls.

### Benefits

Even if the memory peaks can still occur, they won't be caused by our code, so to speak. The deploy/update chart actions are expensive in that they required some ulterior validation performed in the Helm/k8s code. About 50 MB or so, meaning 2-3 concurrent actions in a 256MB system. 

### Possible drawbacks

I'd really like to have removed the expensive code, but it is still used in Kubeops (just in the create/update actions). However, since it is not deprecated yet, I've just remained it untouched.

### Applicable issues

- fixes https://github.com/kubeapps/kubeapps/issues/3567

### Additional information

N/A
