### PR TITLE
Two documentation uses of `enable` that I missed in #3590

### DIFF
--- a/docs/user/using-an-OIDC-provider-with-pinniped.md
+++ b/docs/user/using-an-OIDC-provider-with-pinniped.md
@@ -71,7 +71,7 @@ Finally, because Kubeapps can be configured with multiple clusters, some of whic
 clusters:
   - name: default
     pinnipedConfig:
-      enable: true
+      enabled: true
 ```
 
 The [Kubeapps auth-proxy configuration](./using-an-OIDC-provider.md#deploying-an-auth-proxy-to-access-kubeapps) remains the same as for the standard OIDC setup so that Kubeapps knows to deploy the auth-proxy service configured to redirect to your OIDC provider.
@@ -115,7 +115,7 @@ clusters:
     apiServiceURL: https://... # impersonation proxy URL
     certificateAuthorityData: ... #  impersonation proxy CA
     pinnipedConfig:
-      enable: true
+      enabled: true
 ```
 
 ## Debugging auth failures when using OIDC


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Just two cases of `enable` that I missed, in the documentation for pinniped-proxy setup.

Just noticed while pointing someone else at the docs.

### Benefits

When we do the next release, people will use the consistent key rather than the deprecated key..

### Possible drawbacks

Until we release, people need to use the old key (the new release will support both for now).

For this reason, I'll not land this change until we release.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3590

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
