### PR TITLE
kapp-controller plugin metadata

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -125,6 +125,9 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 		return nil, status.Errorf(codes.Internal, fmt.Sprintf("unable to list kapp-controller packages: %v", err))
 	}
 	pkgVersions, err := pkgVersionsMap(pkgs.Items)
+	if err != nil {
+		return nil, err
+	}
 
 	metaGVR := schema.GroupVersionResource{Group: packageGroup, Version: packageVersion, Resource: packageMetadataResources}
 	pkgMetadatas, err := client.Resource(metaGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
- Basic meta, but need to refactor.
- Switch to use PackageMetadata as available package.

### Description of the change

Carvel's kapp-controller changed their API quite significantly since we'd last looked at this plugin.

This PR switches to use the `PackageMetadata` as the "AvailablePackage", as it is the data which is common across versions, and the Package CR as the specific version.

It then adds the remaining metadata so that carvel and helm packages display side-by side without differences as shown:

![carvel-2-summaries](https://user-images.githubusercontent.com/497518/140460984-0238834b-7347-4790-9703-4b7de7272866.png)

Note: it looks like something is incorrect in the UI with the icon being much smaller, but it's just because of the SVG icon in the carvel test package, which has a size much bigger than the actual content, so in its original format looks like:

![carvel-test-logo-size](https://user-images.githubusercontent.com/497518/140461141-bfe7c021-2370-41aa-baaa-51bf3ae814cc.png)

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

We can browser available packages with the kapp-controller plugin enabled.
(Can't yet look at the details).
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3221

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

cc @migmartri (for when you're back).

Next up, available package detail.