### PR TITLE
flux plugin: add integration test for low memory env and check repo checksum before indexing

### DIFF
--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1818,9 +1818,12 @@ redis:
       ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order 
       ## to make space for the new data added
       - "--maxmemory-policy allkeys-lru"
+      ## ref https://stackoverflow.com/questions/22815364/flushall-and-flushdb-commands-on-redis-return-unk-command
+      ## Redis official Helm chart by default disables FLUSHDB and FLUSHALL commands
+    disableCommands: []
   replica:
     ## @param redis.replica.replicaCount Number of Redis&trade; replicas to deploy
-    replicaCount: 0
+    replicaCount: 1
     ## @param master.extraFlags Array with additional command line flags for Redis&trade; replicas
     extraFlags:
       ## The maxmemory configuration directive is used in order to configure Redis to use a specified
@@ -1831,3 +1834,6 @@ redis:
       ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order 
       ## to make space for the new data added
       - "--maxmemory-policy allkeys-lru"
+      ## ref https://stackoverflow.com/questions/22815364/flushall-and-flushdb-commands-on-redis-return-unk-command
+      ## Redis official Helm chart by default disables FLUSHDB and FLUSHALL commands
+    disableCommands: []

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1834,6 +1834,6 @@ redis:
       ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order 
       ## to make space for the new data added
       - "--maxmemory-policy allkeys-lru"
-      ## ref https://stackoverflow.com/questions/22815364/flushall-and-flushdb-commands-on-redis-return-unk-command
-      ## Redis official Helm chart by default disables FLUSHDB and FLUSHALL commands
+    ## ref https://stackoverflow.com/questions/22815364/flushall-and-flushdb-commands-on-redis-return-unk-command
+    ## Redis official Helm chart by default disables FLUSHDB and FLUSHALL commands
     disableCommands: []

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache.go
@@ -49,8 +49,9 @@ type NamespacedResourceWatcherCache struct {
 	eventProcessedWaitGroup *sync.WaitGroup
 }
 
-type cacheValueSetter func(string, map[string]interface{}) (interface{}, bool, error)
 type cacheValueGetter func(string, interface{}) (interface{}, error)
+type cacheValueAdder func(string, map[string]interface{}) (interface{}, bool, error)
+type cacheValueModifier func(string, map[string]interface{}, interface{}) (interface{}, bool, error)
 type cacheValueDeleter func(string, map[string]interface{}) (bool, error)
 
 // TODO (gfichtenholt) rename this to just Config when caching is separated out into core server
@@ -65,8 +66,8 @@ type cacheConfig struct {
 	// in the cache for a given k8s object (passed in as a untyped/unstructured map)
 	// the list of types actually supported be redis you can find in
 	// https://github.com/go-redis/redis/blob/v8.10.0/internal/proto/writer.go#L61
-	onAdd    cacheValueSetter
-	onModify cacheValueSetter
+	onAdd    cacheValueAdder
+	onModify cacheValueModifier
 	// the semantics of 'onGet' hook is to convert or "reverse engineer" what was previously
 	// stored in the cache (via onAdd/onModify hooks) to an object that the plug-in understands
 	// and wishes to be returned as part of response to fetchCachedObjects() call
@@ -123,13 +124,13 @@ func newCacheWithRedisClient(config cacheConfig, redisCli *redis.Client, waitGro
 	if pong, err := redisCli.Ping(redisCli.Context()).Result(); err != nil {
 		return nil, err
 	} else {
-		log.Infof("Redis [PING] -> [%s]", pong)
+		log.Infof("Redis [PING]: %s", pong)
 	}
 
 	if maxmemory, err := redisCli.ConfigGet(redisCli.Context(), "maxmemory").Result(); err != nil {
 		return nil, err
 	} else if len(maxmemory) > 1 {
-		log.Infof("Redis config maxmemory: %v", maxmemory[1])
+		log.Infof("Redis [CONFIG GET maxmemory]: %v", maxmemory[1])
 	}
 
 	c := NamespacedResourceWatcherCache{
@@ -240,8 +241,14 @@ func (c NamespacedResourceWatcherCache) Watch(options metav1.ListOptions) (watch
 // when it comes to consistency at any given point, as long as EVENTUALLY consistent
 // state is reached, which will be the case
 func (c NamespacedResourceWatcherCache) resync() (string, error) {
-	ctx := context.Background()
+	// clear the entire cache in one call
+	if result, err := c.redisCli.FlushDB(c.redisCli.Context()).Result(); err != nil {
+		return "", err
+	} else {
+		log.Infof("Redis [FLUSHDB]: %s", result)
+	}
 
+	ctx := context.Background()
 	dynamicClient, _, err := c.config.clientGetter(ctx)
 	if err != nil {
 		return "", status.Errorf(codes.FailedPrecondition, "unable to get client due to: %v", err)
@@ -269,12 +276,6 @@ func (c NamespacedResourceWatcherCache) resync() (string, error) {
 	if rv == "" {
 		// fail fast, without a valid resource version the whole workflow breaks down
 		return "", status.Errorf(codes.Internal, "List() call response does not contain resource version")
-	}
-
-	// clear the entire cache in one call
-	c.redisCli.FlushDB(c.redisCli.Context()).Err()
-	if err != nil {
-		return "", err
 	}
 
 	// re-populate the cache with current state from k8s
@@ -342,36 +343,39 @@ func (c NamespacedResourceWatcherCache) onAddOrModify(add bool, unstructuredObj 
 		return nil
 	}
 
+	var oldValue []byte
+	if !add {
+		oldValue, _ = c.redisCli.Get(c.redisCli.Context(), key).Bytes()
+	}
+
+	var newValue interface{}
+	var setVal bool
 	var funcName string
-	var addOrModify cacheValueSetter
-	if add {
+	if oldValue == nil {
 		funcName = "onAdd"
-		addOrModify = c.config.onAdd
+		newValue, setVal, err = c.config.onAdd(key, unstructuredObj)
 	} else {
 		funcName = "onModify"
-		addOrModify = c.config.onModify
+		newValue, setVal, err = c.config.onModify(key, unstructuredObj, oldValue)
 	}
-	value, setVal, err := addOrModify(key, unstructuredObj)
+
 	if err != nil {
 		log.Errorf("Invocation of [%s] for object %s\nfailed due to: %v", funcName, prettyPrintMap(unstructuredObj), err)
 		// clear that key so cache doesn't contain any stale info for this object
 		c.redisCli.Del(c.redisCli.Context(), key)
 		return err
-	}
-
-	if setVal {
+	} else if setVal {
 		// Zero expiration means the key has no expiration time.
 		// However, cache entries may be evicted by redis in order to make room for new ones,
 		// if redis is limited by maxmemory constraint
-		err = c.redisCli.Set(c.redisCli.Context(), key, value, 0).Err()
+		result, err := c.redisCli.Set(c.redisCli.Context(), key, newValue, 0).Result()
 		if err != nil {
 			log.Errorf("Failed to set value for object with key [%s] in cache due to: %v", key, err)
 			return err
 		} else {
-			if log.V(4).Enabled() {
-				usedMemory, totalMemory := c.memoryStats()
-				log.V(4).Infof("Set value for key [%s] in cache. Redis memory usage: [%s/%s]", key, usedMemory, totalMemory)
-			}
+			// debugging an intermittent issue
+			usedMemory, totalMemory := c.memoryStats()
+			log.Infof("Redis [SET %s]: %s. Redis [INFO memory]: [%s/%s]", key, result, usedMemory, totalMemory)
 		}
 	}
 	return nil
@@ -398,10 +402,13 @@ func (c NamespacedResourceWatcherCache) onDelete(unstructuredObj map[string]inte
 	}
 
 	if delete {
-		err = c.redisCli.Del(c.redisCli.Context(), key).Err()
+		keysremoved, err := c.redisCli.Del(c.redisCli.Context(), key).Result()
 		if err != nil {
 			log.Errorf("Failed to delete value for object [%s] from cache due to: %v", key, err)
 			return err
+		} else {
+			// debugging an intermittent failure
+			log.Infof("Redis [DEL %s]: %d", key, keysremoved)
 		}
 	}
 	return nil
@@ -409,9 +416,11 @@ func (c NamespacedResourceWatcherCache) onDelete(unstructuredObj map[string]inte
 
 // this is effectively a cache GET operation
 func (c NamespacedResourceWatcherCache) fetchForOne(key string) (interface{}, error) {
-	log.Infof("+fectchForOne(%s)", key)
-	// read back from cache: should be either what we previously wrote or Redis.Nil if the key does
-	// not exist or has been evicted due to memory pressure/TTL expiry
+	log.V(4).Infof("+fectchForOne(%s)", key)
+	// read back from cache: should be either:
+	//  - what we previously wrote OR
+	//  - Redis.Nil if the key does  not exist or has been evicted due to memory pressure/TTL expiry
+	//
 	// TODO (gfichtenholt) See if there might be a cleaner way than to have onGet() take []byte as
 	// a 2nd argument. In theory, I would have liked to pass in an interface{}, just like onAdd/onModify.
 	// The limitation here is caused by the fact that redis go client does not offer a
@@ -419,21 +428,21 @@ func (c NamespacedResourceWatcherCache) fetchForOne(key string) (interface{}, er
 	// strings which can be converted to desired types as needed, e.g.
 	// redisCli.Get(ctx, key).Bytes() first gets the string and then converts it to bytes.
 	bytes, err := c.redisCli.Get(c.redisCli.Context(), key).Bytes()
+	// debugging an intermittent issue
 	if err == redis.Nil {
-		// this is normal if the key does not exist
+		log.V(4).Infof("Redis [GET %s]: Nil", key)
 		return nil, nil
 	} else if err != nil {
 		log.Errorf("Failed to get value for key [%s] from cache due to: %v", key, err)
 		return nil, err
 	}
+	log.V(4).Infof("Redis [GET %s]: %d bytes read", key, len(bytes))
 
 	val, err := c.config.onGet(key, bytes)
 	if err != nil {
 		log.Errorf("Invocation of 'onGet' for object with key [%s]\nfailed due to: %v", key, err)
 		return nil, err
 	}
-
-	//log.Infof("Fetched value for key [%s]: %v", key, val)
 	return val, nil
 }
 

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
@@ -16,6 +16,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/Masterminds/semver"
@@ -188,18 +189,18 @@ func (s *Server) getChart(ctx context.Context, repo types.NamespacedName, chartN
 		return nil, status.Errorf(codes.FailedPrecondition, "server cache has not been properly initialized")
 	}
 
-	charts, err := s.cache.fetchForOne(s.cache.keyForNamespacedName(repo))
+	entry, err := s.cache.fetchForOne(s.cache.keyForNamespacedName(repo))
 	if err != nil {
 		return nil, err
 	}
 
-	if charts != nil {
-		if typedCharts, ok := charts.([]models.Chart); !ok {
+	if entry != nil {
+		if typedEntry, ok := entry.(repoCacheEntry); !ok {
 			return nil, status.Errorf(
 				codes.Internal,
-				"unexpected value fetched from cache: %v", charts)
+				"unexpected value fetched from cache: type: [%s], value: [%v]", reflect.TypeOf(entry), entry)
 		} else {
-			for _, chart := range typedCharts {
+			for _, chart := range typedEntry.Charts {
 				if chart.Name == chartName {
 					return &chart, nil // found it
 				}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
@@ -463,24 +463,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 				AvailablePackageRef: availableRef("bitnami/redis", "kubeapps"),
 			},
 			expectedStatusCode: codes.OK,
-			expectedResponse: &corev1.GetAvailablePackageVersionsResponse{
-				PackageAppVersions: []*corev1.PackageAppVersion{
-					{PkgVersion: "14.6.1", AppVersion: "6.2.4"},
-					{PkgVersion: "14.6.0", AppVersion: "6.2.4"},
-					{PkgVersion: "14.5.0", AppVersion: "6.2.4"},
-					{PkgVersion: "14.4.0", AppVersion: "6.2.4"},
-					{PkgVersion: "13.0.1", AppVersion: "6.2.1"},
-					{PkgVersion: "13.0.0", AppVersion: "6.2.1"},
-					{PkgVersion: "12.10.1", AppVersion: "6.0.12"},
-					{PkgVersion: "12.10.0", AppVersion: "6.0.12"},
-					{PkgVersion: "12.9.2", AppVersion: "6.0.12"},
-					{PkgVersion: "12.9.1", AppVersion: "6.0.12"},
-					{PkgVersion: "12.9.0", AppVersion: "6.0.12"},
-					{PkgVersion: "12.8.3", AppVersion: "6.0.12"},
-					{PkgVersion: "12.8.2", AppVersion: "6.0.12"},
-					{PkgVersion: "12.8.1", AppVersion: "6.0.12"},
-				},
-			},
+			expectedResponse:   expected_versions_redis,
 		},
 		{
 			name:          "it returns error for non-existent chart",
@@ -704,5 +687,24 @@ var expected_detail_redis_2 = &corev1.AvailablePackageDetail{
 			Name:  "desaintmartin",
 			Email: "cedric@desaintmartin.fr",
 		},
+	},
+}
+
+var expected_versions_redis = &corev1.GetAvailablePackageVersionsResponse{
+	PackageAppVersions: []*corev1.PackageAppVersion{
+		{PkgVersion: "14.6.1", AppVersion: "6.2.4"},
+		{PkgVersion: "14.6.0", AppVersion: "6.2.4"},
+		{PkgVersion: "14.5.0", AppVersion: "6.2.4"},
+		{PkgVersion: "14.4.0", AppVersion: "6.2.4"},
+		{PkgVersion: "13.0.1", AppVersion: "6.2.1"},
+		{PkgVersion: "13.0.0", AppVersion: "6.2.1"},
+		{PkgVersion: "12.10.1", AppVersion: "6.0.12"},
+		{PkgVersion: "12.10.0", AppVersion: "6.0.12"},
+		{PkgVersion: "12.9.2", AppVersion: "6.0.12"},
+		{PkgVersion: "12.9.1", AppVersion: "6.0.12"},
+		{PkgVersion: "12.9.0", AppVersion: "6.0.12"},
+		{PkgVersion: "12.8.3", AppVersion: "6.0.12"},
+		{PkgVersion: "12.8.2", AppVersion: "6.0.12"},
+		{PkgVersion: "12.8.1", AppVersion: "6.0.12"},
 	},
 }

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/integration_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/integration_utils_test.go
@@ -13,9 +13,13 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -36,6 +40,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 )
 
 const (
@@ -316,7 +322,7 @@ func kubeCreateNamespace(t *testing.T, namespace string) error {
 	t.Logf("+kubeCreateNamespace(%s)", namespace)
 	if typedClient, err := kubeGetTypedClient(); err != nil {
 		return err
-	} else if typedClient.CoreV1().Namespaces().Create(
+	} else if _, err = typedClient.CoreV1().Namespaces().Create(
 		context.TODO(),
 		&kubecorev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -333,11 +339,62 @@ func kubeDeleteNamespace(t *testing.T, namespace string) error {
 	t.Logf("+kubeDeleteNamespace(%s)", namespace)
 	if typedClient, err := kubeGetTypedClient(); err != nil {
 		return err
-	} else if typedClient.CoreV1().Namespaces().Delete(
+	} else if err = typedClient.CoreV1().Namespaces().Delete(
 		context.TODO(),
 		namespace,
 		metav1.DeleteOptions{}); err != nil {
 		return err
+	}
+	return nil
+}
+
+func kubeGetSecret(t *testing.T, namespace, name, dataKey string) (string, error) {
+	t.Logf("+kubeGetSecret(%s, %s, %s)", namespace, name, dataKey)
+	if typedClient, err := kubeGetTypedClient(); err != nil {
+		return "", err
+	} else if secret, err := typedClient.CoreV1().Secrets(namespace).Get(
+		context.TODO(),
+		name,
+		metav1.GetOptions{}); err != nil {
+		return "", err
+	} else {
+		token := secret.Data[dataKey]
+		if token == nil {
+			return "", errors.New("No data found")
+		}
+		return string(token), nil
+	}
+}
+
+func kubePortForwardToRedis(t *testing.T, stopChan <-chan struct{}, readyChan chan struct{}) error {
+	t.Logf("+kubePortForwardToRedis")
+	// ref https://github.com/kubernetes/client-go/issues/51
+	if config, err := restConfig(); err != nil {
+		return err
+	} else if roundTripper, upgrader, err := spdy.RoundTripperFor(config); err != nil {
+		return err
+	} else {
+		path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", "kubeapps", "kubeapps-redis-master-0")
+		hostIP := strings.TrimLeft(config.Host, "htps:/")
+		serverURL := url.URL{Scheme: "https", Path: path, Host: hostIP}
+		dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, &serverURL)
+		out, errOut := new(bytes.Buffer), new(bytes.Buffer)
+		if forwarder, err := portforward.New(dialer, []string{"6379"}, stopChan, readyChan, out, errOut); err != nil {
+			return err
+		} else {
+			go func() {
+				for range readyChan { // Kubernetes will close this channel when it has something to tell us.
+				}
+				if len(errOut.String()) != 0 {
+					t.Errorf("kubePortForwardToRedis: %s", errOut.String())
+				} else if len(out.String()) != 0 {
+					t.Logf("kubePortForwardToRedis: %s", out.String())
+				}
+			}()
+			if err = forwarder.ForwardPorts(); err != nil { // Locks until stopChan is closed.
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_integration_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +25,7 @@ import (
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	fluxplugin "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -373,23 +373,21 @@ func TestKindClusterDeleteInstalledPackage(t *testing.T) {
 }
 
 // this integration test is meant to test a scenario when the redis cache is confiured with maxmemory
-// to small to be able to fit all the repos needed to satisfy the request for GetAvailablePackageSummaries
-// and redis cache eviction kicks in. To set up such environment one can use
-// "-f ./docs/user/manifests/kubeapps-local-dev-redis-tiny-values.yaml" option when installing
+// too small to be able to fit all the repos needed to satisfy the request for GetAvailablePackageSummaries
+// and redis cache eviction kicks in. Also, the kubeapps-apis pod should have a large memory limit (1Gb) set
+// To set up such environment one can use  "-f ./docs/user/manifests/kubeapps-local-dev-redis-tiny-values.yaml" option when installing
 // kubeapps via "helm upgrade"
-//
+// It is worth noting that exactly how many copies of bitnami repo can be held in the cache at any given time varies
+// This is because the size of the index.yaml we get from bitnami does fluctuate quite a bit over time:
+// [kubeapps]$ ls -l bitnami_index.yaml
+// -rw-r--r--@ 1 gfichtenholt  staff  8432962 Jun 20 02:35 bitnami_index.yaml
+// [kubeapps]$ ls -l bitnami_index.yaml
+// -rw-rw-rw-@ 1 gfichtenholt  staff  10394218 Nov  7 19:41 bitnami_index.yaml
 func TestKindClusterGetAvailablePackageSummariesForLargeReposAndTinyRedis(t *testing.T) {
 	fluxPlugin := checkEnv(t)
-	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
-	go func() {
-		if err := kubePortForwardToRedis(t, stopChan, readyChan); err != nil {
-			t.Errorf("%+v", err)
-		}
-	}()
-	// this will wait until port-forwarding is set up
-	<-readyChan
-	// this will stop the port forwarding
-	t.Cleanup(func() { close(stopChan) })
+	if err := kubePortForwardToRedis(t); err != nil {
+		t.Fatalf("kubePortForwardToRedis failed due to %+v", err)
+	}
 	redisPwd, err := kubeGetSecret(t, "kubeapps", "kubeapps-redis", "redis-password")
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -399,39 +397,9 @@ func TestKindClusterGetAvailablePackageSummariesForLargeReposAndTinyRedis(t *tes
 		Password: redisPwd,
 		DB:       0,
 	})
-	t.Logf("redisCli = %s", redisCli)
-	maxmemory, err := redisCli.ConfigGet(redisCli.Context(), "maxmemory").Result()
-	if err != nil {
-		t.Fatalf("%v", err)
-	} else {
-		currentMaxMemory := fmt.Sprintf("%v", maxmemory[1])
-		t.Logf("Current maxmemory = [%s]", currentMaxMemory)
-		// this is to restore values after the test is done
-		t.Cleanup(func() {
-			t.Logf("Resetting maxmemory back to [%s]", currentMaxMemory)
-			if err = redisCli.ConfigSet(redisCli.Context(), "maxmemory", currentMaxMemory).Err(); err != nil {
-				t.Logf("%v", err)
-			}
-		})
-	}
-	maxmemoryPolicy, err := redisCli.ConfigGet(redisCli.Context(), "maxmemory-policy").Result()
-	if err != nil {
-		t.Fatalf("%v", err)
-	} else {
-		currentMaxMemoryPolicy := fmt.Sprintf("%v", maxmemoryPolicy[1])
-		t.Logf("Current maxmemory policy = [%s]", currentMaxMemoryPolicy)
-		// this is to restore values after the test is done
-		t.Cleanup(func() {
-			t.Logf("Resetting maxmemory-policy back to [%s]", currentMaxMemoryPolicy)
-			if err = redisCli.ConfigSet(redisCli.Context(), "maxmemory-policy", currentMaxMemoryPolicy).Err(); err != nil {
-				t.Logf("%v", err)
-			}
-		})
-	}
-	if err = redisCli.ConfigSet(redisCli.Context(), "maxmemory", "10mb").Err(); err != nil {
-		t.Fatalf("%v", err)
-	}
-	if err = redisCli.ConfigSet(redisCli.Context(), "maxmemory-policy", "allkeys-lru").Err(); err != nil {
+	t.Logf("redisCli: %s", redisCli)
+	// assume 15Mb redis cache for now
+	if err = redisCheckTinyMaxMemory(t, redisCli, "15728640"); err != nil {
 		t.Fatalf("%v", err)
 	}
 	// ref https://redis.io/topics/notifications
@@ -445,17 +413,57 @@ func TestKindClusterGetAvailablePackageSummariesForLargeReposAndTinyRedis(t *tes
 		}
 	})
 
+	// sanity check, we expect the cache to be empty at this point
+	// if it's not, it's likely that some cleanup didn't happen due to earlier an aborted test
+	// and you should be able to clean up manually
+	// $ kubectl delete helmrepositories --all
+	if keys, err := redisCli.Keys(redisCli.Context(), "*").Result(); err != nil {
+		t.Fatalf("%v", err)
+	} else {
+		if len(keys) != 0 {
+			t.Fatalf("Failing due to unexpected state of the cache. Current keys: %s", keys)
+		}
+	}
 	// ref https://medium.com/nerd-for-tech/redis-getting-notified-when-a-key-is-expired-or-changed-ca3e1f1c7f0a
-	subscribe := redisCli.PSubscribe(redisCli.Context(), "__keyevent@0__:set")
+	subscribe := redisCli.PSubscribe(redisCli.Context(), "__keyevent@0__:*")
 	ch := subscribe.Channel()
+	defer subscribe.Close()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	const MAX_REPOS_NEVER = 100
+	// ref https://stackoverflow.com/questions/32840687/timeout-for-waitgroup-wait
+	evicted := false
+	sem := semaphore.NewWeighted(MAX_REPOS_NEVER)
+	if err := sem.Acquire(context.Background(), MAX_REPOS_NEVER); err != nil {
+		t.Fatalf("%v", err)
+	}
+	go func() {
+		// need to wait until the plug-in has indexed all TOTAL_REPOS repos in the background
+		t.Logf("Listening for events from redis in the background...")
+		for {
+			event, ok := <-ch
+			if !ok {
+				t.Logf("Redis publish channel was closed")
+				break
+			}
+			t.Logf("Redis event: Channel: [%v], Payload: [%v]", event.Channel, event.Payload)
+			if event.Channel == "__keyevent@0__:set" {
+				// signal to the main thread its okay to proceed
+				sem.Release(1)
+			} else if event.Channel == "__keyevent@0__:evicted" {
+				evicted = true
+				sem.Release(1)
+			}
+		}
+	}()
 
 	// now load some large repos (bitnami)
-	// I didn't want to store a large (10MB) copy of bitnami repo in our git, so for now let it fetch from bitnami website
-	for i := range []int{1, 2, 3, 4} {
-		repo := fmt.Sprintf("bitnami-%d", i)
+	// I didn't want to store a large (10MB) copy of bitnami repo in our git,
+	// so for now let it fetch from bitnami website
+	// we'll keep adding repos one at a time, until we get an event from redis
+	// about the first evicted entry
+	totalRepos := 0
+	for ; totalRepos < MAX_REPOS_NEVER && !evicted; totalRepos++ {
+		repo := fmt.Sprintf("bitnami-%d", totalRepos)
 		if err = kubeCreateHelmRepository(t, repo, "https://charts.bitnami.com/bitnami", "default"); err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -464,53 +472,28 @@ func TestKindClusterGetAvailablePackageSummariesForLargeReposAndTinyRedis(t *tes
 				t.Logf("%v", err)
 			}
 		})
-		time.Sleep(1 * time.Second)
-	}
-
-	expected := make(map[string]struct{})
-	for i := range []int{1, 2, 3, 4} {
-		repo := fmt.Sprintf("helmrepositories:default:bitnami-%d", i)
-		expected[repo] = struct{}{}
-	}
-
-	go func() {
-		// need to wait until the plug-in has indexed all 4 repos in the background
-		t.Logf("Waiting for events from Redis now...")
-		for {
-			event, ok := <-ch
-			if !ok {
-				// let the user retry
-				t.Errorf("Redis publish channel was closed")
-				break
-			}
-			t.Logf("Redis event: Channel: [%v], Payload: [%v]", event.Channel, event.Payload)
-			if event.Channel == "__keyevent@0__:set" {
-				delete(expected, event.Payload)
-			}
-			if len(expected) == 0 {
-				wg.Done()
-				break
-			}
+		// wait until this repo have been indexed and cached up to 5 minutes
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+		defer cancel()
+		if err := sem.Acquire(ctx, 1); err != nil {
+			t.Fatalf("Timed out waiting for Redis event: %v", err)
 		}
-	}()
+	}
 
-	// wait until all repos have been indexed and cached
-	// TODO: (gfichtenholt) if this malfunctions it will hang the test forever
-	// Potential fix is to wait with a timeout
-	// ref https://stackoverflow.com/questions/32840687/timeout-for-waitgroup-wait/32840688#32840688
-	wg.Wait()
-	subscribe.Close()
+	if !evicted {
+		t.Fatalf("Failing because redis did not evict any entries")
+	}
 
 	if keys, err := redisCli.Keys(redisCli.Context(), "*").Result(); err != nil {
 		t.Fatalf("%v", err)
 	} else {
-		// the cache is only big enough to be able to hold 3 out of the 4 keys
-		if len(keys) != 3 {
-			t.Fatalf("Expected 3 keys in cache but got [%s]", keys)
+		// the cache should only big enough to be able to (totalRepos-1) of the keys
+		if len(keys) != totalRepos-1 {
+			t.Fatalf("Expected %d keys in cache but got [%s]", totalRepos-1, keys)
 		}
 	}
 
-	// not realted to low laxmemory but as long as we are here might as well check this
+	// not related to low laxmemory but as long as we are here might as well check this
 	_, err = fluxPlugin.GetAvailablePackageSummaries(context.TODO(), &corev1.GetAvailablePackageSummariesRequest{})
 	if err == nil || status.Code(err) != codes.Unauthenticated {
 		t.Fatalf("Expected Unauthenticated, got %v", err)
@@ -521,9 +504,10 @@ func TestKindClusterGetAvailablePackageSummariesForLargeReposAndTinyRedis(t *tes
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
+
 	// we need to make sure that response contains packages from all 4 repositories
-	expected = make(map[string]struct{})
-	for i := range []int{1, 2, 3, 4} {
+	expected := make(map[string]struct{})
+	for i := 0; i < totalRepos; i++ {
 		repo := fmt.Sprintf("bitnami-%d", i)
 		expected[repo] = struct{}{}
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
@@ -159,7 +159,6 @@ func (s *Server) getChartsForRepos(ctx context.Context, match []string) (map[str
 	// Some key may have been evicted due to memory pressure and LRU eviction policy.
 	// ref: https://redis.io/topics/lru-cache
 	// so, first, let's fetch the entries that are still cached before redis evicts those
-	// this for loop should be very fast as it only covers cache hit scenarios
 	chartsUntyped, err := s.cache.fetchForMultiple(repoNames)
 	if err != nil {
 		return nil, err

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
+	"reflect"
 	"regexp"
 	"time"
 
@@ -205,11 +206,14 @@ func (s *Server) getChartsForRepos(ctx context.Context, match []string) (map[str
 			}
 		}
 		if value != nil {
-			typedChartsValue, ok := value.([]models.Chart)
+			typedValue, ok := value.(repoCacheEntry)
 			if !ok {
-				return nil, status.Errorf(codes.Internal, "Unexpected value fetched from cache: %v", value)
+				return nil, status.Errorf(
+					codes.Internal,
+					"unexpected value fetched from cache: type: [%s], value: [%v]",
+					reflect.TypeOf(value), value)
 			}
-			chartsTyped[key] = typedChartsValue
+			chartsTyped[key] = typedValue.Charts
 		}
 	}
 	return chartsTyped, nil
@@ -230,24 +234,17 @@ func isRepoReady(unstructuredRepo map[string]interface{}) bool {
 	return completed && success
 }
 
-func indexOneRepo(unstructuredRepo map[string]interface{}) ([]models.Chart, error) {
+// it is assumed the caller has already checked that this repo is ready
+// At present, there is only one caller of indexOneRepo() and this check is already done by it
+func indexOneRepo(unstructuredRepo map[string]interface{}) (charts []models.Chart, err error) {
 	startTime := time.Now()
 
-	repo, err := newPackageRepository(unstructuredRepo)
+	repo, err := packageRepositoryFromUnstructured(unstructuredRepo)
 	if err != nil {
 		return nil, err
 	}
 
-	// this is just a future-proofing sanity check.
-	// At present, there is only one caller of indexOneRepo() and this check is already done by it,
-	// so this should never really happen
-	if !isRepoReady(unstructuredRepo) {
-		return nil, status.Errorf(codes.Internal,
-			"cannot index repository [%s] because it is not in 'Ready' state. error: %v",
-			repo.Name,
-			err)
-	}
-
+	// ref https://fluxcd.io/docs/components/source/helmrepositories/#status
 	indexUrl, found, err := unstructured.NestedString(unstructuredRepo, "status", "url")
 	if err != nil || !found {
 		return nil, status.Errorf(codes.Internal,
@@ -255,7 +252,7 @@ func indexOneRepo(unstructuredRepo map[string]interface{}) ([]models.Chart, erro
 			repo.Name, err)
 	}
 
-	log.V(4).Infof("indexOneRepo: [%s], index URL: [%s]", repo.Name, indexUrl)
+	log.Infof("+indexOneRepo: [%s], index URL: [%s]", repo.Name, indexUrl)
 
 	// no need to provide authz, userAgent or any of the TLS details, as we are reading index.yaml file from
 	// local cluster, not some remote repo.
@@ -278,15 +275,15 @@ func indexOneRepo(unstructuredRepo map[string]interface{}) ([]models.Chart, erro
 	// shallow = true  => 8-9 sec
 	// shallow = false => 12-13 sec, so deep copy adds 50% to cost, but we need it to
 	// for GetAvailablePackageVersions()
-	charts, err := helm.ChartsFromIndex(bytes, modelRepo, false)
+	charts, err = helm.ChartsFromIndex(bytes, modelRepo, false)
 	if err != nil {
 		return nil, err
 	}
 
 	duration := time.Since(startTime)
-	msg := fmt.Sprintf("indexOneRepo: indexed [%d] packages in repository [%s] in [%d] ms", len(charts), repo.Name, duration.Milliseconds())
+	msg := fmt.Sprintf("-indexOneRepo: [%s], indexed [%d] packages in [%d] ms", repo.Name, len(charts), duration.Milliseconds())
 	if len(charts) > 0 {
-		log.V(4).Info(msg)
+		log.Info(msg)
 	} else {
 		// this is kind of a red flag - an index with 0 charts, most likely contents of index.yaml is
 		// messed up and didn't parse but the helm library didn't raise an error
@@ -295,7 +292,7 @@ func indexOneRepo(unstructuredRepo map[string]interface{}) ([]models.Chart, erro
 	return charts, nil
 }
 
-func newPackageRepository(unstructuredRepo map[string]interface{}) (*v1alpha1.PackageRepository, error) {
+func packageRepositoryFromUnstructured(unstructuredRepo map[string]interface{}) (*v1alpha1.PackageRepository, error) {
 	name, err := namespacedName(unstructuredRepo)
 	if err != nil {
 		return nil, err
@@ -364,26 +361,43 @@ func isHelmRepositoryReady(unstructuredObj map[string]interface{}) (complete boo
 // implements plug-in specific cache-related functionality
 //
 
-// onAddOrModifyRepo essentially tells the cache what to store for a given key
-func onAddOrModifyRepo(key string, unstructuredRepo map[string]interface{}) (interface{}, bool, error) {
-	if isRepoReady(unstructuredRepo) {
+// this is what we store in the cache for each cached repo
+// all struct fields are capitalized so they're exported by gob encoding
+type repoCacheEntry struct {
+	Checksum string
+	Charts   []models.Chart
+}
 
-		// TODO (gfichtenholt): I think we should to compare checksums on what's stored in the cache
-		// vs the modified object to see if the contents has really changed before embarking on
-		// expensive operation below. Kind of like pkg/chart/chart.go does in getIndexFromCache()
+// onAddRepo essentially tells the cache what to store for a given key
+func onAddRepo(key string, unstructuredRepo map[string]interface{}) (interface{}, bool, error) {
+	// first check the repo is ready
+	if isRepoReady(unstructuredRepo) {
+		// ref https://fluxcd.io/docs/components/source/helmrepositories/#status
+		checksum, found, err := unstructured.NestedString(unstructuredRepo, "status", "artifact", "checksum")
+		if err != nil || !found {
+			return nil, false, status.Errorf(codes.Internal,
+				"expected field status.artifact.checksum not found on HelmRepository\n[%s], error %v",
+				prettyPrintMap(unstructuredRepo), err)
+		}
+
 		charts, err := indexOneRepo(unstructuredRepo)
 		if err != nil {
 			return nil, false, err
 		}
 
+		cacheEntry := repoCacheEntry{
+			Checksum: checksum,
+			Charts:   charts,
+		}
+
 		// launch go-routine that will download tarball and extract relevant details for each chart
 		// and cache them for fast lookup
-		//go cacheLatestChartDetails(charts)
+		// TODO (gfichtenholt) go cacheLatestChartDetails(charts)
 
 		// use gob encoding instead of json, it peforms much better
 		var buf bytes.Buffer
 		enc := gob.NewEncoder(&buf)
-		if err = enc.Encode(charts); err != nil {
+		if err = enc.Encode(cacheEntry); err != nil {
 			return nil, false, err
 		}
 		return buf.Bytes(), true, nil
@@ -395,6 +409,69 @@ func onAddOrModifyRepo(key string, unstructuredRepo map[string]interface{}) (int
 	}
 }
 
+// onModifyRepo essentially tells the cache what to store for a given key
+func onModifyRepo(key string, unstructuredRepo map[string]interface{}, oldValue interface{}) (interface{}, bool, error) {
+	// first check the repo is ready
+	if isRepoReady(unstructuredRepo) {
+		// We should to compare checksums on what's stored in the cache
+		// vs the modified object to see if the contents has really changed before embarking on
+		// expensive operation indexOneRepo() below.
+		// ref https://fluxcd.io/docs/components/source/helmrepositories/#status
+		newChecksum, found, err := unstructured.NestedString(unstructuredRepo, "status", "artifact", "checksum")
+		if err != nil || !found {
+			return nil, false, status.Errorf(
+				codes.Internal,
+				"expected field status.artifact.checksum not found on HelmRepository\n[%s], error %v",
+				prettyPrintMap(unstructuredRepo), err)
+		}
+
+		cacheEntryUntyped, err := onGetRepo(key, oldValue)
+		if err != nil {
+			return nil, false, err
+		}
+
+		cacheEntry, ok := cacheEntryUntyped.(repoCacheEntry)
+		if !ok {
+			return nil, false, status.Errorf(
+				codes.Internal,
+				"unexpected value found in cache for key [%s]: %v",
+				key, cacheEntryUntyped)
+		}
+
+		if cacheEntry.Checksum != newChecksum {
+			newCharts, err := indexOneRepo(unstructuredRepo)
+			if err != nil {
+				return nil, false, err
+			}
+
+			cacheEntry = repoCacheEntry{
+				Checksum: newChecksum,
+				Charts:   newCharts,
+			}
+
+			// launch go-routine that will download tarball and extract relevant details for each chart
+			// and cache them for fast lookup
+			// TODO (gfichtenholt) go cacheLatestChartDetails(charts)
+
+			// use gob encoding instead of json, it peforms much better
+			var buf bytes.Buffer
+			enc := gob.NewEncoder(&buf)
+			if err = enc.Encode(cacheEntry); err != nil {
+				return nil, false, err
+			}
+			return buf.Bytes(), true, nil
+		} else {
+			// skip because the content did not change
+			return nil, false, nil
+		}
+	} else {
+		// repo is not quite ready to be indexed - not really an error condition,
+		// just skip it eventually there will be another event when it is in ready state
+		log.V(4).Infof("Skipping packages for repository [%s] because it is not in 'Ready' state", key)
+		return nil, false, nil
+	}
+}
+
 func onGetRepo(key string, value interface{}) (interface{}, error) {
 	b, ok := value.([]byte)
 	if !ok {
@@ -402,12 +479,12 @@ func onGetRepo(key string, value interface{}) (interface{}, error) {
 	}
 
 	dec := gob.NewDecoder(bytes.NewReader(b))
-	var charts []models.Chart
-	if err := dec.Decode(&charts); err != nil {
+	var entry repoCacheEntry
+	if err := dec.Decode(&entry); err != nil {
 		return nil, err
 	}
 
-	return charts, nil
+	return entry, nil
 }
 
 func onDeleteRepo(key string, unstructuredRepo map[string]interface{}) (bool, error) {

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -65,8 +65,8 @@ func NewServer(configGetter server.KubernetesConfigGetter, kubeappsCluster strin
 	cacheConfig := cacheConfig{
 		gvr:          repositoriesGvr,
 		clientGetter: newBackgroundClientGetter(),
-		onAdd:        onAddOrModifyRepo,
-		onModify:     onAddOrModifyRepo,
+		onAdd:        onAddRepo,
+		onModify:     onModifyRepo,
 		onGet:        onGetRepo,
 		onDelete:     onDeleteRepo,
 	}
@@ -130,7 +130,7 @@ func (s *Server) GetPackageRepositories(ctx context.Context, request *v1alpha1.G
 
 	responseRepos := []*v1alpha1.PackageRepository{}
 	for _, repoUnstructured := range repos.Items {
-		repo, err := newPackageRepository(repoUnstructured.Object)
+		repo, err := packageRepositoryFromUnstructured(repoUnstructured.Object)
 		if err != nil {
 			return nil, err
 		}

--- a/docs/user/manifests/kubeapps-local-dev-redis-tiny-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-redis-tiny-values.yaml
@@ -6,16 +6,17 @@ kubeappsapis:
     limits:
       memory: "1Gi"
       cpu: "500m"
+  replicaCount: 1
 
 redis:
   enabled: true
   master: 
     extraFlags:
       ## Intentionally a small number to test scenarios where cache eviction policies kick in
-      - "--maxmemory 10mb"
+      - "--maxmemory 15mb"
       - "--maxmemory-policy allkeys-lru"
   replica:
     extraFlags:
       ## Intentionally a small number to test scenarios where cache eviction policies kick in
-      - "--maxmemory 10mb"
+      - "--maxmemory 15mb"
       - "--maxmemory-policy allkeys-lru"

--- a/script/makefiles/deploy-dev.mk
+++ b/script/makefiles/deploy-dev.mk
@@ -57,7 +57,7 @@ deploy-kapp-controller:
 
 # Add the flux controllers used for testing the kubeapps-apis integration.
 deploy-flux-controllers:
-	kubectl --kubeconfig=${CLUSTER_CONFIG} apply -f https://github.com/fluxcd/flux2/releases/download/v0.20.0/install.yaml
+	kubectl --kubeconfig=${CLUSTER_CONFIG} apply -f https://github.com/fluxcd/flux2/releases/download/v0.21.1/install.yaml
 
 reset-dev:
 	helm --kubeconfig=${CLUSTER_CONFIG} -n kubeapps delete kubeapps  || true


### PR DESCRIPTION
This is mostly an incremental PR which isn't meant to address any big issue, but more specifically
1) adds an integration test for scenarios where redis cache is limited in size, has to evict entries in order to make room for new ones and flux plug-in functions as expected . This took a bit of an effort to make work
2) add a checksum comparison for repos before performing expensive operation of indexing 
3) tidy up/fix a few minor issues in unit tests
