### PR TITLE
Add missing URLEncode in some mgs

### DIFF
--- a/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
+++ b/dashboard/src/components/AppUpgrade/AppUpgrade.tsx
@@ -63,7 +63,7 @@ function AppUpgrade() {
       "package";
     return (
       <LoadingWrapper
-        loadingText={`Fetching ${loadingPkgName} version...`}
+        loadingText={`Fetching ${decodeURIComponent(loadingPkgName)} version...`}
         className="margin-t-xxl"
         loaded={false}
       />

--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -144,7 +144,12 @@ export default function DeploymentForm() {
   }
 
   if (!selectedPackage.availablePackageDetail) {
-    return <LoadingWrapper className="margin-t-xxl" loadingText={`Fetching ${packageId}...`} />;
+    return (
+      <LoadingWrapper
+        className="margin-t-xxl"
+        loadingText={`Fetching ${decodeURIComponent(packageId)}...`}
+      />
+    );
   }
   return (
     <section>

--- a/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.tsx
+++ b/dashboard/src/components/DeploymentFormBody/DeploymentFormBody.tsx
@@ -106,7 +106,12 @@ function DeploymentFormBody({
     );
   }
   if (packagesIsFetching || !availablePackageDetail || !versions.length) {
-    return <LoadingWrapper className="margin-t-xxl" loadingText={`Fetching ${packageId}...`} />;
+    return (
+      <LoadingWrapper
+        className="margin-t-xxl"
+        loadingText={`Fetching ${decodeURIComponent(packageId)}...`}
+      />
+    );
   }
   const tabColumns = [
     "YAML",


### PR DESCRIPTION
### Description of the change

We had a card in our board regarding a "/" not being properly handled at some point. Unfortunately, I wasn't able to fully remember what this was about, so I'll remove it and open a proper issue next time I face it. 

However, I did find a couple of missing URLDecode calls preventing some loading messages to render properly, wherefore this PR.

### Benefits

No more "foo%2Fbar" loading msgs.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
