### PR TITLE
Bump default OLM version up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ parameters:
     default: "v3.7.0"
   OLM_VERSION:
     type: "string"
-    default: "v0.18.3"
+    default: "v0.19.1"
   MKCERT_VERSION:
     type: "string"
     default: "v1.4.3"

--- a/docs/user/operators.md
+++ b/docs/user/operators.md
@@ -17,9 +17,9 @@ Since Kubeapps 2.0, Operators are available by default. Once you access to the d
 Follow the instructions to install the latest OLM version. For example:
 
 ```bash
-curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.18.2/install.sh -o install.sh
+curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.19.1/install.sh -o install.sh
 chmod +x install.sh
-./install.sh 0.18.2
+./install.sh 0.19.1
 ```
 
 Note that you will need special permissions to manage Operators. If you receive a Forbidden error, apply the following ClusterRole to your admin user:


### PR DESCRIPTION
### Description of the change

When installing the OLM for testing the icons I noticed there is a newer version of the OLM, so this PR is to update our default version to this one.

### Benefits

Using (and testing in CI) the latest OLM version

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A