### PR TITLE
Move the core plugin implementation into a versioned module.

### DIFF
--- a/cmd/kubeapps-apis/cmd/root.go
+++ b/cmd/kubeapps-apis/cmd/root.go
@@ -25,12 +25,13 @@ import (
 	"github.com/spf13/viper"
 	log "k8s.io/klog/v2"
 
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 )
 
 var (
 	cfgFile   string
-	serveOpts server.ServeOptions
+	serveOpts core.ServeOptions
 	// This version var is updated during the build
 	// see the -ldflags option in the Dockerfile
 	version = "devel"

--- a/cmd/kubeapps-apis/cmd/root_test.go
+++ b/cmd/kubeapps-apis/cmd/root_test.go
@@ -21,14 +21,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 )
 
 func TestParseFlagsCorrect(t *testing.T) {
 	var tests = []struct {
 		name string
 		args []string
-		conf server.ServeOptions
+		conf core.ServeOptions
 	}{
 		{
 			"all arguments are captured",
@@ -40,7 +40,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--pinniped-proxy-url", "foo03",
 				"--unsafe-local-dev-kubeconfig", "true",
 			},
-			server.ServeOptions{
+			core.ServeOptions{
 				Port:                     901,
 				PluginDirs:               []string{"foo01"},
 				ClustersConfigPath:       "foo02",

--- a/cmd/kubeapps-apis/core/serveopts.go
+++ b/cmd/kubeapps-apis/core/serveopts.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 VMware. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc"
+	"k8s.io/client-go/rest"
+)
+
+// ServeOptions encapsulates the available command-line options.
+type ServeOptions struct {
+	Port                     int
+	PluginDirs               []string
+	ClustersConfigPath       string
+	PluginConfigPath         string
+	PinnipedProxyURL         string
+	UnsafeLocalDevKubeconfig bool
+}
+
+// GatewayHandlerArgs is a helper struct just encapsulating all the args
+// required when registering an HTTP handler for the gateway.
+type GatewayHandlerArgs struct {
+	Ctx         context.Context
+	Mux         *runtime.ServeMux
+	Addr        string
+	DialOptions []grpc.DialOption
+}
+
+// KubernetesConfigGetter is a function type used throughout the apis server so
+// that call-sites don't need to know how to obtain an authenticated client, but
+// rather can just pass the request context and the cluster to get one.
+type KubernetesConfigGetter func(ctx context.Context, cluster string) (*rest.Config, error)

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
@@ -18,9 +18,9 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"github.com/kubeapps/kubeapps/pkg/kube"
 	log "k8s.io/klog/v2"
 )
@@ -38,7 +38,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter,
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
 	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
 	log.Infof("+fluxv2 RegisterWithGRPCServer")
 	svr, err := NewServer(configGetter, clustersConfig.KubeappsClusterName)

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	log "k8s.io/klog/v2"
@@ -55,7 +55,7 @@ type Server struct {
 
 // NewServer returns a Server automatically configured with a function to obtain
 // the k8s client config.
-func NewServer(configGetter server.KubernetesConfigGetter, kubeappsCluster string) (*Server, error) {
+func NewServer(configGetter core.KubernetesConfigGetter, kubeappsCluster string) (*Server, error) {
 	log.Infof("+fluxv2 NewServer(kubeappsCluster: [%v])", kubeappsCluster)
 	repositoriesGvr := schema.GroupVersionResource{
 		Group:    fluxGroup,

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/utils.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/utils.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	"github.com/kubeapps/kubeapps/pkg/agent"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -144,7 +144,7 @@ func namespacedName(unstructuredObj map[string]interface{}) (*types.NamespacedNa
 	return &types.NamespacedName{Name: name, Namespace: namespace}, nil
 }
 
-func newHelmActionConfigGetter(configGetter server.KubernetesConfigGetter, cluster string) helmActionConfigGetter {
+func newHelmActionConfigGetter(configGetter core.KubernetesConfigGetter, cluster string) helmActionConfigGetter {
 	return func(ctx context.Context, namespace string) (*action.Configuration, error) {
 		if configGetter == nil {
 			return nil, status.Errorf(codes.Internal, "configGetter arg required")
@@ -172,7 +172,7 @@ func newHelmActionConfigGetter(configGetter server.KubernetesConfigGetter, clust
 	}
 }
 
-func newClientGetter(configGetter server.KubernetesConfigGetter, cluster string) clientGetter {
+func newClientGetter(configGetter core.KubernetesConfigGetter, cluster string) clientGetter {
 	return func(ctx context.Context) (dynamic.Interface, apiext.Interface, error) {
 		if configGetter == nil {
 			return nil, nil, status.Errorf(codes.Internal, "configGetter arg required")

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
@@ -18,9 +18,9 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"github.com/kubeapps/kubeapps/pkg/kube"
 )
 
@@ -42,7 +42,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter,
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
 	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
 	svr := NewServer(configGetter, clustersConfig.KubeappsClusterName, pluginConfigPath)
 	v1alpha1.RegisterHelmPackagesServiceServer(s, svr)

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -28,10 +28,10 @@ import (
 	"github.com/kubeapps/common/datastore"
 	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
 	helmv1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"github.com/kubeapps/kubeapps/pkg/agent"
 	chartutils "github.com/kubeapps/kubeapps/pkg/chart"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
@@ -129,7 +129,7 @@ func parsePluginConfig(pluginConfigPath string) VersionsInSummary {
 
 // NewServer returns a Server automatically configured with a function to obtain
 // the k8s client config.
-func NewServer(configGetter server.KubernetesConfigGetter, globalPackagingCluster string, pluginConfigPath string) *Server {
+func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster string, pluginConfigPath string) *Server {
 	var kubeappsNamespace = os.Getenv("POD_NAMESPACE")
 	var ASSET_SYNCER_DB_URL = os.Getenv("ASSET_SYNCER_DB_URL")
 	var ASSET_SYNCER_DB_NAME = os.Getenv("ASSET_SYNCER_DB_NAME")

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
@@ -18,9 +18,9 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"github.com/kubeapps/kubeapps/pkg/kube"
 )
 
@@ -37,7 +37,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter,
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
 	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
 	svr := NewServer(configGetter)
 	v1alpha1.RegisterKappControllerPackagesServiceServer(s, svr)

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -35,9 +35,9 @@ import (
 	log "k8s.io/klog/v2"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -77,7 +77,7 @@ type Server struct {
 
 // NewServer returns a Server automatically configured with a function to obtain
 // the k8s client config.
-func NewServer(configGetter server.KubernetesConfigGetter) *Server {
+func NewServer(configGetter core.KubernetesConfigGetter) *Server {
 	return &Server{
 		clientGetter: func(ctx context.Context, cluster string) (dynamic.Interface, error) {
 			if configGetter == nil {

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
@@ -18,9 +18,9 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	"github.com/kubeapps/kubeapps/pkg/kube"
 )
 
@@ -42,7 +42,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter server.KubernetesConfigGetter, clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter, clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
 	svr := NewServer(configGetter)
 	v1alpha1.RegisterResourcesServiceServer(s, svr)
 	return svr, nil

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -13,8 +13,8 @@ limitations under the License.
 package main
 
 import (
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 )
 
 // Currently just a stub unimplemented server. More to come in following PRs.
@@ -22,6 +22,6 @@ type Server struct {
 	v1alpha1.UnimplementedResourcesServiceServer
 }
 
-func NewServer(configGetter server.KubernetesConfigGetter) *Server {
+func NewServer(configGetter core.KubernetesConfigGetter) *Server {
 	return &Server{}
 }

--- a/cmd/kubeapps-apis/server/packages_test.go
+++ b/cmd/kubeapps-apis/server/packages_test.go
@@ -58,7 +58,7 @@ var ignoreUnexportedOpts = cmpopts.IgnoreUnexported(
 	plugins.Plugin{},
 )
 
-func makeDefaultTestPackagingPlugin(pluginName string) *pkgsPluginWithServer {
+func makeDefaultTestPackagingPlugin(pluginName string) pkgPluginsWithServer {
 	pluginDetails := &plugins.Plugin{Name: pluginName, Version: "v1alpha1"}
 	packagingPluginServer := &plugin_test.TestPackagingPluginServer{Plugin: pluginDetails}
 
@@ -79,19 +79,19 @@ func makeDefaultTestPackagingPlugin(pluginName string) *pkgsPluginWithServer {
 	packagingPluginServer.NextPageToken = "1"
 	packagingPluginServer.Categories = []string{plugin_test.DefaultCategory}
 
-	return &pkgsPluginWithServer{
+	return pkgPluginsWithServer{
 		plugin: pluginDetails,
 		server: packagingPluginServer,
 	}
 }
 
-func makeOnlyStatusTestPackagingPlugin(pluginName string, statusCode codes.Code) *pkgsPluginWithServer {
+func makeOnlyStatusTestPackagingPlugin(pluginName string, statusCode codes.Code) pkgPluginsWithServer {
 	pluginDetails := &plugins.Plugin{Name: pluginName, Version: "v1alpha1"}
 	packagingPluginServer := &plugin_test.TestPackagingPluginServer{Plugin: pluginDetails}
 
 	packagingPluginServer.Status = statusCode
 
-	return &pkgsPluginWithServer{
+	return pkgPluginsWithServer{
 		plugin: pluginDetails,
 		server: packagingPluginServer,
 	}
@@ -100,14 +100,14 @@ func makeOnlyStatusTestPackagingPlugin(pluginName string, statusCode codes.Code)
 func TestGetAvailablePackageSummaries(t *testing.T) {
 	testCases := []struct {
 		name              string
-		configuredPlugins []*pkgsPluginWithServer
+		configuredPlugins []pkgPluginsWithServer
 		statusCode        codes.Code
 		request           *corev1.GetAvailablePackageSummariesRequest
 		expectedResponse  *corev1.GetAvailablePackageSummariesResponse
 	}{
 		{
 			name: "it should successfully call the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -131,7 +131,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it should successfully call and paginate (first page) the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -154,7 +154,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it should successfully call and paginate (proper PageSize) the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -180,7 +180,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it should successfully call and paginate (last page - 1) the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -203,7 +203,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it should successfully call and paginate (last page) the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -226,7 +226,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it should successfully call and paginate (last page + 1) the core GetAvailablePackageSummaries operation",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -247,7 +247,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it should fail when calling the core GetAvailablePackageSummaries operation when the package is not present in a plugin",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
@@ -269,7 +269,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &packagesServer{
-				plugins: tc.configuredPlugins,
+				pluginsWithServers: tc.configuredPlugins,
 			}
 			availablePackageSummaries, err := server.GetAvailablePackageSummaries(context.Background(), tc.request)
 
@@ -289,14 +289,14 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 func TestGetAvailablePackageDetail(t *testing.T) {
 	testCases := []struct {
 		name              string
-		configuredPlugins []*pkgsPluginWithServer
+		configuredPlugins []pkgPluginsWithServer
 		statusCode        codes.Code
 		request           *corev1.GetAvailablePackageDetailRequest
 		expectedResponse  *corev1.GetAvailablePackageDetailResponse
 	}{
 		{
 			name: "it should successfully call the core GetAvailablePackageDetail operation",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -319,7 +319,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 		},
 		{
 			name: "it should fail when calling the core GetAvailablePackageDetail operation when the package is not present in a plugin",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
@@ -343,7 +343,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &packagesServer{
-				plugins: tc.configuredPlugins,
+				pluginsWithServers: tc.configuredPlugins,
 			}
 			availablePackageDetail, err := server.GetAvailablePackageDetail(context.Background(), tc.request)
 
@@ -363,14 +363,14 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 func TestGetInstalledPackageSummaries(t *testing.T) {
 	testCases := []struct {
 		name              string
-		configuredPlugins []*pkgsPluginWithServer
+		configuredPlugins []pkgPluginsWithServer
 		statusCode        codes.Code
 		request           *corev1.GetInstalledPackageSummariesRequest
 		expectedResponse  *corev1.GetInstalledPackageSummariesResponse
 	}{
 		{
 			name: "it should successfully call the core GetInstalledPackageSummaries operation",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -393,7 +393,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		},
 		{
 			name: "it should fail when calling the core GetInstalledPackageSummaries operation when the package is not present in a plugin",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
@@ -414,7 +414,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &packagesServer{
-				plugins: tc.configuredPlugins,
+				pluginsWithServers: tc.configuredPlugins,
 			}
 			installedPackageSummaries, err := server.GetInstalledPackageSummaries(context.Background(), tc.request)
 
@@ -434,14 +434,14 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 func TestGetInstalledPackageDetail(t *testing.T) {
 	testCases := []struct {
 		name              string
-		configuredPlugins []*pkgsPluginWithServer
+		configuredPlugins []pkgPluginsWithServer
 		statusCode        codes.Code
 		request           *corev1.GetInstalledPackageDetailRequest
 		expectedResponse  *corev1.GetInstalledPackageDetailResponse
 	}{
 		{
 			name: "it should successfully call the core GetInstalledPackageDetail operation",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -463,7 +463,7 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 		},
 		{
 			name: "it should fail when calling the core GetInstalledPackageDetail operation when the package is not present in a plugin",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
@@ -486,7 +486,7 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &packagesServer{
-				plugins: tc.configuredPlugins,
+				pluginsWithServers: tc.configuredPlugins,
 			}
 			installedPackageDetail, err := server.GetInstalledPackageDetail(context.Background(), tc.request)
 
@@ -506,14 +506,14 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 func TestGetAvailablePackageVersions(t *testing.T) {
 	testCases := []struct {
 		name              string
-		configuredPlugins []*pkgsPluginWithServer
+		configuredPlugins []pkgPluginsWithServer
 		statusCode        codes.Code
 		request           *corev1.GetAvailablePackageVersionsRequest
 		expectedResponse  *corev1.GetAvailablePackageVersionsResponse
 	}{
 		{
 			name: "it should successfully call the core GetAvailablePackageVersions operation",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
@@ -538,7 +538,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 		},
 		{
 			name: "it should fail when calling the core GetAvailablePackageVersions operation when the package is not present in a plugin",
-			configuredPlugins: []*pkgsPluginWithServer{
+			configuredPlugins: []pkgPluginsWithServer{
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
@@ -563,7 +563,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &packagesServer{
-				plugins: tc.configuredPlugins,
+				pluginsWithServers: tc.configuredPlugins,
 			}
 			AvailablePackageVersions, err := server.GetAvailablePackageVersions(context.Background(), tc.request)
 
@@ -648,16 +648,16 @@ func TestCreateInstalledPackage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			configuredPluginServers := []*pkgsPluginWithServer{}
+			configuredPluginServers := []pkgPluginsWithServer{}
 			for _, p := range tc.configuredPlugins {
-				configuredPluginServers = append(configuredPluginServers, &pkgsPluginWithServer{
+				configuredPluginServers = append(configuredPluginServers, pkgPluginsWithServer{
 					plugin: p,
 					server: plugin_test.TestPackagingPluginServer{Plugin: p},
 				})
 			}
 
 			server := &packagesServer{
-				plugins: configuredPluginServers,
+				pluginsWithServers: configuredPluginServers,
 			}
 
 			installedPkgResponse, err := server.CreateInstalledPackage(context.Background(), tc.request)
@@ -729,16 +729,16 @@ func TestUpdateInstalledPackage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			configuredPluginServers := []*pkgsPluginWithServer{}
+			configuredPluginServers := []pkgPluginsWithServer{}
 			for _, p := range tc.configuredPlugins {
-				configuredPluginServers = append(configuredPluginServers, &pkgsPluginWithServer{
+				configuredPluginServers = append(configuredPluginServers, pkgPluginsWithServer{
 					plugin: p,
 					server: plugin_test.TestPackagingPluginServer{Plugin: p},
 				})
 			}
 
 			server := &packagesServer{
-				plugins: configuredPluginServers,
+				pluginsWithServers: configuredPluginServers,
 			}
 
 			updatedPkgResponse, err := server.UpdateInstalledPackage(context.Background(), tc.request)
@@ -802,16 +802,16 @@ func TestDeleteInstalledPackage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			configuredPluginServers := []*pkgsPluginWithServer{}
+			configuredPluginServers := []pkgPluginsWithServer{}
 			for _, p := range tc.configuredPlugins {
-				configuredPluginServers = append(configuredPluginServers, &pkgsPluginWithServer{
+				configuredPluginServers = append(configuredPluginServers, pkgPluginsWithServer{
 					plugin: p,
 					server: plugin_test.TestPackagingPluginServer{Plugin: p},
 				})
 			}
 
 			server := &packagesServer{
-				plugins: configuredPluginServers,
+				pluginsWithServers: configuredPluginServers,
 			}
 
 			_, err := server.DeleteInstalledPackage(context.Background(), tc.request)
@@ -887,7 +887,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &packagesServer{
-				plugins: []*pkgsPluginWithServer{
+				pluginsWithServers: []pkgPluginsWithServer{
 					{
 						plugin: installedPlugin,
 						server: &plugin_test.TestPackagingPluginServer{

--- a/cmd/kubeapps-apis/server/server.go
+++ b/cmd/kubeapps-apis/server/server.go
@@ -21,11 +21,14 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"reflect"
 
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/soheilhy/cmux"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
+	pluginsv1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core/plugins/v1alpha1"
 	packages "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"google.golang.org/grpc"
@@ -34,18 +37,9 @@ import (
 	log "k8s.io/klog/v2"
 )
 
-type ServeOptions struct {
-	Port                     int
-	PluginDirs               []string
-	ClustersConfigPath       string
-	PluginConfigPath         string
-	PinnipedProxyURL         string
-	UnsafeLocalDevKubeconfig bool
-}
-
 // Serve is the root command that is run when no other sub-commands are present.
 // It runs the gRPC service, registering the configured plugins.
-func Serve(serveOpts ServeOptions) error {
+func Serve(serveOpts core.ServeOptions) error {
 	// Create the grpc server and register the reflection server (for now, useful for discovery
 	// using grpcurl) or similar.
 	grpcSrv := grpc.NewServer()
@@ -59,28 +53,40 @@ func Serve(serveOpts ServeOptions) error {
 	if err != nil {
 		return fmt.Errorf("Failed to create gateway: %v", err)
 	}
-	gwArgs := gwHandlerArgs{
-		ctx:         ctx,
-		mux:         gw,
-		addr:        listenAddr,
-		dialOptions: []grpc.DialOption{grpc.WithInsecure()},
+	gwArgs := core.GatewayHandlerArgs{
+		Ctx:         ctx,
+		Mux:         gw,
+		Addr:        listenAddr,
+		DialOptions: []grpc.DialOption{grpc.WithInsecure()},
 	}
 
-	// Create the core.plugins server which handles registration of plugins,
-	// and register it for both grpc and http.
-	pluginsServer, err := NewPluginsServer(serveOpts, grpcSrv, gwArgs)
+	// Create the core.plugins.v1alpha1 server which handles registration of
+	// plugins, and register it for both grpc and http.
+	pluginsServer, err := pluginsv1.NewPluginsServer(serveOpts, grpcSrv, gwArgs)
 	if err != nil {
 		return fmt.Errorf("failed to initialize plugins server: %v", err)
 	}
 	plugins.RegisterPluginsServiceServer(grpcSrv, pluginsServer)
-	err = plugins.RegisterPluginsServiceHandlerFromEndpoint(gwArgs.ctx, gwArgs.mux, gwArgs.addr, gwArgs.dialOptions)
+	// TODO(minelson): should no longer need to split up the gw args now.
+	err = plugins.RegisterPluginsServiceHandlerFromEndpoint(gwArgs.Ctx, gwArgs.Mux, gwArgs.Addr, gwArgs.DialOptions)
 	if err != nil {
 		return fmt.Errorf("failed to register core.plugins handler for gateway: %v", err)
 	}
 
+	// Ask the plugins server for plugins with GRPC servers that fulfil the core
+	// packaging v1alpha1 API, then pass to the constructor below.
+	// The argument for the reflect.TypeOf is based on what grpc-go
+	// does itself at:
+	// https://github.com/grpc/grpc-go/blob/v1.38.0/server.go#L621
+	packagingPlugins := pluginsServer.GetPluginsSatisfyingInterface(reflect.TypeOf((*packages.PackagesServiceServer)(nil)).Elem())
+
 	// Create the core.packages server and register it for both grpc and http.
-	packages.RegisterPackagesServiceServer(grpcSrv, NewPackagesServer(pluginsServer.packagesPlugins))
-	err = packages.RegisterPackagesServiceHandlerFromEndpoint(gwArgs.ctx, gwArgs.mux, gwArgs.addr, gwArgs.dialOptions)
+	packagesServer, err := NewPackagesServer(packagingPlugins)
+	if err != nil {
+		return fmt.Errorf("failed to create core.packages.v1alpha1 server: %w", err)
+	}
+	packages.RegisterPackagesServiceServer(grpcSrv, packagesServer)
+	err = packages.RegisterPackagesServiceHandlerFromEndpoint(gwArgs.Ctx, gwArgs.Mux, gwArgs.Addr, gwArgs.DialOptions)
 	if err != nil {
 		return fmt.Errorf("failed to register core.packages handler for gateway: %v", err)
 	}
@@ -110,7 +116,7 @@ func Serve(serveOpts ServeOptions) error {
 			if webrpcProxy.IsGrpcWebRequest(r) || webrpcProxy.IsAcceptableGrpcCorsRequest(r) || webrpcProxy.IsGrpcWebSocketRequest(r) {
 				webrpcProxy.ServeHTTP(w, r)
 			} else {
-				gwArgs.mux.ServeHTTP(w, r)
+				gwArgs.Mux.ServeHTTP(w, r)
 			}
 		}),
 	}
@@ -144,15 +150,6 @@ func Serve(serveOpts ServeOptions) error {
 	}
 
 	return nil
-}
-
-// gwHandlerArgs is a helper struct just encapsulating all the args
-// required when registering an HTTP handler for the gateway.
-type gwHandlerArgs struct {
-	ctx         context.Context
-	mux         *runtime.ServeMux
-	addr        string
-	dialOptions []grpc.DialOption
 }
 
 // Create a gateway mux that does not emit unpopulated fields.


### PR DESCRIPTION
Untangles the core packaging and plugin implementations.

Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Untangles the core plugin implementation from the core packages. I needed to update the core plugin in small ways for the resources work, but would have been making the situation worse, so decided to move the core plugin implementation now rather than adding the the tech-debt.

The main change is that the core plugin implementation no longer knows anything about the core packages API. Where the core plugin used to check registered plugins to see if they implement the core packaging API, it now instead provides an exported function: `GetPluginsSatisfyingInterface`, which is called by the main executable after registering the plugins to get a slice of plugins that satisfy the core packaging v1alpha1 interface. This is then passed to the core packaging plugin's `NewServer()` to initialize.

Otherwise it works in just the same way. Most of the other changes are just moving structs and function types that are shared between plugins and the core server to a core module where they can be imported by all.


### Benefits

We don't add to the tech-debt as we continue to update the core plugin and packages implementations. I can continue on the resources work without adding to that tech debt :)

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3329 (it'll fix that once I also move the core packages implementation when I get a chance, it'll be trivial now).
- Ref #3403

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

I'll move the core packages implementation in a followup when taking a break from resources and UI integration next week.