### PR TITLE
Move core packages to versioned module.

### DIFF
--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package v1alpha1
 
 import (
 	"context"

--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages_test.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages_test.go
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package server
+package v1alpha1
 
 import (
 	"context"


### PR DESCRIPTION

### Description of the change

Small follow-up to #3750, this time moving the core packages implementation into a versioned module.

As expected, this change was pretty trivial and just worked after the previous PR.

### Benefits

See #3750 .

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

- fixes #3329 (this completes that issue)
- ref #3403

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
