### PR TITLE
Add initial GetResources implementation.

### DIFF
--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -13,15 +13,144 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	log "k8s.io/klog/v2"
+
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
 )
+
+type clientGetter func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error)
 
 // Currently just a stub unimplemented server. More to come in following PRs.
 type Server struct {
 	v1alpha1.UnimplementedResourcesServiceServer
+	// clientGetter is a field so that it can be switched in tests for
+	// a fake client. NewServer() below sets this automatically with the
+	// non-test implementation.
+	clientGetter clientGetter
+
+	// corePackagesClientGetter holds a function to obtain the core.packages.v1alpha1
+	// client. It is similarly initialised in NewServer() below.
+	corePackagesClientGetter func() (pkgsGRPCv1alpha1.PackagesServiceClient, error)
 }
 
 func NewServer(configGetter core.KubernetesConfigGetter) *Server {
-	return &Server{}
+	return &Server{
+		clientGetter: func(ctx context.Context, cluster string) (kubernetes.Interface, dynamic.Interface, error) {
+			if configGetter == nil {
+				return nil, nil, status.Errorf(codes.Internal, "configGetter arg required")
+			}
+			config, err := configGetter(ctx, cluster)
+			if err != nil {
+				return nil, nil, status.Errorf(codes.FailedPrecondition, "unable to get config : %v", err.Error())
+			}
+			dynamicClient, err := dynamic.NewForConfig(config)
+			if err != nil {
+				return nil, nil, status.Errorf(codes.FailedPrecondition, "unable to get dynamic client : %s", err.Error())
+			}
+			typedClient, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return nil, nil, status.Errorf(codes.FailedPrecondition, "unable to get typed client: %s", err.Error())
+			}
+			return typedClient, dynamicClient, nil
+		},
+		corePackagesClientGetter: func() (pkgsGRPCv1alpha1.PackagesServiceClient, error) {
+			port := os.Getenv("PORT")
+			conn, err := grpc.Dial("localhost:"+port, grpc.WithInsecure())
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "unable to dial to localhost grpc service: %s", err.Error())
+			}
+			return pkgsGRPCv1alpha1.NewPackagesServiceClient(conn), nil
+		},
+	}
+}
+
+// GetResources returns the resources for an installed package.
+func (s *Server) GetResources(r *v1alpha1.GetResourcesRequest, stream v1alpha1.ResourcesService_GetResourcesServer) error {
+	namespace := r.GetInstalledPackageRef().GetContext().GetNamespace()
+	cluster := r.GetInstalledPackageRef().GetContext().GetCluster()
+	log.Infof("+resources GetResources (cluster: %q, namespace=%q)", cluster, namespace)
+
+	ctx, err := copyAuthorizationMetadataForOutgoing(stream.Context())
+	if err != nil {
+		return err
+	}
+
+	// First we grab the resource references for the specified installed package.
+	coreClient, err := s.corePackagesClientGetter()
+	if err != nil {
+		return err
+	}
+	refsResponse, err := coreClient.GetInstalledPackageResourceRefs(ctx, &pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest{
+		InstalledPackageRef: r.InstalledPackageRef,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Then look up each referenced resource and send it down the stream.
+	// TODO(minelson): Filter to the resources specified in the request, and 400
+	// if they don't exist for the package.
+	_, dynamicClient, err := s.clientGetter(stream.Context(), cluster)
+	if err != nil {
+		return err
+	}
+	for _, ref := range refsResponse.GetResourceRefs() {
+		groupVersion, err := schema.ParseGroupVersion(ref.ApiVersion)
+		if err != nil {
+			return status.Errorf(codes.Internal, "unable to parse group version from %q: %s", ref.ApiVersion, err.Error())
+		}
+		gvk := groupVersion.WithKind(ref.Kind)
+		// TODO(minelson): Find alternative to UnsafeGuessKindToResource.
+		gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+		resource, err := dynamicClient.Resource(gvr).Namespace(namespace).Get(stream.Context(), ref.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return status.Errorf(codes.Internal, "unable to get resource referenced by %+v: %s", ref, err.Error())
+		}
+
+		resourceBytes, err := json.Marshal(resource)
+		if err != nil {
+			return status.Errorf(codes.Internal, "unable to marshal json for resource: %s", err.Error())
+		}
+		stream.Send(&v1alpha1.GetResourcesResponse{
+			ResourceRef: ref,
+			Manifest: &anypb.Any{
+				Value: resourceBytes,
+			},
+		})
+	}
+
+	return nil
+}
+
+// copyAuthorizationMetadataForOutgoing explicitly copies the authz from the
+// incoming context to the outgoing context when making the outgoing call the
+// core packaging API.
+func copyAuthorizationMetadataForOutgoing(ctx context.Context) (context.Context, error) {
+	notAllowedErr := status.Errorf(codes.PermissionDenied, "unable to get authorization from request context")
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, notAllowedErr
+	}
+	if len(md["authorization"]) == 0 {
+		return nil, notAllowedErr
+	}
+
+	return metadata.AppendToOutgoingContext(ctx, "authorization", md["authorization"][0]), nil
 }

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright © 2021 VMware
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugin_test"
+)
+
+const bufSize = 1024 * 1024
+
+var fakePkgsPlugin *pluginsGRPCv1alpha1.Plugin = &pluginsGRPCv1alpha1.Plugin{Name: "fake.packages", Version: "v1alpha1"}
+
+func resourceRefsForObjects(t *testing.T, objects ...runtime.Object) []*pkgsGRPCv1alpha1.ResourceRef {
+	refs := []*pkgsGRPCv1alpha1.ResourceRef{}
+	for _, obj := range objects {
+		k8sObjValue := reflect.ValueOf(obj).Elem()
+		objMeta, ok := k8sObjValue.FieldByName("ObjectMeta").Interface().(metav1.ObjectMeta)
+		if !ok {
+			t.Fatalf("failed to retrieve object metadata for: %+v", objMeta)
+		}
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		refs = append(refs, &pkgsGRPCv1alpha1.ResourceRef{
+			ApiVersion: gvk.GroupVersion().String(),
+			Kind:       gvk.Kind,
+			Name:       objMeta.Name,
+		})
+	}
+	return refs
+}
+
+// getResourcesClient starts a GRPC server, serving both the resources service,
+// and a test core packages service, but using a buf connection (ie. no need for
+// slow network port etc.). More at
+// https://stackoverflow.com/a/52080545
+func getResourcesClient(t *testing.T, objects ...runtime.Object) (v1alpha1.ResourcesServiceClient, func()) {
+	lis := bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+	bufDialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+
+	// Create and register a fake packages plugin returning resourcerefs for objects.
+	fakePkgsPluginServer := &plugin_test.TestPackagingPluginServer{
+		Plugin:       fakePkgsPlugin,
+		ResourceRefs: resourceRefsForObjects(t, objects...),
+	}
+	pkgsGRPCv1alpha1.RegisterPackagesServiceServer(s, fakePkgsPluginServer)
+
+	// Create the resources service server.
+	v1alpha1.RegisterResourcesServiceServer(s, &Server{
+		// Use a client getter that returns a dynamic client prepped with the
+		// specified objects.
+		clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+			scheme := runtime.NewScheme()
+			fakeDynamicClient := dynfake.NewSimpleDynamicClient(
+				scheme,
+				objects...,
+			)
+			return nil, fakeDynamicClient, nil
+		},
+		// Use a corePackagesClientGetter that returns a client connected to our
+		// running test service.
+		corePackagesClientGetter: func() (pkgsGRPCv1alpha1.PackagesServiceClient, error) {
+			return pkgsGRPCv1alpha1.NewPackagesServiceClient(conn), nil
+		},
+	})
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			// Only valid error should be when the listener is closed.
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
+				return
+			}
+		}
+	}()
+
+	return v1alpha1.NewResourcesServiceClient(conn), func() {
+		conn.Close()
+		lis.Close()
+	}
+}
+
+func TestGetResources(t *testing.T) {
+	testCases := []struct {
+		name              string
+		request           *v1alpha1.GetResourcesRequest
+		withoutAuthz      bool
+		clusterObjects    []runtime.Object
+		expectedErrorCode codes.Code
+		expectedResources []*v1alpha1.GetResourcesResponse
+	}{
+		{
+			name: "it returns permission denied for a request without auth",
+			request: &v1alpha1.GetResourcesRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
+						Cluster:   "default",
+						Namespace: "default",
+					},
+					Identifier: "some-package",
+					Plugin:     fakePkgsPlugin,
+				},
+			},
+			withoutAuthz:      true,
+			expectedErrorCode: codes.PermissionDenied,
+		},
+		{
+			name: "it returns resources for an installed app",
+			request: &v1alpha1.GetResourcesRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
+						Cluster:   "default",
+						Namespace: "default",
+					},
+					Identifier: "some-package",
+					Plugin:     fakePkgsPlugin,
+				},
+			},
+			clusterObjects: []runtime.Object{
+				&apps.Deployment{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-deployment",
+						Namespace: "default",
+					},
+				},
+				&core.Service{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "core/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-service",
+						Namespace: "default",
+					},
+				},
+			},
+			expectedErrorCode: codes.OK,
+			expectedResources: []*v1alpha1.GetResourcesResponse{
+				{
+					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
+						ApiVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "some-deployment",
+					},
+				},
+				{
+					ResourceRef: &pkgsGRPCv1alpha1.ResourceRef{
+						ApiVersion: "core/v1",
+						Kind:       "Service",
+						Name:       "some-service",
+					},
+				},
+			},
+		},
+	}
+
+	ignoredUnexported := cmpopts.IgnoreUnexported(
+		v1alpha1.GetResourcesResponse{},
+		pkgsGRPCv1alpha1.ResourceRef{},
+	)
+	ignoreManifest := cmpopts.IgnoreFields(v1alpha1.GetResourcesResponse{}, "Manifest")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, cleanup := getResourcesClient(t, tc.clusterObjects...)
+			defer cleanup()
+
+			ctx := context.Background()
+			if !tc.withoutAuthz {
+				ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "some-auth-token")
+			}
+
+			responseStream, err := client.GetResources(ctx, tc.request)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+
+			resources := []*v1alpha1.GetResourcesResponse{}
+			for {
+				resource, err := responseStream.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+						t.Fatalf("got: %s, want: %s", got, want)
+					}
+					// If it was an expected error, we continue to the next test.
+					return
+				}
+				resources = append(resources, resource)
+			}
+
+			if got, want := resources, tc.expectedResources; !cmp.Equal(got, want, ignoredUnexported, ignoreManifest) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported, ignoreManifest))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>
### Description of the change

Adds and tests an initial implementation for the GetResources call of the resources plugin.

It'll be followed by further PRs to:
* Filter by the requested resource refs,
* Enable watching for further changes of the requested resource refs
* Replace the use of UnsafeGuessKindToResource.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Enables requesting resources for an installed package.

IRL example:
```
grpcurl -plaintext -d '{"installed_package_ref": {"context": {"cluster": "default", "namespace": "default"}, "plugin": {"name": "helm.packages", "version": "v1alpha1"}, "identifier": "default-kafka-from-flux"}, "watch": true }' -H "Authorization: $token" localhost:8080 kubeappsapis.plugins.resources.v1alpha1.ResourcesService.GetResources{  "resourceRef": {    "apiVersion": "v1",    "kind": "ServiceAccount",    "name": "default-kafka-from-flux"  },
  "manifest": {
    ...
    "@value": "eyJhcGlWZXJzaW9uIjoidjEiLCJhdXRvbW91bnRTZXJ2aWNlQWNjb3VudFRva2VuIjp0cnVlLCJraW5kIjoiU2VydmljZUFjY291bnQiLCJtZXRhZGF0YSI6eyJhbm5vdGF0aW9ucyI6eyJtZXRhLmhlbG0..."
```

where the manifest decodes to:
```
echo "eyJhcGlWZXJzaW9uIjoidjEiLCJhdXRvbW91bnRTZXJ2aWNlQWNjb3VudFRva2VuIjp0cnVlLCJraW5kIjoiU2VydmljZUFjY291bnQiLCJtZXRhZGF0YSI6eyJhbm5vdGF0aW9ucyI6eyJtZXRhLmhlbG0..." | base64 -d | jq .
{
  "apiVersion": "v1",
  "automountServiceAccountToken": true,
  "kind": "ServiceAccount",
  "metadata": {
    "annotations": {
      "meta.helm.sh/release-name": "default-kafka-from-flux",
      "meta.helm.sh/release-namespace": "default"
    },
    "creationTimestamp": "2021-11-10T03:17:31Z",
    "labels": {
      "app.kubernetes.io/component": "kafka",
      "app.kubernetes.io/instance": "default-kafka-from-flux",
      "app.kubernetes.io/managed-by": "Helm",
      "app.kubernetes.io/name": "kafka",
      "helm.sh/chart": "kafka-14.3.0",
      "helm.toolkit.fluxcd.io/name": "kafka-from-flux",
      "helm.toolkit.fluxcd.io/namespace": "default"
    },
    "managedFields": [
      {
        "apiVersion": "v1",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:automountServiceAccountToken": {},
          "f:metadata": {
            "f:annotations": {
              ".": {},
              "f:meta.helm.sh/release-name": {},
              "f:meta.helm.sh/release-namespace": {}
            },
            "f:labels": {
              ".": {},
              "f:app.kubernetes.io/component": {},
              "f:app.kubernetes.io/instance": {},
              "f:app.kubernetes.io/managed-by": {},
              "f:app.kubernetes.io/name": {},
              "f:helm.sh/chart": {},
              "f:helm.toolkit.fluxcd.io/name": {},
              "f:helm.toolkit.fluxcd.io/namespace": {}
            }
          }
        },
        "manager": "helm-controller",
        "operation": "Update",
        "time": "2021-11-10T03:17:31Z"
      },
      {
        "apiVersion": "v1",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:secrets": {
            ".": {},
            "k:{\"name\":\"default-kafka-from-flux-token-9jhpg\"}": {
              ".": {},
              "f:name": {}
            }
          }
        },
        "manager": "kube-controller-manager",
        "operation": "Update",
        "time": "2021-11-10T03:17:31Z"
      }
    ],
    "name": "default-kafka-from-flux",
    "namespace": "default",
    "resourceVersion": "2413873",
    "uid": "5816f313-cfed-4368-b039-30c267d364e1"
  },
  "secrets": [
    {
      "name": "default-kafka-from-flux-token-9jhpg"
    }
  ]
}
```

Note that despite the name, this is just the helm plugin (I'd previously deployed it via flux, but don't currently have the flux plugin enabled).

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3403

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
