### PR TITLE
Ensure only requested refs are returned.

### DIFF
--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -119,7 +119,7 @@ func (s *Server) GetResources(r *v1alpha1.GetResourcesRequest, stream v1alpha1.R
 				}
 			}
 			if !found {
-				return status.Errorf(codes.InvalidArgument, "requested resource %+v does not belonge to installed package %+v", requestedRef, r.GetInstalledPackageRef())
+				return status.Errorf(codes.InvalidArgument, "requested resource %+v does not belong to installed package %+v", requestedRef, r.GetInstalledPackageRef())
 			}
 		}
 		resourcesToReturn = r.GetResourceRefs()

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -103,14 +103,34 @@ func (s *Server) GetResources(r *v1alpha1.GetResourcesRequest, stream v1alpha1.R
 		return err
 	}
 
+	var resourcesToReturn []*pkgsGRPCv1alpha1.ResourceRef
+	// If the request didn't specify a filter of resource refs,
+	// we return all those found for the installed package. Otherwise
+	// we only return the requested ones.
+	if len(r.GetResourceRefs()) == 0 {
+		resourcesToReturn = refsResponse.GetResourceRefs()
+	} else {
+		for _, requestedRef := range r.GetResourceRefs() {
+			found := false
+			for _, pkgRef := range refsResponse.GetResourceRefs() {
+				if resourceRefsEqual(pkgRef, requestedRef) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return status.Errorf(codes.InvalidArgument, "requested resource %+v does not belonge to installed package %+v", requestedRef, r.GetInstalledPackageRef())
+			}
+		}
+		resourcesToReturn = r.GetResourceRefs()
+	}
+
 	// Then look up each referenced resource and send it down the stream.
-	// TODO(minelson): Filter to the resources specified in the request, and 400
-	// if they don't exist for the package.
 	_, dynamicClient, err := s.clientGetter(stream.Context(), cluster)
 	if err != nil {
 		return err
 	}
-	for _, ref := range refsResponse.GetResourceRefs() {
+	for _, ref := range resourcesToReturn {
 		groupVersion, err := schema.ParseGroupVersion(ref.ApiVersion)
 		if err != nil {
 			return status.Errorf(codes.Internal, "unable to parse group version from %q: %s", ref.ApiVersion, err.Error())
@@ -153,4 +173,10 @@ func copyAuthorizationMetadataForOutgoing(ctx context.Context) (context.Context,
 	}
 
 	return metadata.AppendToOutgoingContext(ctx, "authorization", md["authorization"][0]), nil
+}
+
+func resourceRefsEqual(r1, r2 *pkgsGRPCv1alpha1.ResourceRef) bool {
+	return r1.ApiVersion == r2.ApiVersion &&
+		r1.Kind == r2.Kind &&
+		r1.Name == r2.Name
 }


### PR DESCRIPTION
### Description of the change

Following on from #3756 , this PR adds and tests the functionality to:

* Ensure only requested refs are returned (ie. filter by the requested refs)
* Ensure only requested refs belonging to installed pkg are returned.

### Benefits

We don't return unnecessary resources.
We don't expose arbitrary resources in the installed package namespace.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3403 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
