### PR TITLE
Add logging middleware for kubeapps-apis 

### DIFF
--- a/cmd/kubeapps-apis/client/client.go
+++ b/cmd/kubeapps-apis/client/client.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	packagesGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/interceptors"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Create a connection and add our ClientPingCounter interceptor as a UnaryInterceptor to the connection
+	conn, err := grpc.DialContext(ctx, "localhost:50051", grpc.WithInsecure(), grpc.WithBlock(), grpc.WithChainUnaryInterceptor(
+		//interceptors.Identity{ID: "kubeapps-apis-client-junk"}.UnaryClient,
+		interceptors.Identity{ID: "kubeapps-apis-client"}.UnaryClient,
+	))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	// A new GRPC client to use
+	client := packagesGRPCv1alpha1.NewPackagesServiceClient(conn)
+
+	request := &packagesGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+		Context: &packagesGRPCv1alpha1.Context{
+			Cluster:   "",
+			Namespace: "kubeapps",
+		},
+	}
+
+	availablePackageSummaries, err := client.GetAvailablePackageSummaries(ctx, request)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println(availablePackageSummaries)
+}

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
@@ -160,17 +160,17 @@ func (s *pluginsServer) registerGRPC(p *plugin.Plugin, pluginDetail *plugins.Plu
 	if err != nil {
 		return nil, fmt.Errorf("unable to lookup %q for %v: %w", grpcRegisterFunction, pluginDetail, err)
 	}
-	type grpcRegisterFunctionType = func(grpc.ServiceRegistrar, core.KubernetesConfigGetter, kube.ClustersConfig, string) (interface{}, error)
+	type grpcRegisterFunctionType = func(grpc.ServiceRegistrar, core.KubernetesConfigGetter, kube.ClustersConfig, string, core.Logger) (interface{}, error)
 
 	grpcFn, ok := grpcRegFn.(grpcRegisterFunctionType)
 	if !ok {
-		var dummyFn grpcRegisterFunctionType = func(grpc.ServiceRegistrar, core.KubernetesConfigGetter, kube.ClustersConfig, string) (interface{}, error) {
+		var dummyFn grpcRegisterFunctionType = func(grpc.ServiceRegistrar, core.KubernetesConfigGetter, kube.ClustersConfig, string, core.Logger) (interface{}, error) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("unable to use %q in plugin %v due to mismatched signature.\nwant: %T\ngot: %T", grpcRegisterFunction, pluginDetail, dummyFn, grpcRegFn)
 	}
 
-	server, err := grpcFn(registrar, clientGetter, s.clustersConfig, pluginConfigPath)
+	server, err := grpcFn(registrar, clientGetter, s.clustersConfig, pluginConfigPath, core.NewBuiltinKlogger())
 	if err != nil {
 		return nil, fmt.Errorf("plug-in %q failed to register due to: %v", pluginDetail, err)
 	} else if server == nil {

--- a/cmd/kubeapps-apis/core/serveopts.go
+++ b/cmd/kubeapps-apis/core/serveopts.go
@@ -19,9 +19,12 @@ package core
 import (
 	"context"
 
+	"flag"
+
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"k8s.io/client-go/rest"
+	klogv2 "k8s.io/klog/v2"
 )
 
 // ServeOptions encapsulates the available command-line options.
@@ -47,3 +50,45 @@ type GatewayHandlerArgs struct {
 // that call-sites don't need to know how to obtain an authenticated client, but
 // rather can just pass the request context and the cluster to get one.
 type KubernetesConfigGetter func(ctx context.Context, cluster string) (*rest.Config, error)
+
+type Logger interface {
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Info(args ...interface{})
+	Infof(format string, args ...interface{})
+}
+
+type KubeappsApisLogger struct {
+	//use "k8s.io/klog/v2" as default
+}
+
+func NewBuiltinKlogger() KubeappsApisLogger {
+	klogv2.InitFlags(nil) // initializing the flags
+	flag.Set("v", "5")
+	flag.Parse()
+	//defer klogv2.Flush() // flushes all pending log I/O
+	return KubeappsApisLogger{}
+}
+func (l KubeappsApisLogger) Error(args ...interface{}) {
+	klogv2.Error(args...)
+}
+
+func (l KubeappsApisLogger) Errorf(format string, args ...interface{}) {
+	klogv2.Errorf(format, args...)
+}
+func (l KubeappsApisLogger) Info(args ...interface{}) {
+	klogv2.Info(args...)
+}
+
+func (l KubeappsApisLogger) Infof(format string, args ...interface{}) {
+	klogv2.Infof(format, args...)
+}
+func (l KubeappsApisLogger) Fatal(args ...interface{}) {
+	klogv2.Fatal(args...)
+}
+
+func (l KubeappsApisLogger) Fatalf(format string, args ...interface{}) {
+	klogv2.Fatalf(format, args...)
+}

--- a/cmd/kubeapps-apis/interceptors/interceptors.go
+++ b/cmd/kubeapps-apis/interceptors/interceptors.go
@@ -1,0 +1,65 @@
+package interceptors
+
+import (
+	"context"
+
+	log "k8s.io/klog/v2"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type Identity struct {
+	ID string
+}
+
+func (i Identity) UnaryClient(
+	ctx context.Context,
+	method string,
+	req interface{},
+	reply interface{},
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption,
+) error {
+	md := metadata.Pairs()
+	md.Set("client-id", i.ID)
+
+	ctx = metadata.NewOutgoingContext(ctx, md)
+
+	err := invoker(ctx, method, req, reply, cc, opts...)
+
+	return err
+}
+
+func VerifyUnaryServer(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (resp interface{}, err error) {
+
+	// clients can use kubeapps-apis-client in grpc.DialContext
+	// that can be verified here
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok || len(md["client-id"]) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "missing metadata")
+	}
+
+	if md["client-id"][0] != "kubeapps-apis-client" {
+		return nil, status.Error(codes.PermissionDenied, "unexpected client")
+	}
+	log.Info("called VerifyUnaryServer Interceptor")
+	res, err := handler(ctx, req)
+	return res, err
+}
+
+// LogRequest is a gRPC UnaryServerInterceptor that will log the API call to stdOut
+func LogRequest(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (response interface{}, err error) {
+	log.Infof("Interceptor Request for : %s\n", info.FullMethod)
+	res, err := handler(ctx, req)
+	return res, err
+}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
@@ -39,7 +39,7 @@ func init() {
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
 func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
-	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
+	clustersConfig kube.ClustersConfig, pluginConfigPath string, logger core.Logger) (interface{}, error) {
 	log.Infof("+fluxv2 RegisterWithGRPCServer")
 	svr, err := NewServer(configGetter, clustersConfig.KubeappsClusterName)
 	if err != nil {

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
@@ -43,9 +43,8 @@ func init() {
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
 func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
-	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
-	svr := NewServer(configGetter, clustersConfig.KubeappsClusterName, pluginConfigPath)
-	v1alpha1.RegisterHelmPackagesServiceServer(s, svr)
+	clustersConfig kube.ClustersConfig, pluginConfigPath string, logger core.Logger) (interface{}, error) {
+	svr := NewServer(configGetter, clustersConfig.KubeappsClusterName, pluginConfigPath, logger)
 	return svr, nil
 }
 

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
@@ -38,7 +38,7 @@ func init() {
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
 func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
-	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
+	clustersConfig kube.ClustersConfig, pluginConfigPath string, logger core.Logger) (interface{}, error) {
 	svr := NewServer(configGetter)
 	v1alpha1.RegisterKappControllerPackagesServiceServer(s, svr)
 	return svr, nil

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
@@ -42,7 +42,7 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter, clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter, clustersConfig kube.ClustersConfig, pluginConfigPath string, logger core.Logger) (interface{}, error) {
 	svr := NewServer(configGetter)
 	v1alpha1.RegisterResourcesServiceServer(s, svr)
 	return svr, nil

--- a/cmd/kubeapps-apis/server/server.go
+++ b/cmd/kubeapps-apis/server/server.go
@@ -32,6 +32,7 @@ import (
 	pluginsv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core/plugins/v1alpha1"
 	packagesGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/interceptors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -43,7 +44,13 @@ import (
 func Serve(serveOpts core.ServeOptions) error {
 	// Create the grpc server and register the reflection server (for now, useful for discovery
 	// using grpcurl) or similar.
-	grpcSrv := grpc.NewServer()
+	grpcSrv := grpc.NewServer(
+		// Here we add the chaining of interceptors, they will execute in order
+		grpc.ChainUnaryInterceptor(
+			interceptors.VerifyUnaryServer,
+			interceptors.LogRequest,
+		),
+	)
 	reflection.Register(grpcSrv)
 
 	// Create the http server, register our core service followed by any plugins.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

There are two commits addressing the below points:

1)Define a Logger interface in the kubeapps-apis server. A default logger (Klog) is implemented in the server and passed as an input to all plugins. Each plugin can use the given logger interface or create a new one if required.
It is recommended to use the default logger so that any future changes can be done in one place and plugins code need not implement any logging actions.
 See [commit](https://github.com/kubeapps/kubeapps/commit/e04698d3842b1266e841a1386ff85aa26c9f492d)
2) Use an interceptor to automatically log every RPC call to the kubeapps-apis server.
If required an additional client-id can be added as an authorization to further restrict the APIs access from any code. A sample client implementation is added to show this functionality.
 See [commit](https://github.com/kubeapps/kubeapps/commit/1f5109cffbdee7d1f75c917c20a860926b51947f)

### Benefits

<!-- What benefits will be realized by the code change? -->
1. Common logging infra for all kubeapps-apis plugins.
2. intercepting all RPC calls in one location.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- This tries to address the requests in #3385 


### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

N/A