### PR TITLE
Replace the unsafe gvk to gvr conversion with restmapper.

### DIFF
--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
@@ -43,7 +43,10 @@ func init() {
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
 func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter, clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
-	svr := NewServer(configGetter)
+	svr, err := NewServer(configGetter)
+	if err != nil {
+		return nil, err
+	}
 	v1alpha1.RegisterResourcesServiceServer(s, svr)
 	return svr, nil
 }

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server_test.go
@@ -31,8 +31,10 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	dynfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
@@ -104,6 +106,12 @@ func getResourcesClient(t *testing.T, objects ...runtime.Object) (v1alpha1.Resou
 		// running test service.
 		corePackagesClientGetter: func() (pkgsGRPCv1alpha1.PackagesServiceClient, error) {
 			return pkgsGRPCv1alpha1.NewPackagesServiceClient(conn), nil
+		},
+		// For testing, define a kindToResource converter that doesn't require
+		// a rest mapper.
+		kindToResource: func(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+			gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+			return gvr, nil
 		},
 	})
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Who would have thought converting from the GroupVersionKind of a yaml resource to the GroupVersionResource required by the API server would be so arduous?!

This PR replaces the unsafe conversion that was used temporarily, instead initializing a RESTMapper from the APIserver (using the service account) at startup and switching to use that at run-time for the conversion.

Follows on from #3767 

### Benefits

We don't depend on known-to-be-unsafe code.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3403

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
