### PR TITLE
Update dashboard to fetch resource refs via API.

### DIFF
--- a/dashboard/src/actions/apps.test.tsx
+++ b/dashboard/src/actions/apps.test.tsx
@@ -300,7 +300,7 @@ describe("rollbackInstalledPackage", () => {
     const availablePackageDetail = { name: "test" } as AvailablePackageDetail;
 
     App.RollbackInstalledPackage = jest.fn().mockImplementationOnce(() => true);
-    App.getRelease = jest.fn().mockReturnValue({ manifest: {} });
+    App.GetInstalledPackageResourceRefs = jest.fn().mockReturnValue({ resourceRefs: [] });
     App.GetInstalledPackageDetail = jest.fn().mockReturnValue({
       installedPackageDetail: installedPackageDetail,
     });
@@ -309,7 +309,7 @@ describe("rollbackInstalledPackage", () => {
 
     const selectCMD = actions.apps.selectApp(
       installedPackageDetail as any,
-      {},
+      [],
       availablePackageDetail,
     );
     const res2 = await store.dispatch(selectCMD);
@@ -321,7 +321,7 @@ describe("rollbackInstalledPackage", () => {
       { type: getType(actions.apps.requestApps) },
       {
         type: getType(actions.apps.selectApp),
-        payload: { app: installedPackageDetail, manifest: {}, details: availablePackageDetail },
+        payload: { app: installedPackageDetail, resourceRefs: [], details: availablePackageDetail },
       },
     ];
 
@@ -334,7 +334,7 @@ describe("rollbackInstalledPackage", () => {
       },
       1,
     );
-    expect(App.getRelease).toHaveBeenCalledWith({
+    expect(App.GetInstalledPackageResourceRefs).toHaveBeenCalledWith({
       context: { cluster: "default-c", namespace: "default-ns" },
       identifier: "my-release",
       plugin: { name: PluginNames.PACKAGES_HELM, version: "0.0.1" },

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -5,6 +5,7 @@ import ResourceRef, { fromCRD } from "shared/ResourceRef";
 import { IClusterServiceVersionCRD, IKubeState, IResource } from "shared/types";
 import { getType } from "typesafe-actions";
 import actions from ".";
+import { ResourceRef as APIResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 
 const mockStore = configureMockStore([thunk]);
 const clusterName = "cluster-name";
@@ -48,13 +49,11 @@ describe("getResource", () => {
     const r = {
       apiVersion: "v1",
       kind: "Service",
-      metadata: {
-        name: "foo",
-        namespace: "default",
-      },
-    } as IResource;
+      name: "foo",
+      namespace: "default",
+    } as APIResourceRef;
 
-    const ref = new ResourceRef(r, clusterName, "services", true);
+    const ref = new ResourceRef(r, clusterName, "services", true, "default");
 
     await store.dispatch(actions.kube.getResource(ref));
     expect(store.getActions()).toEqual(expectedActions);
@@ -82,13 +81,11 @@ describe("getResource", () => {
     const r = {
       apiVersion: "v1",
       kind: "Service",
-      metadata: {
-        name: "foo",
-        namespace: "default",
-      },
-    } as IResource;
+      name: "foo",
+      namespace: "default",
+    } as APIResourceRef;
 
-    const ref = new ResourceRef(r, clusterName, "services", true);
+    const ref = new ResourceRef(r, clusterName, "services", true, "default");
 
     await store.dispatch(actions.kube.getResource(ref));
     expect(store.getActions()).toEqual([]);
@@ -101,13 +98,11 @@ describe("getAndWatchResource", () => {
     const r = {
       apiVersion: "v1",
       kind: "Service",
-      metadata: {
-        name: "foo",
-        namespace: "default",
-      },
-    } as IResource;
+      name: "foo",
+      namespace: "default",
+    } as APIResourceRef;
 
-    const ref = new ResourceRef(r, clusterName, "services", true);
+    const ref = new ResourceRef(r, clusterName, "services", true, "default");
 
     const expectedActions = [
       {

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -400,14 +400,6 @@ describe("AppView", () => {
     });
   });
 
-  // TODO(minelson): the following features need to be implemented and tested
-  // in the helm plugin before this PR can land:
-  // * Implement support for lists (see deleted test)
-  // * Ensure deplicate labels don't cause error parsing (see deleted test)
-  it("fails until prequal branch lands with supporting functionality from the dashboard moved to the api server", () => {
-    expect(false).toBe(true);
-  });
-
   it("forwards statefulsets and daemonsets to the application status", () => {
     const apiResourceRefs = [resourceRefs.statefulset, resourceRefs.daemonset] as APIResourceRef[];
     const wrapper = mountWrapper(

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -61,10 +61,6 @@ function parseResources(
     services: [],
     secrets: [],
   };
-  // DEBUG remove:
-  if (!apiResourceRefs) {
-    return result;
-  }
   apiResourceRefs.forEach(apiRef => {
     const kind = kinds[apiRef.kind] || {};
     switch (apiRef.kind) {

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -3,7 +3,6 @@ import Alert from "components/js/Alert";
 import Column from "components/js/Column";
 import Row from "components/js/Row";
 import PageHeader from "components/PageHeader/PageHeader";
-import { InstalledPackageReference } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import * as yaml from "js-yaml";
 import { useEffect, useState } from "react";
@@ -34,7 +33,10 @@ import AppValues from "./AppValues/AppValues";
 import PackageInfo from "./PackageInfo/PackageInfo";
 import CustomAppView from "./CustomAppView";
 import ResourceTabs from "./ResourceTabs";
-import { ResourceRef as APIResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
+import {
+  ResourceRef as APIResourceRef,
+  InstalledPackageReference,
+} from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 
 export interface IAppViewResourceRefs {
   deployments: ResourceRef[];

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
@@ -3,6 +3,7 @@ import { initialKinds } from "reducers/kube";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import ResourceRef from "shared/ResourceRef";
+import { ResourceRef as APIResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { IKubeItem, IKubeState, IResource } from "shared/types";
 import AccessURLTableContainer from ".";
 import AccessURLTable from "../../components/AppView/AccessURLTable";
@@ -40,27 +41,25 @@ describe("AccessURLTableContainer", () => {
       {
         apiVersion: "v1",
         kind: "Service",
-        metadata: {
-          namespace: ns,
-          name: `${name}-service`,
-        },
-      } as IResource,
+        namespace: ns,
+        name: `${name}-service`,
+      } as APIResourceRef,
       clusterName,
       "services",
       true,
+      "default",
     );
     const ingressRef = new ResourceRef(
       {
         apiVersion: "v1",
         kind: "Ingress",
-        metadata: {
-          namespace: ns,
-          name: `${name}-ingress`,
-        },
-      } as IResource,
+        namespace: ns,
+        name: `${name}-ingress`,
+      } as APIResourceRef,
       clusterName,
       "ingresses",
       true,
+      "default",
     );
     const wrapper = shallow(
       <AccessURLTableContainer

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
@@ -6,6 +6,7 @@ import ResourceRef from "shared/ResourceRef";
 import { IKubeItem, IKubeState, IResource } from "shared/types";
 import ApplicationStatusContainer from ".";
 import ApplicationStatus from "../../components/ApplicationStatus";
+import { ResourceRef as APIResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 
 const mockStore = configureMockStore([thunk]);
 const clusterName = "cluster-Name";
@@ -32,14 +33,13 @@ describe("ApplicationStatusContainer", () => {
       {
         apiVersion: "apps/v1",
         kind: "Deployment",
-        metadata: {
-          namespace: ns,
-          name,
-        },
-      } as IResource,
+        namespace: ns,
+        name,
+      } as APIResourceRef,
       clusterName,
       "deployments",
       true,
+      "default",
     );
     const wrapper = shallow(
       <ApplicationStatusContainer

--- a/dashboard/src/containers/helpers/index.test.ts
+++ b/dashboard/src/containers/helpers/index.test.ts
@@ -1,6 +1,7 @@
 import ResourceRef from "shared/ResourceRef";
 import { IKubeItem, IKubeState, IResource } from "shared/types";
 import { filterByResourceRefs } from ".";
+import { ResourceRef as APIResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 
 const clusterName = "cluster-name";
 
@@ -10,11 +11,23 @@ describe("filterByResourceRefs", () => {
     kind: "Service",
     metadata: { name: "bar", namespace: "foo" },
   } as IResource;
+  const svc1Ref = {
+    apiVersion: "v1",
+    kind: "Service",
+    name: "bar",
+    namespace: "foo",
+  } as APIResourceRef;
   const svc2 = {
     apiVersion: "v1",
     kind: "Service",
     metadata: { name: "bar", namespace: "foo1" },
   } as IResource;
+  const svc2Ref = {
+    apiVersion: "v1",
+    kind: "Service",
+    name: "bar",
+    namespace: "foo1",
+  } as APIResourceRef;
   const deploy = {
     apiVersion: "apps/v1",
     kind: "Deployment",
@@ -34,25 +47,23 @@ describe("filterByResourceRefs", () => {
   };
   it("returns the IKubeItems in the state referenced by each ResourceRef", () => {
     const resourceRefs: ResourceRef[] = [
-      new ResourceRef(svc1, clusterName, "services", true),
-      new ResourceRef(svc2, clusterName, "services", true),
+      new ResourceRef(svc1Ref, clusterName, "services", true, "foo"),
+      new ResourceRef(svc2Ref, clusterName, "services", true, "foo1"),
     ];
 
     expect(filterByResourceRefs(resourceRefs, items)).toEqual([{ item: svc1 }, { item: svc2 }]);
   });
 
   it("does not return resources that are not in the state", () => {
-    const missingSvc = {
+    const missingSvcRef = {
       apiVersion: "v1",
       kind: "Service",
-      metadata: {
-        name: "missing",
-        namespace: "foo1",
-      },
-    } as IResource;
+      name: "missing",
+      namespace: "foo1",
+    } as APIResourceRef;
     const resourceRefs: ResourceRef[] = [
-      new ResourceRef(svc2, clusterName, "services", true),
-      new ResourceRef(missingSvc, clusterName, "services", true),
+      new ResourceRef(svc2Ref, clusterName, "services", true, "default"),
+      new ResourceRef(missingSvcRef, clusterName, "services", true, "default"),
     ];
 
     expect(filterByResourceRefs(resourceRefs, items)).toEqual([{ item: svc2 }]);

--- a/dashboard/src/reducers/apps.ts
+++ b/dashboard/src/reducers/apps.ts
@@ -43,8 +43,7 @@ const appsReducer = (
           ...action.payload.app,
           // TODO(agamez): remove it once we have a core mechanism for rolling back
           revision: revision,
-          // TODO(agamez): remove it once we return the generated resources as part of the InstalledPackageDetail.
-          manifest: action.payload.manifest,
+          apiResourceRefs: action.payload.resourceRefs,
         },
         selectedDetails: action.payload.details,
       };

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -3,6 +3,7 @@ import { IKubeState, IResource } from "shared/types";
 import { getType } from "typesafe-actions";
 import actions from "../actions";
 import kubeReducer, { initialKinds } from "./kube";
+import { ResourceRef as APIResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 
 const clusterName = "cluster-name";
 
@@ -27,14 +28,13 @@ describe("kubeReducer", () => {
     {
       apiVersion: "v1",
       kind: "Service",
-      metadata: {
-        name: "foo",
-        namespace: "default",
-      },
-    } as IResource,
+      name: "foo",
+      namespace: "default",
+    } as APIResourceRef,
     clusterName,
     "services",
     true,
+    "default",
   );
 
   beforeEach(() => {

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -40,6 +40,14 @@ export class App {
     });
   }
 
+  public static async GetInstalledPackageResourceRefs(
+    installedPackageRef?: InstalledPackageReference,
+  ) {
+    return await this.coreClient().GetInstalledPackageResourceRefs({
+      installedPackageRef: installedPackageRef,
+    });
+  }
+
   public static async CreateInstalledPackage(
     targetContext: Context,
     name: string,

--- a/dashboard/src/shared/ResourceRef.test.ts
+++ b/dashboard/src/shared/ResourceRef.test.ts
@@ -1,29 +1,28 @@
 import { Kube } from "./Kube";
 import ResourceRef, { fromCRD } from "./ResourceRef";
-import { IClusterServiceVersionCRDResource, IResource } from "./types";
+import { IClusterServiceVersionCRDResource } from "./types";
+import { ResourceRef as APIResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 
 const clusterName = "cluster-name";
 
 describe("ResourceRef", () => {
   describe("constructor", () => {
     it("returns a ResourceRef with the correct details", () => {
-      const r = {
+      const apiRef = {
         apiVersion: "apps/v1",
         kind: "Deployment",
-        metadata: {
-          name: "foo",
-          namespace: "bar",
-        },
-      } as IResource;
+        name: "foo",
+        namespace: "bar",
+      } as APIResourceRef;
 
-      const ref = new ResourceRef(r, clusterName, "deployments", true);
+      const ref = new ResourceRef(apiRef, clusterName, "deployments", true, "releaseNamespace");
       expect(ref).toBeInstanceOf(ResourceRef);
       expect(ref).toEqual({
         cluster: clusterName,
-        apiVersion: r.apiVersion,
-        kind: r.kind,
-        name: r.metadata.name,
-        namespace: r.metadata.namespace,
+        apiVersion: apiRef.apiVersion,
+        kind: apiRef.kind,
+        name: apiRef.name,
+        namespace: "bar",
         namespaced: true,
         plural: "deployments",
       });
@@ -33,26 +32,11 @@ describe("ResourceRef", () => {
       const r = {
         apiVersion: "apps/v1",
         kind: "Deployment",
-        metadata: {
-          name: "foo",
-        },
-      } as IResource;
+        name: "foo",
+      } as APIResourceRef;
 
       const ref = new ResourceRef(r, clusterName, "deployments", true, "default");
       expect(ref.namespace).toBe("default");
-    });
-
-    it("allows the default namespace to be provided", () => {
-      const r = {
-        apiVersion: "apps/v1",
-        kind: "Deployment",
-        metadata: {
-          name: "foo",
-        },
-      } as IResource;
-
-      const ref = new ResourceRef(r, clusterName, "deployments", true, "bar");
-      expect(ref.namespace).toBe("bar");
     });
 
     describe("fromCRD", () => {
@@ -123,13 +107,11 @@ describe("ResourceRef", () => {
       const r = {
         apiVersion: "v1",
         kind: "Service",
-        metadata: {
-          name: "foo",
-          namespace: "bar",
-        },
-      } as IResource;
+        name: "foo",
+        namespace: "bar",
+      } as APIResourceRef;
 
-      const ref = new ResourceRef(r, clusterName, "services", true);
+      const ref = new ResourceRef(r, clusterName, "services", true, "default");
 
       ref.getResourceURL();
       expect(kubeGetResourceURLMock).toBeCalledWith(
@@ -156,13 +138,11 @@ describe("ResourceRef", () => {
       const r = {
         apiVersion: "v1",
         kind: "Service",
-        metadata: {
-          name: "foo",
-          namespace: "bar",
-        },
-      } as IResource;
+        name: "foo",
+        namespace: "bar",
+      } as APIResourceRef;
 
-      const ref = new ResourceRef(r, clusterName, "services", true);
+      const ref = new ResourceRef(r, clusterName, "services", true, "default");
 
       ref.watchResourceURL();
       expect(kubeWatchResourceURLMock).toBeCalledWith(
@@ -191,13 +171,11 @@ describe("ResourceRef", () => {
       const r = {
         apiVersion: "v1",
         kind: "Service",
-        metadata: {
-          name: "foo",
-          namespace: "bar",
-        },
-      } as IResource;
+        name: "foo",
+        namespace: "bar",
+      } as APIResourceRef;
 
-      const ref = new ResourceRef(r, clusterName, "services", true);
+      const ref = new ResourceRef(r, clusterName, "services", true, "default");
 
       ref.getResource();
       expect(kubeGetResourceMock).toBeCalledWith(clusterName, "v1", "services", true, "bar", "foo");
@@ -207,13 +185,11 @@ describe("ResourceRef", () => {
       const r = {
         apiVersion: "v1",
         kind: "Service",
-        metadata: {
-          name: "foo",
-          namespace: "bar",
-        },
-      } as IResource;
+        name: "foo",
+        namespace: "bar",
+      } as APIResourceRef;
 
-      const ref = new ResourceRef(r, clusterName, "services", true);
+      const ref = new ResourceRef(r, clusterName, "services", true, "default");
       ref.filter = { metadata: { name: "bar" } };
       Kube.getResource = jest.fn().mockReturnValue({
         items: [r],
@@ -236,13 +212,11 @@ describe("ResourceRef", () => {
       const r = {
         apiVersion: "v1",
         kind: "Service",
-        metadata: {
-          name: "foo",
-          namespace: "bar",
-        },
-      } as IResource;
+        name: "foo",
+        namespace: "bar",
+      } as APIResourceRef;
 
-      const ref = new ResourceRef(r, clusterName, "services", true);
+      const ref = new ResourceRef(r, clusterName, "services", true, "default");
 
       ref.watchResource();
       expect(kubeWatchResourceMock).toBeCalledWith(

--- a/dashboard/src/shared/ResourceRef.ts
+++ b/dashboard/src/shared/ResourceRef.ts
@@ -1,6 +1,7 @@
 import { filter, matches } from "lodash";
 import { Kube } from "./Kube";
 import { IClusterServiceVersionCRDResource, IK8sList, IKind, IResource } from "./types";
+import { ResourceRef as APIResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 
 export function fromCRD(
   r: IClusterServiceVersionCRDResource,
@@ -9,12 +10,11 @@ export function fromCRD(
   namespace: string,
   ownerReference: any,
 ) {
-  const resource = {
+  const apiResourceRef = {
     apiVersion: kind.apiVersion,
     kind: r.kind,
-    metadata: {},
-  } as IResource;
-  const ref = new ResourceRef(resource, cluster, kind.plural, kind.namespaced, namespace);
+  } as APIResourceRef;
+  const ref = new ResourceRef(apiResourceRef, cluster, kind.plural, kind.namespaced, namespace);
   ref.filter = {
     metadata: { ownerReferences: [ownerReference] },
   };
@@ -36,18 +36,18 @@ class ResourceRef {
   // Creates a new ResourceRef instance from an existing IResource. Provide
   // defaultNamespace to set if the IResource doesn't specify a namespace.
   constructor(
-    r: IResource,
+    apiRef: APIResourceRef,
     cluster: string,
     plural: string,
     namespaced: boolean,
-    defaultNamespace?: string,
+    releaseNamespace: string,
   ) {
     this.cluster = cluster;
     this.plural = plural;
-    this.apiVersion = r.apiVersion;
-    this.kind = r.kind;
-    this.name = r.metadata.name;
-    this.namespace = namespaced ? r.metadata.namespace || defaultNamespace || "" : "";
+    this.apiVersion = apiRef.apiVersion;
+    this.kind = apiRef.kind;
+    this.name = apiRef.name;
+    this.namespace = namespaced ? apiRef.namespace || releaseNamespace || "" : "";
     this.namespaced = namespaced;
     return this;
   }

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -7,6 +7,7 @@ import {
   InstalledPackageDetail,
   InstalledPackageSummary,
   PackageAppVersion,
+  ResourceRef,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { IOperatorsState } from "reducers/operators";
 import { IAuthState } from "../reducers/auth";
@@ -479,6 +480,6 @@ export interface IBasicFormSliderParam extends IBasicFormParam {
 }
 
 export interface CustomInstalledPackageDetail extends InstalledPackageDetail {
-  manifest: any;
+  apiResourceRefs: ResourceRef[];
   revision: number;
 }


### PR DESCRIPTION
### Description of the change

This change updates the dashboard so that fetching the list of resource references for an installed package is no longer based on parsing the helm manifest, but instead a call to the apis server.

### Benefits

Other plugins can provide the installed package references for an installed app.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

- ref #3779

### Additional information

While removing some of the dashboard code here, I noticed two cases that the backend may not yet support, so need to update that in the helm plugin.