### PR TITLE
Don't fire external network requests during test.

### DIFF
--- a/dashboard/src/components/AppView/CustomAppView/CustomAppView.test.tsx
+++ b/dashboard/src/components/AppView/CustomAppView/CustomAppView.test.tsx
@@ -66,11 +66,11 @@ const xhrMock: Partial<XMLHttpRequest> = {
   setRequestHeader: jest.fn(),
   readyState: 4,
   status: 200,
-  response: 'Hello World!'
+  response: "Hello World!",
 };
 
 beforeAll((): void => {
-  jest.spyOn(window, 'XMLHttpRequest').mockImplementation(() => xhrMock as XMLHttpRequest);
+  jest.spyOn(window, "XMLHttpRequest").mockImplementation(() => xhrMock as XMLHttpRequest);
 });
 
 it("should render a custom app view", () => {

--- a/dashboard/src/components/AppView/CustomAppView/CustomAppView.test.tsx
+++ b/dashboard/src/components/AppView/CustomAppView/CustomAppView.test.tsx
@@ -59,6 +59,20 @@ const defaultProps = {
   appDetails: {} as AvailablePackageDetail,
 };
 
+// Ensure remote-component doesn't trigger external requests during this test.
+const xhrMock: Partial<XMLHttpRequest> = {
+  open: jest.fn(),
+  send: jest.fn(),
+  setRequestHeader: jest.fn(),
+  readyState: 4,
+  status: 200,
+  response: 'Hello World!'
+};
+
+beforeAll((): void => {
+  jest.spyOn(window, 'XMLHttpRequest').mockImplementation(() => xhrMock as XMLHttpRequest);
+});
+
 it("should render a custom app view", () => {
   const wrapper = mountWrapper(getStore(defaultState), <CustomAppView {...defaultProps} />);
   expect(wrapper.find(CustomAppView)).toExist();

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
@@ -29,15 +29,15 @@ const xhrMock: Partial<XMLHttpRequest> = {
   setRequestHeader: jest.fn(),
   readyState: 4,
   status: 200,
-  response: 'Hello World!'
+  response: "Hello World!",
 };
 
 beforeAll((): void => {
-  jest.spyOn(window, 'XMLHttpRequest').mockImplementation(() => xhrMock as XMLHttpRequest);
+  jest.spyOn(window, "XMLHttpRequest").mockImplementation(() => xhrMock as XMLHttpRequest);
 });
 afterEach((): void => {
   mockOpen.mockReset();
-})
+});
 
 it("should render a custom form component", () => {
   const wrapper = mountWrapper(


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Updates the tests related to the remote component so that they don't try to fetch external resources during tests.

CI was failing on master consistently with:
```
Summary of all failing tests
 FAIL  src/components/InfoCard/InfoCard.test.tsx
  ● Test suite failed to run

    ENOMEM: not enough memory, read

      at Runtime.readFile (node_modules/jest-runtime/build/index.js:1987:21)
      at Object.<anonymous> (node_modules/domutils/lib/index.js:16:14)

 FAIL  src/components/AppView/AppControls/DeleteButton/DeleteButton.test.tsx
  ● Test suite failed to run

    ENOMEM: not enough memory, read

      at Runtime.readFile (node_modules/jest-runtime/build/index.js:1987:21)
      at Object.<anonymous> (node_modules/lodash/_castPath.js:4:16)

 FAIL  src/components/AppView/CustomAppView/CustomAppView.test.tsx
  ● Test suite failed to run

    Call retries were exceeded

      at ChildProcessWorker.initialize (node_modules/jest-worker/build/workers/ChildProcessWorker.js:193:21)

 FAIL  src/components/DeploymentFormBody/BasicDeploymentForm/CustomFormParam.test.tsx
  ● Test suite failed to run

    Call retries were exceeded

      at ChildProcessWorker.initialize (node_modules/jest-worker/build/workers/ChildProcessWorker.js:193:21)


Test Suites: 4 failed, 128 passed, 132 total
Tests:       1104 passed, 1104 total
Snapshots:   32 passed, 32 total
Time:        142.07 s
Ran all test suites.
error Command failed with exit code 1
```

It appears that the external request was being called repeatedly until retries failed, which may have been causing memory issues (just a guess by the other two failures).

### Benefits

CI passing again (? It passed for this PR, but it could have just been chance).

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
