### PR TITLE
CI dashboard tests should garbage-collect earlier.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,8 +598,9 @@ jobs:
   test_dashboard:
     environment:
       # Note that the max old space setting is per worker, so running the tests
-      # with 4 workers on a 4Gb (free plan) needs 1Gb of max old space.
-      NODE_OPTIONS: "--max-old-space-size=1024"
+      # with 4 workers on a 4Gb (free plan) needs 1Gb of max old space. Forcing
+      # garbage collection to start earlier with 512M per worker.
+      NODE_OPTIONS: "--max-old-space-size=512"
     docker:
       - image: circleci/node:<< pipeline.parameters.NODE_VERSION >>
     steps:


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>


### Description of the change

Still seeing some dashboard test runs on CI failing when workers get close to 1Gb (see [details in comment](https://github.com/kubeapps/kubeapps/pull/3797#issuecomment-976041955)). Forgot that we probably need to leave some memory for other processes, so updating to cause GC when a worker has 512Mb old mem.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->
Hopefully more stable CI.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
