### PR TITLE
Show a lint error when there is one in CI.

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,7 +10,7 @@
     "compile-lang": "formatjs compile-folder lang src/locales/ --ast --format simple",
     "copy-clr": "shx cp ./node_modules/@clr/ui/clr-ui-dark.min.css public/clr-ui-dark.min.css && shx cp node_modules/@clr/ui/clr-ui.min.css public/clr-ui.min.css && shx cp ./node_modules/@clr/ui/clr-ui-dark.min.css.map public/clr-ui-dark.min.css.map && shx cp ./node_modules/@clr/ui/clr-ui.min.css.map public/clr-ui.min.css.map",
     "eject": "react-scripts eject",
-    "eslint-check": "eslint --config ./.eslintrc.json 'src/**/*.{js,ts,tsx}' --quiet --max-warnings=0",
+    "eslint-check": "eslint --config ./.eslintrc.json 'src/**/*.{js,ts,tsx}' --max-warnings=0",
     "eslint": "eslint --config ./.eslintrc.json 'src/**/*.{js,ts,tsx}' --fix --max-warnings=0",
     "extract-lang": "formatjs extract 'src/**/*.ts*' --out-file lang/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format simple",
     "lint": "npm-run-all lint-css-check eslint-check",


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

A number of times I've had test_dashboard failing on CI with output like:

```
#!/bin/bash -eo pipefail
yarn --cwd=dashboard run lint

yarn run v1.22.15
$ npm-run-all lint-css-check eslint-check
$ stylelint --config ./.stylelintrc.json 'src/**/*.scss'
$ eslint --config ./.eslintrc.json 'src/**/*.{js,ts,tsx}' --quiet --max-warnings=0
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <4.5.0

YOUR TYPESCRIPT VERSION: 4.5.2

Please only submit bug reports when using the officially supported version.

=============
ESLint found too many warnings (maximum: 0).
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "eslint-check" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

Exited with code exit status 1

CircleCI received exit code 1

```

which means I have to re-run eslint locally (in a container - yes, my own choice) without the --quite option. This change just means CI will show us *why* it fails so we can fix and push :)
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
