### PR TITLE
Adds support for the GetInstalledPackageResourceRefs grpc call for fluxv2

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
@@ -319,6 +319,7 @@ type helmReleaseStub struct {
 	namespace    string
 	chartVersion string
 	notes        string
+	manifest     string
 	status       release.Status
 }
 
@@ -777,6 +778,482 @@ func TestDeleteInstalledPackage(t *testing.T) {
 	}
 }
 
+func TestGetInstalledPackageResourceRefs(t *testing.T) {
+	// Using the redis_existing_stub_completed data with
+	// different manifests for each test.
+	var (
+		releaseNamespace = redis_existing_stub_completed.namespace
+		releaseName      = redis_existing_stub_completed.name
+	)
+	testCases := []struct {
+		name               string
+		existingHelmStubs  []helmReleaseStub
+		request            *corev1.GetInstalledPackageResourceRefsRequest
+		expectedResponse   *corev1.GetInstalledPackageResourceRefsResponse
+		expectedStatusCode codes.Code
+	}{
+		{
+			name: "returns resource references for helm installation",
+			existingHelmStubs: []helmReleaseStub{
+				{
+					name:      releaseName,
+					namespace: releaseNamespace,
+					manifest: `
+---
+# Source: redis/templates/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-test
+  namespace: test
+---
+# Source: redis/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-test
+  namespace: test
+`,
+				},
+			},
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedResponse: &corev1.GetInstalledPackageResourceRefsResponse{
+				Context: &corev1.Context{
+					Cluster:   "default",
+					Namespace: releaseNamespace,
+				},
+				ResourceRefs: []*corev1.ResourceRef{
+					{
+						ApiVersion: "v1",
+						Name:       "redis-test",
+						Namespace:  "test",
+						Kind:       "Service",
+					},
+					{
+						ApiVersion: "apps/v1",
+						Name:       "redis-test",
+						Namespace:  "test",
+						Kind:       "Deployment",
+					},
+				},
+			},
+		},
+		{
+			name: "returns resource references for resources in other namespaces",
+			existingHelmStubs: []helmReleaseStub{
+				{
+					name:      releaseName,
+					namespace: releaseNamespace,
+					manifest: `
+---
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: test-cluster-role
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-other-namespace
+  namespace: some-other-namespace
+`,
+				},
+			},
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedResponse: &corev1.GetInstalledPackageResourceRefsResponse{
+				Context: &corev1.Context{
+					Cluster:   "default",
+					Namespace: releaseNamespace,
+				},
+				ResourceRefs: []*corev1.ResourceRef{
+					{
+						ApiVersion: "v1",
+						Name:       "test-cluster-role",
+						Kind:       "ClusterRole",
+					},
+					{
+						ApiVersion: "apps/v1",
+						Name:       "test-other-namespace",
+						Namespace:  "some-other-namespace",
+						Kind:       "Deployment",
+					},
+				},
+			},
+		},
+		{
+			name: "skips resources that do not have a kind",
+			existingHelmStubs: []helmReleaseStub{
+				{
+					name:      releaseName,
+					namespace: releaseNamespace,
+					manifest: `
+---
+apiVersion: v1
+otherstuff: ignored
+metadata:
+  name: redis-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-test
+`,
+				},
+			},
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedResponse: &corev1.GetInstalledPackageResourceRefsResponse{
+				Context: &corev1.Context{
+					Cluster:   "default",
+					Namespace: releaseNamespace,
+				},
+				ResourceRefs: []*corev1.ResourceRef{
+					{
+						ApiVersion: "apps/v1",
+						Name:       "redis-test",
+						Kind:       "Deployment",
+					},
+				},
+			},
+		},
+		{
+			name: "returns a not found error if the helm release is not found",
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedStatusCode: codes.NotFound,
+		},
+		{
+			name: "returns internal error if the yaml manifest cannot be parsed",
+			existingHelmStubs: []helmReleaseStub{
+				{
+					name:      releaseName,
+					namespace: releaseNamespace,
+					manifest: `
+---
+apiVersion: v1
+should not be :! parsed as yaml$
+`,
+				},
+			},
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedStatusCode: codes.Internal,
+		},
+		{
+			name: "handles duplicate labels in the manifest as helm does",
+			// See https://github.com/kubeapps/kubeapps/issues/632
+			existingHelmStubs: []helmReleaseStub{
+				{
+					name:      releaseName,
+					namespace: releaseNamespace,
+					manifest: `
+---
+# Source: apache/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-test
+  label:
+    chart: "redis-0.2.0"
+    chart: "redis-0.2.0"
+`,
+				},
+			},
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedResponse: &corev1.GetInstalledPackageResourceRefsResponse{
+				Context: &corev1.Context{
+					Cluster:   "default",
+					Namespace: releaseNamespace,
+				},
+				ResourceRefs: []*corev1.ResourceRef{
+					{
+						ApiVersion: "apps/v1",
+						Name:       "redis-test",
+						Kind:       "Deployment",
+					},
+				},
+			},
+		},
+		{
+			name: "supports manifests with YAML type casting",
+			existingHelmStubs: []helmReleaseStub{
+				{
+					name:      releaseName,
+					namespace: releaseNamespace,
+					manifest: `
+---
+# Source: redis/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: !!string redis-test
+`,
+				},
+			},
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedResponse: &corev1.GetInstalledPackageResourceRefsResponse{
+				Context: &corev1.Context{
+					Cluster:   "default",
+					Namespace: releaseNamespace,
+				},
+				ResourceRefs: []*corev1.ResourceRef{
+					{
+						ApiVersion: "apps/v1",
+						Name:       "redis-test",
+						Kind:       "Deployment",
+					},
+				},
+			},
+		},
+		{
+			name: "renders a list of items",
+			existingHelmStubs: []helmReleaseStub{
+				{
+					name:      releaseName,
+					namespace: releaseNamespace,
+					manifest: `
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: redis-test
+    namespace: default
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: redis-test
+    namespace: default
+`,
+				},
+			},
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedResponse: &corev1.GetInstalledPackageResourceRefsResponse{
+				Context: &corev1.Context{
+					Cluster:   "default",
+					Namespace: releaseNamespace,
+				},
+				ResourceRefs: []*corev1.ResourceRef{
+					{
+						ApiVersion: "apps/v1",
+						Name:       "redis-test",
+						Namespace:  "default",
+						Kind:       "Deployment",
+					},
+					{
+						ApiVersion: "v1",
+						Name:       "redis-test",
+						Namespace:  "default",
+						Kind:       "Service",
+					},
+				},
+			},
+		},
+		{
+			name: "renders a rolelist of items",
+			// See https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/role-v1/#RoleList
+			existingHelmStubs: []helmReleaseStub{
+				{
+					name:      releaseName,
+					namespace: releaseNamespace,
+					manifest: `
+---
+apiVersion: v1
+kind: RoleList
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: role-1
+    namespace: default
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: role-2
+    namespace: default
+`,
+				},
+			},
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedResponse: &corev1.GetInstalledPackageResourceRefsResponse{
+				Context: &corev1.Context{
+					Cluster:   "default",
+					Namespace: releaseNamespace,
+				},
+				ResourceRefs: []*corev1.ResourceRef{
+					{
+						ApiVersion: "rbac.authorization.k8s.io/v1",
+						Name:       "role-1",
+						Namespace:  "default",
+						Kind:       "Role",
+					},
+					{
+						ApiVersion: "rbac.authorization.k8s.io/v1",
+						Name:       "role-2",
+						Namespace:  "default",
+						Kind:       "Role",
+					},
+				},
+			},
+		},
+		{
+			name: "renders a ClusterRoleList of items",
+			// See https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/#ClusterRoleList
+			existingHelmStubs: []helmReleaseStub{
+				{
+					name:      releaseName,
+					namespace: releaseNamespace,
+					manifest: `
+---
+apiVersion: v1
+kind: ClusterRoleList
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: clusterrole-1
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: clusterrole-2
+`,
+				},
+			},
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedResponse: &corev1.GetInstalledPackageResourceRefsResponse{
+				Context: &corev1.Context{
+					Cluster:   "default",
+					Namespace: releaseNamespace,
+				},
+				ResourceRefs: []*corev1.ResourceRef{
+					{
+						ApiVersion: "rbac.authorization.k8s.io/v1",
+						Name:       "clusterrole-1",
+						Kind:       "ClusterRole",
+					},
+					{
+						ApiVersion: "rbac.authorization.k8s.io/v1",
+						Name:       "clusterrole-2",
+						Kind:       "ClusterRole",
+					},
+				},
+			},
+		},
+	}
+
+	ignoredFields := cmpopts.IgnoreUnexported(
+		corev1.GetInstalledPackageResourceRefsResponse{},
+		corev1.ResourceRef{},
+		corev1.Context{},
+	)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runtimeObjs, cleanup := newRuntimeObjects(t, []testSpecGetInstalledPackages{redis_existing_spec_completed})
+			defer cleanup()
+			actionConfig := newHelmActionConfig(t, tc.request.InstalledPackageRef.GetContext().GetNamespace(), tc.existingHelmStubs)
+			server, mock, _, err := newServerWithChartsAndReleases(actionConfig, runtimeObjs...)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+
+			response, err := server.GetInstalledPackageResourceRefs(context.Background(), tc.request)
+
+			if got, want := status.Code(err), tc.expectedStatusCode; got != want {
+				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
+			}
+
+			if got, want := response, tc.expectedResponse; !cmp.Equal(want, got, ignoredFields) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredFields))
+			}
+
+			// we make sure that all expectations were met
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
 func newRuntimeObjects(t *testing.T, existingK8sObjs []testSpecGetInstalledPackages) (runtimeObjs []runtime.Object, cleanup func()) {
 	httpServers := []*httptest.Server{}
 	cleanup = func() {
@@ -985,7 +1462,8 @@ func newHelmActionConfig(t *testing.T, namespace string, rels []helmReleaseStub)
 					AppVersion: "1.2.3",
 				},
 			},
-			Config: config,
+			Config:   config,
+			Manifest: r.manifest,
 		}
 		err := actionConfig.Releases.Create(rel)
 		if err != nil {

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"strings"
 
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -493,4 +495,40 @@ func (s *Server) DeleteInstalledPackage(ctx context.Context, request *corev1.Del
 	} else {
 		return &corev1.DeleteInstalledPackageResponse{}, nil
 	}
+}
+
+// GetInstalledPackageResourceRefs returns the references for the Kubernetes
+// resources created by an installed package.
+func (s *Server) GetInstalledPackageResourceRefs(ctx context.Context, request *corev1.GetInstalledPackageResourceRefsRequest) (*corev1.GetInstalledPackageResourceRefsResponse, error) {
+	pkgRef := request.GetInstalledPackageRef()
+	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", pkgRef.GetContext().GetCluster(), pkgRef.GetContext().GetNamespace())
+	identifier := pkgRef.GetIdentifier()
+	log.Infof("+fluxv2 GetResourceRefs %s %s", contextMsg, identifier)
+
+	namespace := pkgRef.GetContext().GetNamespace()
+
+	actionConfig, err := s.actionConfigGetter(ctx, request.GetInstalledPackageRef().GetContext().GetNamespace())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
+	}
+
+	// Grab the released manifest from the release.
+	getcmd := action.NewGet(actionConfig)
+	release, err := getcmd.Run(identifier)
+	if err != nil {
+		if err == driver.ErrReleaseNotFound {
+			return nil, status.Errorf(codes.NotFound, "Unable to find Helm release %q in namespace %q: %+v", identifier, namespace, err)
+		}
+		return nil, status.Errorf(codes.Internal, "Unable to run Helm get action: %v", err)
+	}
+
+	refs, err := resourceRefsFromManifest(release.Manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &corev1.GetInstalledPackageResourceRefsResponse{
+		Context:      pkgRef.GetContext(),
+		ResourceRefs: refs,
+	}, nil
 }

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -513,6 +513,12 @@ func (s *Server) GetInstalledPackageResourceRefs(ctx context.Context, request *c
 	}
 
 	// Grab the released manifest from the release.
+	// TODO(minelson): We're currently getting the resource refs for a package
+	// install by checking the helm manifest, as we do for the helm plugin. With
+	// certain assumptions about the RBAC of the Kubeapps user, we may be able
+	// to instead query for labelled resources. See the discussion following for
+	// more details:
+	// https://github.com/kubeapps/kubeapps/pull/3811#issuecomment-977689570
 	getcmd := action.NewGet(actionConfig)
 	release, err := getcmd.Run(identifier)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

This PR just adds support for the GetInstalledPackageResourceRefs call to the fluxv2 plugin.

The code is the same as that in the helm plugin (longer term we may want to have some shared functionality between the helm and fluxv2 plugins given they both work with flux).

I had to update the tests to work in the same way as the flux model.

I haven't done the in-real-life test (but will do), but this should ensure that we can now view the details of an installed package (and it will watch/track the resources)
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Installed package details for flux can be viewed correctly.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3779

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
