### PR TITLE
Remove last remaining connection to kubeops from dashboard.

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.5.12-dev4
+version: 7.5.12-dev6

--- a/chart/kubeapps/README.md
+++ b/chart/kubeapps/README.md
@@ -278,6 +278,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 
 | Name                                            | Description                                                                               | Value              |
 | ----------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------ |
+| `kubeops.enabled`                               | Specifies whether this component should be installed.                                     | `true`             |
 | `kubeops.image.registry`                        | Kubeops image registry                                                                    | `docker.io`        |
 | `kubeops.image.repository`                      | Kubeops image repository                                                                  | `kubeapps/kubeops` |
 | `kubeops.image.tag`                             | Kubeops image tag (immutable tags are recommended)                                        | `latest`           |

--- a/chart/kubeapps/templates/frontend/configmap.yaml
+++ b/chart/kubeapps/templates/frontend/configmap.yaml
@@ -120,6 +120,49 @@ data:
         proxy_pass {{ include "kubeapps.kubeappsapis.proxy_pass" . -}};
       }
 
+  {{- if .Values.assetsvc.enabled }}
+      # Forward '/api/assetsvc' to '/assetsvc'
+      # but preserving the encoding (eg. '%2F' is not converted to '/')
+      # see https://serverfault.com/a/906479
+      # Ex: from "/api/assetsvc/what$2Fever?param=value"
+      #     it matches as $1="/what$2Fever" and $args="param=value"
+      #     downstream services will receive "/assetsvc/what$2Fever?param=value"
+      location ~* /api/assetsvc {
+        rewrite ^ $request_uri; # pass the encoded url downstream as is,
+        rewrite /api/assetsvc([^?]*) /assetsvc$1?$args break;
+
+    {{- if .Values.frontend.proxypassExtraSetHeader }}
+        proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
+    {{- end }}
+
+    {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
+        # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
+        proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
+    {{- end }}
+        proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
+      }
+  {{- end }}
+
+  {{- if .Values.kubeops.enabled }}
+      location ~* /api/kubeops {
+        # Keep the connection open with the API server even if idle (the default is 60 seconds)
+        # Setting it to 10 minutes which should be enough for our current use case of deploying/upgrading/deleting apps
+        proxy_read_timeout 10m;
+        rewrite /api/kubeops/(.*) /$1 break;
+        rewrite /api/kubeops / break;
+
+    {{- if .Values.frontend.proxypassExtraSetHeader }}
+        proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
+    {{- end }}
+
+    {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
+        # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
+        proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
+    {{- end }}
+
+        proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
+      }
+
       # The route for the Kubeapps backend API is not prefixed.
       location ~* /api/ {
         rewrite /api/(.*) /backend/$1 break;
@@ -136,6 +179,7 @@ data:
 
         proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
       }
+  {{- end }}
 
       location / {
         # Add the Authorization header if exists

--- a/chart/kubeapps/templates/frontend/configmap.yaml
+++ b/chart/kubeapps/templates/frontend/configmap.yaml
@@ -103,47 +103,6 @@ data:
       }
     {{- end }}
 
-      # Forward '/api/assetsvc' to '/assetsvc'
-      # but preserving the encoding (eg. '%2F' is not converted to '/')
-      # see https://serverfault.com/a/906479
-      # Ex: from "/api/assetsvc/what$2Fever?param=value"
-      #     it matches as $1="/what$2Fever" and $args="param=value"
-      #     downstream services will receive "/assetsvc/what$2Fever?param=value"
-      location ~* /api/assetsvc {
-        rewrite ^ $request_uri; # pass the encoded url downstream as is,
-        rewrite /api/assetsvc([^?]*) /assetsvc$1?$args break;
-
-    {{- if .Values.frontend.proxypassExtraSetHeader }}
-        proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
-    {{- end }}
-
-    {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
-        # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
-        proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
-    {{- end }}
-
-        proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
-      }
-
-      location ~* /api/kubeops {
-        # Keep the connection open with the API server even if idle (the default is 60 seconds)
-        # Setting it to 10 minutes which should be enough for our current use case of deploying/upgrading/deleting apps
-        proxy_read_timeout 10m;
-        rewrite /api/kubeops/(.*) /$1 break;
-        rewrite /api/kubeops / break;
-
-    {{- if .Values.frontend.proxypassExtraSetHeader }}
-        proxy_set_header {{ .Values.frontend.proxypassExtraSetHeader }};
-    {{- end }}
-
-    {{- if .Values.frontend.proxypassAccessTokenAsBearer }}
-        # Google Kubernetes Engine requires the access_token as the Bearer when talking to the k8s api server.
-        proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
-    {{- end }}
-
-        proxy_pass {{ include "kubeapps.frontend-config.proxy_pass" . -}};
-      }
-
       location ~* /apis {
         rewrite ^ $request_uri; # pass the encoded url downstream as is,
         rewrite /apis/([^?]*) /$1 break;

--- a/chart/kubeapps/templates/kubeops/deployment.yaml
+++ b/chart/kubeapps/templates/kubeops/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kubeops.enabled }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -140,3 +141,4 @@ spec:
         - name: ca-certs
           emptyDir: {}
       {{- end }}
+{{- end }}

--- a/chart/kubeapps/templates/kubeops/rbac.yaml
+++ b/chart/kubeapps/templates/kubeops/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.kubeops.enabled .Values.rbac.create -}}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:

--- a/chart/kubeapps/templates/kubeops/service.yaml
+++ b/chart/kubeapps/templates/kubeops/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kubeops.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -26,3 +27,4 @@ spec:
       name: http
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: kubeops
+{{- end }}

--- a/chart/kubeapps/templates/kubeops/serviceaccount.yaml
+++ b/chart/kubeapps/templates/kubeops/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kubeops.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,3 +12,4 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -874,6 +874,10 @@ apprepository:
 ## Kubeops parameters
 ##
 kubeops:
+  ## @param kubeops.enabled Specifies whether this component should be installed.
+  ## In a future release we will be setting this to default to false.
+  ##
+  enabled: true
   ## Bitnami Kubeops image
   ## ref: https://hub.docker.com/r/bitnami/kubeops/tags/
   ## @param kubeops.image.registry Kubeops image registry

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -100,16 +100,4 @@ export class App {
       installedPackageRef,
     } as DeleteInstalledPackageRequest);
   }
-
-  // TODO(agamez): remove it once we return the generated resources as part of the InstalledPackageDetail.
-  public static async getRelease(installedPackageRef?: InstalledPackageReference) {
-    const { data } = await axiosWithAuth.get<{ data: { manifest: any } }>(
-      url.kubeops.releases.get(
-        installedPackageRef?.context?.cluster ?? "",
-        installedPackageRef?.context?.namespace ?? "",
-        installedPackageRef?.identifier ?? "",
-      ),
-    );
-    return data.data;
-  }
 }

--- a/dashboard/src/shared/App.ts
+++ b/dashboard/src/shared/App.ts
@@ -12,8 +12,6 @@ import {
   RollbackInstalledPackageRequest,
   RollbackInstalledPackageResponse,
 } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
-import * as url from "shared/url";
-import { axiosWithAuth } from "./AxiosInstance";
 import { KubeappsGrpcClient } from "./KubeappsGrpcClient";
 import { PluginNames } from "./utils";
 

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -118,15 +118,6 @@ export const backend = {
   canI: (cluster: string) => `api/v1/clusters/${cluster}/can-i`,
 };
 
-export const kubeops = {
-  releases: {
-    list: (cluster: string, namespace: string) =>
-      `api/kubeops/v1/clusters/${cluster}/namespaces/${namespace}/releases`,
-    get: (cluster: string, namespace: string, name: string) =>
-      `${kubeops.releases.list(cluster, namespace)}/${name}`,
-  },
-};
-
 export const api = {
   // URLs which are accessing the k8s API server directly are grouped together
   // so we can clearly differentiate and possibly begin to remove.


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Now that the dashboard is using the helm plugin for all helm-related functionality, we have no need for the connection to the kubeops service.

This PR just removes the two small references which are unused afaict.

With this, I believe we can indeed remove the kubeops (and already assetsvc) services? Not sure if we want to do that as part of this release. We'd have to update the internal content team tests I assume. What do you think Antonio?

I've additionally removed the config from the frontend so that no requests are forwarded to the kubeops or assetsvc services to see if anything breaks.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Less moving parts :)
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None here, but if we remove the kubeops/assetsvc from the code and chart, we'll need to update the content teams tests or similar.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3779

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
