### PR TITLE
Add eslint warning if console.log are left

### DIFF
--- a/dashboard/.eslintrc.json
+++ b/dashboard/.eslintrc.json
@@ -37,6 +37,7 @@
     "jest": true
   },
   "rules": {
+    "no-console": "warn", // warns if a console.log is left in the code
     "redos/no-vulnerable": "error", // avoid ReDoS vulnerable regex
     "quotes": [
       "error", // enforce double quotes

--- a/dashboard/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/dashboard/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -4,6 +4,8 @@ import { mount } from "enzyme";
 import React from "react";
 import ErrorBoundary from "./ErrorBoundary";
 
+/* eslint-disable no-console */
+
 const consoleOrig = console.error;
 
 const defaultProps = {

--- a/dashboard/src/registerServiceWorker.ts
+++ b/dashboard/src/registerServiceWorker.ts
@@ -55,11 +55,13 @@ function registerValidSW(swUrl: string) {
                 // the fresh content will have been added to the cache.
                 // It's the perfect time to display a 'New content is
                 // available; please refresh.' message in your web app.
+                /* eslint-disable-next-line no-console */
                 console.log("New content is available; please refresh.");
               } else {
                 // At this point, everything has been precached.
                 // It's the perfect time to display a
                 // 'Content is cached for offline use.' message.
+                /* eslint-disable-next-line no-console */
                 console.log("Content is cached for offline use.");
               }
             }
@@ -68,6 +70,7 @@ function registerValidSW(swUrl: string) {
       };
     })
     .catch(error => {
+      /* eslint-disable-next-line no-console */
       console.error("Error during service worker registration:", error);
     });
 }
@@ -93,6 +96,7 @@ function checkValidServiceWorker(swUrl: string) {
       }
     })
     .catch(() => {
+      /* eslint-disable-next-line no-console */
       console.log("No internet connection found. App is running in offline mode.");
     });
 }


### PR DESCRIPTION
### Description of the change

Minor PR adding just an eslint warning if the committed code includes unnoticed `console.log`. I thought it was enabled by default, but some previous updates in the eslint config must have disabled it.

### Benefits

I won't commit again (or at least, our CI won't let it pass) code with console.log eventually useful for debugging a unit test :P

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

I'd say it was marked (in the past) as an `error`, which prevented eventual console statements when developing, Now it is a warning, we should be able to run `yarn start` without any issues.
