### PR TITLE
Use the same assert library to avoid extra deps

### DIFF
--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -32,7 +33,6 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/arschles/assert"
 	"github.com/disintegration/imaging"
 	"github.com/google/go-cmp/cmp"
 	"github.com/kubeapps/common/datastore"
@@ -44,6 +44,7 @@ import (
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
 	tartest "github.com/kubeapps/kubeapps/pkg/tarutil/test"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/chart"
 )
 
@@ -210,7 +211,7 @@ func Test_syncURLInvalidity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := getHelmRepo("namespace", "test", tt.repoURL, "", nil, &goodHTTPClient{}, "my-user-agent")
-			assert.ExistsErr(t, err, tt.name)
+			assert.Error(t, err, tt.name)
 		})
 	}
 }
@@ -218,7 +219,7 @@ func Test_syncURLInvalidity(t *testing.T) {
 func Test_getOCIRepo(t *testing.T) {
 	t.Run("it should add the auth header to the resolver", func(t *testing.T) {
 		repo, err := getOCIRepo("namespace", "test", "https://test", "Basic auth", nil, []string{}, &http.Client{})
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		helmtest.CheckHeader(t, repo.(*OCIRegistry).puller, "Authorization", "Basic auth")
 	})
 }
@@ -226,7 +227,7 @@ func Test_getOCIRepo(t *testing.T) {
 func Test_parseFilters(t *testing.T) {
 	t.Run("return rules spec", func(t *testing.T) {
 		filters, err := parseFilters(`{"jq":".name == $var1","variables":{"$var1":"wordpress"}}`)
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, filters, &apprepov1alpha1.FilterRuleSpec{
 			JQ: ".name == $var1", Variables: map[string]string{"$var1": "wordpress"},
 		}, "filters")
@@ -250,20 +251,20 @@ func Test_fetchRepoIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			netClient := &goodHTTPClient{}
 			_, err := fetchRepoIndex(tt.url, "", netClient, tt.userAgent)
-			assert.NoErr(t, err)
+			assert.NoError(t, err)
 		})
 	}
 
 	t.Run("authenticated request", func(t *testing.T) {
 		netClient := &authenticatedHTTPClient{}
 		_, err := fetchRepoIndex("https://my.examplerepo.com", "Bearer ThisSecretAccessTokenAuthenticatesTheClient", netClient, "my-user-agent")
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("failed request", func(t *testing.T) {
 		netClient := &badHTTPClient{}
 		_, err := fetchRepoIndex("https://my.examplerepo.com", "", netClient, "my-user-agent")
-		assert.ExistsErr(t, err, "failed request")
+		assert.Error(t, err, errors.New("failed request"))
 	})
 }
 
@@ -295,7 +296,7 @@ func Test_fetchRepoIndexUserAgent(t *testing.T) {
 			netClient := server.Client()
 
 			_, err := fetchRepoIndex(server.URL, "", netClient, userAgent)
-			assert.NoErr(t, err)
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -378,7 +379,7 @@ func Test_newManager(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := datastore.Config{URL: tt.dbURL, Database: tt.dbName, Username: tt.dbUser, Password: tt.dbPass}
 			_, err := newManager(config, "kubeapps")
-			assert.NoErr(t, err)
+			assert.NoError(t, err)
 		})
 	}
 
@@ -393,7 +394,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 		defer cleanup()
 		c := models.Chart{ID: "test/acs-engine-autoscaler"}
 		fImporter := fileImporter{pgManager, &goodHTTPClient{}}
-		assert.NoErr(t, fImporter.fetchAndImportIcon(c, repo, "my-user-agent", false))
+		assert.NoError(t, fImporter.fetchAndImportIcon(c, repo, "my-user-agent", false))
 	})
 
 	charts, _ := helm.ChartsFromIndex([]byte(validRepoIndexYAML), &models.Repo{Name: "test", Namespace: "repo-namespace", URL: "http://testrepo.com"}, false)
@@ -403,7 +404,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 		defer cleanup()
 		netClient := &badHTTPClient{}
 		fImporter := fileImporter{pgManager, netClient}
-		assert.Err(t, fmt.Errorf("GET request to [%s] failed due to status [500]", charts[0].Icon), fImporter.fetchAndImportIcon(charts[0], repo, "my-user-agent", false))
+		assert.Error(t, fmt.Errorf("GET request to [%s] failed due to status [500]", charts[0].Icon), fImporter.fetchAndImportIcon(charts[0], repo, "my-user-agent", false))
 	})
 
 	t.Run("bad icon", func(t *testing.T) {
@@ -412,7 +413,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 		netClient := &badIconClient{}
 		c := charts[0]
 		fImporter := fileImporter{pgManager, netClient}
-		assert.Err(t, image.ErrFormat, fImporter.fetchAndImportIcon(c, repo, "my-user-agent", false))
+		assert.Error(t, image.ErrFormat, fImporter.fetchAndImportIcon(c, repo, "my-user-agent", false))
 	})
 
 	t.Run("valid icon", func(t *testing.T) {
@@ -425,7 +426,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
 
 		fImporter := fileImporter{pgManager, netClient}
-		assert.NoErr(t, fImporter.fetchAndImportIcon(charts[0], repo, "my-user-agent", false))
+		assert.NoError(t, fImporter.fetchAndImportIcon(charts[0], repo, "my-user-agent", false))
 	})
 
 	t.Run("valid SVG icon", func(t *testing.T) {
@@ -443,7 +444,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
 
 		fImporter := fileImporter{pgManager, netClient}
-		assert.NoErr(t, fImporter.fetchAndImportIcon(c, repo, "my-user-agent", false))
+		assert.NoError(t, fImporter.fetchAndImportIcon(c, repo, "my-user-agent", false))
 	})
 
 	t.Run("valid icon (not passing through the auth header by default)", func(t *testing.T) {
@@ -452,7 +453,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 		netClient := &goodAuthenticatedHTTPClient{}
 
 		fImporter := fileImporter{pgManager, netClient}
-		assert.Err(t, fmt.Errorf("GET request to [%s] failed due to status [401]", charts[0].Icon), fImporter.fetchAndImportIcon(charts[0], repo, "my-user-agent", false))
+		assert.Error(t, fmt.Errorf("GET request to [%s] failed due to status [401]", charts[0].Icon), fImporter.fetchAndImportIcon(charts[0], repo, "my-user-agent", false))
 	})
 
 	t.Run("valid icon (not passing through the auth header)", func(t *testing.T) {
@@ -461,7 +462,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 		netClient := &goodAuthenticatedHTTPClient{}
 
 		fImporter := fileImporter{pgManager, netClient}
-		assert.Err(t, fmt.Errorf("GET request to [%s] failed due to status [401]", charts[0].Icon), fImporter.fetchAndImportIcon(charts[0], repo, "my-user-agent", false))
+		assert.Error(t, fmt.Errorf("GET request to [%s] failed due to status [401]", charts[0].Icon), fImporter.fetchAndImportIcon(charts[0], repo, "my-user-agent", false))
 	})
 
 	t.Run("valid icon (passing through the auth header if same domain)", func(t *testing.T) {
@@ -474,7 +475,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
 
 		fImporter := fileImporter{pgManager, netClient}
-		assert.NoErr(t, fImporter.fetchAndImportIcon(charts[0], repoWithAuthorization, "my-user-agent", false))
+		assert.NoError(t, fImporter.fetchAndImportIcon(charts[0], repoWithAuthorization, "my-user-agent", false))
 	})
 
 	t.Run("valid icon (passing through the auth header)", func(t *testing.T) {
@@ -487,7 +488,7 @@ func Test_fetchAndImportIcon(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
 
 		fImporter := fileImporter{pgManager, netClient}
-		assert.NoErr(t, fImporter.fetchAndImportIcon(charts[0], repoWithAuthorization, "my-user-agent", true))
+		assert.NoError(t, fImporter.fetchAndImportIcon(charts[0], repoWithAuthorization, "my-user-agent", true))
 	})
 }
 
@@ -555,7 +556,7 @@ func Test_fetchAndImportFiles(t *testing.T) {
 			RepoInternal: repo,
 			netClient:    netClient,
 		}
-		assert.Err(t, fmt.Errorf("GET request to [https://kubernetes-charts.storage.googleapis.com/acs-engine-autoscaler-2.1.1.tgz] failed due to status [500]"), fImporter.fetchAndImportFiles(charts[0].Name, helmRepo, chartVersion, "my-user-agent", false))
+		assert.Error(t, fmt.Errorf("GET request to [https://kubernetes-charts.storage.googleapis.com/acs-engine-autoscaler-2.1.1.tgz] failed due to status [500]"), fImporter.fetchAndImportFiles(charts[0].Name, helmRepo, chartVersion, "my-user-agent", false))
 	})
 
 	t.Run("file not found", func(t *testing.T) {
@@ -588,7 +589,7 @@ func Test_fetchAndImportFiles(t *testing.T) {
 			netClient:    netClient,
 		}
 		err := fImporter.fetchAndImportFiles(charts[0].Name, helmRepo, chartVersion, "my-user-agent", false)
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("authenticated request", func(t *testing.T) {
@@ -614,7 +615,7 @@ func Test_fetchAndImportFiles(t *testing.T) {
 			netClient:    netClient,
 		}
 		err := fImporter.fetchAndImportFiles(charts[0].Name, repo, chartVersion, "my-user-agent", true)
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("valid tarball", func(t *testing.T) {
@@ -632,7 +633,7 @@ func Test_fetchAndImportFiles(t *testing.T) {
 		fImporter := fileImporter{pgManager, netClient}
 
 		err := fImporter.fetchAndImportFiles(charts[0].Name, fRepo, chartVersion, "my-user-agent", false)
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("file exists", func(t *testing.T) {
@@ -645,7 +646,7 @@ func Test_fetchAndImportFiles(t *testing.T) {
 
 		fImporter := fileImporter{pgManager, &goodHTTPClient{}}
 		err := fImporter.fetchAndImportFiles(charts[0].Name, fRepo, chartVersion, "my-user-agent", false)
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 	})
 }
 
@@ -695,7 +696,7 @@ func Test_ociAPICli(t *testing.T) {
 			},
 		}
 		_, err := apiCli.TagList("apache", "my-user-agent")
-		assert.Err(t, fmt.Errorf("GET request to [http://oci-test/v2/apache/tags/list] failed due to status [500]: forbidden"), err)
+		assert.Error(t, fmt.Errorf("GET request to [http://oci-test/v2/apache/tags/list] failed due to status [500]: forbidden"), err)
 	})
 
 	t.Run("TagList - successful request", func(t *testing.T) {
@@ -706,7 +707,7 @@ func Test_ociAPICli(t *testing.T) {
 			},
 		}
 		result, err := apiCli.TagList("apache", "my-user-agent")
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		expectedTagList := &TagList{Name: "test/apache", Tags: []string{"7.5.1", "8.1.1"}}
 		if !cmp.Equal(result, expectedTagList) {
 			t.Errorf("Unexpected result %v", cmp.Diff(result, expectedTagList))
@@ -720,7 +721,7 @@ func Test_ociAPICli(t *testing.T) {
 			netClient:  &authenticatedOCIAPIHTTPClient{},
 		}
 		_, err := apiCli.TagList("apache", "my-user-agent")
-		assert.Err(t, fmt.Errorf("GET request to [http://oci-test/v2/apache/tags/list] failed due to status [500]"), err)
+		assert.Error(t, fmt.Errorf("GET request to [http://oci-test/v2/apache/tags/list] failed due to status [500]"), err)
 	})
 
 	t.Run("TagList with auth - success", func(t *testing.T) {
@@ -732,7 +733,7 @@ func Test_ociAPICli(t *testing.T) {
 			},
 		}
 		result, err := apiCli.TagList("apache", "my-user-agent")
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		expectedTagList := &TagList{Name: "test/apache", Tags: []string{"7.5.1", "8.1.1"}}
 		if !cmp.Equal(result, expectedTagList) {
 			t.Errorf("Unexpected result %v", cmp.Diff(result, expectedTagList))
@@ -745,7 +746,7 @@ func Test_ociAPICli(t *testing.T) {
 			netClient: &badHTTPClient{},
 		}
 		_, err := apiCli.IsHelmChart("apache", "7.5.1", "my-user-agent")
-		assert.Err(t, fmt.Errorf("GET request to [http://oci-test/v2/apache/manifests/7.5.1] failed due to status [500]"), err)
+		assert.Error(t, fmt.Errorf("GET request to [http://oci-test/v2/apache/manifests/7.5.1] failed due to status [500]"), err)
 	})
 
 	t.Run("IsHelmChart - successful request", func(t *testing.T) {
@@ -760,12 +761,12 @@ func Test_ociAPICli(t *testing.T) {
 			},
 		}
 		is751, err := apiCli.IsHelmChart("test/apache", "7.5.1", "my-user-agent")
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		if is751 {
 			t.Errorf("Tag 7.5.1 should not be a helm chart")
 		}
 		is811, err := apiCli.IsHelmChart("test/apache", "8.1.1", "my-user-agent")
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		if !is811 {
 			t.Errorf("Tag 8.1.1 should be a helm chart")
 		}
@@ -796,7 +797,7 @@ func Test_OCIRegistry(t *testing.T) {
 	t.Run("Checksum - failed request", func(t *testing.T) {
 		repo.ociCli = &fakeOCIAPICli{err: fmt.Errorf("request failed")}
 		_, err := repo.Checksum()
-		assert.Err(t, fmt.Errorf("request failed"), err)
+		assert.Error(t, fmt.Errorf("request failed"), err)
 	})
 
 	t.Run("Checksum - success", func(t *testing.T) {
@@ -804,7 +805,7 @@ func Test_OCIRegistry(t *testing.T) {
 			tagList: &TagList{Name: "test/apache", Tags: []string{"1.0.0", "1.1.0"}},
 		}
 		checksum, err := repo.Checksum()
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, checksum, "b1b1ae17ddc8f83606acb8a175025a264e8634bb174b6e6a5799bdb5d20eaa58", "checksum")
 	})
 
@@ -819,7 +820,7 @@ func Test_OCIRegistry(t *testing.T) {
 			},
 		}
 		_, err := emptyRepo.Checksum()
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, emptyRepo.tags, map[string]TagList{
 			"apache": {Name: "test/apache", Tags: []string{"1.0.0", "1.1.0"}},
 		}, "expected tags")
@@ -1051,7 +1052,7 @@ version: 1.0.0
 				},
 			}
 			charts, err := chartsRepo.Charts(tt.shallow)
-			assert.NoErr(t, err)
+			assert.NoError(t, err)
 			if !cmp.Equal(charts, tt.expected) {
 				t.Errorf("Unexpected result %v", cmp.Diff(charts, tt.expected))
 			}
@@ -1070,7 +1071,7 @@ version: 1.0.0
 			Readme: files["readme"],
 			Schema: files["schema"],
 		}, "my-user-agent", false)
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, result, files, "expected files")
 	})
 }
@@ -1144,7 +1145,7 @@ func Test_extractFilesFromBuffer(t *testing.T) {
 			gzw.Flush()
 
 			r, err := extractFilesFromBuffer(w.Body)
-			assert.NoErr(t, err)
+			assert.NoError(t, err)
 			if !cmp.Equal(r, tt.expected) {
 				t.Errorf("Unexpected result %v", cmp.Diff(r, tt.expected))
 			}

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/ahmetb/go-linq/v3 v3.2.0
-	github.com/arschles/assert v2.0.0+incompatible
 	github.com/containerd/containerd v1.5.7
 	github.com/disintegration/imaging v1.6.2
 	github.com/distribution/distribution v2.7.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,6 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/arschles/assert v2.0.0+incompatible h1:3U7Uinc6Y5LW9YPGJ805po2thDN/X6yhMgbl1/LbKxk=
-github.com/arschles/assert v2.0.0+incompatible/go.mod h1:m/u69zW43x0h8dTHcv3JJZljINyEYgBuf5fYJP6WikI=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -31,12 +31,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/arschles/assert"
 	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	helmfake "github.com/kubeapps/kubeapps/pkg/helm/fake"
 	helmtest "github.com/kubeapps/kubeapps/pkg/helm/test"
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
 	"github.com/kubeapps/kubeapps/pkg/kube"
+	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/repo"
 	corev1 "k8s.io/api/core/v1"
@@ -82,7 +82,7 @@ func Test_resolveChartURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			chartURL, err := resolveChartURL(tt.baseURL, tt.chartURL)
-			assert.NoErr(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, chartURL, tt.wantedURL, "url")
 		})
 	}
@@ -602,7 +602,7 @@ func TestGetChart(t *testing.T) {
 	t.Run("it should fail if the netClient is not instantiated", func(t *testing.T) {
 		cli := NewChartClient("")
 		_, err := cli.GetChart(nil, "")
-		assert.Err(t, fmt.Errorf("unable to retrieve chart, Init should be called first"), err)
+		assert.Error(t, fmt.Errorf("unable to retrieve chart, Init should be called first"), err)
 	})
 }
 
@@ -914,7 +914,7 @@ func TestOCIClient(t *testing.T) {
 	t.Run("GetChart - Fails if the puller has not been instantiated", func(t *testing.T) {
 		cli := NewOCIClient("foo")
 		_, err := cli.GetChart(nil, "")
-		assert.Err(t, fmt.Errorf("unable to retrieve chart, Init should be called first"), err)
+		assert.Error(t, fmt.Errorf("unable to retrieve chart, Init should be called first"), err)
 	})
 
 	t.Run("GetChart - Fails if the URL is not valid", func(t *testing.T) {
@@ -929,7 +929,7 @@ func TestOCIClient(t *testing.T) {
 	t.Run("GetChart - Returns a chart", func(t *testing.T) {
 		cli := NewOCIClient("foo")
 		data, err := ioutil.ReadFile("./testdata/nginx-5.1.1-apiVersionV2.tgz")
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		cli.(*OCIRepoClient).puller = &helmfake.OCIPuller{
 			ExpectedName: "foo/bar/nginx:5.1.1",
 			Content:      map[string]*bytes.Buffer{"5.1.1": bytes.NewBuffer(data)},

--- a/pkg/helm/index_test.go
+++ b/pkg/helm/index_test.go
@@ -16,8 +16,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/arschles/assert"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
+	"github.com/stretchr/testify/assert"
 )
 
 var validRepoIndexYAMLBytes, _ = ioutil.ReadFile("testdata/valid-index.yaml")
@@ -33,13 +33,13 @@ func Test_parseRepoIndex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := parseRepoIndex([]byte(tt.repoYAML))
-			assert.ExistsErr(t, err, tt.name)
+			assert.Error(t, err, tt.name)
 		})
 	}
 
 	t.Run("valid", func(t *testing.T) {
 		index, err := parseRepoIndex([]byte(validRepoIndexYAML))
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, len(index.Entries), 2, "number of charts")
 		assert.Equal(t, index.Entries["acs-engine-autoscaler"][0].Name, "acs-engine-autoscaler", "chart version populated")
 	})
@@ -48,7 +48,7 @@ func Test_parseRepoIndex(t *testing.T) {
 func Test_chartsFromIndex(t *testing.T) {
 	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
 	charts, err := ChartsFromIndex([]byte(validRepoIndexYAML), r, false)
-	assert.NoErr(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, len(charts), 2, "number of charts")
 
 	indexWithDeprecated := validRepoIndexYAML + `
@@ -56,7 +56,7 @@ func Test_chartsFromIndex(t *testing.T) {
   - name: deprecated-chart
     deprecated: true`
 	charts, err = ChartsFromIndex([]byte(indexWithDeprecated), r, false)
-	assert.NoErr(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, len(charts), 2, "number of charts")
 	assert.Equal(t, len(charts[1].ChartVersions), 2, "number of versions")
 }
@@ -64,7 +64,7 @@ func Test_chartsFromIndex(t *testing.T) {
 func Test_shallowChartsFromIndex(t *testing.T) {
 	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
 	charts, err := ChartsFromIndex([]byte(validRepoIndexYAML), r, true)
-	assert.NoErr(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, len(charts), 2, "number of charts")
 	assert.Equal(t, len(charts[1].ChartVersions), 1, "number of versions")
 }
@@ -84,7 +84,7 @@ func Test_loadRepoWithEmptyCharts(t *testing.T) {
 	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
 	indexWithEmptyChart := validRepoIndexYAML + `emptyChart: []`
 	charts, err := ChartsFromIndex([]byte(indexWithEmptyChart), r, true)
-	assert.NoErr(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, len(charts), 2, "number of charts")
 	assert.Equal(t, len(charts[1].ChartVersions), 1, "number of versions")
 }

--- a/pkg/tarutil/tarutil_test.go
+++ b/pkg/tarutil/tarutil_test.go
@@ -19,8 +19,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/arschles/assert"
 	"github.com/kubeapps/kubeapps/pkg/tarutil/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_extractFilesFromTarball(t *testing.T) {
@@ -43,7 +43,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 			r := bytes.NewReader(b.Bytes())
 			tarf := tar.NewReader(r)
 			files, err := ExtractFilesFromTarball(map[string]string{tt.filename: tt.filename}, tarf)
-			assert.NoErr(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, files[tt.filename], tt.want, "file body")
 		})
 	}
@@ -55,7 +55,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 		r := bytes.NewReader(b.Bytes())
 		tarf := tar.NewReader(r)
 		files, err := ExtractFilesFromTarball(map[string]string{tFiles[0].Name: tFiles[0].Name, tFiles[1].Name: tFiles[1].Name}, tarf)
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, len(files), 2, "matches")
 		for _, f := range tFiles {
 			assert.Equal(t, files[f.Name], f.Body, "file body")
@@ -69,7 +69,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 		tarf := tar.NewReader(r)
 		name := "file2.txt"
 		files, err := ExtractFilesFromTarball(map[string]string{name: name}, tarf)
-		assert.NoErr(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, files[name], "", "file body")
 	})
 
@@ -80,7 +80,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 		tarf := tar.NewReader(r)
 		values := "values"
 		files, err := ExtractFilesFromTarball(map[string]string{values: "file2.txt"}, tarf)
-		assert.Err(t, io.ErrUnexpectedEOF, err)
+		assert.Error(t, io.ErrUnexpectedEOF, err)
 		assert.Equal(t, len(files), 0, "file body")
 	})
 }


### PR DESCRIPTION
### Description of the change

I assumed the dependabot error (below) was somethig transient, but it is not. It is due to an old dep causing some problems when auto-upgrading deps. Therefore, this PR is to replace it with the one we have been extensibily using (the other one is from the Monocular times).

![image](https://user-images.githubusercontent.com/11535726/143496101-69ff7b11-bac3-45b1-84b1-37334cba01f5.png)

### Benefits

Dependabot will be able, hopefully, to keep our go deps up to date... and I will be sleep happy knowing everything is smoothly being upgraded :P

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
