### PR TITLE
Remove unused feature flag. Remove use of batch/v1beta1

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.5.12-dev6
+version: 7.5.12-dev7

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1516,7 +1516,6 @@ clusters:
 ## @param featureFlags [object] Feature flags (used to switch on development features)
 ##
 featureFlags:
-  invalidateCache: true
 ## RBAC configuration
 ##
 rbac:

--- a/cmd/apprepository-controller/server/controller.go
+++ b/cmd/apprepository-controller/server/controller.go
@@ -32,7 +32,6 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/kube"
 	log "github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,7 +42,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	batchlisters "k8s.io/client-go/listers/batch/v1beta1"
+	batchlisters "k8s.io/client-go/listers/batch/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -108,7 +107,7 @@ func NewController(
 
 	// obtain references to shared index informers for the CronJob and
 	// AppRepository types.
-	cronjobInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
+	cronjobInformer := kubeInformerFactory.Batch().V1().CronJobs()
 	apprepoInformer := apprepoInformerFactory.Kubeapps().V1alpha1().AppRepositories()
 
 	// Create event broadcaster
@@ -284,7 +283,7 @@ func (c *Controller) syncHandler(key string) error {
 
 			// TODO: Workaround until the sync jobs are moved to the repoNamespace (#1647)
 			// Delete the cronjob in the Kubeapps namespace to avoid re-syncing the repository
-			err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Delete(context.TODO(), cronJobName(namespace, name), metav1.DeleteOptions{})
+			err = c.kubeclientset.BatchV1().CronJobs(c.conf.KubeappsNamespace).Delete(context.TODO(), cronJobName(namespace, name), metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				log.Errorf("Unable to delete sync cronjob: %v", err)
 				return err
@@ -300,7 +299,7 @@ func (c *Controller) syncHandler(key string) error {
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {
 		log.Infof("Creating CronJob %q for AppRepository %q", cronjobName, apprepo.GetName())
-		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Create(context.TODO(), newCronJob(apprepo, c.conf), metav1.CreateOptions{})
+		cronjob, err = c.kubeclientset.BatchV1().CronJobs(c.conf.KubeappsNamespace).Create(context.TODO(), newCronJob(apprepo, c.conf), metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
@@ -310,7 +309,7 @@ func (c *Controller) syncHandler(key string) error {
 	} else if err == nil {
 		// If the resource already exists, we'll update it
 		log.Infof("Updating CronJob %q in namespace %q for AppRepository %q in namespace %q", cronjobName, c.conf.KubeappsNamespace, apprepo.GetName(), apprepo.GetNamespace())
-		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Update(context.TODO(), newCronJob(apprepo, c.conf), metav1.UpdateOptions{})
+		cronjob, err = c.kubeclientset.BatchV1().CronJobs(c.conf.KubeappsNamespace).Update(context.TODO(), newCronJob(apprepo, c.conf), metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
@@ -424,21 +423,21 @@ func ownerReferencesForAppRepo(apprepo *apprepov1alpha1.AppRepository, childName
 // newCronJob creates a new CronJob for a AppRepository resource. It also sets
 // the appropriate OwnerReferences on the resource so handleObject can discover
 // the AppRepository resource that 'owns' it.
-func newCronJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1beta1.CronJob {
-	return &batchv1beta1.CronJob{
+func newCronJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1.CronJob {
+	return &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cronJobName(apprepo.Namespace, apprepo.Name),
 			OwnerReferences: ownerReferencesForAppRepo(apprepo, config.KubeappsNamespace),
 			Labels:          jobLabels(apprepo, config),
 			Annotations:     config.ParsedCustomAnnotations,
 		},
-		Spec: batchv1beta1.CronJobSpec{
+		Spec: batchv1.CronJobSpec{
 			Schedule: config.Crontab,
 			// Set to replace as short-circuit in k8s <1.12
 			// TODO re-evaluate ConcurrentPolicy when 1.12+ is mainstream (i.e 1.14)
 			// https://github.com/kubernetes/kubernetes/issues/54870
 			ConcurrencyPolicy: "Replace",
-			JobTemplate: batchv1beta1.JobTemplateSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: syncJobSpec(apprepo, config),
 			},
 		},

--- a/cmd/apprepository-controller/server/controller_test.go
+++ b/cmd/apprepository-controller/server/controller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -38,7 +37,7 @@ func Test_newCronJob(t *testing.T) {
 		crontab          string
 		userAgentComment string
 		apprepo          *apprepov1alpha1.AppRepository
-		expected         batchv1beta1.CronJob
+		expected         batchv1.CronJob
 	}{
 		{
 			"my-charts",
@@ -62,7 +61,7 @@ func Test_newCronJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 				},
 			},
-			batchv1beta1.CronJob{
+			batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "apprepo-kubeapps-sync-my-charts",
 					OwnerReferences: []metav1.OwnerReference{
@@ -80,10 +79,10 @@ func Test_newCronJob(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: batchv1.CronJobSpec{
 					Schedule:          "*/10 * * * *",
 					ConcurrencyPolicy: "Replace",
-					JobTemplate: batchv1beta1.JobTemplateSpec{
+					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							TTLSecondsAfterFinished: &defaultTTL,
 							Template: corev1.PodTemplateSpec{
@@ -156,7 +155,7 @@ func Test_newCronJob(t *testing.T) {
 					},
 				},
 			},
-			batchv1beta1.CronJob{
+			batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "apprepo-kubeapps-sync-my-charts",
 					OwnerReferences: []metav1.OwnerReference{
@@ -174,10 +173,10 @@ func Test_newCronJob(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: batchv1.CronJobSpec{
 					Schedule:          "*/20 * * * *",
 					ConcurrencyPolicy: "Replace",
-					JobTemplate: batchv1beta1.JobTemplateSpec{
+					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							TTLSecondsAfterFinished: &defaultTTL,
 							Template: corev1.PodTemplateSpec{
@@ -256,7 +255,7 @@ func Test_newCronJob(t *testing.T) {
 					},
 				},
 			},
-			batchv1beta1.CronJob{
+			batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "apprepo-otherns-sync-my-charts-in-otherns",
 					Labels: map[string]string{
@@ -265,10 +264,10 @@ func Test_newCronJob(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: batchv1.CronJobSpec{
 					Schedule:          "*/20 * * * *",
 					ConcurrencyPolicy: "Replace",
-					JobTemplate: batchv1beta1.JobTemplateSpec{
+					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							TTLSecondsAfterFinished: &defaultTTL,
 							Template: corev1.PodTemplateSpec{
@@ -1417,7 +1416,7 @@ func TestObjectBelongsTo(t *testing.T) {
 	}{
 		{
 			name: "it recognises a cronjob belonging to an app repository in another namespace",
-			object: &batchv1beta1.CronJob{
+			object: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apprepo-kubeapps-sync-my-charts",
 					Namespace: "kubeapps",
@@ -1437,7 +1436,7 @@ func TestObjectBelongsTo(t *testing.T) {
 		},
 		{
 			name: "it returns false if the namespace does not match",
-			object: &batchv1beta1.CronJob{
+			object: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apprepo-kubeapps-sync-my-charts",
 					Namespace: "kubeapps",


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Just fixes two small issues I noticed while investigating #3818.

The logs of the app-repository controller are currently just:
```
W1125 09:05:48.815213       1 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W1125 22:06:10.357233       1 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W1125 22:14:02.224164       1 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W1125 22:20:29.230197       1 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```

and the functionality behind the `invalidateCache` feature flag has been removed so the flag does nothing which is confusing.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

One less thing to worry about when running on Kubernetes 1.25+
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None that I can see.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
