### PR TITLE
Revert change in crobjob API. Add kubeops.enabled in CI

### DIFF
--- a/cmd/apprepository-controller/server/controller.go
+++ b/cmd/apprepository-controller/server/controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/kube"
 	log "github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +43,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	batchlisters "k8s.io/client-go/listers/batch/v1"
+	batchlisters "k8s.io/client-go/listers/batch/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -107,7 +108,7 @@ func NewController(
 
 	// obtain references to shared index informers for the CronJob and
 	// AppRepository types.
-	cronjobInformer := kubeInformerFactory.Batch().V1().CronJobs()
+	cronjobInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
 	apprepoInformer := apprepoInformerFactory.Kubeapps().V1alpha1().AppRepositories()
 
 	// Create event broadcaster
@@ -283,7 +284,7 @@ func (c *Controller) syncHandler(key string) error {
 
 			// TODO: Workaround until the sync jobs are moved to the repoNamespace (#1647)
 			// Delete the cronjob in the Kubeapps namespace to avoid re-syncing the repository
-			err = c.kubeclientset.BatchV1().CronJobs(c.conf.KubeappsNamespace).Delete(context.TODO(), cronJobName(namespace, name), metav1.DeleteOptions{})
+			err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Delete(context.TODO(), cronJobName(namespace, name), metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				log.Errorf("Unable to delete sync cronjob: %v", err)
 				return err
@@ -299,7 +300,7 @@ func (c *Controller) syncHandler(key string) error {
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {
 		log.Infof("Creating CronJob %q for AppRepository %q", cronjobName, apprepo.GetName())
-		cronjob, err = c.kubeclientset.BatchV1().CronJobs(c.conf.KubeappsNamespace).Create(context.TODO(), newCronJob(apprepo, c.conf), metav1.CreateOptions{})
+		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Create(context.TODO(), newCronJob(apprepo, c.conf), metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
@@ -309,7 +310,7 @@ func (c *Controller) syncHandler(key string) error {
 	} else if err == nil {
 		// If the resource already exists, we'll update it
 		log.Infof("Updating CronJob %q in namespace %q for AppRepository %q in namespace %q", cronjobName, c.conf.KubeappsNamespace, apprepo.GetName(), apprepo.GetNamespace())
-		cronjob, err = c.kubeclientset.BatchV1().CronJobs(c.conf.KubeappsNamespace).Update(context.TODO(), newCronJob(apprepo, c.conf), metav1.UpdateOptions{})
+		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Update(context.TODO(), newCronJob(apprepo, c.conf), metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
@@ -423,21 +424,21 @@ func ownerReferencesForAppRepo(apprepo *apprepov1alpha1.AppRepository, childName
 // newCronJob creates a new CronJob for a AppRepository resource. It also sets
 // the appropriate OwnerReferences on the resource so handleObject can discover
 // the AppRepository resource that 'owns' it.
-func newCronJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1.CronJob {
-	return &batchv1.CronJob{
+func newCronJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1beta1.CronJob {
+	return &batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cronJobName(apprepo.Namespace, apprepo.Name),
 			OwnerReferences: ownerReferencesForAppRepo(apprepo, config.KubeappsNamespace),
 			Labels:          jobLabels(apprepo, config),
 			Annotations:     config.ParsedCustomAnnotations,
 		},
-		Spec: batchv1.CronJobSpec{
+		Spec: batchv1beta1.CronJobSpec{
 			Schedule: config.Crontab,
 			// Set to replace as short-circuit in k8s <1.12
 			// TODO re-evaluate ConcurrentPolicy when 1.12+ is mainstream (i.e 1.14)
 			// https://github.com/kubernetes/kubernetes/issues/54870
 			ConcurrencyPolicy: "Replace",
-			JobTemplate: batchv1.JobTemplateSpec{
+			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: syncJobSpec(apprepo, config),
 			},
 		},

--- a/cmd/apprepository-controller/server/controller_test.go
+++ b/cmd/apprepository-controller/server/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,7 +38,7 @@ func Test_newCronJob(t *testing.T) {
 		crontab          string
 		userAgentComment string
 		apprepo          *apprepov1alpha1.AppRepository
-		expected         batchv1.CronJob
+		expected         batchv1beta1.CronJob
 	}{
 		{
 			"my-charts",
@@ -61,7 +62,7 @@ func Test_newCronJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 				},
 			},
-			batchv1.CronJob{
+			batchv1beta1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "apprepo-kubeapps-sync-my-charts",
 					OwnerReferences: []metav1.OwnerReference{
@@ -79,10 +80,10 @@ func Test_newCronJob(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 				},
-				Spec: batchv1.CronJobSpec{
+				Spec: batchv1beta1.CronJobSpec{
 					Schedule:          "*/10 * * * *",
 					ConcurrencyPolicy: "Replace",
-					JobTemplate: batchv1.JobTemplateSpec{
+					JobTemplate: batchv1beta1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							TTLSecondsAfterFinished: &defaultTTL,
 							Template: corev1.PodTemplateSpec{
@@ -155,7 +156,7 @@ func Test_newCronJob(t *testing.T) {
 					},
 				},
 			},
-			batchv1.CronJob{
+			batchv1beta1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "apprepo-kubeapps-sync-my-charts",
 					OwnerReferences: []metav1.OwnerReference{
@@ -173,10 +174,10 @@ func Test_newCronJob(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 				},
-				Spec: batchv1.CronJobSpec{
+				Spec: batchv1beta1.CronJobSpec{
 					Schedule:          "*/20 * * * *",
 					ConcurrencyPolicy: "Replace",
-					JobTemplate: batchv1.JobTemplateSpec{
+					JobTemplate: batchv1beta1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							TTLSecondsAfterFinished: &defaultTTL,
 							Template: corev1.PodTemplateSpec{
@@ -255,7 +256,7 @@ func Test_newCronJob(t *testing.T) {
 					},
 				},
 			},
-			batchv1.CronJob{
+			batchv1beta1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "apprepo-otherns-sync-my-charts-in-otherns",
 					Labels: map[string]string{
@@ -264,10 +265,10 @@ func Test_newCronJob(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 				},
-				Spec: batchv1.CronJobSpec{
+				Spec: batchv1beta1.CronJobSpec{
 					Schedule:          "*/20 * * * *",
 					ConcurrencyPolicy: "Replace",
-					JobTemplate: batchv1.JobTemplateSpec{
+					JobTemplate: batchv1beta1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							TTLSecondsAfterFinished: &defaultTTL,
 							Template: corev1.PodTemplateSpec{
@@ -1416,7 +1417,7 @@ func TestObjectBelongsTo(t *testing.T) {
 	}{
 		{
 			name: "it recognises a cronjob belonging to an app repository in another namespace",
-			object: &batchv1.CronJob{
+			object: &batchv1beta1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apprepo-kubeapps-sync-my-charts",
 					Namespace: "kubeapps",
@@ -1436,7 +1437,7 @@ func TestObjectBelongsTo(t *testing.T) {
 		},
 		{
 			name: "it returns false if the namespace does not match",
-			object: &batchv1.CronJob{
+			object: &batchv1beta1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "apprepo-kubeapps-sync-my-charts",
 					Namespace: "kubeapps",

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -189,6 +189,8 @@ installOrUpgradeKubeapps() {
     --set frontend.replicaCount=1
     --set kubeops.replicaCount=1
     --set dashboard.replicaCount=1
+    --set kubeappsapis.replicaCount=1
+    --set kubeops.enabled=true
     --set postgresql.replication.enabled=false
     --set postgresql.postgresqlPassword=password
     --set redis.auth.password=password


### PR DESCRIPTION
### Description of the change

This PR aims at fixing some issues found when preparing the release, namely: 1) enabling kubeops via --set flag (only needed now we added this new param and it is not available in the current-1 chart version yet), 2) reverting the change in the cronjob API.
 
### Benefits

Kubeapps will continue to [work in k8s 1.20](https://app.circleci.com/pipelines/github/kubeapps/kubeapps/5106/workflows/78c1abb8-7a40-442f-9927-6c1c1c74b224/jobs/65517)

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

The issues found arise two questions to me:

1) Should we start using the same approach for selecting the API group version as we did in the past (you know, the fix Michael did when removing the unsafe lookup function) to spin up the cronjobs?

2) Should we clearly state in the project readme the current supported k8s versions?  And, what's more, perhaps also adding the tested stack: like kapp-ctrl 0.30, OLM 1.17, Helm 3.x.x-3.7.1, pinniped 10,etc ?

If you all agree, happy to create a couple of issues to track them
