### PR TITLE
Watch specific resources rather than list of all gvrs.

### DIFF
--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
@@ -282,7 +282,7 @@ func (s *packagesServer) GetInstalledPackageResourceRefs(ctx context.Context, re
 	pkgRef := request.GetInstalledPackageRef()
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", pkgRef.GetContext().GetCluster(), pkgRef.GetContext().GetNamespace())
 	identifier := pkgRef.GetIdentifier()
-	log.Infof("+core GetResources %s %s", contextMsg, identifier)
+	log.Infof("+core GetInstalledPackageResourceRefs %s %s", contextMsg, identifier)
 
 	if request.GetInstalledPackageRef().GetPlugin() == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Unable to retrieve the plugin (missing InstalledPackageRef.Plugin)")

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release.go
@@ -712,8 +712,13 @@ func resourceRefsFromManifest(m, pkgNamespace string) ([]*corev1.ResourceRef, er
 		// Helm does not require that the rendered manifest specifies the
 		// resource namespace so some charts do not do so (ldap).  We explicitly
 		// set the namespace for the resource ref so that it can be used as part
-		// of the key for the resource ref.  At the moment we do not distinguish
-		// between cluster-scoped and namespace-scoped resources for the refs.
+		// of the key for the resource ref.
+		// TODO(minelson): At the moment we do not distinguish between
+		// cluster-scoped and namespace-scoped resources for the refs.  This
+		// does not affect the resources plugin fetching them correctly, but
+		// would be better if we only set the namespace in the reference if (a)
+		// it was not set in the manifest, and (b) it is a namespace-scoped
+		// resource.
 		namespace := doc.Metadata.Namespace
 		if namespace == "" {
 			namespace = pkgNamespace

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
@@ -847,6 +847,46 @@ metadata:
 			},
 		},
 		{
+			name: "returns resource references with explicit namespace when not present in helm manifest",
+			existingHelmStubs: []helmReleaseStub{
+				{
+					name:      releaseName,
+					namespace: releaseNamespace,
+					manifest: `
+---
+# Source: redis/templates/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-test
+`,
+				},
+			},
+			request: &corev1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &corev1.InstalledPackageReference{
+					Context: &corev1.Context{
+						Cluster:   "default",
+						Namespace: releaseNamespace,
+					},
+					Identifier: releaseName,
+				},
+			},
+			expectedResponse: &corev1.GetInstalledPackageResourceRefsResponse{
+				Context: &corev1.Context{
+					Cluster:   "default",
+					Namespace: releaseNamespace,
+				},
+				ResourceRefs: []*corev1.ResourceRef{
+					{
+						ApiVersion: "v1",
+						Name:       "redis-test",
+						Namespace:  "test",
+						Kind:       "Service",
+					},
+				},
+			},
+		},
+		{
 			name: "returns resource references for resources in other namespaces",
 			existingHelmStubs: []helmReleaseStub{
 				{
@@ -885,6 +925,7 @@ metadata:
 					{
 						ApiVersion: "v1",
 						Name:       "test-cluster-role",
+						Namespace:  "test",
 						Kind:       "ClusterRole",
 					},
 					{
@@ -934,6 +975,7 @@ metadata:
 					{
 						ApiVersion: "apps/v1",
 						Name:       "redis-test",
+						Namespace:  "test",
 						Kind:       "Deployment",
 					},
 				},
@@ -1014,6 +1056,7 @@ metadata:
 					{
 						ApiVersion: "apps/v1",
 						Name:       "redis-test",
+						Namespace:  "test",
 						Kind:       "Deployment",
 					},
 				},
@@ -1053,6 +1096,7 @@ metadata:
 					{
 						ApiVersion: "apps/v1",
 						Name:       "redis-test",
+						Namespace:  "test",
 						Kind:       "Deployment",
 					},
 				},
@@ -1208,11 +1252,13 @@ items:
 					{
 						ApiVersion: "rbac.authorization.k8s.io/v1",
 						Name:       "clusterrole-1",
+						Namespace:  "test",
 						Kind:       "ClusterRole",
 					},
 					{
 						ApiVersion: "rbac.authorization.k8s.io/v1",
 						Name:       "clusterrole-2",
+						Namespace:  "test",
 						Kind:       "ClusterRole",
 					},
 				},

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -528,7 +528,7 @@ func (s *Server) GetInstalledPackageResourceRefs(ctx context.Context, request *c
 		return nil, status.Errorf(codes.Internal, "Unable to run Helm get action: %v", err)
 	}
 
-	refs, err := resourceRefsFromManifest(release.Manifest)
+	refs, err := resourceRefsFromManifest(release.Manifest, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -1210,7 +1210,7 @@ func (s *Server) GetInstalledPackageResourceRefs(ctx context.Context, request *c
 	pkgRef := request.GetInstalledPackageRef()
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", pkgRef.GetContext().GetCluster(), pkgRef.GetContext().GetNamespace())
 	identifier := pkgRef.GetIdentifier()
-	log.Infof("+helm GetResources %s %s", contextMsg, identifier)
+	log.Infof("+helm GetInstalledPackageResourceRefs %s %s", contextMsg, identifier)
 
 	namespace := pkgRef.GetContext().GetNamespace()
 
@@ -1229,7 +1229,7 @@ func (s *Server) GetInstalledPackageResourceRefs(ctx context.Context, request *c
 		return nil, status.Errorf(codes.Internal, "Unable to run Helm get action: %v", err)
 	}
 
-	refs, err := resourceRefsFromManifest(release.Manifest)
+	refs, err := resourceRefsFromManifest(release.Manifest, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -1253,7 +1253,8 @@ type YAMLResource struct {
 }
 
 // resourceRefsFromManifest returns the resource refs for a given yaml manifest.
-func resourceRefsFromManifest(m string) ([]*corev1.ResourceRef, error) {
+// TODO(minelson): share common functionality between plugins.
+func resourceRefsFromManifest(m, pkgNamespace string) ([]*corev1.ResourceRef, error) {
 	decoder := yaml.NewYAMLToJSONDecoder(strings.NewReader(m))
 	refs := []*corev1.ResourceRef{}
 	doc := YAMLResource{}
@@ -1270,20 +1271,33 @@ func resourceRefsFromManifest(m string) ([]*corev1.ResourceRef, error) {
 		}
 		if doc.Kind == "List" || doc.Kind == "RoleList" || doc.Kind == "ClusterRoleList" {
 			for _, i := range doc.Items {
+				namespace := i.Metadata.Namespace
+				if namespace == "" {
+					namespace = pkgNamespace
+				}
 				refs = append(refs, &corev1.ResourceRef{
 					ApiVersion: i.APIVersion,
 					Kind:       i.Kind,
 					Name:       i.Metadata.Name,
-					Namespace:  i.Metadata.Namespace,
+					Namespace:  namespace,
 				})
 			}
 			continue
+		}
+		// Helm does not require that the rendered manifest specifies the
+		// resource namespace so some charts do not do so (ldap).  We explicitly
+		// set the namespace for the resource ref so that it can be used as part
+		// of the key for the resource ref.  At the moment we do not distinguish
+		// between cluster-scoped and namespace-scoped resources for the refs.
+		namespace := doc.Metadata.Namespace
+		if namespace == "" {
+			namespace = pkgNamespace
 		}
 		refs = append(refs, &corev1.ResourceRef{
 			ApiVersion: doc.APIVersion,
 			Kind:       doc.Kind,
 			Name:       doc.Metadata.Name,
-			Namespace:  doc.Metadata.Namespace,
+			Namespace:  namespace,
 		})
 	}
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -1287,8 +1287,13 @@ func resourceRefsFromManifest(m, pkgNamespace string) ([]*corev1.ResourceRef, er
 		// Helm does not require that the rendered manifest specifies the
 		// resource namespace so some charts do not do so (ldap).  We explicitly
 		// set the namespace for the resource ref so that it can be used as part
-		// of the key for the resource ref.  At the moment we do not distinguish
-		// between cluster-scoped and namespace-scoped resources for the refs.
+		// of the key for the resource ref.
+		// TODO(minelson): At the moment we do not distinguish between
+		// cluster-scoped and namespace-scoped resources for the refs.  This
+		// does not affect the resources plugin fetching them correctly, but
+		// would be better if we only set the namespace in the reference if (a)
+		// it was not set in the manifest, and (b) it is a namespace-scoped
+		// resource.
 		namespace := doc.Metadata.Namespace
 		if namespace == "" {
 			namespace = pkgNamespace

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server_test.go
@@ -112,9 +112,9 @@ func getResourcesClient(t *testing.T, objects ...runtime.Object) (v1alpha1.Resou
 		},
 		// For testing, define a kindToResource converter that doesn't require
 		// a rest mapper.
-		kindToResource: func(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+		kindToResource: func(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVersionResource, meta.RESTScopeName, error) {
 			gvr, _ := meta.UnsafeGuessKindToResource(gvk)
-			return gvr, nil
+			return gvr, meta.RESTScopeNameNamespace, nil
 		},
 	})
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

While testing the Dashboard using the new resources plugin to watch k8s resources, I found a few issues in the plugin itself.

The main one being that the watch request was not limited to a particular resource but rather all gvr's in the namespace. Only noticed because I had two deployments in the default namespace with different replicas and was seeing the wrong number of pods in the UI.

Other small changes which I'll comment on inline.

### Benefits

<!-- What benefits will be realized by the code change? -->
Dashboard UX won't get confused when displaying k8s resources for an installed package (when I update to use the resources plugin in a following PR).

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3779

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
