### PR TITLE
Add actions for getting resources from resources plugin.

### DIFF
--- a/dashboard/.eslintrc.json
+++ b/dashboard/.eslintrc.json
@@ -13,7 +13,10 @@
       "version": "detect"
     },
     "import/resolver": {
-      "typescript": {}
+      "typescript": {},
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
     }
   },
   "extends": [

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -362,6 +362,7 @@ describe("getResources", () => {
           watch,
           handler: expect.any(Function),
           onError: expect.any(Function),
+          onComplete: expect.any(Function),
         },
       },
     ];

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -337,7 +337,7 @@ describe("getResourceKinds", () => {
 });
 
 describe("getResources", () => {
-  it("dispatches an requestResources action", () => {
+  it("dispatches a requestResources action", () => {
     const refs = [
       {
         apiVersion: "v1",
@@ -405,6 +405,35 @@ describe("processGetResourcesResponse", () => {
           key: expectedKey,
           resource: expectedResource,
         },
+      },
+    ];
+
+    actions.kube.processGetResourcesResponse(getResourcesResponse, store.dispatch);
+
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("dispatches an error action if the resourceRef is missing", () => {
+    const expectedResource = {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        name: "foo",
+        namespace: "default",
+      },
+    } as IResource;
+
+    const getResourcesResponse = {
+      manifest: {
+        value: new TextEncoder().encode(JSON.stringify(expectedResource)),
+        typeUrl: "",
+      },
+    } as GetResourcesResponse;
+
+    const expectedActions = [
+      {
+        type: getType(actions.kube.receiveResourcesError),
+        payload: new Error("received resource without a resource reference"),
       },
     ];
 

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -58,11 +58,16 @@ export const requestResources = createAction("REQUEST_RESOURCES", resolve => {
     watch: boolean,
     handler: (r: GetResourcesResponse) => void,
     onError: (e: Event) => void,
-  ) => resolve({ pkg, refs, watch, handler, onError });
+    onComplete: (pkg: InstalledPackageReference) => void,
+  ) => resolve({ pkg, refs, watch, handler, onError, onComplete });
 });
 
 export const receiveResourcesError = createAction("RECEIVE_RESOURCES_ERROR", resolve => {
   return (err: Error) => resolve(err);
+});
+
+export const closeRequestResources = createAction("CLOSE_REQUEST_RESOURCES", resolve => {
+  return (pkg: InstalledPackageReference) => resolve(pkg);
 });
 
 export const addTimer = createAction("ADD_TIMER", resolve => {
@@ -81,6 +86,7 @@ const allActions = [
   closeWatchResource,
   requestResources,
   receiveResourcesError,
+  closeRequestResources,
   receiveResourceFromList,
   requestResourceKinds,
   receiveResourceKinds,
@@ -188,6 +194,9 @@ export function getResources(
         },
         (e: any) => {
           dispatch(receiveResourcesError(e));
+        },
+        (pkg: InstalledPackageReference) => {
+          dispatch(closeRequestResources(pkg));
         },
       ),
     );

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -207,6 +207,10 @@ export function processGetResourcesResponse(
   r: GetResourcesResponse,
   dispatch: ThunkDispatch<IStoreState, null, KubeAction>,
 ) {
+  if (!r.resourceRef) {
+    dispatch(receiveResourcesError(new Error("received resource without a resource reference")))
+    return
+  }
   const key = keyForResourceRef(
     r.resourceRef!.apiVersion,
     r.resourceRef!.kind,

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -208,8 +208,8 @@ export function processGetResourcesResponse(
   dispatch: ThunkDispatch<IStoreState, null, KubeAction>,
 ) {
   if (!r.resourceRef) {
-    dispatch(receiveResourcesError(new Error("received resource without a resource reference")))
-    return
+    dispatch(receiveResourcesError(new Error("received resource without a resource reference")));
+    return;
   }
   const key = keyForResourceRef(
     r.resourceRef!.apiVersion,

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -1,8 +1,13 @@
-import { ThunkAction } from "redux-thunk";
+import { ThunkAction, ThunkDispatch } from "redux-thunk";
 import { Kube } from "shared/Kube";
-import ResourceRef from "shared/ResourceRef";
+import ResourceRef, { keyForResourceRef } from "shared/ResourceRef";
 import { IK8sList, IResource, IStoreState } from "shared/types";
 import { ActionType, deprecated } from "typesafe-actions";
+import {
+  ResourceRef as APIResourceRef,
+  InstalledPackageReference,
+} from "gen/kubeappsapis/core/packages/v1alpha1/packages";
+import { GetResourcesResponse } from "gen/kubeappsapis/plugins/resources/v1alpha1/resources";
 
 const { createAction } = deprecated;
 
@@ -44,6 +49,22 @@ export const closeWatchResource = createAction("CLOSE_WATCH_RESOURCE", resolve =
   return (ref: ResourceRef) => resolve(ref);
 });
 
+// requestResources takes a ResourceRef[] and subscribes to an observable to
+// process the responses as they arrive.
+export const requestResources = createAction("REQUEST_RESOURCES", resolve => {
+  return (
+    pkg: InstalledPackageReference,
+    refs: APIResourceRef[],
+    watch: boolean,
+    handler: (r: GetResourcesResponse) => void,
+    onError: (e: Event) => void,
+  ) => resolve({ pkg, refs, watch, handler, onError });
+});
+
+export const receiveResourcesError = createAction("RECEIVE_RESOURCES_ERROR", resolve => {
+  return (err: Error) => resolve(err);
+});
+
 export const addTimer = createAction("ADD_TIMER", resolve => {
   return (id: string, timer: () => void) => resolve({ id, timer });
 });
@@ -58,6 +79,8 @@ const allActions = [
   receiveResourceError,
   openWatchResource,
   closeWatchResource,
+  requestResources,
+  receiveResourcesError,
   receiveResourceFromList,
   requestResourceKinds,
   receiveResourceKinds,
@@ -145,4 +168,43 @@ export function getAndWatchResource(
       ),
     );
   };
+}
+
+// getResources requests and processes the responses for the resources
+// associated with an installed package.
+export function getResources(
+  pkg: InstalledPackageReference,
+  refs: APIResourceRef[],
+  watch: boolean,
+): ThunkAction<void, IStoreState, null, KubeAction> {
+  return dispatch => {
+    dispatch(
+      requestResources(
+        pkg,
+        refs,
+        watch,
+        (r: GetResourcesResponse) => {
+          processGetResourcesResponse(r, dispatch);
+        },
+        (e: any) => {
+          dispatch(receiveResourcesError(e));
+        },
+      ),
+    );
+  };
+}
+
+export function processGetResourcesResponse(
+  r: GetResourcesResponse,
+  dispatch: ThunkDispatch<IStoreState, null, KubeAction>,
+) {
+  const key = keyForResourceRef(
+    r.resourceRef!.apiVersion,
+    r.resourceRef!.kind,
+    r.resourceRef!.namespace,
+    r.resourceRef!.name,
+  );
+  const manifest = new TextDecoder().decode(r.manifest!.value);
+  const resource: IResource = JSON.parse(manifest);
+  dispatch(receiveResource({ key, resource }));
 }

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
@@ -16,6 +16,7 @@ const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
     items: resources,
     kinds: initialKinds,
     sockets: {},
+    subscriptions: {},
     timers: {},
   };
   return mockStore({ kube: state, config: { featureFlags: {} } });

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
@@ -16,6 +16,7 @@ const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
     items: resources,
     kinds: initialKinds,
     sockets: {},
+    subscriptions: {},
     timers: {},
   };
   return mockStore({ kube: state, config: { featureFlags: {} } });

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -50,8 +50,6 @@ describe("kubeReducer", () => {
       kinds: initialKinds,
       timers: {},
     };
-
-    Kube.getResources;
   });
 
   describe("reducer actions", () => {

--- a/dashboard/src/setupTests.ts
+++ b/dashboard/src/setupTests.ts
@@ -2,6 +2,7 @@ import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
 import Enzyme from "enzyme";
 import "jest-enzyme";
 import { WebSocket } from "mock-socket";
+import { TextDecoder, TextEncoder } from "util";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -12,3 +13,6 @@ jest.spyOn(window.localStorage.__proto__, "setItem");
 jest.spyOn(window.localStorage.__proto__, "removeItem");
 
 (global as any).WebSocket = WebSocket;
+
+(global as any).TextDecoder = TextDecoder;
+(global as any).TextEncoder = TextEncoder;

--- a/dashboard/src/shared/KubeappsGrpcClient.ts
+++ b/dashboard/src/shared/KubeappsGrpcClient.ts
@@ -1,12 +1,13 @@
 import { grpc } from "@improbable-eng/grpc-web";
 import { PackagesServiceClientImpl } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
-import {
-  GrpcWebImpl,
-  PluginsServiceClientImpl,
-} from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
+import { PluginsServiceClientImpl } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import { FluxV2PackagesServiceClientImpl } from "gen/kubeappsapis/plugins/fluxv2/packages/v1alpha1/fluxv2";
 import { HelmPackagesServiceClientImpl } from "gen/kubeappsapis/plugins/helm/packages/v1alpha1/helm";
 import { KappControllerPackagesServiceClientImpl } from "gen/kubeappsapis/plugins/kapp_controller/packages/v1alpha1/kapp_controller";
+import {
+  GrpcWebImpl,
+  ResourcesServiceClientImpl,
+} from "gen/kubeappsapis/plugins/resources/v1alpha1/resources";
 import { Auth } from "./Auth";
 import * as URL from "./url";
 
@@ -45,6 +46,11 @@ export class KubeappsGrpcClient {
 
   public getPluginsServiceClientImpl() {
     return new PluginsServiceClientImpl(this.getGrpcClient());
+  }
+
+  // Resources API
+  public getResourcesServiceClientImpl() {
+    return new ResourcesServiceClientImpl(this.getGrpcClient());
   }
 
   // Plugins (packages) APIs

--- a/dashboard/src/shared/ResourceRef.ts
+++ b/dashboard/src/shared/ResourceRef.ts
@@ -21,7 +21,7 @@ export function fromCRD(
   return ref;
 }
 
-// TODO: (minelson) Update to use API resourceRef type once old model removed.
+// TODO(minelson): Update to use API resourceRef type once old model removed.
 export const keyForResourceRef = (
   apiVersion: string,
   kind: string,

--- a/dashboard/src/shared/ResourceRef.ts
+++ b/dashboard/src/shared/ResourceRef.ts
@@ -21,6 +21,14 @@ export function fromCRD(
   return ref;
 }
 
+// TODO: (minelson) Update to use API resourceRef type once old model removed.
+export const keyForResourceRef = (
+  apiVersion: string,
+  kind: string,
+  namespace: string,
+  name: string,
+) => `${apiVersion}/${kind}/${namespace}/${name}`;
+
 // ResourceRef defines a reference to a namespaced Kubernetes API Object and
 // provides helpers to retrieve the resource URL
 class ResourceRef {

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -1,5 +1,7 @@
 import { JSONSchemaType } from "ajv";
 import { RouterState } from "connected-react-router";
+/* eslint-disable-next-line import/no-unresolved */
+import { Subscription } from "rxjs";
 import {
   AvailablePackageDetail,
   AvailablePackageSummary,
@@ -14,6 +16,7 @@ import { IAuthState } from "../reducers/auth";
 import { IClustersState } from "../reducers/cluster";
 import { IConfigState } from "../reducers/config";
 import { IAppRepositoryState } from "../reducers/repos";
+
 class CustomError extends Error {
   // The constructor is defined so we can later on compare the returned object
   // via err.contructor  == FOO
@@ -441,6 +444,7 @@ export interface IKind {
 export interface IKubeState {
   items: { [s: string]: IKubeItem<IResource | IK8sList<IResource, {}>> };
   sockets: { [s: string]: { socket: WebSocket; onError: (e: Event) => void } };
+  subscriptions: { [s: string]: Subscription };
   kinds: { [kind: string]: IKind };
   kindsError?: Error;
   timers: { [id: string]: NodeJS.Timer | undefined };

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -1,8 +1,5 @@
 import { JSONSchemaType } from "ajv";
 import { RouterState } from "connected-react-router";
-// TODO(minelson): Why is lint complaining:
-// error  Unable to resolve path to module 'rxjs'  import/no-unresolved
-/* eslint-disable-next-line import/no-unresolved */
 import { Subscription } from "rxjs";
 import {
   AvailablePackageDetail,

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -1,5 +1,8 @@
 import { JSONSchemaType } from "ajv";
 import { RouterState } from "connected-react-router";
+// TODO(minelson): Why is lint complaining:
+// error  Unable to resolve path to module 'rxjs'  import/no-unresolved
+/* eslint-disable-next-line import/no-unresolved */
 import { Subscription } from "rxjs";
 import {
   AvailablePackageDetail,

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -1,6 +1,5 @@
 import { JSONSchemaType } from "ajv";
 import { RouterState } from "connected-react-router";
-/* eslint-disable-next-line import/no-unresolved */
 import { Subscription } from "rxjs";
 import {
   AvailablePackageDetail,


### PR DESCRIPTION
### Description of the change

This PR adds the new required actions (and handling of those actions in the reducer) for interacting with the new resources plugin to get and watch resources.

This allows a single request to the resources plugin to watch many resources. The streaming rpc call uses [server-side events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) rather than web sockets, with the grpc-web client using rxjs observables which makes the implementation quite tidy.

### Benefits

This PR doesn't change the AppView yet, so the only benefit is preparation for the next PR where the AppView will be updated to use the new action.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3779 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
