### PR TITLE
Allow to sync and store charts with spaces in name (#3758)

### DIFF
--- a/cmd/asset-syncer/server/testdata/helm-index-spaces.yaml
+++ b/cmd/asset-syncer/server/testdata/helm-index-spaces.yaml
@@ -1,0 +1,7 @@
+entries:
+  chart-with-spaces:
+    - appVersion: v1
+      name: "chart\x20with\x20spaces"
+  chart-without-spaces:
+    - appVersion: v2
+      name: "chart-without-spaces"

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -1296,6 +1296,101 @@ func Test_filterCharts(t *testing.T) {
 	}
 }
 
+func TestUnescapeCharsData(t *testing.T) {
+	tests := []struct {
+		description string
+		input       []models.Chart
+		expected    []models.Chart
+	}{
+		{
+			"chart with encoded spaces in id",
+			[]models.Chart{
+				{ID: "foo%20bar"},
+			},
+			[]models.Chart{
+				{ID: "foo bar"},
+			},
+		},
+		{
+			"chart with encoded spaces in name",
+			[]models.Chart{
+				{Name: "foo%20bar"},
+			},
+			[]models.Chart{
+				{Name: "foo bar"},
+			},
+		},
+		{
+			"chart with mixed encoding in name",
+			[]models.Chart{
+				{Name: "test/foo%20bar"},
+			},
+			[]models.Chart{
+				{Name: "test/foo bar"},
+			},
+		},
+		{
+			"chart with no encoding nor spaces",
+			[]models.Chart{
+				{Name: "test/foobar"},
+			},
+			[]models.Chart{
+				{Name: "test/foobar"},
+			},
+		},
+		{
+			"chart with unencoded spaces",
+			[]models.Chart{
+				{Name: "test/foo bar"},
+			},
+			[]models.Chart{
+				{Name: "test/foo bar"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			res := unescapeChartsData(tt.input)
+			if !cmp.Equal(res, tt.expected) {
+				t.Errorf("Unexpected result: %v", cmp.Diff(res, tt.expected))
+			}
+		})
+	}
+}
+
+func TestHelmRepoAppliesUnescape(t *testing.T) {
+	repo := &models.RepoInternal{Name: "test", Namespace: "repo-namespace", URL: "http://testrepo.com"}
+	expectedRepo := &models.Repo{Name: repo.Name, Namespace: repo.Namespace, URL: repo.URL}
+	repoIndexYAMLBytes, _ := ioutil.ReadFile("testdata/helm-index-spaces.yaml")
+	repoIndexYAML := string(repoIndexYAMLBytes)
+	expectedCharts := []models.Chart{
+		{
+			ID:            "test/chart with spaces",
+			Name:          "chart with spaces",
+			Repo:          expectedRepo,
+			Maintainers:   []chart.Maintainer{},
+			ChartVersions: []models.ChartVersion{{AppVersion: "v1"}},
+		},
+		{
+			ID:            "test/chart-without-spaces",
+			Name:          "chart-without-spaces",
+			Repo:          expectedRepo,
+			Maintainers:   []chart.Maintainer{},
+			ChartVersions: []models.ChartVersion{{AppVersion: "v2"}},
+		},
+	}
+	helmRepo := &HelmRepo{
+		content:      []byte(repoIndexYAML),
+		RepoInternal: repo,
+	}
+	t.Run("Helm repo applies unescaping to chart data", func(t *testing.T) {
+		charts, _ := helmRepo.Charts(false)
+		if !cmp.Equal(charts, expectedCharts) {
+			t.Errorf("Unexpected result: %v", cmp.Diff(charts, expectedCharts))
+		}
+	})
+}
+
 func Test_isURLDomainEqual(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -1296,7 +1296,7 @@ func Test_filterCharts(t *testing.T) {
 	}
 }
 
-func TestUnescapeCharsData(t *testing.T) {
+func TestUnescapeChartsData(t *testing.T) {
 	tests := []struct {
 		description string
 		input       []models.Chart


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This PR allows to sync and store in DB charts that contain spaces in name. End user will then be allowed to reach to the package details page, and when deploying, the error thrown by Helm will be shown.
Applied only to Helm repos, not to OCI.

### Benefits

Kubeapps is transparent with regards to charts containing spaces in name. Those charts are synced and stored properly, and end user can navigate to package details now. However Helm installation will still fail due to its restrictions. [See here](https://github.com/kubeapps/kubeapps/issues/3758#issuecomment-981748752)

### Possible drawbacks

Packages that can not be installed are listed.
This fix applies only to spaces in name: should we do the same exercise for other special characters? Helm only allows alphanumeric, dash, dot and underscore.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #3758 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
