### PR TITLE
Add retries in CI rollback step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,6 +567,11 @@ local_e2e_steps: &local_e2e_steps
         command: for image in /tmp/images/*; do kind load image-archive "$image" --name kubeapps-ci; done
     - <<: *install_multicluster_deps
     - <<: *run_e2e_tests
+    - run:
+        name: Print k8s KubeappsAPIs logs if the tests fail
+        command: |
+            kubectl --context kind-kubeapps-ci --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci logs -n kubeapps-ci deploy/kubeapps-internal-kubeappsapis --previous=true
+        when: on_fail
     - store_artifacts:
         path: integration/reports
     - run: exit $TEST_RESULT

--- a/integration/use-cases/08-rollback.js
+++ b/integration/use-cases/08-rollback.js
@@ -57,26 +57,47 @@ test("Rolls back an application", async () => {
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   // Rollback to the previous revision (default selected value)
-  await page.waitForTimeout(2000);
-  await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
-  await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).not.toMatch("Loading");
-  await expect(page).toMatch("(current: 2)");
-  await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
+  await utils.retryAndRefresh(
+    page,
+    3,
+    async () => {
+      await page.waitForTimeout(2000);
+      await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
+      await expect(page).toClick("cds-button", { text: "Rollback" });
+      await expect(page).not.toMatch("Loading");
+      await expect(page).toMatch("(current: 2)");
+      await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
+    },
+    testName,
+  );
 
   // Check revision and rollback to a revision (manual selected value)
-  await page.waitForTimeout(2000);
-  await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).not.toMatch("Loading");
-  await expect(page).toMatch("(current: 3)");
+  await utils.retryAndRefresh(
+    page,
+    3,
+    async () => {
+      await page.waitForTimeout(2000);
+      await expect(page).toClick("cds-button", { text: "Rollback" });
+      await expect(page).not.toMatch("Loading");
+      await expect(page).toMatch("(current: 3)");
 
-  await expect(page).toSelect("cds-select > select", "1");
-  await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
+      await expect(page).toSelect("cds-select > select", "1");
+      await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
+    },
+    testName,
+  );
 
   // Check revisions
-  await page.waitForTimeout(2000);
-  await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
-  await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).not.toMatch("Loading");
-  await expect(page).toMatch("(current: 4)");
+  await utils.retryAndRefresh(
+    page,
+    3,
+    async () => {
+      await page.waitForTimeout(2000);
+      await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
+      await expect(page).toClick("cds-button", { text: "Rollback" });
+      await expect(page).not.toMatch("Loading");
+      await expect(page).toMatch("(current: 4)");
+    },
+    testName,
+  );
 });


### PR DESCRIPTION
### Description of the change

As one of the steps of the CI is increasingly failing, this PR adds some retries to absorb any transient issue related to network or timeouts.

### Benefits

CI passing again? Let's see....

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
