### PR TITLE
Use two replicas for Kubeapps-apis service in CI

### DIFF
--- a/integration/use-cases/08-rollback.js
+++ b/integration/use-cases/08-rollback.js
@@ -57,26 +57,47 @@ test("Rolls back an application", async () => {
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   // Rollback to the previous revision (default selected value)
-  await page.waitForTimeout(2000);
-  await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
-  await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).not.toMatch("Loading");
-  await expect(page).toMatch("(current: 2)");
-  await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
+  await utils.retryAndRefresh(
+    page,
+    3,
+    async () => {
+      await page.waitForTimeout(2000);
+      await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
+      await expect(page).toClick("cds-button", { text: "Rollback" });
+      await expect(page).not.toMatch("Loading");
+      await expect(page).toMatch("(current: 2)");
+      await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
+    },
+    testName,
+  );
 
   // Check revision and rollback to a revision (manual selected value)
-  await page.waitForTimeout(2000);
-  await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).not.toMatch("Loading");
-  await expect(page).toMatch("(current: 3)");
+  await utils.retryAndRefresh(
+    page,
+    3,
+    async () => {
+      await page.waitForTimeout(2000);
+      await expect(page).toClick("cds-button", { text: "Rollback" });
+      await expect(page).not.toMatch("Loading");
+      await expect(page).toMatch("(current: 3)");
 
-  await expect(page).toSelect("cds-select > select", "1");
-  await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
+      await expect(page).toSelect("cds-select > select", "1");
+      await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
+    },
+    testName,
+  );
 
   // Check revisions
-  await page.waitForTimeout(2000);
-  await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
-  await expect(page).toClick("cds-button", { text: "Rollback" });
-  await expect(page).not.toMatch("Loading");
-  await expect(page).toMatch("(current: 4)");
+  await utils.retryAndRefresh(
+    page,
+    3,
+    async () => {
+      await page.waitForTimeout(2000);
+      await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
+      await expect(page).toClick("cds-button", { text: "Rollback" });
+      await expect(page).not.toMatch("Loading");
+      await expect(page).toMatch("(current: 4)");
+    },
+    testName,
+  );
 });

--- a/integration/use-cases/08-rollback.js
+++ b/integration/use-cases/08-rollback.js
@@ -57,47 +57,26 @@ test("Rolls back an application", async () => {
   await expect(page).toClick("cds-button", { text: "Deploy" });
 
   // Rollback to the previous revision (default selected value)
-  await utils.retryAndRefresh(
-    page,
-    3,
-    async () => {
-      await page.waitForTimeout(2000);
-      await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
-      await expect(page).toClick("cds-button", { text: "Rollback" });
-      await expect(page).not.toMatch("Loading");
-      await expect(page).toMatch("(current: 2)");
-      await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
-    },
-    testName,
-  );
+  await page.waitForTimeout(2000);
+  await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
+  await expect(page).toClick("cds-button", { text: "Rollback" });
+  await expect(page).not.toMatch("Loading");
+  await expect(page).toMatch("(current: 2)");
+  await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
 
   // Check revision and rollback to a revision (manual selected value)
-  await utils.retryAndRefresh(
-    page,
-    3,
-    async () => {
-      await page.waitForTimeout(2000);
-      await expect(page).toClick("cds-button", { text: "Rollback" });
-      await expect(page).not.toMatch("Loading");
-      await expect(page).toMatch("(current: 3)");
+  await page.waitForTimeout(2000);
+  await expect(page).toClick("cds-button", { text: "Rollback" });
+  await expect(page).not.toMatch("Loading");
+  await expect(page).toMatch("(current: 3)");
 
-      await expect(page).toSelect("cds-select > select", "1");
-      await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
-    },
-    testName,
-  );
+  await expect(page).toSelect("cds-select > select", "1");
+  await expect(page).toClick("cds-modal-actions cds-button", { text: "Rollback" });
 
   // Check revisions
-  await utils.retryAndRefresh(
-    page,
-    3,
-    async () => {
-      await page.waitForTimeout(2000);
-      await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
-      await expect(page).toClick("cds-button", { text: "Rollback" });
-      await expect(page).not.toMatch("Loading");
-      await expect(page).toMatch("(current: 4)");
-    },
-    testName,
-  );
+  await page.waitForTimeout(2000);
+  await expect(page).toMatchElement(".application-status-pie-chart h5", { text: "Ready" });
+  await expect(page).toClick("cds-button", { text: "Rollback" });
+  await expect(page).not.toMatch("Loading");
+  await expect(page).toMatch("(current: 4)");
 });

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -189,7 +189,7 @@ installOrUpgradeKubeapps() {
     --set frontend.replicaCount=1
     --set kubeops.replicaCount=1
     --set dashboard.replicaCount=1
-    --set kubeappsapis.replicaCount=1
+    --set kubeappsapis.replicaCount=2
     --set kubeops.enabled=true
     --set postgresql.replication.enabled=false
     --set postgresql.postgresqlPassword=password


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Updates the CI deployment to use two replicas for the kubeapps-apis service.

We've been experiencing intermittent issues with the last e2e test, `08-rollback.js`, lately that appear to be getting more frequent.

I first added the same retries as Antonio had done in #3866 so that I could continue debugging, and found that the first screenshot (first failure) shows an error:

![08-rollback-0](https://user-images.githubusercontent.com/497518/144160163-267ef497-491e-477c-95a4-7a0d016e35c1.png)

while the second and third retries are just reloading the same page (though note that the update to the replicas is lost, so it shows 1 again) without error:

![08-rollback-1](https://user-images.githubusercontent.com/497518/144160316-08a7c4c7-a707-4883-b9a1-0cf2f036d2cc.png)

So an error is occurring, but then the retry is simply re-loading the page (without re-clicking on the deploy), which works fine, but is a different state to that expected. 

I then retried the e2e test with SSH enabled 3 times, and of course, it passed three times straight (perhaps they allocate more memory when ssh is enabled, not sure as I didn't check).

But I can reproduce the exact same error locally by getting a package ready to deploy, then scaling the apis server to 0, then deploying (same screenshot as first error above).

So I'm confident that the issue is a 502 at that point, perhaps due to OOM or similar.

I started investigating how we could work around this in the CI test by retrying with the deploy click included, or handling a 502, but realised that we're working around a problem which kubernetes already solves by avoiding a single point-of-failure. The only reason we're hitting this is because we scale all deployments to a single replica in CI to keep resources down, whereas a valid solution here is to not run with a SPOF for the kubeapps apis service and let k8s route the requests.

Of course, this doesn't mean we shouldn't also continue to learn more about the memory usage of the service, but it does provide a more realistic e2e test and solve the current CI intermittent issue, IMO.

### Benefits

More stable CI.

### Possible drawbacks

Extra resource required in CI (not a big deal)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
