### PR TITLE
Switch AppView to use new getResources.

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.6.1-dev1
+version: 7.6.2-dev1

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.6.2-dev0
+version: 7.6.1-dev1

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1605,6 +1605,7 @@ kubeappsapis:
   ##
   enabledPlugins:
     - helm
+    - resources
   pluginConfig:
     core:
       packages:

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
@@ -2,6 +2,7 @@ import actions from "actions";
 import LoadingWrapper from "components/LoadingWrapper/LoadingWrapper";
 import context from "jest-plugin-context";
 import * as ReactRedux from "react-redux";
+import ResourceRef, { keyForResourceRef } from "shared/ResourceRef";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
 import { IIngressSpec, IResource, IServiceSpec, IServiceStatus } from "shared/types";
 import AccessURLTable from "./AccessURLTable";
@@ -52,10 +53,16 @@ describe("when receiving ingresses", () => {
 context("when some resource is fetching", () => {
   it("shows a loadingWrapper when fetching services", () => {
     const serviceItem = { isFetching: true };
-    const svcUrl = "svc";
-    const serviceRefs = [{ name: "svc", getResourceURL: jest.fn(() => svcUrl) } as any];
+    const svcRef = {
+      apiVersion: "v1",
+      kind: "Service",
+      namespace: "test",
+      name: "svc",
+    } as ResourceRef;
+    const serviceRefs = [svcRef];
+    const svcKey = keyForResourceRef(svcRef.apiVersion, svcRef.kind, svcRef.namespace, svcRef.name);
     const state = {
-      kube: { items: { [svcUrl]: serviceItem } },
+      kube: { items: { [svcKey]: serviceItem } },
     };
     const store = getStore(state);
     const wrapper = mountWrapper(
@@ -68,10 +75,21 @@ context("when some resource is fetching", () => {
 
   it("displays the error (while fetching)", () => {
     const ingressItem = { isFetching: true };
-    const ingressUrl = "ingress";
-    const ingressRefs = [{ name: "svc", getResourceURL: jest.fn(() => ingressUrl) } as any];
+    const ingressRef = {
+      apiVersion: "v1",
+      kind: "Ingress",
+      namespace: "test",
+      name: "ingress",
+    } as ResourceRef;
+    const ingressRefs = [ingressRef];
+    const ingressKey = keyForResourceRef(
+      ingressRef.apiVersion,
+      ingressRef.kind,
+      ingressRef.namespace,
+      ingressRef.name,
+    );
     const state = {
-      kube: { items: { [ingressUrl]: ingressItem } },
+      kube: { items: { [ingressKey]: ingressItem } },
     };
     const store = getStore(state);
     const wrapper = mountWrapper(
@@ -105,9 +123,15 @@ context("when the app contains services", () => {
       } as IServiceStatus,
     } as IResource;
     const serviceItem = { isFetching: false, item: service };
-    const url = service.metadata.selfLink;
-    const serviceRefs = [{ name: "svc", getResourceURL: jest.fn(() => url) } as any];
-    const state = { kube: { items: { [url]: serviceItem } } };
+    const svcRef = {
+      apiVersion: "v1",
+      kind: "Service",
+      namespace: "test",
+      name: "svc",
+    } as ResourceRef;
+    const serviceRefs = [svcRef];
+    const svcKey = keyForResourceRef(svcRef.apiVersion, svcRef.kind, svcRef.namespace, svcRef.name);
+    const state = { kube: { items: { [svcKey]: serviceItem } } };
     const store = getStore(state);
     const wrapper = mountWrapper(
       store,
@@ -132,9 +156,15 @@ context("when the app contains services", () => {
       } as IServiceStatus,
     } as IResource;
     const serviceItem = { isFetching: false, item: service };
-    const url = service.metadata.selfLink;
-    const serviceRefs = [{ name: "svc", getResourceURL: jest.fn(() => url) } as any];
-    const state = { kube: { items: { [url]: serviceItem } } };
+    const svcRef = {
+      apiVersion: "v1",
+      kind: "Service",
+      namespace: "test",
+      name: "svc",
+    } as ResourceRef;
+    const serviceRefs = [svcRef];
+    const svcKey = keyForResourceRef(svcRef.apiVersion, svcRef.kind, svcRef.namespace, svcRef.name);
+    const state = { kube: { items: { [svcKey]: serviceItem } } };
     const store = getStore(state);
     const wrapper = mountWrapper(
       store,
@@ -164,9 +194,20 @@ context("when the app contains ingresses", () => {
       } as IIngressSpec,
     } as IResource;
     const ingressItem = { isFetching: false, item: ingress };
-    const url = ingress.metadata.selfLink;
-    const ingressRefs = [{ name: "svc", getResourceURL: jest.fn(() => url) } as any];
-    const state = { kube: { items: { [url]: ingressItem } } };
+    const ingressRef = {
+      apiVersion: "v1",
+      kind: "Ingress",
+      namespace: "test",
+      name: "ingress",
+    } as ResourceRef;
+    const ingressRefs = [ingressRef];
+    const ingressKey = keyForResourceRef(
+      ingressRef.apiVersion,
+      ingressRef.kind,
+      ingressRef.namespace,
+      ingressRef.name,
+    );
+    const state = { kube: { items: { [ingressKey]: ingressItem } } };
     const store = getStore(state);
     const wrapper = mountWrapper(
       store,
@@ -195,9 +236,20 @@ context("when the app contains ingresses", () => {
       } as IIngressSpec,
     } as IResource;
     const ingressItem = { isFetching: false, item: ingress };
-    const url = ingress.metadata.selfLink;
-    const ingressRefs = [{ name: "svc", getResourceURL: jest.fn(() => url) } as any];
-    const state = { kube: { items: { [url]: ingressItem } } };
+    const ingressRef = {
+      apiVersion: "v1",
+      kind: "Ingress",
+      namespace: "test",
+      name: "ingress",
+    } as ResourceRef;
+    const ingressRefs = [ingressRef];
+    const ingressKey = keyForResourceRef(
+      ingressRef.apiVersion,
+      ingressRef.kind,
+      ingressRef.namespace,
+      ingressRef.name,
+    );
+    const state = { kube: { items: { [ingressKey]: ingressItem } } };
     const store = getStore(state);
     const wrapper = mountWrapper(
       store,
@@ -236,8 +288,13 @@ context("when the app contains services and ingresses", () => {
       } as IServiceStatus,
     } as IResource;
     const serviceItem = { isFetching: false, item: service };
-    const svcUrl = service.metadata.selfLink;
-    const serviceRefs = [{ name: "svc", getResourceURL: jest.fn(() => svcUrl) } as any];
+    const svcRef = {
+      apiVersion: "v1",
+      kind: "Service",
+      namespace: "test",
+      name: "svc",
+    } as ResourceRef;
+    const serviceRefs = [svcRef];
     const ingress = {
       kind: "Ingress",
       metadata: {
@@ -256,10 +313,22 @@ context("when the app contains services and ingresses", () => {
       } as IIngressSpec,
     } as IResource;
     const ingressItem = { isFetching: false, item: ingress };
-    const ingressUrl = ingress.metadata.selfLink;
-    const ingressRefs = [{ name: "svc", getResourceURL: jest.fn(() => ingressUrl) } as any];
+    const ingressRef = {
+      apiVersion: "v1",
+      kind: "Ingress",
+      namespace: "test",
+      name: "ingress",
+    } as ResourceRef;
+    const ingressRefs = [ingressRef];
+    const svcKey = keyForResourceRef(svcRef.apiVersion, svcRef.kind, svcRef.namespace, svcRef.name);
+    const ingressKey = keyForResourceRef(
+      ingressRef.apiVersion,
+      ingressRef.kind,
+      ingressRef.namespace,
+      ingressRef.name,
+    );
     const state = {
-      kube: { items: { [svcUrl]: serviceItem, [ingressUrl]: ingressItem } },
+      kube: { items: { [svcKey]: serviceItem, [ingressKey]: ingressItem } },
     };
     const store = getStore(state);
     const wrapper = mountWrapper(
@@ -274,13 +343,30 @@ context("when the app contains services and ingresses", () => {
 context("when the app contains resources with errors", () => {
   it("displays the error (when resources with errors)", () => {
     const serviceItem = { isFetching: false, error: new Error("could not find Service") };
-    const svcUrl = "svc";
-    const serviceRefs = [{ name: "svc", getResourceURL: jest.fn(() => svcUrl) } as any];
+    const svcRef = {
+      apiVersion: "v1",
+      kind: "Service",
+      namespace: "test",
+      name: "svc",
+    } as ResourceRef;
+    const serviceRefs = [svcRef];
     const ingressItem = { isFetching: false, error: new Error("could not find Ingress") };
-    const ingressUrl = "ingress";
-    const ingressRefs = [{ name: "svc", getResourceURL: jest.fn(() => ingressUrl) } as any];
+    const ingressRef = {
+      apiVersion: "v1",
+      kind: "Ingress",
+      namespace: "test",
+      name: "ingress",
+    } as ResourceRef;
+    const ingressRefs = [ingressRef];
+    const svcKey = keyForResourceRef(svcRef.apiVersion, svcRef.kind, svcRef.namespace, svcRef.name);
+    const ingressKey = keyForResourceRef(
+      ingressRef.apiVersion,
+      ingressRef.kind,
+      ingressRef.namespace,
+      ingressRef.name,
+    );
     const state = {
-      kube: { items: { [svcUrl]: serviceItem, [ingressUrl]: ingressItem } },
+      kube: { items: { [svcKey]: serviceItem, [ingressKey]: ingressItem } },
     };
     const store = getStore(state);
     const wrapper = mountWrapper(

--- a/dashboard/src/components/AppView/AppSecrets/AppSecrets.test.tsx
+++ b/dashboard/src/components/AppView/AppSecrets/AppSecrets.test.tsx
@@ -1,4 +1,4 @@
-import ResourceRef from "shared/ResourceRef";
+import ResourceRef, { keyForResourceRef } from "shared/ResourceRef";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
 import { ISecret } from "shared/types";
 import SecretItemDatum from "../ResourceTable/ResourceItem/SecretItem/SecretItemDatum";
@@ -40,10 +40,16 @@ it("shows a message if there are no secrets", () => {
 });
 
 it("renders a secretItemDatum per secret", () => {
+  const key = keyForResourceRef(
+    sampleResourceRef.apiVersion,
+    sampleResourceRef.kind,
+    sampleResourceRef.namespace,
+    sampleResourceRef.name,
+  );
   const state = getStore({
     kube: {
       items: {
-        "secret-foo": {
+        [key]: {
           isFetching: false,
           item: secret,
         },

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -1,4 +1,5 @@
 import actions from "actions";
+import { getType } from "typesafe-actions";
 import Alert from "components/js/Alert";
 import LoadingWrapper from "components/LoadingWrapper/LoadingWrapper";
 import PageHeader from "components/PageHeader";
@@ -43,92 +44,92 @@ let spyOnUseDispatch: jest.SpyInstance;
 const appActions = { ...actions.apps };
 const kubeaActions = { ...actions.kube };
 
-beforeEach(() => {
-  actions.apps = {
-    ...actions.apps,
-    getApp: jest.fn(),
-  };
-  actions.kube = {
-    ...actions.kube,
-    getAndWatchResource: jest.fn(),
-    closeWatchResource: jest.fn(),
-  };
-  const mockDispatch = jest.fn();
-  spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
-});
+const installedPackage = {
+  name: "test",
+  postInstallationNotes: "test",
+  valuesApplied: "test",
+  availablePackageRef: {
+    identifier: "apache/1",
+    plugin: { name: PluginNames.PACKAGES_HELM },
+    context: { cluster: "", namespace: "chart-namespace" } as Context,
+  } as AvailablePackageReference,
+  currentVersion: { appVersion: "10.0.0", pkgVersion: "1.0.0" } as PackageAppVersion,
+  installedPackageRef: {
+    identifier: "apache/1",
+    pkgVersion: "1.0.0",
+    context: { cluster: "", namespace: "package-namespace" } as Context,
+    plugin: { name: "my.plugin", version: "0.0.1" } as Plugin,
+  } as InstalledPackageReference,
+  latestMatchingVersion: { appVersion: "10.0.0", pkgVersion: "1.0.0" } as PackageAppVersion,
+  latestVersion: { appVersion: "10.0.0", pkgVersion: "1.0.0" } as PackageAppVersion,
+  pkgVersionReference: { version: "1" } as VersionReference,
+  reconciliationOptions: {},
+  status: {
+    ready: true,
+    reason: InstalledPackageStatus_StatusReason.STATUS_REASON_INSTALLED,
+    userReason: "deployed",
+  } as InstalledPackageStatus,
+} as InstalledPackageDetail;
 
-afterEach(() => {
-  actions.apps = { ...appActions };
-  actions.kube = { ...kubeaActions };
-  spyOnUseDispatch.mockRestore();
-});
+const resourceRefs = {
+  configMap: { apiVersion: "v1", kind: "ConfigMap", name: "cm-one" } as APIResourceRef,
+  deployment: {
+    apiVersion: "apps/v1beta1",
+    kind: "Deployment",
+    name: "deployment-one",
+  } as APIResourceRef,
+  service: { apiVersion: "v1", kind: "Service", name: "svc-one" } as APIResourceRef,
+  ingress: {
+    apiVersion: "extensions/v1beta1",
+    kind: "Ingress",
+    name: "ingress-one",
+  } as APIResourceRef,
+  secret: {
+    apiVersion: "v1",
+    kind: "Secret",
+    name: "secret-one",
+  } as APIResourceRef,
+  daemonset: {
+    apiVersion: "apps/v1beta1",
+    kind: "DaemonSet",
+    name: "daemonset-one",
+  } as APIResourceRef,
+  statefulset: {
+    apiVersion: "apps/v1beta1",
+    kind: "StatefulSet",
+    name: "statefulset-one",
+  } as APIResourceRef,
+};
+
+const validState = {
+  apps: {
+    selected: {
+      ...installedPackage,
+      resourceRefs: [resourceRefs.configMap] as APIResourceRef[],
+    },
+  },
+};
 
 describe("AppView", () => {
-  const installedPackage = {
-    name: "test",
-    postInstallationNotes: "test",
-    valuesApplied: "test",
-    availablePackageRef: {
-      identifier: "apache/1",
-      plugin: { name: PluginNames.PACKAGES_HELM },
-      context: { cluster: "", namespace: "chart-namespace" } as Context,
-    } as AvailablePackageReference,
-    currentVersion: { appVersion: "10.0.0", pkgVersion: "1.0.0" } as PackageAppVersion,
-    installedPackageRef: {
-      identifier: "apache/1",
-      pkgVersion: "1.0.0",
-      context: { cluster: "", namespace: "package-namespace" } as Context,
-      plugin: { name: "my.plugin", version: "0.0.1" } as Plugin,
-    } as InstalledPackageReference,
-    latestMatchingVersion: { appVersion: "10.0.0", pkgVersion: "1.0.0" } as PackageAppVersion,
-    latestVersion: { appVersion: "10.0.0", pkgVersion: "1.0.0" } as PackageAppVersion,
-    pkgVersionReference: { version: "1" } as VersionReference,
-    reconciliationOptions: {},
-    status: {
-      ready: true,
-      reason: InstalledPackageStatus_StatusReason.STATUS_REASON_INSTALLED,
-      userReason: "deployed",
-    } as InstalledPackageStatus,
-  } as InstalledPackageDetail;
+  beforeEach(() => {
+    actions.apps = {
+      ...actions.apps,
+      getApp: jest.fn(),
+    };
+    actions.kube = {
+      ...actions.kube,
+      getAndWatchResource: jest.fn(),
+      closeWatchResource: jest.fn(),
+    };
+    const mockDispatch = jest.fn();
+    spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
+  });
 
-  const resourceRefs = {
-    configMap: { apiVersion: "v1", kind: "ConfigMap", name: "cm-one" } as APIResourceRef,
-    deployment: {
-      apiVersion: "apps/v1beta1",
-      kind: "Deployment",
-      name: "deployment-one",
-    } as APIResourceRef,
-    service: { apiVersion: "v1", kind: "Service", name: "svc-one" } as APIResourceRef,
-    ingress: {
-      apiVersion: "extensions/v1beta1",
-      kind: "Ingress",
-      name: "ingress-one",
-    } as APIResourceRef,
-    secret: {
-      apiVersion: "v1",
-      kind: "Secret",
-      name: "secret-one",
-    } as APIResourceRef,
-    daemonset: {
-      apiVersion: "apps/v1beta1",
-      kind: "DaemonSet",
-      name: "daemonset-one",
-    } as APIResourceRef,
-    statefulset: {
-      apiVersion: "apps/v1beta1",
-      kind: "StatefulSet",
-      name: "statefulset-one",
-    } as APIResourceRef,
-  };
-
-  const validState = {
-    apps: {
-      selected: {
-        ...installedPackage,
-        resourceRefs: [resourceRefs.configMap] as APIResourceRef[],
-      },
-    },
-  };
+  afterEach(() => {
+    actions.apps = { ...appActions };
+    actions.kube = { ...kubeaActions };
+    spyOnUseDispatch.mockRestore();
+  });
 
   it("renders a loading wrapper", () => {
     const wrapper = mountWrapper(defaultStore, <AppView />);
@@ -289,33 +290,6 @@ describe("AppView", () => {
       ]);
     });
 
-    it("watches the given resources and close watchers", async () => {
-      const getResources = jest.fn();
-      const closeRequestResources = jest.fn();
-      actions.kube = {
-        ...actions.kube,
-        getResources,
-        closeRequestResources,
-      };
-      const apiResourceRefs = [resourceRefs.deployment, resourceRefs.service] as APIResourceRef[];
-
-      const wrapper = mountWrapper(
-        getStore({ apps: { selected: { ...installedPackage, apiResourceRefs } } }),
-        <MemoryRouter initialEntries={[routePathParam]}>
-          <Route path={routePath}>
-            <AppView />
-          </Route>
-        </MemoryRouter>,
-      );
-      expect(getResources).toHaveBeenCalledWith(
-        installedPackage.installedPackageRef,
-        apiResourceRefs,
-        true,
-      );
-      wrapper.unmount();
-      expect(closeRequestResources).toHaveBeenCalledWith(installedPackage.installedPackageRef);
-    });
-
     it("stores other k8s resources", () => {
       const apiResourceRefs = [
         resourceRefs.deployment,
@@ -415,6 +389,76 @@ describe("AppView", () => {
         true,
         installedPackage.installedPackageRef!.context!.namespace,
       ),
+    ]);
+  });
+});
+
+describe("AppView actions", () => {
+  it("watches the given resources when mounted", async () => {
+    const apiResourceRefs = [resourceRefs.deployment, resourceRefs.service] as APIResourceRef[];
+    const store = getStore({ apps: { selected: { ...installedPackage, apiResourceRefs } } });
+
+    mountWrapper(
+      store,
+      <MemoryRouter initialEntries={[routePathParam]}>
+        <Route path={routePath}>
+          <AppView />
+        </Route>
+      </MemoryRouter>,
+    );
+
+    const watch = true;
+    expect(store.getActions()).toEqual([
+      {
+        type: getType(actions.apps.requestApps),
+      },
+      {
+        type: getType(actions.kube.requestResources),
+        payload: {
+          pkg: installedPackage.installedPackageRef,
+          refs: apiResourceRefs,
+          watch,
+          handler: expect.any(Function),
+          onError: expect.any(Function),
+          onComplete: expect.any(Function),
+        },
+      },
+    ]);
+  });
+  it("closes the watches when unmounted", async () => {
+    const apiResourceRefs = [resourceRefs.deployment, resourceRefs.service] as APIResourceRef[];
+
+    const store = getStore({ apps: { selected: { ...installedPackage, apiResourceRefs } } });
+    const wrapper = mountWrapper(
+      store,
+      <MemoryRouter initialEntries={[routePathParam]}>
+        <Route path={routePath}>
+          <AppView />
+        </Route>
+      </MemoryRouter>,
+    );
+    wrapper.unmount();
+
+    const watch = true;
+    expect(store.getActions()).toEqual([
+      {
+        type: getType(actions.apps.requestApps),
+      },
+      {
+        type: getType(actions.kube.requestResources),
+        payload: {
+          pkg: installedPackage.installedPackageRef,
+          refs: apiResourceRefs,
+          watch,
+          handler: expect.any(Function),
+          onError: expect.any(Function),
+          onComplete: expect.any(Function),
+        },
+      },
+      {
+        type: getType(actions.kube.closeRequestResources),
+        payload: installedPackage.installedPackageRef,
+      },
     ]);
   });
 });

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -290,32 +290,14 @@ describe("AppView", () => {
     });
 
     it("watches the given resources and close watchers", async () => {
-      const watchResource = jest.fn();
-      const closeWatch = jest.fn();
+      const getResources = jest.fn();
+      const closeRequestResources = jest.fn();
       actions.kube = {
         ...actions.kube,
-        getAndWatchResource: watchResource,
-        closeWatchResource: closeWatch,
+        getResources,
+        closeRequestResources,
       };
       const apiResourceRefs = [resourceRefs.deployment, resourceRefs.service] as APIResourceRef[];
-      const depResource = {
-        cluster: routeParams.cluster,
-        apiVersion: resourceRefs.deployment.apiVersion,
-        kind: resourceRefs.deployment.kind,
-        name: resourceRefs.deployment.name,
-        namespace: installedPackage.installedPackageRef?.context?.namespace,
-        namespaced: true,
-        plural: "deployments",
-      };
-      const svcResource = {
-        cluster: routeParams.cluster,
-        apiVersion: resourceRefs.service.apiVersion,
-        kind: resourceRefs.service.kind,
-        name: resourceRefs.service.name,
-        namespace: installedPackage.installedPackageRef?.context?.namespace,
-        namespaced: true,
-        plural: "services",
-      };
 
       const wrapper = mountWrapper(
         getStore({ apps: { selected: { ...installedPackage, apiResourceRefs } } }),
@@ -325,11 +307,13 @@ describe("AppView", () => {
           </Route>
         </MemoryRouter>,
       );
-      expect(watchResource).toHaveBeenCalledWith(depResource);
-      expect(watchResource).toHaveBeenCalledWith(svcResource);
+      expect(getResources).toHaveBeenCalledWith(
+        installedPackage.installedPackageRef,
+        apiResourceRefs,
+        true,
+      );
       wrapper.unmount();
-      expect(closeWatch).toHaveBeenCalledWith(depResource);
-      expect(closeWatch).toHaveBeenCalledWith(svcResource);
+      expect(closeRequestResources).toHaveBeenCalledWith(installedPackage.installedPackageRef);
     });
 
     it("stores other k8s resources", () => {

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -219,7 +219,7 @@ export default function AppView() {
     return function cleanup() {
       actions.kube.closeRequestResources(app!.installedPackageRef!);
     };
-  }, [dispatch, app?.apiResourceRefs]);
+  }, [dispatch, app]);
 
   const forceRetry = () => {
     dispatch(actions.apps.clearErrorApp());

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -215,7 +215,7 @@ export default function AppView() {
     // TODO(minelson): Update to watch only those resources that
     // we're interested in watching change (deployments, statefulsets etc.)
     // and get the rest.
-    dispatch(actions.kube.getResources(app!.installedPackageRef!, app!.apiResourceRefs, true));
+    dispatch(actions.kube.getResources(app.installedPackageRef, app.apiResourceRefs, true));
     return function cleanup() {
       dispatch(actions.kube.closeRequestResources(app!.installedPackageRef!));
     };

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -217,7 +217,7 @@ export default function AppView() {
     // and get the rest.
     dispatch(actions.kube.getResources(app!.installedPackageRef!, app!.apiResourceRefs, true));
     return function cleanup() {
-      actions.kube.closeRequestResources(app!.installedPackageRef!);
+      dispatch(actions.kube.closeRequestResources(app!.installedPackageRef!));
     };
   }, [dispatch, app]);
 

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
@@ -1,6 +1,6 @@
 import Table from "components/js/Table";
 import LoadingWrapper from "components/LoadingWrapper/LoadingWrapper";
-import ResourceRef from "shared/ResourceRef";
+import ResourceRef, { keyForResourceRef } from "shared/ResourceRef";
 import { getStore, mountWrapper } from "shared/specs/mountWrapper";
 import { IResource } from "shared/types";
 import ResourceTable from "./ResourceTable";
@@ -21,11 +21,14 @@ const sampleResourceRef = {
   filter: "",
   plural: "deployments",
   namespaced: true,
-  getResourceURL: jest.fn(() => "deployment-foo"),
-  watchResourceURL: jest.fn(),
-  getResource: jest.fn(),
-  watchResource: jest.fn(),
 } as ResourceRef;
+
+const sampleKey = keyForResourceRef(
+  sampleResourceRef.apiVersion,
+  sampleResourceRef.kind,
+  sampleResourceRef.namespace,
+  sampleResourceRef.name,
+);
 
 const deployment = {
   kind: "Deployment",
@@ -43,7 +46,7 @@ it("renders a table with a resource", () => {
   const state = getStore({
     kube: {
       items: {
-        "deployment-foo": {
+        [sampleKey]: {
           isFetching: false,
           item: deployment as IResource,
         },
@@ -63,7 +66,7 @@ it("renders a table with a loading resource", () => {
   const state = getStore({
     kube: {
       items: {
-        "deployment-foo": {
+        [sampleKey]: {
           isFetching: true,
         },
       },
@@ -84,7 +87,7 @@ it("renders a table with an error", () => {
   const state = getStore({
     kube: {
       items: {
-        "deployment-foo": {
+        [sampleKey]: {
           isFetching: false,
           error: new Error("Boom!"),
         },
@@ -106,7 +109,7 @@ it("do not fail if the resources are already populated but the refs not yet", ()
   const state = getStore({
     kube: {
       items: {
-        "deployment-foo": {
+        [sampleKey]: {
           isFetching: false,
           item: deployment as IResource,
         },
@@ -115,30 +118,4 @@ it("do not fail if the resources are already populated but the refs not yet", ()
   });
   const wrapper = mountWrapper(state, <ResourceTable {...defaultProps} resourceRefs={[]} />);
   expect(wrapper.find(Table)).not.toExist();
-});
-
-it("renders the table with two entries with a list reference", () => {
-  const state = getStore({
-    kube: {
-      items: {
-        "deployment-foo": {
-          isFetching: false,
-          item: {
-            items: [
-              deployment as IResource,
-              { ...deployment, metadata: { name: "bar" } } as IResource,
-            ],
-          },
-        },
-      },
-    },
-  });
-  const wrapper = mountWrapper(
-    state,
-    <ResourceTable
-      {...defaultProps}
-      resourceRefs={[{ ...sampleResourceRef, name: "" } as ResourceRef]}
-    />,
-  );
-  expect(wrapper.find(Table).prop("data")).toHaveLength(2);
 });

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
@@ -2,7 +2,7 @@ import { shallow } from "enzyme";
 import { initialKinds } from "reducers/kube";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
-import ResourceRef from "shared/ResourceRef";
+import ResourceRef, { keyForResourceRef } from "shared/ResourceRef";
 import { ResourceRef as APIResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { IKubeItem, IKubeState, IResource } from "shared/types";
 import AccessURLTableContainer from ".";
@@ -34,10 +34,6 @@ describe("AccessURLTableContainer", () => {
       isFetching: false,
       item: { metadata: { name: `${name}-ingress` } } as IResource,
     };
-    const store = makeStore({
-      [`api/clusters/${clusterName}/api/v1/namespaces/wee/services/foo-service`]: service,
-      [`api/clusters/${clusterName}/api/v1/namespaces/wee/ingresses/foo-ingress`]: ingress,
-    });
     const serviceRef = new ResourceRef(
       {
         apiVersion: "v1",
@@ -49,6 +45,12 @@ describe("AccessURLTableContainer", () => {
       "services",
       true,
       "default",
+    );
+    const serviceKey = keyForResourceRef(
+      serviceRef.apiVersion,
+      serviceRef.kind,
+      serviceRef.namespace,
+      serviceRef.name,
     );
     const ingressRef = new ResourceRef(
       {
@@ -62,6 +64,16 @@ describe("AccessURLTableContainer", () => {
       true,
       "default",
     );
+    const ingressKey = keyForResourceRef(
+      ingressRef.apiVersion,
+      ingressRef.kind,
+      ingressRef.namespace,
+      ingressRef.name,
+    );
+    const store = makeStore({
+      [serviceKey]: service,
+      [ingressKey]: ingress,
+    });
     const wrapper = shallow(
       <AccessURLTableContainer
         store={store}

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
@@ -2,7 +2,7 @@ import { shallow } from "enzyme";
 import { initialKinds } from "reducers/kube";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
-import ResourceRef from "shared/ResourceRef";
+import ResourceRef, { keyForResourceRef } from "shared/ResourceRef";
 import { IKubeItem, IKubeState, IResource } from "shared/types";
 import ApplicationStatusContainer from ".";
 import ApplicationStatus from "../../components/ApplicationStatus";
@@ -27,9 +27,6 @@ describe("ApplicationStatusContainer", () => {
     const ns = "wee";
     const name = "foo";
     const item = { isFetching: false, item: { metadata: { name } } as IResource };
-    const store = makeStore({
-      [`api/clusters/${clusterName}/apis/apps/v1/namespaces/wee/deployments/foo`]: item,
-    });
     const ref = new ResourceRef(
       {
         apiVersion: "apps/v1",
@@ -42,6 +39,10 @@ describe("ApplicationStatusContainer", () => {
       true,
       "default",
     );
+    const key = keyForResourceRef(ref.apiVersion, ref.kind, ref.namespace, ref.name);
+    const store = makeStore({
+      [key]: item,
+    });
     const wrapper = shallow(
       <ApplicationStatusContainer
         store={store}

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.ts
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.ts
@@ -30,6 +30,7 @@ function mapDispatchToProps(
   props: IApplicationStatusContainerProps,
 ) {
   return {
+    // TODO: Why are we also dispatching a watch here for these?
     watchWorkloads: () => {
       [...props.deployRefs, ...props.statefulsetRefs, ...props.daemonsetRefs].forEach(r => {
         dispatch(actions.kube.getAndWatchResource(r));

--- a/dashboard/src/containers/helpers/index.test.ts
+++ b/dashboard/src/containers/helpers/index.test.ts
@@ -1,4 +1,4 @@
-import ResourceRef from "shared/ResourceRef";
+import ResourceRef, { keyForResourceRef } from "shared/ResourceRef";
 import { IKubeItem, IKubeState, IResource } from "shared/types";
 import { filterByResourceRefs } from ".";
 import { ResourceRef as APIResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
@@ -17,6 +17,12 @@ describe("filterByResourceRefs", () => {
     name: "bar",
     namespace: "foo",
   } as APIResourceRef;
+  const svc1Key = keyForResourceRef(
+    svc1Ref.apiVersion,
+    svc1Ref.kind,
+    svc1Ref.namespace,
+    svc1Ref.name,
+  );
   const svc2 = {
     apiVersion: "v1",
     kind: "Service",
@@ -28,6 +34,12 @@ describe("filterByResourceRefs", () => {
     name: "bar",
     namespace: "foo1",
   } as APIResourceRef;
+  const svc2Key = keyForResourceRef(
+    svc2Ref.apiVersion,
+    svc2Ref.kind,
+    svc2Ref.namespace,
+    svc2Ref.name,
+  );
   const deploy = {
     apiVersion: "apps/v1",
     kind: "Deployment",
@@ -35,13 +47,13 @@ describe("filterByResourceRefs", () => {
   } as IResource;
 
   const items: IKubeState["items"] = {
-    [`api/clusters/${clusterName}/api/v1/namespaces/foo/services/bar`]: {
+    [svc1Key]: {
       item: svc1,
     } as IKubeItem<IResource>,
-    [`api/clusters/${clusterName}/api/v1/namespaces/foo1/services/bar`]: {
+    [svc2Key]: {
       item: svc2,
     } as IKubeItem<IResource>,
-    [`api/clusters/${clusterName}/apis/apps/v1/namespaces/foo1/deployments/bar`]: {
+    "unused-key": {
       item: deploy,
     } as IKubeItem<IResource>,
   };

--- a/dashboard/src/containers/helpers/index.ts
+++ b/dashboard/src/containers/helpers/index.ts
@@ -1,4 +1,5 @@
-import ResourceRef from "shared/ResourceRef";
+import { keyForResourceRef } from "shared/ResourceRef";
+import { ResourceRef } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { IKubeState } from "shared/types";
 
 // Takes a set of ResourceRefs and the resources from the Redux state and
@@ -6,5 +7,7 @@ import { IKubeState } from "shared/types";
 // found are filtered out and the response will only contain resources that are
 // available in the state.
 export function filterByResourceRefs(refs: ResourceRef[], resources: IKubeState["items"]) {
-  return refs.map(r => resources[r.getResourceURL()]).filter(r => r !== undefined);
+  return refs
+    .map(r => resources[keyForResourceRef(r.apiVersion, r.kind, r.namespace, r.name)])
+    .filter(r => r !== undefined);
 }

--- a/dashboard/src/shared/utils.ts
+++ b/dashboard/src/shared/utils.ts
@@ -4,7 +4,7 @@ import fluxIcon from "../icons/flux.svg";
 import helmIcon from "../icons/helm.svg";
 import olmIcon from "../icons/olm-icon.svg";
 import placeholder from "../placeholder.png";
-import ResourceRef from "./ResourceRef";
+import ResourceRef, { keyForResourceRef } from "./ResourceRef";
 import { IK8sList, IKubeItem, IResource, ISecret } from "./types";
 
 export enum PluginNames {
@@ -51,7 +51,8 @@ export function flattenResources(
 ) {
   const result: Array<IKubeItem<IResource | ISecret>> = [];
   refs.forEach(ref => {
-    const kubeItem = resources[ref.getResourceURL()];
+    const kubeItem =
+      resources[keyForResourceRef(ref.apiVersion, ref.kind, ref.namespace, ref.name)];
     if (kubeItem) {
       const itemList = kubeItem.item as IK8sList<IResource | ISecret, {}>;
       if (itemList && itemList.items) {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Switches the AppView to use the new `getResources` action (using the resources plugin), with minimal changes to other code.

Checking the application detail for the Kubeapps app now only shows a single request for api server's `getResources` rather than 16 or so watch requests directly to the k8s api server:

![kubeapps-watch-resources](https://user-images.githubusercontent.com/497518/144186559-e2bb7c78-211b-4632-b499-161e14864f14.png)

And creating a new installation watches for updates so that the UI gets updated when pods are ready:

![apache-install](https://user-images.githubusercontent.com/497518/144186638-9a6503ed-ec75-4550-a652-40bac5f359c6.png)

### Benefits

* Single request for watching all resources.
* No longer hitting the k8s API server to do so
* Can now remove *lots* of code and simplify other code.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

See what CI says.
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3779

### Additional information

There will be a few PRs to follow removing lots of code, extracting the current `ResourceRef` model and all its dependencies, removing the request for all resource kinds from the server, and other indicated improvements like not watching all resources etc.

BTW: This is the third PR in a series, I've not yet landed the first until I hear that we're good to do so (ie., when the current release tag is final). Let me know :)
