### PR TITLE
Fix css overflow issues

### DIFF
--- a/dashboard/src/components/Header/Header.scss
+++ b/dashboard/src/components/Header/Header.scss
@@ -72,10 +72,15 @@
     padding-bottom: 0.6rem;
     border-bottom: 2px solid var(--cds-alias-object-border-color, #f1f1f1);
     margin: 0.6rem;
+    overflow-wrap: anywhere;
 
     &-title {
       margin: 0 0 0.2rem;
       font-weight: 600;
+    }
+
+    ul {
+      list-style-type: none;
     }
   }
 }

--- a/dashboard/src/components/PageHeader/PageHeader.scss
+++ b/dashboard/src/components/PageHeader/PageHeader.scss
@@ -1,6 +1,6 @@
 .kubeapps-header {
   width: 100%;
-  height: 4rem;
+  height: auto;
   padding-top: 0.3rem;
   border-bottom: 2px solid var(--cds-alias-object-overlay-background, #f1f1f1);
   background-color: var(--cds-alias-object-app-background, #fff);

--- a/dashboard/src/components/PageHeader/PageHeader.tsx
+++ b/dashboard/src/components/PageHeader/PageHeader.tsx
@@ -29,7 +29,7 @@ function PageHeader({
     <header className="kubeapps-header">
       <div className="kubeapps-header-content">
         <Row>
-          <Column span={7}>
+          <Column>
             <div className="kubeapps-title-section">
               <div className="img-container">{icon && <Icon icon={icon} />}</div>
               <div className="kubeapps-title-block">
@@ -50,7 +50,7 @@ function PageHeader({
               {filter}
             </div>
           </Column>
-          <Column span={5}>
+          <Column>
             <div className="control-buttons">
               {version && <div className="header-version">{version}</div>}
               {buttons ? (


### PR DESCRIPTION
### Description of the change

Since I'm working on the deployment/upgrade views, I couldn't resist fixing something that really annoys me: a wrong overflow when reducing the size of the window:sweat_smile: 

I also removed some <ul> bullets, but happy to revert back if you like them.

Before:

![image](https://user-images.githubusercontent.com/11535726/144288695-8c528876-6476-47f0-8e88-6ab4fa668148.png)

![image](https://user-images.githubusercontent.com/11535726/144289026-11b5e6d4-796d-4f86-972f-4e8e8877f839.png)


After:

![image](https://user-images.githubusercontent.com/11535726/144288763-8940cc02-3d7d-4267-8a08-a82d928ac549.png)

![image](https://user-images.githubusercontent.com/11535726/144288958-4c658627-9802-4142-8a75-eec946f9a995.png)



### Benefits

Better UI?

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
