### PR TITLE
Use cds-select in the deployment/upgrade views

### DIFF
--- a/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
+++ b/dashboard/src/components/DeploymentForm/DeploymentForm.tsx
@@ -1,3 +1,5 @@
+import { CdsFormGroup } from "@cds/react/forms";
+import { CdsInput } from "@cds/react/input";
 import actions from "actions";
 import AvailablePackageDetailExcerpt from "components/Catalog/AvailablePackageDetailExcerpt";
 import Alert from "components/js/Alert";
@@ -151,6 +153,7 @@ export default function DeploymentForm() {
       />
     );
   }
+  /* eslint-disable jsx-a11y/label-has-associated-control */
   return (
     <section>
       <PackageHeader
@@ -172,23 +175,24 @@ export default function DeploymentForm() {
           <Column span={9}>
             {error && <Alert theme="danger">An error occurred: {error.message}</Alert>}
             <form onSubmit={handleDeploy}>
-              <div>
-                <label
-                  htmlFor="releaseName"
-                  className="deployment-form-label deployment-form-label-text-param"
-                >
-                  Name
-                </label>
-                <input
-                  id="releaseName"
-                  pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
-                  title="Use lower case alphanumeric characters, '-' or '.'"
-                  className="clr-input deployment-form-text-input"
-                  onChange={handleReleaseNameChange}
-                  value={releaseName}
-                  required={true}
-                />
-              </div>
+              <CdsFormGroup
+                validate={true}
+                className="deployment-form"
+                layout="vertical"
+                controlWidth="shrink"
+              >
+                <CdsInput>
+                  <label>Name</label>
+                  <input
+                    id="releaseName"
+                    pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+                    title="Use lowercase alphanumeric characters, '-' or '.'"
+                    onChange={handleReleaseNameChange}
+                    value={releaseName}
+                    required={true}
+                  />
+                </CdsInput>
+              </CdsFormGroup>
               <DeploymentFormBody
                 deploymentEvent="install"
                 packageId={packageId}

--- a/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.scss
+++ b/dashboard/src/components/DeploymentFormBody/BasicDeploymentForm/BasicDeploymentForm.scss
@@ -30,6 +30,11 @@
   padding: 0.6rem 0;
 }
 
+.deployment-form {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
 .deployment-form-label {
   margin-bottom: 0.2rem;
   font-weight: 600;

--- a/dashboard/src/components/PackageHeader/PackageHeader.test.tsx
+++ b/dashboard/src/components/PackageHeader/PackageHeader.test.tsx
@@ -40,9 +40,10 @@ const testProps: IPackageHeaderProps = {
   onSelect: jest.fn(),
 };
 
-it("renders a header for the package", () => {
+it("renders a header for the package with display name", () => {
   const wrapper = mount(<PackageHeader {...testProps} />);
-  expect(wrapper.text()).toContain("testrepo/foo");
+  expect(wrapper.text()).toContain("foo");
+  expect(wrapper.text()).not.toContain("testrepo/foo");
 });
 
 it("displays the appVersion", () => {

--- a/dashboard/src/components/PackageHeader/PackageHeader.tsx
+++ b/dashboard/src/components/PackageHeader/PackageHeader.tsx
@@ -42,30 +42,32 @@ export default function PackageHeader({
       plugin={availablePackageDetail.availablePackageRef.plugin}
       version={
         <>
-          <label className="header-version-label" htmlFor="package-versions">
-            Package Version{" "}
-            <Tooltip
-              label="package-versions-tooltip"
-              id="package-versions-tooltip"
-              position="bottom-left"
-              iconProps={{ solid: true, size: "sm" }}
-            >
-              Package and application versions can be increased independently.{" "}
-              <a
-                href="https://helm.sh/docs/topics/charts/#charts-and-versioning"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                More info here
-              </a>
-              .{" "}
-            </Tooltip>
-          </label>
           <PackageVersionSelector
             versions={versions}
             onSelect={onSelect}
             selectedVersion={selectedVersion}
             currentVersion={currentVersion}
+            label={
+              <>
+                Package Version{" "}
+                <Tooltip
+                  label="package-versions-tooltip"
+                  id="package-versions-tooltip"
+                  position="bottom-left"
+                  iconProps={{ solid: true, size: "sm" }}
+                >
+                  Package and application versions can be increased independently.{" "}
+                  <a
+                    href="https://helm.sh/docs/topics/charts/#charts-and-versioning"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    More info here
+                  </a>
+                  .{" "}
+                </Tooltip>
+              </>
+            }
           />
         </>
       }

--- a/dashboard/src/components/PackageHeader/PackageHeader.tsx
+++ b/dashboard/src/components/PackageHeader/PackageHeader.tsx
@@ -35,7 +35,7 @@ export default function PackageHeader({
           ? `${releaseName} (${decodeURIComponent(
               availablePackageDetail.availablePackageRef.identifier,
             )})`
-          : `${decodeURIComponent(availablePackageDetail.availablePackageRef.identifier)}`
+          : `${decodeURIComponent(availablePackageDetail.displayName)}`
       }
       titleSize="md"
       icon={availablePackageDetail?.iconUrl ? availablePackageDetail.iconUrl : placeholder}

--- a/dashboard/src/components/PackageHeader/PackageVersionSelector.tsx
+++ b/dashboard/src/components/PackageHeader/PackageVersionSelector.tsx
@@ -1,11 +1,14 @@
+import { CdsControlMessage } from "@cds/react/forms";
+import { CdsSelect } from "@cds/react/select";
 import { PackageAppVersion } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import React from "react";
-
 interface IPackageVersionSelectorProps {
   versions: PackageAppVersion[];
   onSelect: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   currentVersion?: string;
   selectedVersion?: string;
+  label?: JSX.Element | string;
+  message?: string;
 }
 
 export default function PackageVersionSelector({
@@ -13,24 +16,26 @@ export default function PackageVersionSelector({
   onSelect,
   currentVersion,
   selectedVersion,
+  label,
+  message,
 }: IPackageVersionSelectorProps) {
+  /* eslint-disable jsx-a11y/label-has-associated-control */
   return (
-    <div className="clr-select-wrapper">
+    <CdsSelect>
+      <label>{label}</label>
       <select
         name="package-versions"
-        className="clr-page-size-select"
-        onChange={onSelect}
         value={selectedVersion || currentVersion || (versions.length ? versions[0].pkgVersion : "")}
+        onChange={onSelect}
       >
-        {versions.map(v => {
-          return (
-            <option key={`package-version-selector-${v.pkgVersion}`} value={v.pkgVersion}>
-              {v.pkgVersion} / App Version {v.appVersion}
-              {currentVersion === v.pkgVersion ? " (current)" : ""}
-            </option>
-          );
-        })}
+        {versions.map(v => (
+          <option key={`package-version-selector-${v.pkgVersion}`} value={v.pkgVersion}>
+            {v.pkgVersion} / App Version {v.appVersion}
+            {currentVersion === v.pkgVersion ? " (current)" : ""}
+          </option>
+        ))}
       </select>
-    </div>
+      {message ? <CdsControlMessage>{message}</CdsControlMessage> : <></>}
+    </CdsSelect>
   );
 }

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.scss
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.scss
@@ -1,3 +1,0 @@
-.upgrade-form-version-selector {
-  margin: 1.2rem 0 0.6rem;
-}

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -18,7 +18,6 @@ import { IStoreState } from "../../shared/types";
 import * as url from "../../shared/url";
 import DeploymentFormBody from "../DeploymentFormBody/DeploymentFormBody";
 import LoadingWrapper from "../LoadingWrapper/LoadingWrapper";
-import "./UpgradeForm.css";
 
 export interface IUpgradeFormProps {
   version?: string;

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -1,3 +1,4 @@
+import { CdsFormGroup } from "@cds/react/forms";
 import actions from "actions";
 import AvailablePackageDetailExcerpt from "components/Catalog/AvailablePackageDetailExcerpt";
 import Alert from "components/js/Alert";
@@ -219,10 +220,11 @@ function UpgradeForm(props: IUpgradeFormProps) {
                     </Column>
                     <Column span={9}>
                       <form onSubmit={handleDeploy}>
-                        <div className="upgrade-form-version-selector">
-                          <label className="centered deployment-form-label deployment-form-label-text-param">
-                            Upgrade to Version
-                          </label>
+                        <CdsFormGroup
+                          className="deployment-form"
+                          layout="vertical"
+                          controlWidth="shrink"
+                        >
                           <PackageVersionSelector
                             versions={versions}
                             selectedVersion={pkgVersion}
@@ -230,8 +232,10 @@ function UpgradeForm(props: IUpgradeFormProps) {
                             currentVersion={
                               installedAppInstalledPackageDetail?.currentVersion?.pkgVersion
                             }
+                            label={"Package Version"}
+                            message={"Select the version this package will be upgraded to."}
                           />
-                        </div>
+                        </CdsFormGroup>
                         <DeploymentFormBody
                           deploymentEvent="upgrade"
                           packageId={

--- a/integration/use-cases/02-create-private-registry.js
+++ b/integration/use-cases/02-create-private-registry.js
@@ -120,7 +120,7 @@ test("Creates a private registry", async () => {
     await new Promise(r => setTimeout(r, 500));
 
     packagehartVersionElement = await expect(page).toMatchElement(
-      '.upgrade-form-version-selector select[name="package-versions"]',
+      'select[name="package-versions"]',
     );
     packagehartVersionElementContent = await packageVersionElement.getProperty("value");
     packagehartVersionValue = await packageVersionElementContent.jsonValue();
@@ -137,7 +137,7 @@ test("Creates a private registry", async () => {
   await new Promise(r => setTimeout(r, 1000));
 
   await expect(page).toSelect(
-    '.upgrade-form-version-selector select[name="package-versions"]',
+    'select[name="package-versions"]',
     "8.6.3",
   );
 
@@ -145,7 +145,7 @@ test("Creates a private registry", async () => {
 
   // Ensure that the new value is selected
   packageVersionElement = await expect(page).toMatchElement(
-    '.upgrade-form-version-selector select[name="package-versions"]',
+    'select[name="package-versions"]',
   );
   packageVersionElementContent = await packageVersionElement.getProperty("value");
   packageVersionValue = await packageVersionElementContent.jsonValue();


### PR DESCRIPTION
### Description of the change

As part of the slow and continuous (?) process to migrate our UI to use the new Clarity CDS core components, I've moved the pkg version selects to the new ones. 

Before:

![image](https://user-images.githubusercontent.com/11535726/144290247-0a743980-560e-4106-ab38-8ae34c624c88.png)

![image](https://user-images.githubusercontent.com/11535726/144291260-e083b7e7-8120-449c-afd4-e68a323489c1.png)


After:

![image](https://user-images.githubusercontent.com/11535726/144290209-963b0427-a328-4f73-89e7-04f24ea9cbf7.png)

![image](https://user-images.githubusercontent.com/11535726/144291363-d0168de9-e7e9-40b5-b983-6713cda5fd47.png)


### Benefits

We will be able to add more components (like the ServiceAccount selector) without mixing `clr` and `cds` components.

Also, the `cds` component looks much better, it has a responsive layout already built-in, so less thing to worry about.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

I don't know if there is an actual reason for keeping two package version selectors... what do you think about removing the one in the header (just for the upgrade view, I mean). If you agree, I'll do it in a separate PR (perhaps it has some e2e tests implications and I want to land this one soon for the service account selector thing)
