### PR TITLE
Add GoFlag in CommandLine

### DIFF
--- a/cmd/kubeapps-apis/cmd/root.go
+++ b/cmd/kubeapps-apis/cmd/root.go
@@ -17,16 +17,17 @@ limitations under the License.
 package cmd
 
 import (
+	goflag "flag"
 	"fmt"
 	"os"
 
-	homedir "github.com/mitchellh/go-homedir"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	log "k8s.io/klog/v2"
-
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	log "k8s.io/klog/v2"
 )
 
 var (
@@ -65,10 +66,13 @@ func Execute() {
 }
 
 func init() {
+	log.InitFlags(nil)
 	cobra.OnInitialize(initConfig)
 	rootCmd = newRootCmd()
 	rootCmd.SetVersionTemplate(version)
 	setFlags(rootCmd)
+	goflag.Set("v", "3")
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 }
 
 func setFlags(c *cobra.Command) {
@@ -79,6 +83,7 @@ func setFlags(c *cobra.Command) {
 	c.Flags().StringVar(&serveOpts.PluginConfigPath, "plugin-config-path", "", "Configuration for plugins")
 	c.Flags().StringVar(&serveOpts.PinnipedProxyURL, "pinniped-proxy-url", "http://kubeapps-internal-pinniped-proxy.kubeapps:3333", "internal url to be used for requests to clusters configured for credential proxying via pinniped")
 	c.Flags().BoolVar(&serveOpts.UnsafeLocalDevKubeconfig, "unsafe-local-dev-kubeconfig", false, "if true, it will use the local kubeconfig at the KUBECONFIG env var instead of using the inCluster configuration.")
+
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Adding GoFlag command-line argument to kubeapps-apis binary. 

### Benefits

<!-- What benefits will be realized by the code change? -->
Developers can control the verbosity (--v) of log levels.


### Possible drawbacks

<!-- Describe any known limitations with your change -->
A bunch of more flags are listed in usage/help.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

[PR 3766 ](https://github.com/kubeapps/kubeapps/pull/3766)


