### PR TITLE
Fix install repo firing twice (#3678)

### DIFF
--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -123,15 +123,13 @@ it("should not call the install method when the validation fails unless forced",
       .text(),
   ).toContain("Install Repo (force)");
 
-  // So disabling this test for the moment.
   await act(async () => {
-    await (
-      wrapper
-        .find(CdsButton)
-        .filterWhere(b => b.html().includes("Install Repo (force)"))
-        .prop("onClick") as () => Promise<any>
-    )();
+    wrapper
+      .find(CdsButton)
+      .filterWhere(b => b.html().includes("Install Repo (force)"))
+      .simulate("submit");
   });
+  wrapper.update();
   expect(install).toHaveBeenCalled();
 });
 

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -50,6 +50,22 @@ it("disables the submit button while fetching", () => {
   ).toBe(true);
 });
 
+it("submit button can not be fired more than once", async () => {
+  const onSubmit = jest.fn().mockReturnValue(true);
+  const onAfterInstall = jest.fn().mockReturnValue(true);
+  const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} onSubmit={onSubmit} onAfterInstall={onAfterInstall} />);
+  const installButton = wrapper.find(CdsButton).filterWhere(b => b.html().includes("Install Repo"));
+  await act(async () => {
+    Promise.all([
+      installButton.simulate('submit'),
+      installButton.simulate('submit'),
+      installButton.simulate('submit')
+    ])
+  });
+  wrapper.update();
+  expect(onSubmit.mock.calls.length).toBe(1);
+});
+
 it("should show a validation error", () => {
   const wrapper = mountWrapper(
     getStore({ repos: { errors: { validate: new Error("Boom!") } } }),

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -53,14 +53,17 @@ it("disables the submit button while fetching", () => {
 it("submit button can not be fired more than once", async () => {
   const onSubmit = jest.fn().mockReturnValue(true);
   const onAfterInstall = jest.fn().mockReturnValue(true);
-  const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} onSubmit={onSubmit} onAfterInstall={onAfterInstall} />);
+  const wrapper = mountWrapper(
+    defaultStore,
+    <AppRepoForm {...defaultProps} onSubmit={onSubmit} onAfterInstall={onAfterInstall} />,
+  );
   const installButton = wrapper.find(CdsButton).filterWhere(b => b.html().includes("Install Repo"));
   await act(async () => {
     Promise.all([
-      installButton.simulate('submit'),
-      installButton.simulate('submit'),
-      installButton.simulate('submit')
-    ])
+      installButton.simulate("submit"),
+      installButton.simulate("submit"),
+      installButton.simulate("submit"),
+    ]);
   });
   wrapper.update();
   expect(onSubmit.mock.calls.length).toBe(1);

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -7,7 +7,7 @@ import { CdsTextarea } from "@cds/react/textarea";
 import actions from "actions";
 import Alert from "components/js/Alert";
 import * as yaml from "js-yaml";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
@@ -49,6 +49,7 @@ const TYPE_OCI = "oci";
 
 export function AppRepoForm(props: IAppRepoFormProps) {
   const { onSubmit, onAfterInstall, namespace, kubeappsNamespace, repo, secret } = props;
+  const workingRef = useRef(false);
   const dispatch: ThunkDispatch<IStoreState, null, Action> = useDispatch();
 
   const [authMethod, setAuthMethod] = useState(AUTH_METHOD_NONE);
@@ -156,6 +157,11 @@ export function AppRepoForm(props: IAppRepoFormProps) {
   };
 
   const install = async () => {
+    if (workingRef.current) {
+      // Another installation is ongoing
+      return;
+    }
+    workingRef.current = true;
     let finalHeader = "";
     let dockerRegCreds = "";
     switch (authMethod) {
@@ -217,6 +223,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
         onAfterInstall();
       }
     }
+    workingRef.current = false;
   };
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value);
@@ -620,7 +627,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
         </Alert>
       )}
       <div className="margin-t-xl">
-        <CdsButton disabled={validating} onClick={install}>
+        <CdsButton type="submit" disabled={validating}>
           {validating
             ? "Validating..."
             : `${repo ? "Update" : "Install"} Repo ${validated === false ? "(force)" : ""}`}

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -49,7 +49,7 @@ const TYPE_OCI = "oci";
 
 export function AppRepoForm(props: IAppRepoFormProps) {
   const { onSubmit, onAfterInstall, namespace, kubeappsNamespace, repo, secret } = props;
-  const workingRef = useRef(false);
+  const isInstallingRef = useRef(false);
   const dispatch: ThunkDispatch<IStoreState, null, Action> = useDispatch();
 
   const [authMethod, setAuthMethod] = useState(AUTH_METHOD_NONE);
@@ -157,11 +157,11 @@ export function AppRepoForm(props: IAppRepoFormProps) {
   };
 
   const install = async () => {
-    if (workingRef.current) {
+    if (isInstallingRef.current) {
       // Another installation is ongoing
       return;
     }
-    workingRef.current = true;
+    isInstallingRef.current = true;
     let finalHeader = "";
     let dockerRegCreds = "";
     switch (authMethod) {
@@ -223,7 +223,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
         onAfterInstall();
       }
     }
-    workingRef.current = false;
+    isInstallingRef.current = false;
   };
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value);


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Fixes the problem of "Install Repo" button being fired multiple times.

### Benefits

Repo installation process is not triggered more than once.

### Possible drawbacks

N/A

### Applicable issues

- fixes #3678

### Additional information

Makes use of [React's useRef](https://reactjs.org/docs/hooks-reference.html#useref)
