### PR TITLE
Remove watchResource and associated code.

### DIFF
--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -18,7 +18,8 @@ beforeEach(() => {
   store = mockStore({
     kube: {
       items: {},
-      sockets: {},
+      subscriptions: {},
+      kinds: {},
     } as IKubeState,
   });
 });

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -51,14 +51,6 @@ export const closeRequestResources = createAction("CLOSE_REQUEST_RESOURCES", res
   return (pkg: InstalledPackageReference) => resolve(pkg);
 });
 
-export const addTimer = createAction("ADD_TIMER", resolve => {
-  return (id: string, timer: () => void) => resolve({ id, timer });
-});
-
-export const removeTimer = createAction("REMOVE_TIMER", resolve => {
-  return (id: string) => resolve(id);
-});
-
 const allActions = [
   receiveResource,
   receiveResourceError,
@@ -68,8 +60,6 @@ const allActions = [
   requestResourceKinds,
   receiveResourceKinds,
   receiveKindsError,
-  addTimer,
-  removeTimer,
 ];
 
 export type KubeAction = ActionType<typeof allActions[number]>;
@@ -124,12 +114,7 @@ export function processGetResourcesResponse(
     dispatch(receiveResourcesError(new Error("received resource without a resource reference")));
     return;
   }
-  const key = keyForResourceRef(
-    r.resourceRef!.apiVersion,
-    r.resourceRef!.kind,
-    r.resourceRef!.namespace,
-    r.resourceRef!.name,
-  );
+  const key = keyForResourceRef(r.resourceRef);
   const manifest = new TextDecoder().decode(r.manifest!.value);
   const resource: IResource = JSON.parse(manifest);
   dispatch(receiveResource({ key, resource }));

--- a/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
+++ b/dashboard/src/components/AppView/AccessURLTable/AccessURLTable.test.tsx
@@ -21,7 +21,7 @@ context("when some resource is fetching", () => {
       name: "svc",
     } as ResourceRef;
     const serviceRefs = [svcRef];
-    const svcKey = keyForResourceRef(svcRef.apiVersion, svcRef.kind, svcRef.namespace, svcRef.name);
+    const svcKey = keyForResourceRef(svcRef);
     const state = {
       kube: { items: { [svcKey]: serviceItem } },
     };
@@ -43,12 +43,7 @@ context("when some resource is fetching", () => {
       name: "ingress",
     } as ResourceRef;
     const ingressRefs = [ingressRef];
-    const ingressKey = keyForResourceRef(
-      ingressRef.apiVersion,
-      ingressRef.kind,
-      ingressRef.namespace,
-      ingressRef.name,
-    );
+    const ingressKey = keyForResourceRef(ingressRef);
     const state = {
       kube: { items: { [ingressKey]: ingressItem } },
     };
@@ -91,7 +86,7 @@ context("when the app contains services", () => {
       name: "svc",
     } as ResourceRef;
     const serviceRefs = [svcRef];
-    const svcKey = keyForResourceRef(svcRef.apiVersion, svcRef.kind, svcRef.namespace, svcRef.name);
+    const svcKey = keyForResourceRef(svcRef);
     const state = { kube: { items: { [svcKey]: serviceItem } } };
     const store = getStore(state);
     const wrapper = mountWrapper(
@@ -124,7 +119,7 @@ context("when the app contains services", () => {
       name: "svc",
     } as ResourceRef;
     const serviceRefs = [svcRef];
-    const svcKey = keyForResourceRef(svcRef.apiVersion, svcRef.kind, svcRef.namespace, svcRef.name);
+    const svcKey = keyForResourceRef(svcRef);
     const state = { kube: { items: { [svcKey]: serviceItem } } };
     const store = getStore(state);
     const wrapper = mountWrapper(
@@ -162,12 +157,7 @@ context("when the app contains ingresses", () => {
       name: "ingress",
     } as ResourceRef;
     const ingressRefs = [ingressRef];
-    const ingressKey = keyForResourceRef(
-      ingressRef.apiVersion,
-      ingressRef.kind,
-      ingressRef.namespace,
-      ingressRef.name,
-    );
+    const ingressKey = keyForResourceRef(ingressRef);
     const state = { kube: { items: { [ingressKey]: ingressItem } } };
     const store = getStore(state);
     const wrapper = mountWrapper(
@@ -204,12 +194,7 @@ context("when the app contains ingresses", () => {
       name: "ingress",
     } as ResourceRef;
     const ingressRefs = [ingressRef];
-    const ingressKey = keyForResourceRef(
-      ingressRef.apiVersion,
-      ingressRef.kind,
-      ingressRef.namespace,
-      ingressRef.name,
-    );
+    const ingressKey = keyForResourceRef(ingressRef);
     const state = { kube: { items: { [ingressKey]: ingressItem } } };
     const store = getStore(state);
     const wrapper = mountWrapper(
@@ -281,13 +266,8 @@ context("when the app contains services and ingresses", () => {
       name: "ingress",
     } as ResourceRef;
     const ingressRefs = [ingressRef];
-    const svcKey = keyForResourceRef(svcRef.apiVersion, svcRef.kind, svcRef.namespace, svcRef.name);
-    const ingressKey = keyForResourceRef(
-      ingressRef.apiVersion,
-      ingressRef.kind,
-      ingressRef.namespace,
-      ingressRef.name,
-    );
+    const svcKey = keyForResourceRef(svcRef);
+    const ingressKey = keyForResourceRef(ingressRef);
     const state = {
       kube: { items: { [svcKey]: serviceItem, [ingressKey]: ingressItem } },
     };
@@ -319,13 +299,8 @@ context("when the app contains resources with errors", () => {
       name: "ingress",
     } as ResourceRef;
     const ingressRefs = [ingressRef];
-    const svcKey = keyForResourceRef(svcRef.apiVersion, svcRef.kind, svcRef.namespace, svcRef.name);
-    const ingressKey = keyForResourceRef(
-      ingressRef.apiVersion,
-      ingressRef.kind,
-      ingressRef.namespace,
-      ingressRef.name,
-    );
+    const svcKey = keyForResourceRef(svcRef);
+    const ingressKey = keyForResourceRef(ingressRef);
     const state = {
       kube: { items: { [svcKey]: serviceItem, [ingressKey]: ingressItem } },
     };

--- a/dashboard/src/components/AppView/AppSecrets/AppSecrets.test.tsx
+++ b/dashboard/src/components/AppView/AppSecrets/AppSecrets.test.tsx
@@ -33,12 +33,7 @@ it("shows a message if there are no secrets", () => {
 });
 
 it("renders a secretItemDatum per secret", () => {
-  const key = keyForResourceRef(
-    sampleResourceRef.apiVersion,
-    sampleResourceRef.kind,
-    sampleResourceRef.namespace,
-    sampleResourceRef.name,
-  );
+  const key = keyForResourceRef(sampleResourceRef);
   const state = getStore({
     kube: {
       items: {

--- a/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
+++ b/dashboard/src/components/AppView/ResourceTable/ResourceTable.test.tsx
@@ -9,8 +9,6 @@ import ResourceTable from "./ResourceTable";
 const defaultProps = {
   id: "test",
   resourceRefs: [],
-  watchResource: jest.fn(),
-  closeWatch: jest.fn(),
 };
 
 const sampleResourceRef = {
@@ -20,12 +18,7 @@ const sampleResourceRef = {
   namespace: "default",
 } as ResourceRef;
 
-const sampleKey = keyForResourceRef(
-  sampleResourceRef.apiVersion,
-  sampleResourceRef.kind,
-  sampleResourceRef.namespace,
-  sampleResourceRef.name,
-);
+const sampleKey = keyForResourceRef(sampleResourceRef);
 
 const deployment = {
   kind: "Deployment",

--- a/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
+++ b/dashboard/src/containers/AccessURLTableContainer/AccessURLTableContainer.test.tsx
@@ -14,9 +14,7 @@ const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
   const state: IKubeState = {
     items: resources,
     kinds: initialKinds,
-    sockets: {},
     subscriptions: {},
-    timers: {},
   };
   return mockStore({ kube: state, config: { featureFlags: {} } });
 };
@@ -39,24 +37,14 @@ describe("AccessURLTableContainer", () => {
       namespace: ns,
       name: `${name}-service`,
     } as ResourceRef;
-    const serviceKey = keyForResourceRef(
-      serviceRef.apiVersion,
-      serviceRef.kind,
-      serviceRef.namespace,
-      serviceRef.name,
-    );
+    const serviceKey = keyForResourceRef(serviceRef);
     const ingressRef = {
       apiVersion: "v1",
       kind: "Ingress",
       namespace: ns,
       name: `${name}-ingress`,
     } as ResourceRef;
-    const ingressKey = keyForResourceRef(
-      ingressRef.apiVersion,
-      ingressRef.kind,
-      ingressRef.namespace,
-      ingressRef.name,
-    );
+    const ingressKey = keyForResourceRef(ingressRef);
     const store = makeStore({
       [serviceKey]: service,
       [ingressKey]: ingress,

--- a/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
+++ b/dashboard/src/containers/ApplicationStatusContainer/ApplicationStatusContainer.test.tsx
@@ -14,9 +14,7 @@ const makeStore = (resources: { [s: string]: IKubeItem<IResource> }) => {
   const state: IKubeState = {
     items: resources,
     kinds: initialKinds,
-    sockets: {},
     subscriptions: {},
-    timers: {},
   };
   return mockStore({ kube: state, config: { featureFlags: {} } });
 };
@@ -32,7 +30,7 @@ describe("ApplicationStatusContainer", () => {
       namespace: ns,
       name,
     } as ResourceRef;
-    const key = keyForResourceRef(ref.apiVersion, ref.kind, ref.namespace, ref.name);
+    const key = keyForResourceRef(ref);
     const store = makeStore({
       [key]: item,
     });

--- a/dashboard/src/containers/helpers/index.test.ts
+++ b/dashboard/src/containers/helpers/index.test.ts
@@ -15,12 +15,7 @@ describe("filterByResourceRefs", () => {
     name: "bar",
     namespace: "foo",
   } as ResourceRef;
-  const svc1Key = keyForResourceRef(
-    svc1Ref.apiVersion,
-    svc1Ref.kind,
-    svc1Ref.namespace,
-    svc1Ref.name,
-  );
+  const svc1Key = keyForResourceRef(svc1Ref);
   const svc2 = {
     apiVersion: "v1",
     kind: "Service",
@@ -32,12 +27,7 @@ describe("filterByResourceRefs", () => {
     name: "bar",
     namespace: "foo1",
   } as ResourceRef;
-  const svc2Key = keyForResourceRef(
-    svc2Ref.apiVersion,
-    svc2Ref.kind,
-    svc2Ref.namespace,
-    svc2Ref.name,
-  );
+  const svc2Key = keyForResourceRef(svc2Ref);
   const deploy = {
     apiVersion: "apps/v1",
     kind: "Deployment",

--- a/dashboard/src/containers/helpers/index.ts
+++ b/dashboard/src/containers/helpers/index.ts
@@ -7,7 +7,5 @@ import { IKubeState } from "shared/types";
 // found are filtered out and the response will only contain resources that are
 // available in the state.
 export function filterByResourceRefs(refs: ResourceRef[], resources: IKubeState["items"]) {
-  return refs
-    .map(r => resources[keyForResourceRef(r.apiVersion, r.kind, r.namespace, r.name)])
-    .filter(r => r !== undefined);
+  return refs.map(r => resources[keyForResourceRef(r)]).filter(r => r !== undefined);
 }

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -6,7 +6,6 @@ import {
   Context,
   InstalledPackageReference,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
-import { Kube } from "shared/Kube";
 
 describe("kubeReducer", () => {
   let initialState: IKubeState;

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -116,22 +116,6 @@ describe("kubeReducer", () => {
 
         expect(newState.subscriptions[key]).toBeDefined();
       });
-
-      it("does not create a new subscription if one exists in the state", () => {
-        const subscription = Kube.getResources(pkg, [], true).subscribe({});
-        const state = {
-          ...initialState,
-          subscriptions: {
-            [key]: subscription,
-          },
-        };
-        const newState = kubeReducer(state, {
-          type: getType(actions.kube.requestResources),
-          payload: defaultPayload,
-        });
-        expect(newState).toBe(state);
-        expect(newState.subscriptions[key]).toBe(subscription);
-      });
     });
   });
 });

--- a/dashboard/src/reducers/kube.test.ts
+++ b/dashboard/src/reducers/kube.test.ts
@@ -17,17 +17,13 @@ describe("kubeReducer", () => {
     receiveResourceKinds: getType(actions.kube.receiveResourceKinds),
     requestResourceKinds: getType(actions.kube.requestResourceKinds),
     receiveKindsError: getType(actions.kube.receiveKindsError),
-    addTimer: getType(actions.kube.addTimer),
-    removeTimer: getType(actions.kube.removeTimer),
   };
 
   beforeEach(() => {
     initialState = {
       items: {},
-      sockets: {},
       subscriptions: {},
       kinds: initialKinds,
-      timers: {},
     };
   });
 
@@ -47,67 +43,6 @@ describe("kubeReducer", () => {
       expect(kubeReducer(undefined, { type, payload })).toEqual({
         ...initialState,
         items: { foo: { isFetching: false, error } },
-      });
-    });
-
-    describe("addTimer", () => {
-      it("should add a timer", () => {
-        const newState = kubeReducer(initialState, {
-          type: actionTypes.addTimer,
-          payload: { id: "foo", timer: jest.fn() },
-        });
-        expect(newState).toEqual({
-          ...initialState,
-          timers: { foo: expect.any(Number) },
-        });
-      });
-
-      it("should not add a timer if there is already one", () => {
-        jest.useFakeTimers();
-        const f1 = jest.fn();
-        const f2 = jest.fn();
-        const timer = setTimeout(f1, 1);
-        const newState = kubeReducer(
-          {
-            ...initialState,
-            timers: { foo: timer },
-          },
-          {
-            type: actionTypes.addTimer,
-            payload: { id: "foo", timer: f2 },
-          },
-        );
-        expect(newState).toEqual({
-          ...initialState,
-          timers: { foo: timer },
-        });
-        jest.runAllTimers();
-        expect(f1).toHaveBeenCalled();
-        expect(f2).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("removeTimer", () => {
-      it("remove a timer", () => {
-        jest.useFakeTimers();
-        const f1 = jest.fn();
-        const timer = setTimeout(f1, 1);
-        const newState = kubeReducer(
-          {
-            ...initialState,
-            timers: { foo: timer },
-          },
-          {
-            type: actionTypes.removeTimer,
-            payload: "foo",
-          },
-        );
-        expect(newState).toEqual({
-          ...initialState,
-          timers: { foo: undefined },
-        });
-        jest.runAllTimers();
-        expect(f1).not.toHaveBeenCalled();
       });
     });
 

--- a/dashboard/src/reducers/kube.ts
+++ b/dashboard/src/reducers/kube.ts
@@ -122,7 +122,9 @@ export const initialState: IKubeState = {
   items: {},
   kinds: initialKinds,
   // We book keep on subscriptions, keyed by the installed package ref,
-  // so that we can
+  // so that we can unsubscribe when the closeRequestResources action is
+  // dispatched (usually because the component is unmounted when the user
+  // navigates away).
   subscriptions: {},
 };
 

--- a/dashboard/src/reducers/kube.ts
+++ b/dashboard/src/reducers/kube.ts
@@ -121,9 +121,9 @@ export const initialKinds = {
 export const initialState: IKubeState = {
   items: {},
   kinds: initialKinds,
+  // We book keep on subscriptions, keyed by the installed package ref,
+  // so that we can
   subscriptions: {},
-  sockets: {},
-  timers: {},
 };
 
 const kubeReducer = (
@@ -150,12 +150,6 @@ const kubeReducer = (
     case getType(actions.kube.requestResources): {
       const { pkg, refs, handler, watch, onError, onComplete } = action.payload;
       const key = `${pkg.context?.cluster}/${pkg.context?.namespace}/${pkg.identifier}`;
-      if (state.subscriptions[key]) {
-        // subscription for this resource already open, do nothing
-        // TODO(minelson): We may instead want to unsubscribe from
-        // the previous one and replace it.
-        return state;
-      }
       const observable = Kube.getResources(pkg, refs, watch);
       const subscription = observable.subscribe({
         next(r) {
@@ -189,31 +183,6 @@ const kubeReducer = (
         ...state,
         subscriptions: otherSubscriptions,
       };
-    }
-    case getType(actions.kube.addTimer): {
-      if (!state.timers[action.payload.id]) {
-        return {
-          ...state,
-          timers: {
-            ...state.timers,
-            [action.payload.id]: setInterval(action.payload.timer, 5000),
-          },
-        };
-      }
-      return state;
-    }
-    case getType(actions.kube.removeTimer): {
-      if (state.timers[action.payload]) {
-        clearInterval(state.timers[action.payload] as NodeJS.Timer);
-        return {
-          ...state,
-          timers: {
-            ...state.timers,
-            [action.payload]: undefined,
-          },
-        };
-      }
-      return state;
     }
     case LOCATION_CHANGE:
       return { ...state, items: {} };

--- a/dashboard/src/shared/Kube.test.ts
+++ b/dashboard/src/shared/Kube.test.ts
@@ -98,71 +98,6 @@ describe("App", () => {
     });
   });
 
-  describe("watchResourceURL", () => {
-    [
-      {
-        description: "returns the version and resource",
-        args: {
-          cluster: clusterName,
-          apiVersion: "",
-          resource: "pods",
-          namespaced: true,
-        },
-        result: `ws://localhost/api/clusters/${clusterName}/api/v1/pods?watch=true`,
-      },
-      {
-        description: "returns the version, resource in a namespace",
-        args: {
-          cluster: clusterName,
-          apiVersion: "",
-          resource: "pods",
-          namespaced: true,
-          namespace: "default",
-        },
-        result: `ws://localhost/api/clusters/${clusterName}/api/v1/namespaces/default/pods?watch=true`,
-      },
-      {
-        description: "returns the version, resource in a namespace with a name",
-        args: {
-          cluster: clusterName,
-          apiVersion: "",
-          resource: "pods",
-          namespaced: true,
-          namespace: "default",
-          name: "foo",
-        },
-        result: `ws://localhost/api/clusters/${clusterName}/api/v1/namespaces/default/pods?watch=true&fieldSelector=metadata.name%3Dfoo`,
-      },
-      {
-        description: "returns the version, resource in a namespace with a name and a query",
-        args: {
-          cluster: clusterName,
-          apiVersion: "",
-          resource: "pods",
-          namespaced: true,
-          namespace: "default",
-          name: "foo",
-          query: "label=bar",
-        },
-        result: `ws://localhost/api/clusters/${clusterName}/api/v1/namespaces/default/pods?watch=true&fieldSelector=metadata.name%3Dfoo&label=bar`,
-      },
-    ].forEach(t => {
-      it(t.description, () => {
-        expect(
-          Kube.watchResourceURL(
-            t.args.cluster,
-            t.args.apiVersion,
-            t.args.resource,
-            t.args.namespaced,
-            t.args.namespace,
-            t.args.name,
-            t.args.query,
-          ),
-        ).toBe(t.result);
-      });
-    });
-  });
-
   describe("getResource", () => {
     const resource = { name: "foo" };
     beforeEach(() => {
@@ -180,17 +115,6 @@ describe("App", () => {
       expect(moxios.requests.mostRecent().url).toBe(
         `api/clusters/${clusterName}/api/v1/namespaces/default/pods/foo?label=bar`,
       );
-    });
-  });
-
-  describe("watchResource", () => {
-    it("should open a socket", async () => {
-      const socket = Kube.watchResource(clusterName, "v1", "pods", true, "default", "foo");
-      expect(socket.url).toBe(
-        `ws://localhost/api/clusters/${clusterName}/api/v1/namespaces/default/pods?watch=true&fieldSelector=metadata.name%3Dfoo`,
-      );
-      // it's a mock socket, so doesn't actually need to be closed
-      socket.close();
     });
   });
 

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -1,5 +1,4 @@
 import * as url from "shared/url";
-import { Auth } from "./Auth";
 import { axiosWithAuth } from "./AxiosInstance";
 import { IK8sList, IKubeState, IResource } from "./types";
 import { KubeappsGrpcClient } from "./KubeappsGrpcClient";
@@ -46,26 +45,6 @@ export class Kube {
     return u;
   }
 
-  public static watchResourceURL(
-    cluster: string,
-    apiVersion: string,
-    resource: string,
-    namespaced: boolean,
-    namespace?: string,
-    name?: string,
-    query?: string,
-  ) {
-    let u = this.getResourceURL(cluster, apiVersion, resource, namespaced, namespace);
-    u = `${WebSocketAPIBase}${u}?watch=true`;
-    if (name) {
-      u += `&fieldSelector=metadata.name%3D${name}`;
-    }
-    if (query) {
-      u += `&${query}`;
-    }
-    return u;
-  }
-
   public static async getResource(
     cluster: string,
     apiVersion: string,
@@ -79,25 +58,6 @@ export class Kube {
       this.getResourceURL(cluster, apiVersion, resource, namespaced, namespace, name, query),
     );
     return data;
-  }
-
-  // Opens and returns a WebSocket for the requested resource. Note: it is
-  // important that this socket be properly closed when no longer needed. The
-  // returned WebSocket can be attached to an event listener to read data from
-  // the socket.
-  public static watchResource(
-    cluster: string,
-    apiVersion: string,
-    resource: string,
-    namespaced: boolean,
-    namespace?: string,
-    name?: string,
-    query?: string,
-  ) {
-    return new WebSocket(
-      this.watchResourceURL(cluster, apiVersion, resource, namespaced, namespace, name, query),
-      Auth.wsProtocols(),
-    );
   }
 
   // getResources returns a subscription to an observable for resources from the server.

--- a/dashboard/src/shared/ResourceRef.test.ts
+++ b/dashboard/src/shared/ResourceRef.test.ts
@@ -125,37 +125,6 @@ describe("ResourceRef", () => {
     });
   });
 
-  describe("watchResourceURL", () => {
-    let kubeWatchResourceURLMock: jest.Mock;
-    beforeEach(() => {
-      kubeWatchResourceURLMock = jest.fn();
-      Kube.watchResourceURL = kubeWatchResourceURLMock;
-    });
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-    it("calls Kube.watchResourceURL with the correct arguments", () => {
-      const r = {
-        apiVersion: "v1",
-        kind: "Service",
-        name: "foo",
-        namespace: "bar",
-      } as APIResourceRef;
-
-      const ref = new ResourceRef(r, clusterName, "services", true, "default");
-
-      ref.watchResourceURL();
-      expect(kubeWatchResourceURLMock).toBeCalledWith(
-        clusterName,
-        "v1",
-        "services",
-        true,
-        "bar",
-        "foo",
-      );
-    });
-  });
-
   describe("getResource", () => {
     let kubeGetResourceMock: jest.Mock;
     beforeEach(() => {
@@ -196,37 +165,6 @@ describe("ResourceRef", () => {
       });
       const res = await ref.getResource();
       expect(res).toEqual({ items: [] });
-    });
-  });
-
-  describe("watchResource", () => {
-    let kubeWatchResourceMock: jest.Mock;
-    beforeEach(() => {
-      kubeWatchResourceMock = jest.fn();
-      Kube.watchResource = kubeWatchResourceMock;
-    });
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-    it("calls Kube.watchResource with the correct arguments", () => {
-      const r = {
-        apiVersion: "v1",
-        kind: "Service",
-        name: "foo",
-        namespace: "bar",
-      } as APIResourceRef;
-
-      const ref = new ResourceRef(r, clusterName, "services", true, "default");
-
-      ref.watchResource();
-      expect(kubeWatchResourceMock).toBeCalledWith(
-        clusterName,
-        "v1",
-        "services",
-        true,
-        "bar",
-        "foo",
-      );
     });
   });
 });

--- a/dashboard/src/shared/ResourceRef.ts
+++ b/dashboard/src/shared/ResourceRef.ts
@@ -21,13 +21,10 @@ export function fromCRD(
   return ref;
 }
 
-// TODO(minelson): Update to use API resourceRef type once old model removed.
-export const keyForResourceRef = (
-  apiVersion: string,
-  kind: string,
-  namespace: string,
-  name: string,
-) => `${apiVersion}/${kind}/${namespace}/${name}`;
+// keyForResourceRef is used to create a key for the redux state tracking resources
+// keyed by references.
+export const keyForResourceRef = (r: APIResourceRef) =>
+  `${r.apiVersion}/${r.kind}/${r.namespace}/${r.name}`;
 
 // ResourceRef defines a reference to a namespaced Kubernetes API Object and
 // provides helpers to retrieve the resource URL
@@ -72,17 +69,6 @@ class ResourceRef {
     );
   }
 
-  public watchResourceURL() {
-    return Kube.watchResourceURL(
-      this.cluster,
-      this.apiVersion,
-      this.plural,
-      this.namespaced,
-      this.namespace,
-      this.name,
-    );
-  }
-
   public async getResource() {
     const resource = await Kube.getResource(
       this.cluster,
@@ -98,21 +84,6 @@ class ResourceRef {
       return resourceList;
     }
     return resource;
-  }
-
-  // Opens and returns a WebSocket for the requested resource. Note: it is
-  // important that this socket be properly closed when no longer needed. The
-  // returned WebSocket can be attached to an event listener to read data from
-  // the socket.
-  public watchResource() {
-    return Kube.watchResource(
-      this.cluster,
-      this.apiVersion,
-      this.plural,
-      this.namespaced,
-      this.namespace,
-      this.name,
-    );
   }
 }
 

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -441,14 +441,12 @@ export interface IKind {
 }
 
 export interface IKubeState {
-  // TODO(minelson): Remove IKubeItem, sockets, kinds, kindsError and possibly
-  // timers once all call-sites updated.
   items: { [s: string]: IKubeItem<IResource | IK8sList<IResource, {}>> };
-  sockets: { [s: string]: { socket: WebSocket; onError: (e: Event) => void } };
   subscriptions: { [s: string]: Subscription };
+  // TODO(minelson): Remove kinds and kindsError once the operator support is
+  // removed from the dashboard or replaced with a plugin.
   kinds: { [kind: string]: IKind };
   kindsError?: Error;
-  timers: { [id: string]: NodeJS.Timer | undefined };
 }
 
 export interface IBasicFormParam {


### PR DESCRIPTION
### Description of the change

Following on from the other #3779 PRs, this PR removes more now-unused code (after switching to the new resources plugin endpoint) and simplifies the `keyForResourceRef` helper now that it is used solely with our protobuf-generated resourceref.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3779

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
