### PR TITLE
Only watch resources that are updated in UX.

### DIFF
--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -85,10 +85,8 @@ describe("getResourceKinds", () => {
     expect(Kube.getAPIGroups).toHaveBeenCalledWith("cluster-1");
     expect(Kube.getResourceKinds).toHaveBeenCalledWith("cluster-1", groups);
   });
-});
 
-describe("getResources", () => {
-  it("dispatches a requestResources action", () => {
+  it("dispatches a requestResources action with an onComplete that closes request when watching", () => {
     const refs = [
       {
         apiVersion: "v1",
@@ -120,6 +118,102 @@ describe("getResources", () => {
 
     store.dispatch(actions.kube.getResources(pkg, refs, watch));
     expect(store.getActions()).toEqual(expectedActions);
+
+    const expectedCompletionActions = [
+      expectedActions[0],
+      {
+        type: getType(actions.kube.closeRequestResources),
+        payload: pkg,
+      },
+    ];
+    const onComplete = store.getActions()[0].payload.onComplete;
+    onComplete();
+    expect(store.getActions()).toEqual(expectedCompletionActions);
+  });
+
+  it("dispatches a requestResources action with an onComplete that does nothing when not watching", () => {
+    const refs = [
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        name: "foo",
+        namespace: "default",
+      },
+    ] as APIResourceRef[];
+
+    const pkg = {
+      identifier: "test-pkg",
+    } as InstalledPackageReference;
+
+    const watch = false;
+
+    const expectedActions = [
+      {
+        type: getType(actions.kube.requestResources),
+        payload: {
+          pkg,
+          refs,
+          watch,
+          handler: expect.any(Function),
+          onError: expect.any(Function),
+          onComplete: expect.any(Function),
+        },
+      },
+    ];
+
+    store.dispatch(actions.kube.getResources(pkg, refs, watch));
+    expect(store.getActions()).toEqual(expectedActions);
+
+    const onComplete = store.getActions()[0].payload.onComplete;
+    onComplete();
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe("getResources", () => {
+  it("dispatches a requestResources action with an onComplete that closes request", () => {
+    const refs = [
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        name: "foo",
+        namespace: "default",
+      },
+    ] as APIResourceRef[];
+
+    const pkg = {
+      identifier: "test-pkg",
+    } as InstalledPackageReference;
+
+    const watch = true;
+
+    const expectedActions = [
+      {
+        type: getType(actions.kube.requestResources),
+        payload: {
+          pkg,
+          refs,
+          watch,
+          handler: expect.any(Function),
+          onError: expect.any(Function),
+          onComplete: expect.any(Function),
+        },
+      },
+    ];
+
+    store.dispatch(actions.kube.getResources(pkg, refs, watch));
+    expect(store.getActions()).toEqual(expectedActions);
+
+    const expectedCompletionActions = [
+      expectedActions[0],
+      {
+        type: getType(actions.kube.closeRequestResources),
+        payload: pkg,
+      },
+    ];
+    const onComplete = store.getActions()[0].payload.onComplete;
+    onComplete();
+    expect(store.getActions()).toEqual(expectedCompletionActions);
   });
 });
 

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -85,7 +85,9 @@ describe("getResourceKinds", () => {
     expect(Kube.getAPIGroups).toHaveBeenCalledWith("cluster-1");
     expect(Kube.getResourceKinds).toHaveBeenCalledWith("cluster-1", groups);
   });
+});
 
+describe("getResources", () => {
   it("dispatches a requestResources action with an onComplete that closes request when watching", () => {
     const refs = [
       {
@@ -167,53 +169,6 @@ describe("getResourceKinds", () => {
     const onComplete = store.getActions()[0].payload.onComplete;
     onComplete();
     expect(store.getActions()).toEqual(expectedActions);
-  });
-});
-
-describe("getResources", () => {
-  it("dispatches a requestResources action with an onComplete that closes request", () => {
-    const refs = [
-      {
-        apiVersion: "v1",
-        kind: "Service",
-        name: "foo",
-        namespace: "default",
-      },
-    ] as APIResourceRef[];
-
-    const pkg = {
-      identifier: "test-pkg",
-    } as InstalledPackageReference;
-
-    const watch = true;
-
-    const expectedActions = [
-      {
-        type: getType(actions.kube.requestResources),
-        payload: {
-          pkg,
-          refs,
-          watch,
-          handler: expect.any(Function),
-          onError: expect.any(Function),
-          onComplete: expect.any(Function),
-        },
-      },
-    ];
-
-    store.dispatch(actions.kube.getResources(pkg, refs, watch));
-    expect(store.getActions()).toEqual(expectedActions);
-
-    const expectedCompletionActions = [
-      expectedActions[0],
-      {
-        type: getType(actions.kube.closeRequestResources),
-        payload: pkg,
-      },
-    ];
-    const onComplete = store.getActions()[0].payload.onComplete;
-    onComplete();
-    expect(store.getActions()).toEqual(expectedCompletionActions);
   });
 });
 

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -99,6 +99,10 @@ export function getResources(
           dispatch(receiveResourcesError(e));
         },
         () => {
+          // The onComplete handler should only dispatch a closeRequestResources
+          // action if this call to `getResources` is for watching. If it is not
+          // watching resources, the server will close the request automatically
+          // (and we have no book-keeping in the redux state).
           if (watch) {
             dispatch(closeRequestResources(pkg));
           }

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -39,7 +39,7 @@ export const requestResources = createAction("REQUEST_RESOURCES", resolve => {
     watch: boolean,
     handler: (r: GetResourcesResponse) => void,
     onError: (e: Event) => void,
-    onComplete: (pkg: InstalledPackageReference) => void,
+    onComplete: () => void,
   ) => resolve({ pkg, refs, watch, handler, onError, onComplete });
 });
 
@@ -98,8 +98,10 @@ export function getResources(
         (e: any) => {
           dispatch(receiveResourcesError(e));
         },
-        (pkg: InstalledPackageReference) => {
-          dispatch(closeRequestResources(pkg));
+        () => {
+          if (watch) {
+            dispatch(closeRequestResources(pkg));
+          }
         },
       ),
     );


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Rather than watching all resources for an installed package (as Kubeapps has done for quite some time), this PR updates so that we only watch the resources which are updated in the UX and just fetch the rest once only when the AppView is mounted.

### Benefits

Viewing Kubeapps, for example, now results in only 13 watches on the k8s API server (from the plugin), rather than ~40.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #3779

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
