### PR TITLE
Switch dashboard to use checkNamespaceExists.

### DIFF
--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces.go
@@ -1,0 +1,110 @@
+/*
+Copyright © 2021 VMware
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"context"
+
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	log "k8s.io/klog/v2"
+)
+
+// CheckNamespaceExists returns whether a namespace exists on the cluster, or
+// an error if the user does not have the required RBAC.
+func (s *Server) CheckNamespaceExists(ctx context.Context, r *v1alpha1.CheckNamespaceExistsRequest) (*v1alpha1.CheckNamespaceExistsResponse, error) {
+	namespace := r.GetContext().GetNamespace()
+	cluster := r.GetContext().GetCluster()
+	log.Infof("+resources CheckNamespaceExists (cluster: %q, namespace=%q)", cluster, namespace)
+
+	typedClient, _, err := s.clientGetter(ctx, cluster)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
+	}
+
+	_, err = typedClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return &v1alpha1.CheckNamespaceExistsResponse{
+				Exists: false,
+			}, nil
+		}
+		return nil, errorByStatus("get", "Namespace", namespace, err)
+	}
+
+	return &v1alpha1.CheckNamespaceExistsResponse{
+		Exists: true,
+	}, nil
+}
+
+// CreateNamespace create the namespace for the given context
+// if the user has the required RBAC
+func (s *Server) CreateNamespace(ctx context.Context, r *v1alpha1.CreateNamespaceRequest) (*v1alpha1.CreateNamespaceResponse, error) {
+	namespace := r.GetContext().GetNamespace()
+	cluster := r.GetContext().GetCluster()
+	log.Infof("+resources CreateNamespace (cluster: %q, namespace=%q)", cluster, namespace)
+
+	typedClient, _, err := s.clientGetter(ctx, cluster)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
+	}
+
+	_, err = typedClient.CoreV1().Namespaces().Create(ctx, &core.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, errorByStatus("get", "Namespace", namespace, err)
+	}
+
+	return &v1alpha1.CreateNamespaceResponse{}, nil
+}
+
+// GetNamespaceNames returns the list of namespace names for a cluster if the
+// user has the required RBAC.
+//
+// Note that we can't yet use this from the dashboard to replace the similar endpoint
+// in kubeops until we update to ensure a configured service account can also be
+// passed in (resources plugin config) and used if the user does not have RBAC.
+func (s *Server) GetNamespaceNames(ctx context.Context, r *v1alpha1.GetNamespaceNamesRequest) (*v1alpha1.GetNamespaceNamesResponse, error) {
+	cluster := r.GetCluster()
+	log.Infof("+resources GetNamespaceNames (cluster: %q)", cluster)
+
+	typedClient, _, err := s.clientGetter(ctx, cluster)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
+	}
+
+	namespaceList, err := typedClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, errorByStatus("list", "Namespaces", "", err)
+	}
+
+	namespaces := make([]string, len(namespaceList.Items))
+	for i, ns := range namespaceList.Items {
+		namespaces[i] = ns.Name
+	}
+
+	return &v1alpha1.GetNamespaceNamesResponse{
+		NamespaceNames: namespaces,
+	}, nil
+}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces_test.go
@@ -1,0 +1,331 @@
+/*
+Copyright © 2021 VMware
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	core "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	typfake "k8s.io/client-go/kubernetes/fake"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	clientGoTesting "k8s.io/client-go/testing"
+)
+
+func TestCheckNamespaceExists(t *testing.T) {
+
+	ignoredUnexported := cmpopts.IgnoreUnexported(
+		v1alpha1.CheckNamespaceExistsResponse{},
+	)
+
+	testCases := []struct {
+		name              string
+		request           *v1alpha1.CheckNamespaceExistsRequest
+		k8sError          error
+		expectedResponse  *v1alpha1.CheckNamespaceExistsResponse
+		expectedErrorCode codes.Code
+		existingObjects   []runtime.Object
+	}{
+		{
+			name: "returns true if namespace exists",
+			request: &v1alpha1.CheckNamespaceExistsRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			existingObjects: []runtime.Object{
+				&core.Namespace{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Namespace",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+				},
+			},
+			expectedResponse: &v1alpha1.CheckNamespaceExistsResponse{
+				Exists: true,
+			},
+		},
+		{
+			name: "returns false if namespace does not exist",
+			request: &v1alpha1.CheckNamespaceExistsRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			expectedResponse: &v1alpha1.CheckNamespaceExistsResponse{
+				Exists: false,
+			},
+		},
+		{
+			name: "returns permission denied if k8s returns a forbidden error",
+			request: &v1alpha1.CheckNamespaceExistsRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			k8sError: k8serrors.NewForbidden(schema.GroupResource{
+				Group:    "v1",
+				Resource: "namespaces",
+			}, "default", errors.New("Bang")),
+			expectedErrorCode: codes.PermissionDenied,
+		},
+		{
+			name: "returns an internal error if k8s returns an unexpected error",
+			request: &v1alpha1.CheckNamespaceExistsRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
+			expectedErrorCode: codes.Internal,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			fakeClient := typfake.NewSimpleClientset(tc.existingObjects...)
+			if tc.k8sError != nil {
+				fakeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor("get", "namespaces", func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.Namespace{}, tc.k8sError
+				})
+			}
+			s := Server{
+				clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+					return fakeClient, nil, nil
+				},
+			}
+
+			response, err := s.CheckNamespaceExists(context.Background(), tc.request)
+
+			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
+			}
+
+			if got, want := response, tc.expectedResponse; !cmp.Equal(got, want, ignoredUnexported) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported))
+			}
+		})
+	}
+}
+
+func TestCreateNamespace(t *testing.T) {
+
+	ignoredUnexported := cmpopts.IgnoreUnexported(
+		v1alpha1.CreateNamespaceResponse{},
+	)
+
+	emptyResponse := &v1alpha1.CreateNamespaceResponse{}
+	testCases := []struct {
+		name              string
+		request           *v1alpha1.CreateNamespaceRequest
+		k8sError          error
+		expectedResponse  *v1alpha1.CreateNamespaceResponse
+		expectedErrorCode codes.Code
+		existingObjects   []runtime.Object
+	}{
+		{
+			name: "creates a new namespace",
+			request: &v1alpha1.CreateNamespaceRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			expectedResponse: emptyResponse,
+		},
+		{
+			name: "returns permission denied if k8s returns a forbidden error",
+			request: &v1alpha1.CreateNamespaceRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			k8sError: k8serrors.NewForbidden(schema.GroupResource{
+				Group:    "v1",
+				Resource: "namespaces",
+			}, "default", errors.New("Bang")),
+			expectedErrorCode: codes.PermissionDenied,
+		},
+		{
+			name: "returns already exists if k8s returns an already exists error",
+			request: &v1alpha1.CreateNamespaceRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			k8sError: k8serrors.NewAlreadyExists(schema.GroupResource{
+				Group:    "v1",
+				Resource: "namespaces",
+			}, "default"),
+			expectedErrorCode: codes.AlreadyExists,
+		},
+		{
+			name: "returns an internal error if k8s returns an unexpected error",
+			request: &v1alpha1.CreateNamespaceRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
+			expectedErrorCode: codes.Internal,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			fakeClient := typfake.NewSimpleClientset(tc.existingObjects...)
+			if tc.k8sError != nil {
+				fakeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor("create", "namespaces", func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.Namespace{}, tc.k8sError
+				})
+			}
+			s := Server{
+				clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+					return fakeClient, nil, nil
+				},
+			}
+
+			response, err := s.CreateNamespace(context.Background(), tc.request)
+
+			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
+			}
+
+			if got, want := response, tc.expectedResponse; !cmp.Equal(got, want, ignoredUnexported) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported))
+			}
+		})
+	}
+}
+
+func TestGetNamespaceNames(t *testing.T) {
+
+	ignoredUnexported := cmpopts.IgnoreUnexported(
+		v1alpha1.GetNamespaceNamesResponse{},
+	)
+
+	testCases := []struct {
+		name              string
+		request           *v1alpha1.GetNamespaceNamesRequest
+		k8sError          error
+		expectedResponse  *v1alpha1.GetNamespaceNamesResponse
+		expectedErrorCode codes.Code
+		existingObjects   []runtime.Object
+	}{
+		{
+			name: "returns existing namespaces if user has RBAC",
+			request: &v1alpha1.GetNamespaceNamesRequest{
+				Cluster: "default",
+			},
+			existingObjects: []runtime.Object{
+				&core.Namespace{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Namespace",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+				},
+				&core.Namespace{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Namespace",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubeapps",
+					},
+				},
+			},
+			expectedResponse: &v1alpha1.GetNamespaceNamesResponse{
+				NamespaceNames: []string{
+					"default",
+					"kubeapps",
+				},
+			},
+		},
+		{
+			name: "returns permission denied if k8s returns a forbidden error",
+			request: &v1alpha1.GetNamespaceNamesRequest{
+				Cluster: "default",
+			},
+			k8sError: k8serrors.NewForbidden(schema.GroupResource{
+				Group:    "v1",
+				Resource: "namespaces",
+			}, "default", errors.New("Bang")),
+			expectedErrorCode: codes.PermissionDenied,
+		},
+		{
+			name: "returns an internal error if k8s returns an unexpected error",
+			request: &v1alpha1.GetNamespaceNamesRequest{
+				Cluster: "default",
+			},
+			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
+			expectedErrorCode: codes.Internal,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			fakeClient := typfake.NewSimpleClientset(tc.existingObjects...)
+			if tc.k8sError != nil {
+				fakeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor("list", "namespaces", func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.NamespaceList{}, tc.k8sError
+				})
+			}
+			s := Server{
+				clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+					return fakeClient, nil, nil
+				},
+			}
+
+			response, err := s.GetNamespaceNames(context.Background(), tc.request)
+
+			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
+			}
+
+			if got, want := response, tc.expectedResponse; !cmp.Equal(got, want, ignoredUnexported) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported))
+			}
+		})
+	}
+}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -416,7 +416,6 @@ func resourceRefsEqual(r1, r2 *pkgsGRPCv1alpha1.ResourceRef) bool {
 
 // errorByStatus generates a meaningful error message
 func errorByStatus(verb, resource, identifier string, err error) error {
-	// If the error is already a k8s StatusError, return the StatusErr
 	if identifier == "" {
 		identifier = "all"
 	}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -416,13 +416,16 @@ func resourceRefsEqual(r1, r2 *pkgsGRPCv1alpha1.ResourceRef) bool {
 
 // errorByStatus generates a meaningful error message
 func errorByStatus(verb, resource, identifier string, err error) error {
+	// If the error is already a k8s StatusError, return the StatusErr
 	if identifier == "" {
 		identifier = "all"
 	}
 	if errors.IsNotFound(err) {
 		return status.Errorf(codes.NotFound, "unable to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
 	} else if errors.IsForbidden(err) || errors.IsUnauthorized(err) {
-		return status.Errorf(codes.Unauthenticated, "Unauthorized to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+		return status.Errorf(codes.PermissionDenied, "Unauthorized to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+	} else if errors.IsAlreadyExists(err) {
+		return status.Errorf(codes.AlreadyExists, "Cannot %s the %s '%s' due to '%v' as it already exists", verb, resource, identifier, err)
 	}
 	return status.Errorf(codes.Internal, "unable to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
 }

--- a/dashboard/src/actions/namespace.ts
+++ b/dashboard/src/actions/namespace.ts
@@ -7,11 +7,11 @@ import { ActionType, deprecated } from "typesafe-actions";
 
 const { createAction } = deprecated;
 
-export const requestNamespace = createAction("REQUEST_NAMESPACE", resolve => {
+export const requestNamespaceExists = createAction("REQUEST_NAMESPACE", resolve => {
   return (cluster: string, namespace: string) => resolve({ cluster, namespace });
 });
-export const receiveNamespace = createAction("RECEIVE_NAMESPACE", resolve => {
-  return (cluster: string, namespace: IResource) => resolve({ cluster, namespace });
+export const receiveNamespaceExists = createAction("RECEIVE_NAMESPACE", resolve => {
+  return (cluster: string, namespace: string) => resolve({ cluster, namespace });
 });
 
 export const setNamespaceState = createAction("SET_NAMESPACE", resolve => {
@@ -37,8 +37,8 @@ export const setAllowCreate = createAction("ALLOW_CREATE_NAMESPACE", resolve => 
 export const clearClusters = createAction("CLEAR_CLUSTERS");
 
 const allActions = [
-  requestNamespace,
-  receiveNamespace,
+  requestNamespaceExists,
+  receiveNamespaceExists,
   setNamespaceState,
   receiveNamespaces,
   errorNamespaces,
@@ -93,16 +93,18 @@ export function createNamespace(
   };
 }
 
-export function getNamespace(
+export function checkNamespaceExists(
   cluster: string,
   ns: string,
 ): ThunkAction<Promise<boolean>, IStoreState, null, NamespaceAction> {
   return async dispatch => {
     try {
-      dispatch(requestNamespace(cluster, ns));
-      const namespace = await Namespace.get(cluster, ns);
-      dispatch(receiveNamespace(cluster, namespace));
-      return true;
+      dispatch(requestNamespaceExists(cluster, ns));
+      const exists = await Namespace.exists(cluster, ns);
+      if (exists) {
+        dispatch(receiveNamespaceExists(cluster, ns));
+      }
+      return exists;
     } catch (e: any) {
       dispatch(errorNamespaces(cluster, e, "get"));
       return false;

--- a/dashboard/src/components/Header/ContextSelector.test.tsx
+++ b/dashboard/src/components/Header/ContextSelector.test.tsx
@@ -19,7 +19,7 @@ beforeEach(() => {
   actions.namespace = {
     ...actions.namespace,
     fetchNamespaces: jest.fn(),
-    getNamespace: jest.fn(),
+    checkNamespaceExists: jest.fn(),
     setNamespace: jest.fn(),
     createNamespace: jest.fn(),
   };
@@ -37,11 +37,11 @@ afterEach(() => {
 });
 
 it("gets a namespace", () => {
-  const getNamespace = jest.fn();
-  actions.namespace.getNamespace = getNamespace;
+  const checkNamespaceExists = jest.fn();
+  actions.namespace.checkNamespaceExists = checkNamespaceExists;
   mountWrapper(defaultStore, <ContextSelector />);
 
-  expect(getNamespace).toHaveBeenCalledWith(
+  expect(checkNamespaceExists).toHaveBeenCalledWith(
     initialState.clusters.currentCluster,
     initialState.clusters.clusters[initialState.clusters.currentCluster].currentNamespace,
   );

--- a/dashboard/src/components/Header/ContextSelector.tsx
+++ b/dashboard/src/components/Header/ContextSelector.tsx
@@ -39,7 +39,7 @@ function ContextSelector() {
 
   useEffect(() => {
     if (namespaceSelected) {
-      dispatch(actions.namespace.getNamespace(clusters.currentCluster, namespaceSelected));
+      dispatch(actions.namespace.checkNamespaceExists(clusters.currentCluster, namespaceSelected));
     }
   }, [dispatch, namespaceSelected, clusters.currentCluster]);
 

--- a/dashboard/src/reducers/cluster.test.ts
+++ b/dashboard/src/reducers/cluster.test.ts
@@ -3,7 +3,6 @@ import { Location } from "history";
 import context from "jest-plugin-context";
 import { Auth } from "shared/Auth";
 import { IConfig } from "shared/Config";
-import { IResource } from "shared/types";
 import { getType } from "typesafe-actions";
 import actions from "../actions";
 import clusterReducer, { IClustersState, initialState } from "./cluster";
@@ -179,10 +178,10 @@ describe("clusterReducer", () => {
             },
           } as IClustersState,
           {
-            type: getType(actions.namespace.receiveNamespace),
+            type: getType(actions.namespace.receiveNamespaceExists),
             payload: {
               cluster: "other",
-              namespace: { metadata: { name: "bar" } } as IResource,
+              namespace: "bar",
             },
           },
         ),

--- a/dashboard/src/reducers/cluster.ts
+++ b/dashboard/src/reducers/cluster.ts
@@ -44,12 +44,8 @@ const clusterReducer = (
   action: ConfigAction | NamespaceAction | LocationChangeAction | AuthAction,
 ): IClustersState => {
   switch (action.type) {
-    case getType(actions.namespace.receiveNamespace): {
-      if (
-        !state.clusters[action.payload.cluster].namespaces.includes(
-          action.payload.namespace.metadata.name,
-        )
-      ) {
+    case getType(actions.namespace.receiveNamespaceExists): {
+      if (!state.clusters[action.payload.cluster].namespaces.includes(action.payload.namespace)) {
         return {
           ...state,
           clusters: {
@@ -57,7 +53,7 @@ const clusterReducer = (
             [action.payload.cluster]: {
               ...state.clusters[action.payload.cluster],
               namespaces: state.clusters[action.payload.cluster].namespaces
-                .concat(action.payload.namespace.metadata.name)
+                .concat(action.payload.namespace)
                 .sort(),
               error: undefined,
             },

--- a/dashboard/src/shared/Namespace.ts
+++ b/dashboard/src/shared/Namespace.ts
@@ -10,8 +10,8 @@ export default class Namespace {
 
   public static async list(cluster: string) {
     // This call is hitting an actual backend endpoint (see pkg/http-handler.go)
-    // while the other calls (create, get) are hitting the k8s API via the
-    // frountend nginx.
+    // while the other two calls (create, get) have been updated to use the
+    // resources client rather than the k8s API server.
     const { data } = await axiosWithAuth.get<{ namespaces: IResource[] }>(
       url.backend.namespaces.list(cluster),
     );
@@ -19,14 +19,12 @@ export default class Namespace {
   }
 
   public static async create(cluster: string, namespace: string) {
-    const { data } = await axiosWithAuth.post<IResource>(url.api.k8s.namespaces(cluster), {
-      apiVersion: "v1",
-      kind: "Namespace",
-      metadata: {
-        name: namespace,
+    await this.resourcesClient().CreateNamespace({
+      context: {
+        cluster,
+        namespace,
       },
     });
-    return data;
   }
 
   public static async exists(cluster: string, namespace: string) {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Updates the dashboard to use the resources plugin to check if a namespace exists (rather than the more generic getNamespace which was hitting the k8s API server directly from the dashboard).

Also updates the `Namespace.create` shared helper to use the resources client.

### Benefits

See #3896 

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3896

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
