### PR TITLE
Add implementation for resources secret endpoints

### DIFF
--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets.go
@@ -1,0 +1,78 @@
+/*
+Copyright © 2021 VMware
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	log "k8s.io/klog/v2"
+)
+
+// CreateSecret creates the secret in the given context if the user has the
+// required RBAC
+func (s *Server) CreateSecret(ctx context.Context, r *v1alpha1.CreateSecretRequest) (*v1alpha1.CreateSecretResponse, error) {
+	namespace := r.GetContext().GetNamespace()
+	cluster := r.GetContext().GetCluster()
+	log.Infof("+resources CreateSecret (cluster: %q, namespace=%q)", cluster, namespace)
+
+	typedClient, _, err := s.clientGetter(ctx, cluster)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
+	}
+
+	_, err = typedClient.CoreV1().Secrets(namespace).Create(ctx, &core.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      r.GetName(),
+		},
+		Type:       secretTypeForEnum(r.GetType()),
+		StringData: r.GetStringData(),
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, errorByStatus("get", "Namespace", namespace, err)
+	}
+
+	return &v1alpha1.CreateSecretResponse{}, nil
+}
+
+func secretTypeForEnum(secretType v1alpha1.SecretType) core.SecretType {
+	switch secretType {
+	case v1alpha1.SecretType_SECRET_TYPE_OPAQUE_UNSPECIFIED:
+		return core.SecretTypeOpaque
+	case v1alpha1.SecretType_SECRET_TYPE_SERVICE_ACCOUNT_TOKEN:
+		return core.SecretTypeServiceAccountToken
+	case v1alpha1.SecretType_SECRET_TYPE_DOCKER_CONFIG:
+		return core.SecretTypeDockercfg
+	case v1alpha1.SecretType_SECRET_TYPE_DOCKER_CONFIG_JSON:
+		return core.SecretTypeDockerConfigJson
+	case v1alpha1.SecretType_SECRET_TYPE_BASIC_AUTH:
+		return core.SecretTypeBasicAuth
+	case v1alpha1.SecretType_SECRET_TYPE_SSH_AUTH:
+		return core.SecretTypeSSHAuth
+	case v1alpha1.SecretType_SECRET_TYPE_TLS:
+		return core.SecretTypeTLS
+	case v1alpha1.SecretType_SECRET_TYPE_BOOTSTRAP_TOKEN:
+		return core.SecretTypeBootstrapToken
+	}
+	return core.SecretTypeOpaque
+}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets.go
@@ -38,8 +38,8 @@ func (s *Server) CreateSecret(ctx context.Context, r *v1alpha1.CreateSecretReque
 
 	_, err = typedClient.CoreV1().Secrets(namespace).Create(ctx, &core.Secret{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
+			Kind:       core.ResourceSecrets.String(),
+			APIVersion: core.SchemeGroupVersion.WithResource(core.ResourceSecrets.String()).String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	core "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -139,6 +140,128 @@ func TestCreateSecret(t *testing.T) {
 			}
 			if got, want := secret.StringData, tc.request.GetStringData(); !cmp.Equal(got, want) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func TestGetSecretNames(t *testing.T) {
+
+	ignoredUnexported := cmpopts.IgnoreUnexported(
+		v1alpha1.GetSecretNamesResponse{},
+	)
+
+	testCases := []struct {
+		name              string
+		request           *v1alpha1.GetSecretNamesRequest
+		k8sError          error
+		expectedResponse  *v1alpha1.GetSecretNamesResponse
+		expectedErrorCode codes.Code
+		existingObjects   []runtime.Object
+	}{
+		{
+			name: "returns existing namespaces from the context namespace only if user has RBAC",
+			request: &v1alpha1.GetSecretNamesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			existingObjects: []runtime.Object{
+				&core.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Namespace",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret-1",
+						Namespace: "default",
+					},
+					Type: core.SecretTypeOpaque,
+					StringData: map[string]string{
+						"ignored": "we don't use it",
+					},
+				},
+				&core.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Namespace",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret-2",
+						Namespace: "default",
+					},
+					Type: core.SecretTypeDockerConfigJson,
+				},
+				&core.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Namespace",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret-other-namespace",
+						Namespace: "other-namespace",
+					},
+					Type: core.SecretTypeDockerConfigJson,
+				},
+			},
+			expectedResponse: &v1alpha1.GetSecretNamesResponse{
+				SecretNames: map[string]v1alpha1.SecretType{
+					"secret-1": v1alpha1.SecretType_SECRET_TYPE_OPAQUE_UNSPECIFIED,
+					"secret-2": v1alpha1.SecretType_SECRET_TYPE_DOCKER_CONFIG_JSON,
+				},
+			},
+		},
+		{
+			name: "returns permission denied if k8s returns a forbidden error",
+			request: &v1alpha1.GetSecretNamesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			k8sError: k8serrors.NewForbidden(schema.GroupResource{
+				Group:    "v1",
+				Resource: "secrets",
+			}, "default", errors.New("Bang")),
+			expectedErrorCode: codes.PermissionDenied,
+		},
+		{
+			name: "returns an internal error if k8s returns an unexpected error",
+			request: &v1alpha1.GetSecretNamesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
+			expectedErrorCode: codes.Internal,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			fakeClient := typfake.NewSimpleClientset(tc.existingObjects...)
+			if tc.k8sError != nil {
+				fakeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor("list", "secrets", func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.SecretList{}, tc.k8sError
+				})
+			}
+			s := Server{
+				clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+					return fakeClient, nil, nil
+				},
+			}
+
+			response, err := s.GetSecretNames(context.Background(), tc.request)
+
+			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
+			}
+
+			if got, want := response, tc.expectedResponse; !cmp.Equal(got, want, ignoredUnexported) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported))
 			}
 		})
 	}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright © 2021 VMware
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	typfake "k8s.io/client-go/kubernetes/fake"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	clientGoTesting "k8s.io/client-go/testing"
+)
+
+func TestCreateSecret(t *testing.T) {
+
+	ignoredUnexported := cmpopts.IgnoreUnexported(
+		v1alpha1.CreateSecretResponse{},
+	)
+
+	emptyResponse := &v1alpha1.CreateSecretResponse{}
+	testCases := []struct {
+		name              string
+		request           *v1alpha1.CreateSecretRequest
+		k8sError          error
+		expectedResponse  *v1alpha1.CreateSecretResponse
+		expectedErrorCode codes.Code
+		existingObjects   []runtime.Object
+	}{
+		{
+			name: "creates an opaque secret by default",
+			request: &v1alpha1.CreateSecretRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+			},
+			expectedResponse: emptyResponse,
+		},
+		{
+			name: "returns permission denied if k8s returns a forbidden error",
+			request: &v1alpha1.CreateSecretRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			k8sError: k8serrors.NewForbidden(schema.GroupResource{
+				Group:    "v1",
+				Resource: "secrets",
+			}, "default", errors.New("Bang")),
+			expectedErrorCode: codes.PermissionDenied,
+		},
+		{
+			name: "returns already exists if k8s returns an already exists error",
+			request: &v1alpha1.CreateSecretRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			k8sError: k8serrors.NewAlreadyExists(schema.GroupResource{
+				Group:    "v1",
+				Resource: "secrets",
+			}, "default"),
+			expectedErrorCode: codes.AlreadyExists,
+		},
+		{
+			name: "returns an internal error if k8s returns an unexpected error",
+			request: &v1alpha1.CreateSecretRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
+					Cluster:   "default",
+					Namespace: "default",
+				},
+			},
+			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
+			expectedErrorCode: codes.Internal,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			fakeClient := typfake.NewSimpleClientset(tc.existingObjects...)
+			if tc.k8sError != nil {
+				fakeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor("create", "secrets", func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &v1.Secret{}, tc.k8sError
+				})
+			}
+			s := Server{
+				clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+					return fakeClient, nil, nil
+				},
+			}
+
+			response, err := s.CreateSecret(context.Background(), tc.request)
+
+			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
+			}
+
+			if got, want := response, tc.expectedResponse; !cmp.Equal(got, want, ignoredUnexported) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported))
+			}
+
+			if tc.expectedErrorCode != codes.OK {
+				return
+			}
+			secret, err := fakeClient.CoreV1().Secrets(tc.request.GetContext().GetNamespace()).Get(context.Background(), tc.request.GetName(), metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			if got, want := secret.StringData, tc.request.GetStringData(); !cmp.Equal(got, want) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -416,6 +416,7 @@ func resourceRefsEqual(r1, r2 *pkgsGRPCv1alpha1.ResourceRef) bool {
 
 // errorByStatus generates a meaningful error message
 func errorByStatus(verb, resource, identifier string, err error) error {
+	// If the error is already a k8s StatusError, return the StatusErr
 	if identifier == "" {
 		identifier = "all"
 	}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -416,7 +416,6 @@ func resourceRefsEqual(r1, r2 *pkgsGRPCv1alpha1.ResourceRef) bool {
 
 // errorByStatus generates a meaningful error message
 func errorByStatus(verb, resource, identifier string, err error) error {
-	// If the error is already a k8s StatusError, return the StatusErr
 	if identifier == "" {
 		identifier = "all"
 	}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Following on from #3914, this PR adds the implementations for `CreateSecret` and `GetSecretNames`.

### Benefits

Can now update the dashboard to use the new endpoints rather than hitting the k8s API server.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3896 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
