### PR TITLE
Switch dashboard's createDockerRegistrySecret to use resources API.

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -1214,17 +1214,33 @@ describe("fetchImagePullSecrets", () => {
 
 describe("createDockerRegistrySecret", () => {
   it("creates a docker registry", async () => {
-    const secret = {
-      type: "kubernetes.io/dockerconfigjson",
-    };
-    Secret.createPullSecret = jest.fn().mockReturnValue(secret);
+    Secret.createPullSecret = jest.fn();
     const expectedActions = [
       {
         type: getType(repoActions.createImagePullSecret),
-        payload: secret,
+        payload: "secret-name",
       },
     ];
-    await store.dispatch(repoActions.createDockerRegistrySecret("", "", "", "", "", ""));
+
+    await store.dispatch(
+      repoActions.createDockerRegistrySecret(
+        "secret-name",
+        "user",
+        "password",
+        "email",
+        "server",
+        "namespace",
+      ),
+    );
+    expect(Secret.createPullSecret).toHaveBeenCalledWith(
+      "default",
+      "secret-name",
+      "user",
+      "password",
+      "email",
+      "server",
+      "namespace",
+    );
     expect(store.getActions()).toEqual(expectedActions);
   });
 

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -73,7 +73,7 @@ export const receiveImagePullSecrets = createAction("RECEIVE_IMAGE_PULL_SECRETS"
 });
 
 export const createImagePullSecret = createAction("CREATE_IMAGE_PULL_SECRET", resolve => {
-  return (secret: ISecret) => resolve(secret);
+  return (secretName: string) => resolve(secretName);
 });
 
 const allActions = [
@@ -433,16 +433,8 @@ export function createDockerRegistrySecret(
       clusters: { currentCluster },
     } = getState();
     try {
-      const secret = await Secret.createPullSecret(
-        currentCluster,
-        name,
-        user,
-        password,
-        email,
-        server,
-        namespace,
-      );
-      dispatch(createImagePullSecret(secret));
+      await Secret.createPullSecret(currentCluster, name, user, password, email, server, namespace);
+      dispatch(createImagePullSecret(name));
       return true;
     } catch (e: any) {
       dispatch(errorRepos(e, "fetch"));

--- a/dashboard/src/shared/Secret.test.ts
+++ b/dashboard/src/shared/Secret.test.ts
@@ -1,5 +1,11 @@
 import { axiosWithAuth } from "./AxiosInstance";
 import Secret from "./Secret";
+import {
+  CreateSecretRequest,
+  CreateSecretResponse,
+  SecretType,
+} from "gen/kubeappsapis/plugins/resources/v1alpha1/resources";
+import { KubeappsGrpcClient } from "./KubeappsGrpcClient";
 
 it("gets a secret", async () => {
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: "ok" });
@@ -17,28 +23,44 @@ it("lists secrets", async () => {
   );
 });
 
-it("creates a pull secret", async () => {
-  axiosWithAuth.post = jest.fn().mockReturnValue({ data: "ok" });
-  const name = "repo-1";
-  const user = "foo";
-  const password = "pass";
-  const email = "foo@bar.com";
-  const server = "docker.io";
-  const namespace = "default";
-  expect(
-    await Secret.createPullSecret("default", name, user, password, email, server, namespace),
-  ).toBe("ok");
-  expect(axiosWithAuth.post).toHaveBeenCalledWith(
-    "api/clusters/default/api/v1/namespaces/default/secrets",
-    {
-      apiVersion: "v1",
+describe("createSecret", () => {
+  // Create a real client, but we'll stub out the function we're interested in.
+  const client = new KubeappsGrpcClient().getResourcesServiceClientImpl();
+  let mockClientCreateSecret: jest.MockedFunction<typeof client.CreateSecret>;
+  beforeEach(() => {
+    mockClientCreateSecret = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({} as CreateSecretResponse));
+
+    jest.spyOn(client, "CreateSecret").mockImplementation(mockClientCreateSecret);
+    jest.spyOn(Secret, "resourcesClient").mockImplementation(() => client);
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("creates a pull secret", async () => {
+    const cluster = "default";
+    const name = "repo-1";
+    const user = "foo";
+    const password = "pass";
+    const email = "foo@bar.com";
+    const server = "docker.io";
+    const namespace = "default";
+
+    await Secret.createPullSecret("default", name, user, password, email, server, namespace);
+
+    expect(mockClientCreateSecret).toHaveBeenCalledWith({
+      context: {
+        cluster,
+        namespace,
+      },
+      name,
       stringData: {
         ".dockerconfigjson":
           '{"auths":{"docker.io":{"username":"foo","password":"pass","email":"foo@bar.com","auth":"Zm9vOnBhc3M="}}}',
       },
-      kind: "Secret",
-      metadata: { name: "repo-1" },
-      type: "kubernetes.io/dockerconfigjson",
-    },
-  );
+      type: SecretType.SECRET_TYPE_DOCKER_CONFIG_JSON,
+    } as CreateSecretRequest);
+  });
 });


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Switches the `Secret.createDockerRegistrySecret` helper from using the k8s API directly to using the resources plugin.

Tested IRL to ensure both the dashboard change and the backend grpc function work together as expected (which they do).

### Benefits

* No longer receive the secret data over the network when creating a secret,
* One less call-site using the k8s API
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3896 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
Next up is switching the dashboard's `Secret.list` to use the plugin's `GetSecretNames` which will be trickier, as it also involves updating the dashboard to no longer require the secret data for the UX interaction.