### PR TITLE
suppress noisy logs

### DIFF
--- a/cmd/kubeapps-apis/server/server.go
+++ b/cmd/kubeapps-apis/server/server.go
@@ -28,9 +28,6 @@ import (
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/soheilhy/cmux"
 
-	"log"
-	"os"
-
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	packagesv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core/packages/v1alpha1"
@@ -43,28 +40,6 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	klogv2 "k8s.io/klog/v2"
 )
-
-// LogRequest is a gRPC UnaryServerInterceptor that will log the API call
-func CreateRequestLogger() func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (response interface{}, err error) {
-
-	// Include micro seconds in timestamp
-	logger := log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Lmicroseconds)
-
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (response interface{}, err error) {
-
-		start := time.Now()
-		res, err := handler(ctx, req)
-
-		// Format string : [timestamp] [status code] [duration] [full path]
-		// 2021-11-29 15:10:21.642313 OK 97.752µs /kubeappsapis.core.packages.v1alpha1.PackagesService/GetAvailablePackageSummaries
-		logger.Printf("%v %s %s\n",
-			status.Code(err),
-			time.Since(start),
-			info.FullMethod)
-
-		return res, err
-	}
-}
 
 func getLogLevelOfEndpoint(endpoint string) klogv2.Level {
 
@@ -84,6 +59,7 @@ func getLogLevelOfEndpoint(endpoint string) klogv2.Level {
 	return level
 }
 
+// LogRequest is a gRPC UnaryServerInterceptor that will log the API call
 func LogRequest(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (response interface{}, err error) {
 
 	start := time.Now()


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Kubeapps-api is using "httpGet probe" for livenessProbe & readinessProbe every 10secs.
values.yaml
```
  livenessProbe:
    enabled: true
    httpGet:
      path: /core/plugins/v1alpha1/configured-plugins
      port: 50051
    initialDelaySeconds: 60
    periodSeconds: 10

  readinessProbe:
    enabled: true
    httpGet:
      path: /core/plugins/v1alpha1/configured-plugins
      port: 50051
    initialDelaySeconds: 0
    periodSeconds: 10
```

This is causing noisy logs of probe endpoint
`/kubeappsapis.core.plugins.v1alpha1.PluginsService/GetConfiguredPlugins`

as mentioned in PR#[3780](https://github.com/kubeapps/kubeapps/pull/3780)

 
Solution:

Option-1:
We can probably use "GRPC Health Checking Protocol" as mentioned in  [health-checking-grpc-servers-on-kubernetes](https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/)


Adding “grpc-health-probe” needs to implement standard health check "protocol" as in [health-checking](https://grpc.github.io/grpc/core/md_doc_health-checking.html)  and bundle health check utility "tool" with the kubeapps-api binary.

But this still does not solve the noisy logging of RPC calls.


Option-2:
Suppress the endpoints in the grpc interceptor call.

The commit implements 
1) Suppress the noisy endpoints
2) uses consistent logging format (same as klog)
### Benefits

<!-- What benefits will be realized by the code change? -->
no noisy endpoints logs 

### Possible drawbacks

<!-- Describe any known limitations with your change -->
N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
