### PR TITLE
App repository update form fix for filters (#3447)

### DIFF
--- a/dashboard/src/shared/AppRepository.test.ts
+++ b/dashboard/src/shared/AppRepository.test.ts
@@ -1,0 +1,113 @@
+import * as moxios from "moxios";
+import { AppRepository } from "./AppRepository";
+import { axiosWithAuth } from "./AxiosInstance";
+import * as url from "./url";
+import { IAppRepositoryFilter } from "shared/types";
+
+describe("AppRepository", () => {
+  const cluster = "cluster";
+  const namespace = "namespace";
+  const repo = {
+    name: "repo-test",
+    repoURL: "repo-url",
+    type: "repo-type",
+    description: "repo-description",
+    authHeader: "repo-authHeader",
+    authRegCreds: "repo-authRegCreds",
+    customCA: "repo-customCA",
+    syncJobPodTemplate: { type: "helm" },
+    registrySecrets: ["repo-secret1"],
+    ociRepositories: ["oci-repo1"],
+    tlsInsecureSkipVerify: false,
+    passCredentials: true,
+    filterRule: {
+      jq: ".name == $var0",
+      variables: { $var0: "nginx" },
+    } as IAppRepositoryFilter,
+  };
+
+  beforeEach(() => {
+    // Import as "any" to avoid typescript syntax error
+    moxios.install(axiosWithAuth as any);
+  });
+  afterEach(() => {
+    moxios.uninstall(axiosWithAuth as any);
+    jest.restoreAllMocks();
+  });
+
+  it("create repository", async () => {
+    const createRepoUrl = url.backend.apprepositories.create(cluster, namespace);
+    moxios.stubRequest(createRepoUrl, {
+      status: 200,
+      response: {},
+    });
+
+    await AppRepository.create(
+      cluster,
+      repo.name,
+      namespace,
+      repo.repoURL,
+      repo.type,
+      repo.description,
+      repo.authHeader,
+      repo.authRegCreds,
+      repo.customCA,
+      repo.syncJobPodTemplate,
+      repo.registrySecrets,
+      repo.ociRepositories,
+      repo.tlsInsecureSkipVerify,
+      repo.passCredentials,
+      repo.filterRule,
+    );
+
+    const request = moxios.requests.mostRecent();
+    expect(request.config.method).toEqual("post");
+    expect(request.url).toBe(createRepoUrl);
+    expect(JSON.parse(request.config.data)).toEqual({ appRepository: repo });
+  });
+
+  it("update repository", async () => {
+    const updateRepoUrl = url.backend.apprepositories.update(cluster, namespace, repo.name);
+    moxios.stubRequest(updateRepoUrl, {
+      status: 200,
+      response: {},
+    });
+
+    await AppRepository.update(
+      cluster,
+      repo.name,
+      namespace,
+      repo.repoURL,
+      repo.type,
+      repo.description,
+      repo.authHeader,
+      repo.authRegCreds,
+      repo.customCA,
+      repo.syncJobPodTemplate,
+      repo.registrySecrets,
+      repo.ociRepositories,
+      repo.tlsInsecureSkipVerify,
+      repo.passCredentials,
+      repo.filterRule,
+    );
+
+    const request = moxios.requests.mostRecent();
+    expect(request.config.method).toEqual("put");
+    expect(request.url).toBe(updateRepoUrl);
+    expect(JSON.parse(request.config.data)).toEqual({ appRepository: repo });
+  });
+
+  it("delete repository", async () => {
+    const deleteRepoUrl = url.backend.apprepositories.delete(cluster, namespace, repo.name);
+    moxios.stubRequest(deleteRepoUrl, {
+      status: 200,
+      response: {},
+    });
+
+    await AppRepository.delete(cluster, namespace, repo.name);
+
+    const request = moxios.requests.mostRecent();
+    expect(request.config.method).toEqual("delete");
+    expect(request.url).toBe(deleteRepoUrl);
+  });
+});

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -59,7 +59,7 @@ export class AppRepository {
           ociRepositories,
           tlsInsecureSkipVerify: skipTLS,
           passCredentials: passCredentials,
-          filter,
+          filterRule: filter,
         },
       },
     );


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR fixes a problem with updating an app repository with filters.
Repo filter data is now processed correctly both in backend and frontend.

### Benefits

App repository filters are no longer gone after repo data update.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #3447

### Additional information

I have added a test file for `AppRepository` given that none was existing.
