### PR TITLE
Fix for malformed can-i URL (#2719)

### DIFF
--- a/dashboard/src/shared/Kube.test.ts
+++ b/dashboard/src/shared/Kube.test.ts
@@ -264,5 +264,9 @@ describe("App", () => {
       const allowed = await Kube.canI("cluster", "v1", "namespaces", "create", "");
       expect(allowed).toBe(true);
     });
+    it("should ignore empty clusters", async () => {
+      const allowed = await Kube.canI("", "v1", "namespaces", "create", "");
+      expect(allowed).toBe(false);
+    });
   });
 });

--- a/dashboard/src/shared/Kube.ts
+++ b/dashboard/src/shared/Kube.ts
@@ -120,6 +120,9 @@ export class Kube {
     namespace: string,
   ) {
     try {
+      if (!cluster) {
+        return false;
+      }
       const { data } = await axiosWithAuth.post<{ allowed: boolean }>(url.backend.canI(cluster), {
         group,
         resource,


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This PR prevents FE from placing can-i requests with malformed URLs that otherwise end up in 404 or 405 HTTP errors.
Thought that it was more correct formally not placing the requests instead of returning `200 OK` with body `authorized: no`. Reason being that the URL was incorrect, and not the parameters.

### Benefits

Less useless requests from browser to backend for can-i checks.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #2719

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
