### PR TITLE
Fix repeated operator resources shown in dashboard (#3574)

### DIFF
--- a/dashboard/src/actions/operators.ts
+++ b/dashboard/src/actions/operators.ts
@@ -321,7 +321,7 @@ export function getResources(
         try {
           const csvResources = await Operators.listResources(
             cluster,
-            namespace,
+            csv.metadata.namespace,
             `${group}/${crd.version}`,
             plural,
           );

--- a/dashboard/src/components/AppList/AppList.test.tsx
+++ b/dashboard/src/components/AppList/AppList.test.tsx
@@ -356,10 +356,14 @@ context("when apps available", () => {
 
 context("when custom resources available", () => {
   const state = deepClone(initialState) as IStoreState;
-  const cr = { kind: "KubeappsCluster", metadata: { name: "foo-cluster" } } as any;
+  const cr = {
+    kind: "KubeappsCluster",
+    metadata: { name: "foo-cluster", namespace: "foo-ns" },
+  } as any;
   const csv = {
     metadata: {
       name: "foo",
+      namespace: "foo-ns",
     },
     spec: {
       customresourcedefinitions: {
@@ -384,7 +388,7 @@ context("when custom resources available", () => {
     const wrapper = mountWrapper(getStore(state), <AppList />);
     const itemList = wrapper.find(CustomResourceListItem);
     expect(itemList).toExist();
-    expect(itemList.key()).toBe("foo-cluster");
+    expect(itemList.key()).toBe("foo-cluster_foo-ns");
   });
 
   it("filters out items", () => {

--- a/dashboard/src/components/AppList/AppListGrid.tsx
+++ b/dashboard/src/components/AppList/AppListGrid.tsx
@@ -67,7 +67,7 @@ function AppListGrid(props: IAppListProps) {
           return (
             <CustomResourceListItem
               cluster={cluster}
-              key={r.metadata.name}
+              key={r.metadata.name + "_" + r.metadata.namespace}
               resource={r}
               csv={csv!}
             />

--- a/dashboard/src/components/AppList/CustomResourceListItem.tsx
+++ b/dashboard/src/components/AppList/CustomResourceListItem.tsx
@@ -25,7 +25,7 @@ function CustomResourceListItem(props: ICustomResourceListItemProps) {
   const icon = getIcon(csv);
   return (
     <InfoCard
-      key={resource.metadata.name}
+      key={resource.metadata.name + "_" + resource.metadata.namespace}
       link={app.operatorInstances.view(
         cluster,
         resource.metadata.namespace,
@@ -40,6 +40,7 @@ function CustomResourceListItem(props: ICustomResourceListItemProps) {
         <>
           <div>App: {resource.kind}</div>
           <div>Operator: {csv.spec.version || "-"}</div>
+          <div>Namespace: {resource.metadata.namespace || "-"}</div>
         </>
       }
       bgIcon={getPluginIcon("operator")}


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>


### Description of the change

Fix for operators resources showing repeated times (as many as namespaces existing in cluster) when listing installed items with "Show apps in all namespaces" marked in Dashboard.
Also added the label with namespace to cards.

Issue affects only the Dashboard/FE.

### Benefits

Realistic view of what operators resources are installed on each namespace.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #3574

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
