### PR TITLE
Added some more cases to the tests for chars encoding (#3758)

### DIFF
--- a/cmd/asset-syncer/server/testdata/helm-index-spaces.yaml
+++ b/cmd/asset-syncer/server/testdata/helm-index-spaces.yaml
@@ -5,3 +5,9 @@ entries:
   chart-without-spaces:
     - appVersion: v2
       name: "chart-without-spaces"
+  chart-with-special-chars-1:
+    - appVersion: v3
+      name: "chart\x23with\x23hashes"
+  chart-with-special-chars-4:
+    - appVersion: v1
+      name: "chart\x24with\x24chars"

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -1347,6 +1347,15 @@ func TestUnescapeChartsData(t *testing.T) {
 				{Name: "test/foo bar"},
 			},
 		},
+		{
+			"chart with encoded chars in name",
+			[]models.Chart{
+				{Name: "foo%23bar%2ebar"},
+			},
+			[]models.Chart{
+				{Name: "foo#bar.bar"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
@@ -1365,11 +1374,25 @@ func TestHelmRepoAppliesUnescape(t *testing.T) {
 	repoIndexYAML := string(repoIndexYAMLBytes)
 	expectedCharts := []models.Chart{
 		{
+			ID:            "test/chart$with$chars",
+			Name:          "chart$with$chars",
+			Repo:          expectedRepo,
+			Maintainers:   []chart.Maintainer{},
+			ChartVersions: []models.ChartVersion{{AppVersion: "v1"}},
+		},
+		{
 			ID:            "test/chart with spaces",
 			Name:          "chart with spaces",
 			Repo:          expectedRepo,
 			Maintainers:   []chart.Maintainer{},
 			ChartVersions: []models.ChartVersion{{AppVersion: "v1"}},
+		},
+		{
+			ID:            "test/chart#with#hashes",
+			Name:          "chart#with#hashes",
+			Repo:          expectedRepo,
+			Maintainers:   []chart.Maintainer{},
+			ChartVersions: []models.ChartVersion{{AppVersion: "v3"}},
 		},
 		{
 			ID:            "test/chart-without-spaces",


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Extension of tests introduced in #3758 to cover characters other than space in chart names, although Helm specifies that `chart names must contain only lower case letters and numbers. Words may be separated with dashes (-)`. See [Helm general conventions](https://helm.sh/docs/chart_best_practices/conventions/#chart-names).

Therefore, the special characters tested in this PR won't have effect for Helm, as it will fail if chart contains them. Maybe for systems other than Helm is useful.

### Benefits

Bit more test coverage for special characters encoding on chart names

### Possible drawbacks

N/A

### Applicable issues

- fixes #3758

### Additional information

Maybe we should limit the possible characters available for package names.