### PR TITLE
Disable the version selector when upgrading pkgs

### DIFF
--- a/dashboard/src/components/PackageHeader/PackageHeader.tsx
+++ b/dashboard/src/components/PackageHeader/PackageHeader.tsx
@@ -17,6 +17,7 @@ export interface IPackageHeaderProps {
   currentVersion?: string;
   selectedVersion?: string;
   deployButton?: JSX.Element;
+  hideVersionsSelector?: boolean;
 }
 
 export default function PackageHeader({
@@ -27,6 +28,7 @@ export default function PackageHeader({
   currentVersion,
   deployButton,
   selectedVersion,
+  hideVersionsSelector,
 }: IPackageHeaderProps) {
   return availablePackageDetail?.availablePackageRef?.identifier ? (
     <PageHeader
@@ -41,35 +43,39 @@ export default function PackageHeader({
       icon={availablePackageDetail?.iconUrl ? availablePackageDetail.iconUrl : placeholder}
       plugin={availablePackageDetail.availablePackageRef.plugin}
       version={
-        <>
-          <PackageVersionSelector
-            versions={versions}
-            onSelect={onSelect}
-            selectedVersion={selectedVersion}
-            currentVersion={currentVersion}
-            label={
-              <>
-                Package Version{" "}
-                <Tooltip
-                  label="package-versions-tooltip"
-                  id="package-versions-tooltip"
-                  position="bottom-left"
-                  iconProps={{ solid: true, size: "sm" }}
-                >
-                  Package and application versions can be increased independently.{" "}
-                  <a
-                    href="https://helm.sh/docs/topics/charts/#charts-and-versioning"
-                    target="_blank"
-                    rel="noopener noreferrer"
+        hideVersionsSelector ? (
+          <></>
+        ) : (
+          <>
+            <PackageVersionSelector
+              versions={versions}
+              onSelect={onSelect}
+              selectedVersion={selectedVersion}
+              currentVersion={currentVersion}
+              label={
+                <>
+                  Package Version{" "}
+                  <Tooltip
+                    label="package-versions-tooltip"
+                    id="package-versions-tooltip"
+                    position="bottom-left"
+                    iconProps={{ solid: true, size: "sm" }}
                   >
-                    More info here
-                  </a>
-                  .{" "}
-                </Tooltip>
-              </>
-            }
-          />
-        </>
+                    Package and application versions can be increased independently.{" "}
+                    <a
+                      href="https://helm.sh/docs/topics/charts/#charts-and-versioning"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      More info here
+                    </a>
+                    .{" "}
+                  </Tooltip>
+                </>
+              }
+            />
+          </>
+        )
       }
       buttons={deployButton ? [deployButton] : undefined}
     />

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -226,6 +226,9 @@ it("hides the PackageVersionSelector in the PackageHeader", () => {
       selectedDetails: availablePkgDetail,
       isFetching: false,
     } as IAppState,
+    packages: {
+      selected: selectedPkg,
+    } as IPackageState,
   };
   const wrapper = mountWrapper(
     getStore({ ...state }),

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -189,27 +189,6 @@ describe("it behaves like a loading component", () => {
 });
 
 it("fetches the available versions", () => {
-  const state = {
-    ...defaultStore,
-    apps: {
-      selected: installedPkgDetail,
-      selectedDetails: availablePkgDetail,
-      isFetching: false,
-    } as IAppState,
-  };
-  mountWrapper(
-    getStore({ ...state }),
-    <MemoryRouter initialEntries={[routePathParam]}>
-      <Route path={routePath}>
-        <UpgradeForm />,
-      </Route>
-    </MemoryRouter>,
-  );
-
-  expect(UpgradeForm);
-});
-
-it("fetches the available versions", () => {
   const getAvailablePackageVersions = jest.fn();
   PackagesService.getAvailablePackageVersions = getAvailablePackageVersions;
 
@@ -239,6 +218,27 @@ it("fetches the available versions", () => {
   } as AvailablePackageReference);
 });
 
+it("hides the PackageVersionSelector in the PackageHeader", () => {
+  const state = {
+    ...defaultStore,
+    apps: {
+      selected: installedPkgDetail,
+      selectedDetails: availablePkgDetail,
+      isFetching: false,
+    } as IAppState,
+  };
+  const wrapper = mountWrapper(
+    getStore({ ...state }),
+    <MemoryRouter initialEntries={[routePathParam]}>
+      <Route path={routePath}>
+        <UpgradeForm />,
+      </Route>
+    </MemoryRouter>,
+  );
+  expect(wrapper.find(PackageVersionSelector)).toHaveLength(1);
+  expect(wrapper.find(PackageHeader)).toHaveProp("hideVersionsSelector", true);
+});
+
 it("does not fetch the current package version if there is already one in the state", () => {
   const getAvailablePackageDetail = jest.fn();
   PackagesService.getAvailablePackageDetail = getAvailablePackageDetail;
@@ -253,7 +253,7 @@ it("does not fetch the current package version if there is already one in the st
       selected: selectedPkg,
     } as IPackageState,
   };
-  const wrapper = mountWrapper(
+  mountWrapper(
     getStore({ ...state }),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
@@ -261,8 +261,7 @@ it("does not fetch the current package version if there is already one in the st
       </Route>
     </MemoryRouter>,
   );
-  expect(wrapper.find(PackageVersionSelector)).toHaveLength(1);
-  expect(wrapper.find(PackageHeader)).toHaveProp("hideVersionsSelector", true);
+  expect(getAvailablePackageDetail).not.toHaveBeenCalled();
 });
 
 describe("renders an error", () => {

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -2,6 +2,8 @@ import actions from "actions";
 import DeploymentFormBody from "components/DeploymentFormBody/DeploymentFormBody";
 import Alert from "components/js/Alert";
 import LoadingWrapper from "components/LoadingWrapper/LoadingWrapper";
+import PackageVersionSelector from "components/PackageHeader/PackageVersionSelector";
+import PackageHeader from "components/PackageHeader/PackageHeader";
 import {
   AvailablePackageDetail,
   AvailablePackageReference,
@@ -187,6 +189,27 @@ describe("it behaves like a loading component", () => {
 });
 
 it("fetches the available versions", () => {
+  const state = {
+    ...defaultStore,
+    apps: {
+      selected: installedPkgDetail,
+      selectedDetails: availablePkgDetail,
+      isFetching: false,
+    } as IAppState,
+  };
+  mountWrapper(
+    getStore({ ...state }),
+    <MemoryRouter initialEntries={[routePathParam]}>
+      <Route path={routePath}>
+        <UpgradeForm />,
+      </Route>
+    </MemoryRouter>,
+  );
+
+  expect(UpgradeForm);
+});
+
+it("fetches the available versions", () => {
   const getAvailablePackageVersions = jest.fn();
   PackagesService.getAvailablePackageVersions = getAvailablePackageVersions;
 
@@ -230,7 +253,7 @@ it("does not fetch the current package version if there is already one in the st
       selected: selectedPkg,
     } as IPackageState,
   };
-  mountWrapper(
+  const wrapper = mountWrapper(
     getStore({ ...state }),
     <MemoryRouter initialEntries={[routePathParam]}>
       <Route path={routePath}>
@@ -238,7 +261,8 @@ it("does not fetch the current package version if there is already one in the st
       </Route>
     </MemoryRouter>,
   );
-  expect(getAvailablePackageDetail).not.toHaveBeenCalled();
+  expect(wrapper.find(PackageVersionSelector)).toHaveLength(1);
+  expect(wrapper.find(PackageHeader)).toHaveProp("hideVersionsSelector", true);
 });
 
 describe("renders an error", () => {

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -202,6 +202,7 @@ function UpgradeForm(props: IUpgradeFormProps) {
               onSelect={selectVersion}
               currentVersion={installedAppAvailablePackageDetail?.version?.pkgVersion}
               selectedVersion={pkgVersion}
+              hideVersionsSelector={true}
             />
             <LoadingWrapper
               loaded={


### PR DESCRIPTION
### Description of the change

In this PR, we add an attribute to conditionally render the version selector in the header, so that we can choose where we should render it.

### Benefits

No duplicated version selectors. In the picture, install vs upgrade views:

![image](https://user-images.githubusercontent.com/11535726/147923080-bafc7c95-66ad-4f9b-bb95-45a18953ef54.png)


### Possible drawbacks

If the CI fails, we should also add some fixes there.

### Applicable issues

- fixes https://github.com/kubeapps/kubeapps/issues/3890

### Additional information

(it's my first PR of 2022 :P)
