### PR TITLE
Set variable for Kind cluster name in makefile

### DIFF
--- a/script/makefiles/cluster-kind.mk
+++ b/script/makefiles/cluster-kind.mk
@@ -31,10 +31,10 @@ cluster-kind: ${CLUSTER_CONFIG}
 # reuse the key and cert from the apiserver, which already includes v3 extensions
 # for the correct alternative name (using the IP address).
 devel/dex.crt:
-	docker cp kubeapps-control-plane:/etc/kubernetes/pki/apiserver.crt ./devel/dex.crt
+	docker cp ${CLUSTER_NAME}-control-plane:/etc/kubernetes/pki/apiserver.crt ./devel/dex.crt
 
 devel/dex.key:
-	docker cp kubeapps-control-plane:/etc/kubernetes/pki/apiserver.key ./devel/dex.key
+	docker cp ${CLUSTER_NAME}-control-plane:/etc/kubernetes/pki/apiserver.key ./devel/dex.key
 
 ${ADDITIONAL_CLUSTER_CONFIG}: devel/dex.crt
 	kind create cluster \


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR brings a small adjustment for the Makefile in order to use the right cluster name when accessing the Kind node.

Kind creates nodes in Docker based on the `--name` parameter.
```
kind create cluster \
		[...]
		--name ${CLUSTER_NAME} \
                [...]
```

So when accessing those nodes, the corresponding name from variable is now used.

### Benefits

Previously the key+cert files were being retrieved from a hardcoded Kind node name. Now it is in line with the cluster name.

### Possible drawbacks

N/A

### Applicable issues

None

