### PR TITLE
Set the `ValuesSchema` and `DefaultValues` in Carvel pkgs

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
@@ -130,7 +130,7 @@ func (s *Server) buildAvailablePackageDetail(pkgMetadata *datapackagingv1alpha1.
 		foundPkgSemver.pkg.Spec.Licenses,
 		foundPkgSemver.pkg.Spec.ReleasedAt,
 	)
-	defaultValues, err := defaultValuesFromSchema(foundPkgSemver.pkg.Spec.ValuesSchema.OpenAPIv3.Raw)
+	defaultValues, err := defaultValuesFromSchema(foundPkgSemver.pkg.Spec.ValuesSchema.OpenAPIv3.Raw, true)
 	if err != nil {
 		log.Warningf("Failed to parse default values from schema: %v", err)
 		defaultValues = "# There is an error while parsing the schema."

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_adapters.go
@@ -130,6 +130,11 @@ func (s *Server) buildAvailablePackageDetail(pkgMetadata *datapackagingv1alpha1.
 		foundPkgSemver.pkg.Spec.Licenses,
 		foundPkgSemver.pkg.Spec.ReleasedAt,
 	)
+	defaultValues, err := defaultValuesFromSchema(foundPkgSemver.pkg.Spec.ValuesSchema.OpenAPIv3.Raw)
+	if err != nil {
+		log.Warningf("Failed to parse default values from schema: %v", err)
+		defaultValues = "# There is an error while parsing the schema."
+	}
 	availablePackageDetail := &corev1.AvailablePackageDetail{
 		AvailablePackageRef: &corev1.AvailablePackageReference{
 			Context: &corev1.Context{
@@ -151,24 +156,15 @@ func (s *Server) buildAvailablePackageDetail(pkgMetadata *datapackagingv1alpha1.
 			PkgVersion: requestedPkgVersion,
 			AppVersion: requestedPkgVersion,
 		},
-		Maintainers: maintainers,
-		Readme:      readme,
-
-		// TODO(agamez): we might need to have a default value (from the openapi schema?)
-		// and/or perform some changes in the UI
-		// DefaultValues: "",
-
-		// TODO(agamez): pkgs have an OpenAPI Schema object,
-		// but currently we aren't able to parse it from the UI
-		// ValuesSchema: foundPkgSemver.pkg.Spec.ValuesSchema.String(),
-
+		Maintainers:   maintainers,
+		Readme:        readme,
+		ValuesSchema:  string(foundPkgSemver.pkg.Spec.ValuesSchema.OpenAPIv3.Raw),
+		DefaultValues: defaultValues,
 		// TODO(agamez): fields 'HomeUrl','RepoUrl' are not being populated right now,
 		// but some fields (eg, release notes) have URLs (but not sure if in every pkg also happens)
 		// HomeUrl: "",
 		// RepoUrl:  "",
-
 	}
-
 	return availablePackageDetail, nil
 }
 

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -25,7 +26,11 @@ import (
 	datapackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 )
 
 type pkgSemver struct {
@@ -126,5 +131,126 @@ func extractValue(body string, key string) string {
 	r, _ := regexp.Compile(keystr)
 	match := r.FindString(body)
 	keyValMatch := strings.Split(match, ":")
-	return strings.ReplaceAll(keyValMatch[1], "\"", "")
+	value := ""
+	if len(keyValMatch) > 1 {
+		value = strings.ReplaceAll(keyValMatch[1], "\"", "")
+	}
+	return value
+}
+
+// defaultValuesFromSchema returns a yaml string with default values generated from an OpenAPI v3 Schema
+func defaultValuesFromSchema(schema []byte) (string, error) {
+	if len(schema) == 0 {
+		return "", nil
+	}
+	jsonSchemaProps := &apiextensions.JSONSchemaProps{}
+	if err := yaml.Unmarshal(schema, jsonSchemaProps); err != nil {
+		return "", err
+	}
+	structural, err := structuralschema.NewStructural(jsonSchemaProps)
+	if err != nil {
+		return "", err
+	}
+	unstructured := make(map[string]interface{})
+
+	defaultValues(unstructured, structural)
+	yaml, err := yaml.Marshal(unstructured)
+	if err != nil {
+		return "", err
+	}
+	return string(yaml), nil
+}
+
+// Default does defaulting of x depending on default values in s.
+// Based upon https://github.com/kubernetes/apiextensions-apiserver/blob/release-1.21/pkg/apiserver/schema/defaulting/algorithm.go
+// Plus modifications from https://github.com/vmware-tanzu/tanzu-framework/pull/1422
+// In short, it differs from upstream in that:
+// -- 1. Prevent deep copy of int as it panics
+// -- 2. For type object scan the first level properties for any defaults to create an empty map to populate
+// -- 3. If the property does not have a default, add one based on the type ("", false,)
+func defaultValues(x interface{}, s *structuralschema.Structural) {
+	if s == nil {
+		return
+	}
+
+	switch x := x.(type) {
+	case map[string]interface{}:
+		for k, prop := range s.Properties { //nolint
+			// if Default for object is nil, scan first level of properties for any defaults to create an empty default
+			if prop.Default.Object == nil {
+				createDefault := false
+				if prop.Properties != nil {
+					for _, v := range prop.Properties { //nolint
+						if v.Default.Object != nil {
+							createDefault = true
+							break
+						}
+					}
+				}
+				if createDefault {
+					prop.Default.Object = make(map[string]interface{})
+					// If not generating an empty object, fall back to the data type's defaults
+				} else {
+					switch prop.Type {
+					case "string":
+						prop.Default.Object = ""
+					case "number":
+						prop.Default.Object = 0
+					case "integer":
+						prop.Default.Object = 0
+					case "boolean":
+						prop.Default.Object = false
+					case "array":
+						prop.Default.Object = []interface{}{}
+					case "object":
+						prop.Default.Object = make(map[string]interface{})
+					}
+				}
+			}
+			if _, found := x[k]; !found || isNonNullableNull(x[k], &prop) {
+				if isKindInt(prop.Default.Object) {
+					x[k] = prop.Default.Object
+				} else {
+					x[k] = runtime.DeepCopyJSONValue(prop.Default.Object)
+				}
+			}
+		}
+		for k := range x {
+			if prop, found := s.Properties[k]; found {
+				defaultValues(x[k], &prop)
+			} else if s.AdditionalProperties != nil {
+				if isNonNullableNull(x[k], s.AdditionalProperties.Structural) {
+					if isKindInt(s.AdditionalProperties.Structural.Default.Object) {
+						x[k] = s.AdditionalProperties.Structural.Default.Object
+					} else {
+						x[k] = runtime.DeepCopyJSONValue(s.AdditionalProperties.Structural.Default.Object)
+					}
+				}
+				defaultValues(x[k], s.AdditionalProperties.Structural)
+			}
+		}
+	case []interface{}:
+		for i := range x {
+			if isNonNullableNull(x[i], s.Items) {
+				if isKindInt(s.Items.Default.Object) {
+					x[i] = s.Items.Default.Object
+				} else {
+					x[i] = runtime.DeepCopyJSONValue(s.Items.Default.Object)
+				}
+			}
+			defaultValues(x[i], s.Items)
+		}
+	default:
+		// scalars, do nothing
+	}
+}
+
+// isNonNullalbeNull returns true if the item is nil AND it's nullable
+func isNonNullableNull(x interface{}, s *structuralschema.Structural) bool {
+	return x == nil && s != nil && !s.Generic.Nullable
+}
+
+// isKindInt returns true if the item is an int
+func isKindInt(src interface{}) bool {
+	return src != nil && reflect.TypeOf(src).Kind() == reflect.Int
 }

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
@@ -1,0 +1,524 @@
+/*
+Copyright © 2021 VMware
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	kappctrlv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	datapackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+func TestGetPkgVersionsMap(t *testing.T) {
+	version123, _ := semver.NewVersion("1.2.3")
+	version124, _ := semver.NewVersion("1.2.4")
+	version127, _ := semver.NewVersion("1.2.7")
+	tests := []struct {
+		name                   string
+		packages               []*datapackagingv1alpha1.Package
+		expectedPkgVersionsMap map[string][]pkgSemver
+	}{
+		{"empty packages", []*datapackagingv1alpha1.Package{}, map[string][]pkgSemver{}},
+		{"multiple package versions", []*datapackagingv1alpha1.Package{
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       pkgResource,
+					APIVersion: datapackagingAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "tetris.foo.example.com.1.2.3",
+				},
+				Spec: datapackagingv1alpha1.PackageSpec{
+					RefName:                         "tetris.foo.example.com",
+					Version:                         "1.2.3",
+					Licenses:                        []string{"my-license"},
+					ReleaseNotes:                    "release notes",
+					CapactiyRequirementsDescription: "capacity description",
+				},
+			},
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       pkgResource,
+					APIVersion: datapackagingAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "tetris.foo.example.com.1.2.7",
+				},
+				Spec: datapackagingv1alpha1.PackageSpec{
+					RefName:                         "tetris.foo.example.com",
+					Version:                         "1.2.7",
+					Licenses:                        []string{"my-license"},
+					ReleaseNotes:                    "release notes",
+					CapactiyRequirementsDescription: "capacity description",
+				},
+			},
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       pkgResource,
+					APIVersion: datapackagingAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "tetris.foo.example.com.1.2.4",
+				},
+				Spec: datapackagingv1alpha1.PackageSpec{
+					RefName:                         "tetris.foo.example.com",
+					Version:                         "1.2.4",
+					Licenses:                        []string{"my-license"},
+					ReleaseNotes:                    "release notes",
+					CapactiyRequirementsDescription: "capacity description",
+				},
+			},
+		}, map[string][]pkgSemver{
+			"tetris.foo.example.com": {
+				{
+					pkg:     &datapackagingv1alpha1.Package{},
+					version: version123,
+				},
+				{
+					pkg:     &datapackagingv1alpha1.Package{},
+					version: version124,
+				},
+				{
+					pkg:     &datapackagingv1alpha1.Package{},
+					version: version127,
+				},
+			},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkgVersionsMap, err := getPkgVersionsMap(tt.packages)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			opts := cmpopts.IgnoreUnexported(pkgSemver{})
+			if want, got := tt.expectedPkgVersionsMap, pkgVersionsMap; !cmp.Equal(want, got, opts) {
+				t.Errorf("in %s: mismatch (-want +got):\n%s", tt.name, cmp.Diff(want, got, opts))
+			}
+		})
+	}
+}
+
+func TestStatusReasonForKappStatus(t *testing.T) {
+	tests := []struct {
+		name                 string
+		status               kappctrlv1alpha1.AppConditionType
+		expectedStatusReason corev1.InstalledPackageStatus_StatusReason
+	}{
+		{"ReconcileSucceeded", kappctrlv1alpha1.AppConditionType("ReconcileSucceeded"), corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED},
+		{"ValuesSchemaCheckFailed", kappctrlv1alpha1.AppConditionType("ValuesSchemaCheckFailed"), corev1.InstalledPackageStatus_STATUS_REASON_FAILED},
+		{"ReconcileFailed", kappctrlv1alpha1.AppConditionType("ReconcileFailed"), corev1.InstalledPackageStatus_STATUS_REASON_FAILED},
+		{"Reconciling", kappctrlv1alpha1.AppConditionType("Reconciling"), corev1.InstalledPackageStatus_STATUS_REASON_PENDING},
+		{"Unknown", kappctrlv1alpha1.AppConditionType("foo"), corev1.InstalledPackageStatus_STATUS_REASON_UNSPECIFIED},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userReason := statusReasonForKappStatus(tt.status)
+			if want, got := tt.expectedStatusReason, userReason; !cmp.Equal(want, got) {
+				t.Errorf("in %s: mismatch (-want +got):\n%s", tt.name, cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func TestUserReasonForKappStatus(t *testing.T) {
+	tests := []struct {
+		name               string
+		status             kappctrlv1alpha1.AppConditionType
+		expectedUserReason string
+	}{
+		{"ReconcileSucceeded", kappctrlv1alpha1.AppConditionType("ReconcileSucceeded"), "Reconcile succeeded"},
+		{"ValuesSchemaCheckFailed", kappctrlv1alpha1.AppConditionType("ValuesSchemaCheckFailed"), "Reconcile failed"},
+		{"ReconcileFailed", kappctrlv1alpha1.AppConditionType("ReconcileFailed"), "Reconcile failed"},
+		{"Reconciling", kappctrlv1alpha1.AppConditionType("Reconciling"), "Reconciling"},
+		{"Unknown", kappctrlv1alpha1.AppConditionType("foo"), "Unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userReason := userReasonForKappStatus(tt.status)
+			if want, got := tt.expectedUserReason, userReason; !cmp.Equal(want, got) {
+				t.Errorf("in %s: mismatch (-want +got):\n%s", tt.name, cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func TestErrorByStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		verb        string
+		resource    string
+		identifier  string
+		err         error
+		expectedErr error
+	}{
+		{"error msg for all resources ", "get", "my-resource", "", status.Errorf(codes.InvalidArgument, "boom!"), status.Errorf(codes.Internal, "unable to get the my-resource 'all' due to 'rpc error: code = InvalidArgument desc = boom!'")},
+		{"error msg for a single resources ", "get", "my-resource", "my-id", status.Errorf(codes.InvalidArgument, "boom!"), status.Errorf(codes.Internal, "unable to get the my-resource 'my-id' due to 'rpc error: code = InvalidArgument desc = boom!'")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := errorByStatus(tt.verb, tt.resource, tt.identifier, tt.err)
+			if got, want := err.Error(), tt.expectedErr.Error(); !cmp.Equal(want, got) {
+				t.Errorf("in %s: mismatch (-want +got):\n%s", tt.name, cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func TestExtractValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		key      string
+		expected string
+	}{
+		{"retrieves a top level key", `{"a": "foo"}`, "a", " foo"},
+		{"returns '' in nested keys", `{"a": { b: "foo"}}`, "b", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := extractValue(tt.body, tt.key)
+			if !cmp.Equal(tt.expected, values) {
+				t.Errorf("mismatch in '%s': %s", tt.name, cmp.Diff(tt.expected, values))
+			}
+		})
+	}
+}
+
+func TestDefaultValuesFromSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   []byte
+		expected string
+	}{
+		{"schema with and without defaults", []byte(`properties:
+  valueWithDefault:
+    default: 80
+    description: Value with default
+    type: integer
+  missingDefaultInteger:
+    description: Missing default integer
+    type: integer
+  missingDefaultNumber:
+    description: Missing default number
+    type: number
+  missingDefaultString:
+    description: Missing default string
+    type: string
+  missingDefaultBoolean:
+    description: Missing default boolean
+    type: boolean
+  missingDefaultArray:
+    description: Missing default array
+    type: array
+  missingDefaultObject:
+    description: Missing default object
+    type: object`,
+		),
+			`missingDefaultArray: []
+missingDefaultBoolean: false
+missingDefaultInteger: 0
+missingDefaultNumber: 0
+missingDefaultObject: {}
+missingDefaultString: ""
+valueWithDefault: 80
+`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, err := defaultValuesFromSchema(tt.schema)
+			if err != nil {
+				t.Errorf("unexpected error = %v", err)
+			}
+			if !cmp.Equal(tt.expected, values) {
+				t.Errorf("mismatch in '%s': %s", tt.name, cmp.Diff(tt.expected, values))
+			}
+		})
+	}
+}
+
+// From https://github.com/kubernetes/apiextensions-apiserver/blob/release-1.21/pkg/apiserver/schema/defaulting/algorithm_test.go
+// With a new test case ("object without default values")
+func TestDefaultValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		schema   *structuralschema.Structural
+		expected string
+	}{
+		{"empty", "null", nil, "null"},
+		{"scalar", "4", &structuralschema.Structural{
+			Generic: structuralschema.Generic{
+				Default: structuralschema.JSON{"foo"},
+			},
+		}, "4"},
+		{"scalar array", "[1,2]", &structuralschema.Structural{
+			Items: &structuralschema.Structural{
+				Generic: structuralschema.Generic{
+					Default: structuralschema.JSON{"foo"},
+				},
+			},
+		}, "[1,2]"},
+		{"object array", `[{"a":1},{"b":1},{"c":1}]`, &structuralschema.Structural{
+			Items: &structuralschema.Structural{
+				Properties: map[string]structuralschema.Structural{
+					"a": {
+						Generic: structuralschema.Generic{
+							Default: structuralschema.JSON{"A"},
+						},
+					},
+					"b": {
+						Generic: structuralschema.Generic{
+							Default: structuralschema.JSON{"B"},
+						},
+					},
+					"c": {
+						Generic: structuralschema.Generic{
+							Default: structuralschema.JSON{"C"},
+						},
+					},
+				},
+			},
+		}, `[{"a":1,"b":"B","c":"C"},{"a":"A","b":1,"c":"C"},{"a":"A","b":"B","c":1}]`},
+		// New test case checking our tweaks
+		{"object without default values", `{}`, &structuralschema.Structural{
+			Properties: map[string]structuralschema.Structural{
+				"a": {
+					Generic: structuralschema.Generic{
+						Type: "string",
+					},
+				},
+				"b": {
+					Generic: structuralschema.Generic{
+						Type: "boolean",
+					},
+				},
+				"c": {
+					Generic: structuralschema.Generic{
+						Type: "array",
+					},
+				},
+				"d": {
+					Generic: structuralschema.Generic{
+						Type: "number",
+					},
+				},
+				"e": {
+					Generic: structuralschema.Generic{
+						Type: "integer",
+					},
+				},
+				"f": {
+					Generic: structuralschema.Generic{
+						Type: "object",
+					},
+				},
+			},
+		}, `{
+  "a": "",
+  "b": false,
+  "c": [],
+  "d": 0,
+  "e": 0,
+  "f": {}
+}
+`},
+		{"object array object", `{"array":[{"a":1},{"b":2}],"object":{"a":1},"additionalProperties":{"x":{"a":1},"y":{"b":2}}}`, &structuralschema.Structural{
+			Properties: map[string]structuralschema.Structural{
+				"array": {
+					Items: &structuralschema.Structural{
+						Properties: map[string]structuralschema.Structural{
+							"a": {
+								Generic: structuralschema.Generic{
+									Default: structuralschema.JSON{"A"},
+								},
+							},
+							"b": {
+								Generic: structuralschema.Generic{
+									Default: structuralschema.JSON{"B"},
+								},
+							},
+						},
+					},
+				},
+				"object": {
+					Properties: map[string]structuralschema.Structural{
+						"a": {
+							Generic: structuralschema.Generic{
+								Default: structuralschema.JSON{"N"},
+							},
+						},
+						"b": {
+							Generic: structuralschema.Generic{
+								Default: structuralschema.JSON{"O"},
+							},
+						},
+					},
+				},
+				"additionalProperties": {
+					Generic: structuralschema.Generic{
+						AdditionalProperties: &structuralschema.StructuralOrBool{
+							Structural: &structuralschema.Structural{
+								Properties: map[string]structuralschema.Structural{
+									"a": {
+										Generic: structuralschema.Generic{
+											Default: structuralschema.JSON{"alpha"},
+										},
+									},
+									"b": {
+										Generic: structuralschema.Generic{
+											Default: structuralschema.JSON{"beta"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"foo": {
+					Generic: structuralschema.Generic{
+						Default: structuralschema.JSON{"bar"},
+					},
+				},
+			},
+		}, `{"array":[{"a":1,"b":"B"},{"a":"A","b":2}],"object":{"a":1,"b":"O"},"additionalProperties":{"x":{"a":1,"b":"beta"},"y":{"a":"alpha","b":2}},"foo":"bar"}`},
+		{"empty and null", `[{},{"a":1},{"a":0},{"a":0.0},{"a":""},{"a":null},{"a":[]},{"a":{}}]`, &structuralschema.Structural{
+			Items: &structuralschema.Structural{
+				Properties: map[string]structuralschema.Structural{
+					"a": {
+						Generic: structuralschema.Generic{
+							Default: structuralschema.JSON{"A"},
+						},
+					},
+				},
+			},
+		}, `[{"a":"A"},{"a":1},{"a":0},{"a":0.0},{"a":""},{"a":"A"},{"a":[]},{"a":{}}]`},
+		{"null in nullable list", `[null]`, &structuralschema.Structural{
+			Generic: structuralschema.Generic{
+				Nullable: true,
+			},
+			Items: &structuralschema.Structural{
+				Properties: map[string]structuralschema.Structural{
+					"a": {
+						Generic: structuralschema.Generic{
+							Default: structuralschema.JSON{"A"},
+						},
+					},
+				},
+			},
+		}, `[null]`},
+		{"null in non-nullable list", `[null]`, &structuralschema.Structural{
+			Generic: structuralschema.Generic{
+				Nullable: false,
+			},
+			Items: &structuralschema.Structural{
+				Generic: structuralschema.Generic{
+					Default: structuralschema.JSON{"A"},
+				},
+			},
+		}, `["A"]`},
+		{"null in nullable object", `{"a": null}`, &structuralschema.Structural{
+			Generic: structuralschema.Generic{},
+			Properties: map[string]structuralschema.Structural{
+				"a": {
+					Generic: structuralschema.Generic{
+						Nullable: true,
+						Default:  structuralschema.JSON{"A"},
+					},
+				},
+			},
+		}, `{"a": null}`},
+		{"null in non-nullable object", `{"a": null}`, &structuralschema.Structural{
+			Properties: map[string]structuralschema.Structural{
+				"a": {
+					Generic: structuralschema.Generic{
+						Nullable: false,
+						Default:  structuralschema.JSON{"A"},
+					},
+				},
+			},
+		}, `{"a": "A"}`},
+		{"null in nullable object with additionalProperties", `{"a": null}`, &structuralschema.Structural{
+			Generic: structuralschema.Generic{
+				AdditionalProperties: &structuralschema.StructuralOrBool{
+					Structural: &structuralschema.Structural{
+						Generic: structuralschema.Generic{
+							Nullable: true,
+							Default:  structuralschema.JSON{"A"},
+						},
+					},
+				},
+			},
+		}, `{"a": null}`},
+		{"null in non-nullable object with additionalProperties", `{"a": null}`, &structuralschema.Structural{
+			Generic: structuralschema.Generic{
+				AdditionalProperties: &structuralschema.StructuralOrBool{
+					Structural: &structuralschema.Structural{
+						Generic: structuralschema.Generic{
+							Nullable: false,
+							Default:  structuralschema.JSON{"A"},
+						},
+					},
+				},
+			},
+		}, `{"a": "A"}`},
+		{"null unknown field", `{"a": null}`, &structuralschema.Structural{
+			Generic: structuralschema.Generic{
+				AdditionalProperties: &structuralschema.StructuralOrBool{
+					Bool: true,
+				},
+			},
+		}, `{"a": null}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var in interface{}
+			if err := json.Unmarshal([]byte(tt.json), &in); err != nil {
+				t.Fatal(err)
+			}
+
+			var expected interface{}
+			if err := json.Unmarshal([]byte(tt.expected), &expected); err != nil {
+				t.Fatal(err)
+			}
+
+			defaultValues(in, tt.schema)
+			if !reflect.DeepEqual(in, expected) {
+				var buf bytes.Buffer
+				enc := json.NewEncoder(&buf)
+				enc.SetIndent("", "  ")
+				err := enc.Encode(in)
+				if err != nil {
+					t.Fatalf("unexpected result mashalling error: %v", err)
+				}
+				if tt.expected != buf.String() {
+					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(tt.expected, buf.String()))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of the change

This PR is aimed at providing a set of initial values for users when installing/upgrading a Carvel package. Particularly, in this PR:

* The raw schema is passed through the wire (for the custom form, if ever implemented - see https://github.com/kubeapps/kubeapps/issues/3853#issuecomment-1004746080)
* The default values are calculated as follows: if a `.Default` property exists, use it; otherwise, fall back to each data type default value (eg., `""` or `0`)
* Several tests have been written since I noticed the `server_utils_test` wasn't being tested. 

### Benefits

Users will get more information about the values that a package requires, being a similar UX as in other pkg formats (Helm).

### Possible drawbacks

Some problems arise:

* I've noticed some schemas (from our usual Carvel repos) have problems when performing the yaml un/marshaling operation. For example, `Fluent Bit` package fails. In these cases, I've added a commented-out warning message.
  * Edit: the root cause seems to be an `additionalProperties: string` (where it should be either an object or a boolean; [reported to the TCE pkgs team](https://kubernetes.slack.com/archives/C02GY94A8KT/p1641389173476200)) https://github.com/vmware-tanzu/community-edition/issues/2772
* The logic behind retrieving the defaults from is heavily inspired by https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/schema/defaulting/algorithm.go; I don't like the idea of re-writing k8s code, but I haven't been able to find any other dep for the same purpose. Happy to hear any alternatives.

### Applicable issues

- fixes  https://github.com/kubeapps/kubeapps/issues/3853

### Additional information

IRL example: 
![image](https://user-images.githubusercontent.com/11535726/148054463-81e158d3-a64f-45fd-966c-94f23d7fc390.png)

