### PR TITLE
Add GetAppRepository to kubeops backend

### DIFF
--- a/pkg/http-handler/http-handler_test.go
+++ b/pkg/http-handler/http-handler_test.go
@@ -37,13 +37,12 @@ import (
 	v1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 )
 
-func checkAppResponse(t *testing.T, response *httptest.ResponseRecorder, expectedRepo *v1alpha1.AppRepository) {
+func checkAppResponse(t *testing.T, response *httptest.ResponseRecorder, expectedResponse appRepositoryResponse) {
 	var appRepoResponse appRepositoryResponse
 	err := json.NewDecoder(response.Body).Decode(&appRepoResponse)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
-	expectedResponse := appRepositoryResponse{AppRepository: *expectedRepo}
 	if got, want := appRepoResponse, expectedResponse; !cmp.Equal(want, got) {
 		t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 	}
@@ -116,6 +115,7 @@ func TestGetAppRepository(t *testing.T) {
 	testCases := []struct {
 		name         string
 		appRepo      *v1alpha1.AppRepository
+		secret       *corev1.Secret
 		err          error
 		expectedCode int
 	}{
@@ -125,9 +125,59 @@ func TestGetAppRepository(t *testing.T) {
 			expectedCode: 200,
 		},
 		{
-			name:         "it should return a 404 if not found",
+			name: "it should return a corresponding secret if present",
+			appRepo: &v1alpha1.AppRepository{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "kubeapps"},
+				Spec: v1alpha1.AppRepositorySpec{
+					Auth: v1alpha1.AppRepositoryAuth{
+						Header: &v1alpha1.AppRepositoryAuthHeader{
+							SecretKeyRef: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "repo-secret",
+								},
+								Key: "authorizationHeader",
+							},
+						},
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "repo-secret", Namespace: "kubeapps"},
+				StringData: map[string]string{
+					"authorizationHeader": "someheader",
+				},
+			},
+			expectedCode: 200,
+		},
+		{
+			name:         "it should return a 404 if app repository not found",
 			appRepo:      &v1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "kubeapps"}},
 			err:          k8sErrors.NewNotFound(schema.GroupResource{}, "foo"),
+			expectedCode: 404,
+		},
+		{
+			name: "it should return a 404 if related secret is not found",
+			appRepo: &v1alpha1.AppRepository{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "kubeapps"},
+				Spec: v1alpha1.AppRepositorySpec{
+					Auth: v1alpha1.AppRepositoryAuth{
+						Header: &v1alpha1.AppRepositoryAuthHeader{
+							SecretKeyRef: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "repo-secret",
+								},
+								Key: "authorizationHeader",
+							},
+						},
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "another-repo-secret", Namespace: "kubeapps"},
+				StringData: map[string]string{
+					"authorizationHeader": "someheader",
+				},
+			},
 			expectedCode: 404,
 		},
 		{
@@ -139,7 +189,11 @@ func TestGetAppRepository(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			getAppFunc := GetAppRepository(&kube.FakeHandler{AppRepos: []*v1alpha1.AppRepository{tc.appRepo}, Err: tc.err})
+			getAppFunc := GetAppRepository(&kube.FakeHandler{
+				AppRepos: []*v1alpha1.AppRepository{tc.appRepo},
+				Secrets:  []*corev1.Secret{tc.secret},
+				Err:      tc.err,
+			})
 			req := httptest.NewRequest("GET", "https://foo.bar/backend/v1/namespaces/kubeapps/apprepositories/foo", strings.NewReader(""))
 			req = mux.SetURLVars(req, map[string]string{"namespace": "kubeapps", "name": "foo"})
 
@@ -148,6 +202,13 @@ func TestGetAppRepository(t *testing.T) {
 
 			if got, want := response.Code, tc.expectedCode; got != want {
 				t.Errorf("got: %d, want: %d\nBody: %s", got, want, response.Body)
+			}
+			expectedResponse := appRepositoryResponse{AppRepository: *tc.appRepo}
+			if tc.secret != nil {
+				expectedResponse.Secret = *tc.secret
+			}
+			if response.Code == 200 {
+				checkAppResponse(t, response, expectedResponse)
 			}
 		})
 	}
@@ -194,7 +255,7 @@ func TestCreateAppRepository(t *testing.T) {
 			}
 
 			if response.Code == 201 {
-				checkAppResponse(t, response, tc.appRepo)
+				checkAppResponse(t, response, appRepositoryResponse{AppRepository: *tc.appRepo})
 			} else {
 				checkError(t, response, tc.err)
 			}
@@ -239,7 +300,7 @@ func TestUpdateAppRepository(t *testing.T) {
 			}
 
 			if response.Code == 200 {
-				checkAppResponse(t, response, tc.appRepo)
+				checkAppResponse(t, response, appRepositoryResponse{AppRepository: *tc.appRepo})
 			} else {
 				checkError(t, response, tc.err)
 			}

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -23,6 +23,8 @@ import (
 	v1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	authorizationapi "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // FakeHandler represents a fake Handler for testing purposes
@@ -85,12 +87,15 @@ func (c *FakeHandler) DeleteAppRepository(name, namespace string) error {
 
 // GetAppRepository fake
 func (c *FakeHandler) GetAppRepository(name, namespace string) (*v1alpha1.AppRepository, error) {
+	if c.Err != nil {
+		return nil, c.Err
+	}
 	for _, r := range c.AppRepos {
 		if r.Name == name && r.Namespace == namespace {
 			return r, nil
 		}
 	}
-	return nil, fmt.Errorf("not found")
+	return nil, k8sErrors.NewNotFound(schema.GroupResource{}, "foo")
 }
 
 // GetNamespaces fake

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kube
 
 import (
-	"fmt"
 	"io"
 
 	v1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
@@ -113,7 +112,7 @@ func (c *FakeHandler) GetSecret(name, namespace string) (*corev1.Secret, error) 
 			return r, nil
 		}
 	}
-	return nil, fmt.Errorf("not found")
+	return nil, k8sErrors.NewNotFound(schema.GroupResource{}, "foo")
 }
 
 // ValidateAppRepository fake


### PR DESCRIPTION
### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This PR primarily adds an endpoint to the current kubeops backend handler to get an app repository, importantly, that includes the related auth header/ca.crt secret in the response. The dashboard currently relies on fetching app repo secrets directly from the k8s API server, which we want to remove. This is an initial work-around to avoid requiring a generic get secret endpoint (see #3922 for discussion of options).

While there, I've fixed the `returnK8sError` helper which was logging incorrect and hence confusing information.

### Benefits

It'll enable the followup PR which updates the dashboard to no longer fetch secrets via the k8s API.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3922 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
