### PR TITLE
Remove repo secrets from redux state, fetch on mount

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -75,6 +75,7 @@
   "devDependencies": {
     "@formatjs/cli": "^4.7.0",
     "@improbable-eng/grpc-web-fake-transport": "^0.15.0",
+    "@testing-library/react": "^12.1.2",
     "@types/enzyme": "^3.10.11",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/google-protobuf": "^3.15.5",

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -784,10 +784,6 @@ describe("updateRepo", () => {
         type: getType(repoActions.repoUpdated),
         payload: r,
       },
-      {
-        type: getType(repoActions.receiveReposSecret),
-        payload: secret,
-      },
     ];
 
     await store.dispatch(
@@ -845,10 +841,6 @@ describe("updateRepo", () => {
       {
         type: getType(repoActions.repoUpdated),
         payload: r,
-      },
-      {
-        type: getType(repoActions.receiveReposSecret),
-        payload: secret,
       },
     ];
 

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -316,53 +316,6 @@ describe("fetchRepos", () => {
   });
 });
 
-describe("fetchRepoSecret", () => {
-  const namespace = "default";
-  it("dispatches receiveReposSecret if no error", async () => {
-    const appRepoSecret = {
-      metadata: {
-        name: "foo",
-        ownerReferences: [{ kind: "AppRepository" }],
-      },
-    };
-    Secret.get = jest.fn().mockReturnValue({
-      appRepoSecret,
-    });
-    const expectedActions = [
-      {
-        type: getType(repoActions.receiveReposSecret),
-        payload: {
-          appRepoSecret: {
-            metadata: {
-              name: "foo",
-              ownerReferences: [{ kind: "AppRepository" }],
-            },
-          },
-        },
-      },
-    ];
-
-    await store.dispatch(repoActions.fetchRepoSecret(namespace, "foo"));
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-
-  it("dispatches errorRepos if error fetching secret", async () => {
-    Secret.get = jest.fn().mockImplementationOnce(() => {
-      throw new Error("Boom!");
-    });
-
-    const expectedActions = [
-      {
-        type: getType(repoActions.errorRepos),
-        payload: { err: new Error("Boom!"), op: "fetch" },
-      },
-    ];
-
-    await store.dispatch(repoActions.fetchRepoSecret(namespace, "foo"));
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-});
-
 describe("installRepo", () => {
   const installRepoCMD = repoActions.installRepo(
     "my-repo",

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -41,10 +41,6 @@ export const concatRepos = createAction("RECEIVE_REPOS", resolve => {
   return (repos: IAppRepository[]) => resolve(repos);
 });
 
-export const receiveReposSecret = createAction("RECEIVE_REPOS_SECRET", resolve => {
-  return (secret: ISecret) => resolve(secret);
-});
-
 export const requestRepo = createAction("REQUEST_REPO");
 export const receiveRepo = createAction("RECEIVE_REPO", resolve => {
   return (repo: IAppRepository) => resolve(repo);
@@ -87,7 +83,6 @@ const allActions = [
   requestRepos,
   receiveRepo,
   receiveRepos,
-  receiveReposSecret,
   createErrorPackage,
   requestRepo,
   redirect,
@@ -139,23 +134,6 @@ export const resyncAllRepos = (
     repos.forEach(repo => {
       dispatch(resyncRepo(repo.name, repo.namespace));
     });
-  };
-};
-
-export const fetchRepoSecret = (
-  namespace: string,
-  name: string,
-): ThunkAction<Promise<void>, IStoreState, null, AppReposAction> => {
-  return async (dispatch, getState) => {
-    const {
-      clusters: { currentCluster },
-    } = getState();
-    try {
-      const secret = await Secret.get(currentCluster, namespace, name);
-      dispatch(receiveReposSecret(secret));
-    } catch (e: any) {
-      dispatch(errorRepos(e, "fetch"));
-    }
   };
 };
 

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -287,22 +287,6 @@ export const updateRepo = (
         filter,
       );
       dispatch(repoUpdated(data.appRepository));
-      // Re-fetch the helm repo secret that could have been modified with the updated headers
-      // so that if the user chooses to edit the app repo again, they will see the current value.
-      if (data.appRepository.spec?.auth) {
-        let secretName = "";
-        if (data.appRepository.spec.auth.header) {
-          secretName = data.appRepository.spec.auth.header.secretKeyRef.name;
-          dispatch(fetchRepoSecret(namespace, secretName));
-        }
-        if (
-          data.appRepository.spec.auth.customCA &&
-          secretName !== data.appRepository.spec.auth.customCA.secretKeyRef.name
-        ) {
-          secretName = data.appRepository.spec.auth.customCA.secretKeyRef.name;
-          dispatch(fetchRepoSecret(namespace, secretName));
-        }
-      }
       return true;
     } catch (e: any) {
       dispatch(errorRepos(e, "update"));

--- a/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoButton.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
-import { IAppRepository, IAppRepositoryFilter, ISecret, IStoreState } from "shared/types";
+import { IAppRepository, IAppRepositoryFilter, IStoreState } from "shared/types";
 import { AppRepoForm } from "./AppRepoForm";
 
 interface IAppRepoAddButtonProps {
@@ -15,7 +15,6 @@ interface IAppRepoAddButtonProps {
   text?: string;
   primary?: boolean;
   repo?: IAppRepository;
-  secret?: ISecret;
   disabled?: boolean;
   title?: string;
 }
@@ -25,7 +24,6 @@ export function AppRepoAddButton({
   namespace,
   kubeappsNamespace,
   repo,
-  secret,
   primary = true,
   title,
   disabled,
@@ -108,7 +106,6 @@ export function AppRepoAddButton({
               onSubmit={onSubmit}
               onAfterInstall={closeModal}
               repo={repo}
-              secret={secret}
               namespace={namespace}
               kubeappsNamespace={kubeappsNamespace}
             />

--- a/dashboard/src/components/Config/AppRepoList/AppRepoControl.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoControl.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
-import { IAppRepository, ISecret, IStoreState } from "shared/types";
+import { IAppRepository, IStoreState } from "shared/types";
 import actions from "../../../actions";
 import ConfirmDialog from "../../ConfirmDialog/ConfirmDialog";
 import { AppRepoAddButton } from "./AppRepoButton";
@@ -12,16 +12,10 @@ import "./AppRepoControl.css";
 interface IAppRepoListItemProps {
   repo: IAppRepository;
   kubeappsNamespace: string;
-  secret?: ISecret;
   refetchRepos: () => void;
 }
 
-export function AppRepoControl({
-  repo,
-  secret,
-  kubeappsNamespace,
-  refetchRepos,
-}: IAppRepoListItemProps) {
+export function AppRepoControl({ repo, kubeappsNamespace, refetchRepos }: IAppRepoListItemProps) {
   const [modalIsOpen, setModalOpen] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const openModal = () => setModalOpen(true);
@@ -64,7 +58,6 @@ export function AppRepoControl({
         kubeappsNamespace={kubeappsNamespace}
         text="Edit"
         repo={repo}
-        secret={secret}
         primary={false}
       />
 

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -537,6 +537,7 @@ describe("when the repository info is already populated", () => {
       });
 
       await waitFor(() => {
+        wrapper.update();
         expect(AppRepository.getSecretForRepo).toHaveBeenCalledWith(
           "default-cluster",
           "default",
@@ -560,6 +561,7 @@ describe("when the repository info is already populated", () => {
       });
 
       await waitFor(() => {
+        wrapper.update();
         expect(AppRepository.getSecretForRepo).toHaveBeenCalledWith(
           "default-cluster",
           "default",
@@ -570,7 +572,10 @@ describe("when the repository info is already populated", () => {
     });
 
     it("should parse the existing basic auth", async () => {
-      const repo = { metadata: { name: "foo", namespace: "default" } } as any;
+      const repo = {
+        metadata: { name: "foo", namespace: "default" },
+        spec: { auth: { header: { secretKeyRef: { name: "bar" } } } },
+      } as any;
       const secret = { data: { authorizationHeader: "QmFzaWMgWm05dk9tSmhjZz09" } } as any;
       AppRepository.getSecretForRepo = jest.fn(() => secret);
 
@@ -580,6 +585,7 @@ describe("when the repository info is already populated", () => {
       });
 
       await waitFor(() => {
+        wrapper.update();
         expect(wrapper.find("#kubeapps-repo-username").prop("value")).toBe("foo");
         expect(wrapper.find("#kubeapps-repo-password").prop("value")).toBe("bar");
       });
@@ -607,7 +613,10 @@ describe("when the repository info is already populated", () => {
     });
 
     it("should parse a bearer token", async () => {
-      const repo = { metadata: { name: "foo" } } as any;
+      const repo = {
+        metadata: { name: "foo", namespace: "default" },
+        spec: { auth: { header: { secretKeyRef: { name: "bar" } } } },
+      } as any;
       const secret = { data: { authorizationHeader: "QmVhcmVyIGZvbw==" } } as any;
       AppRepository.getSecretForRepo = jest.fn(() => secret);
 
@@ -617,12 +626,16 @@ describe("when the repository info is already populated", () => {
       });
 
       await waitFor(() => {
+        wrapper.update();
         expect(wrapper.find("#kubeapps-repo-token").prop("value")).toBe("foo");
       });
     });
 
     it("should select a docker secret as auth mechanism", async () => {
-      const repo = { metadata: { name: "foo" } } as any;
+      const repo = {
+        metadata: { name: "foo", namespace: "default" },
+        spec: { auth: { header: { secretKeyRef: { name: "bar" } } } },
+      } as any;
       const secret = { data: { ".dockerconfigjson": "QmVhcmVyIGZvbw==" } } as any;
       AppRepository.getSecretForRepo = jest.fn(() => secret);
 
@@ -632,6 +645,7 @@ describe("when the repository info is already populated", () => {
       });
 
       await waitFor(() => {
+        wrapper.update();
         expect(wrapper.find("#kubeapps-repo-auth-method-registry")).toBeChecked();
       });
     });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -7,6 +7,8 @@ import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper"
 import { ISecret } from "shared/types";
 import AppRepoAddDockerCreds from "./AppRepoAddDockerCreds";
 import { AppRepoForm } from "./AppRepoForm";
+import { AppRepository } from "shared/AppRepository";
+import { waitFor } from "@testing-library/react";
 
 const defaultProps = {
   onSubmit: jest.fn(),
@@ -521,50 +523,75 @@ describe("when the repository info is already populated", () => {
   });
 
   describe("when there is a secret associated to the repo", () => {
-    it("should parse the existing CA cert", () => {
+    it("should parse the existing CA cert", async () => {
       const repo = {
-        metadata: { name: "foo" },
+        metadata: { name: "foo", namespace: "default" },
         spec: { auth: { customCA: { secretKeyRef: { name: "bar" } } } },
       } as any;
       const secret = { data: { "ca.crt": "Zm9v" } } as any;
-      const wrapper = mountWrapper(
-        defaultStore,
-        <AppRepoForm {...defaultProps} repo={repo} secret={secret} />,
-      );
-      expect(actions.repos.fetchRepoSecret).toHaveBeenCalledWith("default", "bar");
-      expect(wrapper.find("#kubeapps-repo-custom-ca").prop("value")).toBe("foo");
+      AppRepository.getSecretForRepo = jest.fn(() => secret);
+
+      let wrapper: any;
+      act(() => {
+        wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
+      });
+
+      await waitFor(() => {
+        expect(AppRepository.getSecretForRepo).toHaveBeenCalledWith(
+          "default-cluster",
+          "default",
+          "foo",
+        );
+        expect(wrapper.find("#kubeapps-repo-custom-ca").prop("value")).toBe("foo");
+      });
     });
 
-    it("should parse the existing auth header", () => {
+    it("should parse the existing auth header", async () => {
       const repo = {
-        metadata: { name: "foo" },
+        metadata: { name: "foo", namespace: "default" },
         spec: { auth: { header: { secretKeyRef: { name: "bar" } } } },
       } as any;
       const secret = { data: { authorizationHeader: "Zm9v" } } as any;
-      const wrapper = mountWrapper(
-        defaultStore,
-        <AppRepoForm {...defaultProps} repo={repo} secret={secret} />,
-      );
-      expect(actions.repos.fetchRepoSecret).toHaveBeenCalledWith("default", "bar");
-      expect(wrapper.find("#kubeapps-repo-custom-header").prop("value")).toBe("foo");
+      AppRepository.getSecretForRepo = jest.fn(() => secret);
+
+      let wrapper: any;
+      act(() => {
+        wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
+      });
+
+      await waitFor(() => {
+        expect(AppRepository.getSecretForRepo).toHaveBeenCalledWith(
+          "default-cluster",
+          "default",
+          "foo",
+        );
+        expect(wrapper.find("#kubeapps-repo-custom-header").prop("value")).toBe("foo");
+      });
     });
 
-    it("should parse the existing basic auth", () => {
-      const repo = { metadata: { name: "foo" } } as any;
+    it("should parse the existing basic auth", async () => {
+      const repo = { metadata: { name: "foo", namespace: "default" } } as any;
       const secret = { data: { authorizationHeader: "QmFzaWMgWm05dk9tSmhjZz09" } } as any;
-      const wrapper = mountWrapper(
-        defaultStore,
-        <AppRepoForm {...defaultProps} repo={repo} secret={secret} />,
-      );
-      expect(wrapper.find("#kubeapps-repo-username").prop("value")).toBe("foo");
-      expect(wrapper.find("#kubeapps-repo-password").prop("value")).toBe("bar");
+      AppRepository.getSecretForRepo = jest.fn(() => secret);
+
+      let wrapper: any;
+      act(() => {
+        wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
+      });
+
+      await waitFor(() => {
+        expect(wrapper.find("#kubeapps-repo-username").prop("value")).toBe("foo");
+        expect(wrapper.find("#kubeapps-repo-password").prop("value")).toBe("bar");
+      });
     });
 
-    it("should parse the existing type", () => {
+    it("should parse the existing type", async () => {
       const repo = { metadata: { name: "foo" }, spec: { type: "oci" } } as any;
       const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
-      expect(wrapper.find("#kubeapps-repo-type-oci")).toBeChecked();
-      expect(wrapper.find("#kubeapps-oci-repositories")).toExist();
+      await waitFor(() => {
+        expect(wrapper.find("#kubeapps-repo-type-oci")).toBeChecked();
+        expect(wrapper.find("#kubeapps-oci-repositories")).toExist();
+      });
     });
 
     it("should parse the existing skip tls config", () => {
@@ -579,27 +606,37 @@ describe("when the repository info is already populated", () => {
       expect(wrapper.find("#kubeapps-repo-pass-credentials")).toBeChecked();
     });
 
-    it("should parse a bearer token", () => {
+    it("should parse a bearer token", async () => {
       const repo = { metadata: { name: "foo" } } as any;
       const secret = { data: { authorizationHeader: "QmVhcmVyIGZvbw==" } } as any;
-      const wrapper = mountWrapper(
-        defaultStore,
-        <AppRepoForm {...defaultProps} repo={repo} secret={secret} />,
-      );
-      expect(wrapper.find("#kubeapps-repo-token").prop("value")).toBe("foo");
+      AppRepository.getSecretForRepo = jest.fn(() => secret);
+
+      let wrapper: any;
+      act(() => {
+        wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
+      });
+
+      await waitFor(() => {
+        expect(wrapper.find("#kubeapps-repo-token").prop("value")).toBe("foo");
+      });
     });
 
-    it("should select a docker secret as auth mechanism", () => {
+    it("should select a docker secret as auth mechanism", async () => {
       const repo = { metadata: { name: "foo" } } as any;
       const secret = { data: { ".dockerconfigjson": "QmVhcmVyIGZvbw==" } } as any;
-      const wrapper = mountWrapper(
-        defaultStore,
-        <AppRepoForm {...defaultProps} repo={repo} secret={secret} />,
-      );
-      expect(wrapper.find("#kubeapps-repo-auth-method-registry")).toBeChecked();
+      AppRepository.getSecretForRepo = jest.fn(() => secret);
+
+      let wrapper: any;
+      act(() => {
+        wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
+      });
+
+      await waitFor(() => {
+        expect(wrapper.find("#kubeapps-repo-auth-method-registry")).toBeChecked();
+      });
     });
 
-    it("should pre-select the existing docker registry secret", () => {
+    it("should pre-select the existing docker registry secret", async () => {
       const secret = {
         metadata: {
           name: "foo",
@@ -612,10 +649,12 @@ describe("when the repository info is already populated", () => {
         }),
         <AppRepoForm {...defaultProps} repo={repo} />,
       );
-      expect(wrapper.find("select").prop("value")).toBe("foo");
+      await waitFor(() => {
+        expect(wrapper.find("select").prop("value")).toBe("foo");
+      });
     });
 
-    it("should parse the existing filter (simple)", () => {
+    it("should parse the existing filter (simple)", async () => {
       const repo = {
         metadata: { name: "foo" },
         spec: {
@@ -627,12 +666,15 @@ describe("when the repository info is already populated", () => {
         },
       } as any;
       const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
-      expect(wrapper.find("textarea").at(0).prop("value")).toBe("nginx, wordpress");
 
-      expect(wrapper.find('input[type="checkbox"]').at(0)).not.toBeChecked();
-      expect(wrapper.find('input[type="checkbox"]').at(1)).not.toBeChecked();
+      await waitFor(() => {
+        expect(wrapper.find("textarea").at(0).prop("value")).toBe("nginx, wordpress");
+        expect(wrapper.find('input[type="checkbox"]').at(0)).not.toBeChecked();
+        expect(wrapper.find('input[type="checkbox"]').at(1)).not.toBeChecked();
+      });
     });
-    it("should parse the existing filter (negated regex)", () => {
+
+    it("should parse the existing filter (negated regex)", async () => {
       const repo = {
         metadata: { name: "foo" },
         spec: {
@@ -641,10 +683,12 @@ describe("when the repository info is already populated", () => {
         },
       } as any;
       const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
-      expect(wrapper.find("textarea").at(0).prop("value")).toBe("nginx");
 
-      expect(wrapper.find('input[type="checkbox"]').at(0)).toBeChecked();
-      expect(wrapper.find('input[type="checkbox"]').at(1)).toBeChecked();
+      await waitFor(() => {
+        expect(wrapper.find("textarea").at(0).prop("value")).toBe("nginx");
+        expect(wrapper.find('input[type="checkbox"]').at(0)).toBeChecked();
+        expect(wrapper.find('input[type="checkbox"]').at(1)).toBeChecked();
+      });
     });
   });
 });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -23,7 +23,6 @@ beforeEach(() => {
     ...actions.repos,
     validateRepo: jest.fn().mockReturnValue(true),
     fetchImagePullSecrets: jest.fn(),
-    fetchRepoSecret: jest.fn(),
   };
   const mockDispatch = jest.fn(r => r);
   spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.tsx
@@ -25,7 +25,7 @@ function AppRepoList() {
   const dispatch = useDispatch();
   const location = useLocation();
   const {
-    repos: { errors, isFetchingElem, repos, repoSecrets },
+    repos: { errors, isFetchingElem, repos },
     clusters: { clusters, currentCluster },
     config: { kubeappsCluster, kubeappsNamespace },
   } = useSelector((state: IStoreState) => state);
@@ -118,11 +118,6 @@ function AppRepoList() {
         ) : (
           <AppRepoControl
             repo={repo}
-            secret={repoSecrets.find(secret =>
-              secret.metadata.ownerReferences?.some(
-                ownerRef => ownerRef.name === repo.metadata.name,
-              ),
-            )}
             refetchRepos={refetchRepos}
             kubeappsNamespace={kubeappsNamespace}
           />

--- a/dashboard/src/reducers/repos.test.ts
+++ b/dashboard/src/reducers/repos.test.ts
@@ -24,7 +24,6 @@ describe("reposReducer", () => {
       validating: false,
       repo: {} as IAppRepository,
       repos: [],
-      repoSecrets: [],
       imagePullSecrets: [],
     };
   });
@@ -37,7 +36,6 @@ describe("reposReducer", () => {
       repoUpdated: getType(actions.repos.repoUpdated),
       requestRepos: getType(actions.repos.requestRepos),
       receiveRepos: getType(actions.repos.receiveRepos),
-      receiveReposSecret: getType(actions.repos.receiveReposSecret),
       requestRepo: getType(actions.repos.requestRepo),
       receiveRepo: getType(actions.repos.receiveRepo),
       repoValidating: getType(actions.repos.repoValidating),
@@ -98,20 +96,6 @@ describe("reposReducer", () => {
           }),
         ).toEqual({ ...initialState, repo });
       });
-    });
-
-    it("receives a repo secret", () => {
-      const secret = { metadata: { name: "foo", namespace: "bar" } } as any;
-      const modifiedSecret = { ...secret, spec: { foo: "bar" } };
-      expect(
-        reposReducer(
-          { ...initialState, repoSecrets: [secret] },
-          {
-            type: actionTypes.receiveReposSecret as any,
-            payload: modifiedSecret,
-          },
-        ),
-      ).toEqual({ ...initialState, repoSecrets: [modifiedSecret] });
     });
 
     it("adds a repo", () => {

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -22,7 +22,6 @@ export interface IAppRepositoryState {
   validating: boolean;
   repo: IAppRepository;
   repos: IAppRepository[];
-  repoSecrets: ISecret[];
   form: {
     name: string;
     namespace: string;
@@ -50,7 +49,6 @@ export const initialState: IAppRepositoryState = {
   validating: false,
   repo: {} as IAppRepository,
   repos: [],
-  repoSecrets: [],
   imagePullSecrets: [],
 };
 
@@ -84,22 +82,6 @@ const reposReducer = (
         repo: action.payload,
         errors: {},
       };
-    case getType(actions.repos.receiveReposSecret): {
-      const secret = action.payload;
-      const existingSecret = state.repoSecrets.findIndex(
-        s =>
-          s.metadata.name === secret.metadata.name &&
-          s.metadata.namespace === secret.metadata.namespace,
-      );
-      let repoSecrets: ISecret[];
-      if (existingSecret > -1) {
-        repoSecrets = [...state.repoSecrets];
-        repoSecrets[existingSecret] = secret;
-      } else {
-        repoSecrets = state.repoSecrets.concat(secret);
-      }
-      return { ...state, repoSecrets };
-    }
     case getType(actions.repos.requestRepos):
       return { ...state, ...isFetching(state, "repositories", true) };
     case getType(actions.repos.addRepo):

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -12,10 +12,17 @@ export class AppRepository {
   }
 
   public static async get(cluster: string, namespace: string, name: string) {
-    const { data } = await axiosWithAuth.get<any>(
-      AppRepository.getSelfLink(cluster, namespace, name),
-    );
-    return data;
+    const {
+      data: { appRepository },
+    } = await axiosWithAuth.get<any>(url.backend.apprepositories.get(cluster, namespace, name));
+    return appRepository;
+  }
+
+  public static async getSecretForRepo(cluster: string, namespace: string, name: string) {
+    const {
+      data: { secret },
+    } = await axiosWithAuth.get<any>(url.backend.apprepositories.get(cluster, namespace, name));
+    return secret;
   }
 
   public static async resync(cluster: string, namespace: string, name: string) {

--- a/dashboard/src/shared/AppRepository.ts
+++ b/dashboard/src/shared/AppRepository.ts
@@ -1,5 +1,4 @@
 import { axiosWithAuth } from "./AxiosInstance";
-import { APIBase } from "./Kube";
 import { IAppRepositoryFilter, ICreateAppRepositoryResponse } from "./types";
 import * as url from "./url";
 
@@ -151,14 +150,5 @@ export class AppRepository {
       },
     );
     return data;
-  }
-
-  private static APIEndpoint(cluster: string): string {
-    return `${APIBase(cluster)}/apis/kubeapps.com/v1alpha1`;
-  }
-  private static getSelfLink(cluster: string, namespace: string, name?: string): string {
-    return `${AppRepository.APIEndpoint(cluster)}/namespaces/${namespace}/apprepositories${
-      name ? `/${name}` : ""
-    }`;
   }
 }

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -108,6 +108,8 @@ export const backend = {
     list: (cluster: string, namespace: string) => backend.apprepositories.base(cluster, namespace),
     validate: (cluster: string, namespace: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/validate`,
+    get: (cluster: string, namespace: string, name: string) =>
+      `${backend.apprepositories.base(cluster, namespace)}/${name}`,
     delete: (cluster: string, namespace: string, name: string) =>
       `${backend.apprepositories.base(cluster, namespace)}/${name}`,
     refresh: (cluster: string, namespace: string, name: string) =>

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -2058,10 +2058,37 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@testing-library/dom@^8.0.0":
+  version "8.11.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.1.tgz#03fa2684aa09ade589b460db46b4c7be9fc69753"
+  integrity sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@^12.1.2":
+  version "12.1.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.2.tgz#f1bc9a45943461fa2a598bb4597df1ae044cfc76"
+  integrity sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.0.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.16"
@@ -3141,6 +3168,11 @@ aria-query@^4.2.2:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
 
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
+
 arity-n@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745"
@@ -4087,7 +4119,7 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -5271,6 +5303,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz#caa6d08f60388d0bb4539dd75fe458a9a1d0014c"
+  integrity sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -9171,6 +9208,11 @@ lru-queue@^0.1.0:
   dependencies:
     es5-ext "~0.10.2"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -11602,6 +11644,15 @@ pretty-format@^27.0.0, pretty-format@^27.3.1:
   integrity sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==
   dependencies:
     "@jest/types" "^27.2.5"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.2:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.6.tgz#1b784d2f53c68db31797b2348fa39b49e31846b7"
+  integrity sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==
+  dependencies:
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"


### PR DESCRIPTION
### Description of the change

Following on from #4027, this PR updates the AppRepoForm component so that it no longer receives a related secret as a prop (from the redux state?), but rather fetches the secret when mounting and uses the local component state.

### Benefits

The new endpoint for fetching a secret for a repo's secret is used (rather than the k8s API), and it avoids the need to update the redux state when a repo is updated (since we always fetch the secret when loading the form). Also avoids storing all repo secrets in the redux state (and removes the related actions/reducers).

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3922 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

As always, testing the combination of an async react hook (useEffect) turned out to be painful to realise, but got there after a lot of head scratching.

I still need to test this IRL locally before landing (once CI passes etc.)
