### PR TITLE
No more secret requests to K8s API

### DIFF
--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -1113,50 +1113,6 @@ describe("validateRepo", () => {
   });
 });
 
-describe("fetchImagePullSecrets", () => {
-  it("fetches image pull secrets", async () => {
-    const secret1 = {
-      type: "kubernetes.io/dockerconfigjson",
-    };
-    Secret.list = jest.fn().mockReturnValue({
-      items: [secret1],
-    });
-    const expectedActions = [
-      {
-        type: getType(repoActions.requestImagePullSecrets),
-        payload: "default",
-      },
-      {
-        type: getType(repoActions.receiveImagePullSecrets),
-        payload: [secret1],
-      },
-    ];
-    await store.dispatch(repoActions.fetchImagePullSecrets("default"));
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-
-  it("dispatches an error", async () => {
-    Secret.list = jest.fn(() => {
-      throw new Error("boom");
-    });
-    const expectedActions = [
-      {
-        type: getType(repoActions.requestImagePullSecrets),
-        payload: "default",
-      },
-      {
-        type: getType(repoActions.errorRepos),
-        payload: {
-          err: new Error("boom"),
-          op: "fetch",
-        },
-      },
-    ];
-    await store.dispatch(repoActions.fetchImagePullSecrets("default"));
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-});
-
 describe("createDockerRegistrySecret", () => {
   it("creates a docker registry", async () => {
     Secret.createPullSecret = jest.fn();

--- a/dashboard/src/actions/repos.test.tsx
+++ b/dashboard/src/actions/repos.test.tsx
@@ -51,9 +51,6 @@ beforeEach(() => {
   AppRepository.create = jest.fn().mockImplementationOnce(() => {
     return { appRepository: { metadata: { name: "repo-abc" } } };
   });
-  Secret.list = jest.fn().mockReturnValue({
-    items: [],
-  });
 });
 
 afterEach(jest.restoreAllMocks);
@@ -724,11 +721,9 @@ describe("updateRepo", () => {
       metadata: { name: "repo-abc" },
       spec: { auth: { header: { secretKeyRef: { name: "apprepo-repo-abc" } } } },
     };
-    const secret = { metadata: { name: "apprepo-repo-abc" } };
     AppRepository.update = jest.fn().mockReturnValue({
       appRepository: r,
     });
-    Secret.get = jest.fn().mockReturnValue(secret);
     const expectedActions = [
       {
         type: getType(repoActions.requestRepoUpdate),
@@ -782,11 +777,9 @@ describe("updateRepo", () => {
       metadata: { name: "repo-abc" },
       spec: { auth: { customCA: { secretKeyRef: { name: "apprepo-repo-abc" } } } },
     };
-    const secret = { metadata: { name: "apprepo-repo-abc" } };
     AppRepository.update = jest.fn().mockReturnValue({
       appRepository: r,
     });
-    Secret.get = jest.fn().mockReturnValue(secret);
     const expectedActions = [
       {
         type: getType(repoActions.requestRepoUpdate),

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -61,13 +61,6 @@ export const errorRepos = createAction("ERROR_REPOS", resolve => {
     resolve({ err, op });
 });
 
-export const requestImagePullSecrets = createAction("REQUEST_IMAGE_PULL_SECRETS", resolve => {
-  return (namespace: string) => resolve(namespace);
-});
-export const receiveImagePullSecrets = createAction("RECEIVE_IMAGE_PULL_SECRETS", resolve => {
-  return (secrets: ISecret[]) => resolve(secrets);
-});
-
 export const createImagePullSecret = createAction("CREATE_IMAGE_PULL_SECRET", resolve => {
   return (secretName: string) => resolve(secretName);
 });
@@ -87,8 +80,6 @@ const allActions = [
   requestRepo,
   redirect,
   redirected,
-  requestImagePullSecrets,
-  receiveImagePullSecrets,
   createImagePullSecret,
 ];
 export type AppReposAction = ActionType<typeof allActions[number]>;
@@ -354,30 +345,6 @@ export function findPackageInRepo(
         ),
       );
       return false;
-    }
-  };
-}
-
-export function fetchImagePullSecrets(
-  namespace: string,
-): ThunkAction<Promise<void>, IStoreState, null, AppReposAction> {
-  return async (dispatch, getState) => {
-    const {
-      clusters: { currentCluster },
-    } = getState();
-    try {
-      dispatch(requestImagePullSecrets(namespace));
-      // TODO(andresmgot): Create an endpoint for returning just the list of secret names
-      // to avoid listing all the secrets with protected information
-      // https://github.com/kubeapps/kubeapps/issues/1686
-      const secrets = await Secret.list(
-        currentCluster,
-        namespace,
-        "type=kubernetes.io/dockerconfigjson",
-      );
-      dispatch(receiveImagePullSecrets(secrets.items));
-    } catch (e: any) {
-      dispatch(errorRepos(e, "fetch"));
     }
   };
 }

--- a/dashboard/src/actions/repos.ts
+++ b/dashboard/src/actions/repos.ts
@@ -12,7 +12,6 @@ import {
   IAppRepository,
   IAppRepositoryFilter,
   IAppRepositoryKey,
-  ISecret,
   IStoreState,
   NotFoundError,
 } from "shared/types";

--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.test.tsx
@@ -2,19 +2,8 @@ import actions from "actions";
 import { shallow } from "enzyme";
 import { act } from "react-dom/test-utils";
 import * as ReactRedux from "react-redux";
-import { ISecret } from "shared/types";
 import AppRepoAddDockerCreds from "./AppRepoAddDockerCreds";
 
-const secret1 = {
-  metadata: {
-    name: "foo",
-  },
-} as ISecret;
-const secret2 = {
-  metadata: {
-    name: "bar",
-  },
-} as ISecret;
 const defaultProps = {
   imagePullSecrets: [],
   selectPullSecret: jest.fn(),

--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.test.tsx
@@ -48,22 +48,22 @@ it("shows an info message if there are no secrets", () => {
 
 it("shows the list of available pull secrets", () => {
   const wrapper = shallow(
-    <AppRepoAddDockerCreds {...defaultProps} imagePullSecrets={[secret1, secret2]} />,
+    <AppRepoAddDockerCreds {...defaultProps} imagePullSecrets={["secret-1", "secret-2"]} />,
   );
-  expect(wrapper.text()).toContain(secret1.metadata.name);
-  expect(wrapper.text()).toContain(secret2.metadata.name);
+  expect(wrapper.text()).toContain("secret-1");
+  expect(wrapper.text()).toContain("secret-2");
 });
 
 it("select a secret", () => {
   const wrapper = shallow(
     <AppRepoAddDockerCreds
       {...defaultProps}
-      imagePullSecrets={[secret1, secret2]}
-      selectedImagePullSecret={secret1.metadata.name}
+      imagePullSecrets={["secret-1", "secret-2", "secret-3"]}
+      selectedImagePullSecret={"secret-2"}
     />,
   );
 
-  expect(wrapper.find("select").prop("value")).toBe(secret1.metadata.name);
+  expect(wrapper.find("select").prop("value")).toBe("secret-2");
 });
 
 it("renders the form to create a registry secret", () => {

--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
@@ -70,9 +70,7 @@ export function AppRepoAddDockerCreds({
     if (success) {
       // Re-fetching secrets cause a re-render and the modal to be closed,
       // using local state to avoid that.
-      setCurrentImagePullSecrets(
-        currentImagePullSecrets.concat(secretName),
-      );
+      setCurrentImagePullSecrets(currentImagePullSecrets.concat(secretName));
       setUser("");
       setSecretName("");
       setPassword("");

--- a/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoAddDockerCreds.tsx
@@ -7,11 +7,11 @@ import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Action } from "redux";
 import { ThunkDispatch } from "redux-thunk";
-import { ISecret, IStoreState } from "shared/types";
+import { IStoreState } from "shared/types";
 import "./AppRepoAddDockerCreds.css";
 
 interface IAppRepoFormProps {
-  imagePullSecrets: ISecret[];
+  imagePullSecrets: string[];
   selectPullSecret: (imagePullSecret: string) => void;
   selectedImagePullSecret: string;
   namespace: string;
@@ -71,7 +71,7 @@ export function AppRepoAddDockerCreds({
       // Re-fetching secrets cause a re-render and the modal to be closed,
       // using local state to avoid that.
       setCurrentImagePullSecrets(
-        currentImagePullSecrets.concat({ metadata: { name: secretName, namespace } } as ISecret),
+        currentImagePullSecrets.concat(secretName),
       );
       setUser("");
       setSecretName("");
@@ -132,8 +132,8 @@ export function AppRepoAddDockerCreds({
           disabled={disabled}
         >
           <option />
-          {currentImagePullSecrets.map(secret => {
-            return <option key={`option-${secret.metadata.name}`}>{secret.metadata.name}</option>;
+          {currentImagePullSecrets.map(secretName => {
+            return <option key={`option-${secretName}`}>{secretName}</option>;
           })}
         </select>
       </CdsSelect>

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -23,7 +23,6 @@ beforeEach(() => {
   actions.repos = {
     ...actions.repos,
     validateRepo: jest.fn().mockReturnValue(true),
-    fetchImagePullSecrets: jest.fn(),
   };
   const mockDispatch = jest.fn(r => r);
   spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
@@ -37,7 +36,10 @@ afterEach(() => {
 
 it("fetches repos and imagePullSecrets", () => {
   mountWrapper(defaultStore, <AppRepoForm {...defaultProps} />);
-  expect(Secret.getDockerConfigSecretNames).toHaveBeenCalledWith("default-cluster", defaultProps.namespace);
+  expect(Secret.getDockerConfigSecretNames).toHaveBeenCalledWith(
+    "default-cluster",
+    defaultProps.namespace,
+  );
 });
 
 it("disables the submit button while fetching", () => {
@@ -652,12 +654,14 @@ describe("when the repository info is already populated", () => {
     });
 
     it("should pre-select the existing docker registry secret", async () => {
-      const repo = { metadata: { name: "foo" }, spec: { dockerRegistrySecrets: ["secret-2"] } } as any;
-      Secret.getDockerConfigSecretNames = jest.fn(() => Promise.resolve(["secret-1", "secret-2", "secret-3"]));
-      const wrapper = mountWrapper(
-        defaultStore,
-        <AppRepoForm {...defaultProps} repo={repo} />,
+      const repo = {
+        metadata: { name: "foo" },
+        spec: { dockerRegistrySecrets: ["secret-2"] },
+      } as any;
+      Secret.getDockerConfigSecretNames = jest.fn(() =>
+        Promise.resolve(["secret-1", "secret-2", "secret-3"]),
       );
+      const wrapper = mountWrapper(defaultStore, <AppRepoForm {...defaultProps} repo={repo} />);
       await waitFor(() => {
         wrapper.update();
         expect(wrapper.find("select").prop("value")).toBe("secret-2");

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.test.tsx
@@ -9,6 +9,7 @@ import AppRepoAddDockerCreds from "./AppRepoAddDockerCreds";
 import { AppRepoForm } from "./AppRepoForm";
 import { AppRepository } from "shared/AppRepository";
 import { waitFor } from "@testing-library/react";
+import Secret from "shared/Secret";
 
 const defaultProps = {
   onSubmit: jest.fn(),
@@ -26,6 +27,7 @@ beforeEach(() => {
   };
   const mockDispatch = jest.fn(r => r);
   spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);
+  Secret.getDockerConfigSecretNames = jest.fn(() => Promise.resolve([]));
 });
 
 afterEach(() => {
@@ -35,7 +37,7 @@ afterEach(() => {
 
 it("fetches repos and imagePullSecrets", () => {
   mountWrapper(defaultStore, <AppRepoForm {...defaultProps} />);
-  expect(actions.repos.fetchImagePullSecrets).toHaveBeenCalledWith(defaultProps.namespace);
+  expect(Secret.getDockerConfigSecretNames).toHaveBeenCalledWith("default-cluster", defaultProps.namespace);
 });
 
 it("disables the submit button while fetching", () => {
@@ -650,20 +652,15 @@ describe("when the repository info is already populated", () => {
     });
 
     it("should pre-select the existing docker registry secret", async () => {
-      const secret = {
-        metadata: {
-          name: "foo",
-        },
-      } as ISecret;
-      const repo = { metadata: { name: "foo" }, spec: { dockerRegistrySecrets: ["foo"] } } as any;
+      const repo = { metadata: { name: "foo" }, spec: { dockerRegistrySecrets: ["secret-2"] } } as any;
+      Secret.getDockerConfigSecretNames = jest.fn(() => Promise.resolve(["secret-1", "secret-2", "secret-3"]));
       const wrapper = mountWrapper(
-        getStore({
-          repos: { imagePullSecrets: [secret] },
-        }),
+        defaultStore,
         <AppRepoForm {...defaultProps} repo={repo} />,
       );
       await waitFor(() => {
-        expect(wrapper.find("select").prop("value")).toBe("foo");
+        wrapper.update();
+        expect(wrapper.find("select").prop("value")).toBe("secret-2");
       });
     });
 

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -86,7 +86,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
 
   useEffect(() => {
     fetchImagePullSecrets(currentCluster, namespace);
-  }, [dispatch, namespace]);
+  }, [dispatch, namespace, currentCluster]);
 
   async function fetchImagePullSecrets(cluster: string, repoNamespace: string) {
     setImagePullSecrets(await Secret.getDockerConfigSecretNames(cluster, repoNamespace));
@@ -96,7 +96,6 @@ export function AppRepoForm(props: IAppRepoFormProps) {
     // Select the pull secrets if they are already selected in the existing repo
     imagePullSecrets.forEach(secretName => {
       if (repo?.spec?.dockerRegistrySecrets?.some(s => s === secretName)) {
-        console.log(`setting selectedImagePullSecret: ${secretName}`);
         setSelectedImagePullSecret(secretName);
       }
     });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoForm.tsx
@@ -96,7 +96,7 @@ export function AppRepoForm(props: IAppRepoFormProps) {
     // Select the pull secrets if they are already selected in the existing repo
     imagePullSecrets.forEach(secretName => {
       if (repo?.spec?.dockerRegistrySecrets?.some(s => s === secretName)) {
-        console.log(`setting selectedImagePullSecret: ${secretName}`)
+        console.log(`setting selectedImagePullSecret: ${secretName}`);
         setSelectedImagePullSecret(secretName);
       }
     });

--- a/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
+++ b/dashboard/src/components/Config/AppRepoList/AppRepoList.test.tsx
@@ -26,7 +26,6 @@ beforeEach(() => {
   actions.repos = {
     ...actions.repos,
     fetchRepos: jest.fn(),
-    fetchImagePullSecrets: jest.fn(),
   };
   const mockDispatch = jest.fn();
   spyOnUseDispatch = jest.spyOn(ReactRedux, "useDispatch").mockReturnValue(mockDispatch);

--- a/dashboard/src/reducers/repos.test.ts
+++ b/dashboard/src/reducers/repos.test.ts
@@ -43,8 +43,6 @@ describe("reposReducer", () => {
       redirect: getType(actions.repos.redirect),
       redirected: getType(actions.repos.redirected),
       errorRepos: getType(actions.repos.errorRepos),
-      requestImagePullSecrets: getType(actions.repos.requestImagePullSecrets),
-      receiveImagePullSecrets: getType(actions.repos.receiveImagePullSecrets),
       createImagePullSecret: getType(actions.repos.createImagePullSecret),
     };
 
@@ -141,24 +139,6 @@ describe("reposReducer", () => {
           type: actionTypes.repoValidated as any,
         }),
       ).toEqual({ ...initialState });
-    });
-
-    it("receives image pull secrets", () => {
-      const pullSecret = { metadata: { name: "foo" } } as any;
-      const state = reposReducer(undefined, {
-        type: actionTypes.requestImagePullSecrets as any,
-      });
-      expect(state).toEqual({
-        ...initialState,
-        isFetching: true,
-        isFetchingElem: { repositories: false, secrets: true },
-      });
-      expect(
-        reposReducer(state, {
-          type: actionTypes.receiveImagePullSecrets as any,
-          payload: [pullSecret],
-        }),
-      ).toEqual({ ...initialState, imagePullSecrets: [pullSecret] });
     });
   });
 });

--- a/dashboard/src/reducers/repos.ts
+++ b/dashboard/src/reducers/repos.ts
@@ -111,10 +111,6 @@ const reposReducer = (
       return { ...state, redirectTo: action.payload };
     case getType(actions.repos.redirected):
       return { ...state, redirectTo: undefined };
-    case getType(actions.repos.requestImagePullSecrets):
-      return { ...state, ...isFetching(state, "secrets", true) };
-    case getType(actions.repos.receiveImagePullSecrets):
-      return { ...state, ...isFetching(state, "secrets", false), imagePullSecrets: action.payload };
     case getType(actions.repos.errorRepos):
       return {
         ...state,

--- a/dashboard/src/shared/Secret.test.ts
+++ b/dashboard/src/shared/Secret.test.ts
@@ -3,9 +3,40 @@ import Secret from "./Secret";
 import {
   CreateSecretRequest,
   CreateSecretResponse,
+  GetSecretNamesResponse,
   SecretType,
 } from "gen/kubeappsapis/plugins/resources/v1alpha1/resources";
 import { KubeappsGrpcClient } from "./KubeappsGrpcClient";
+
+describe("getSecretNames", () => {
+  const expectedSecretNames = {
+    "secret-one": SecretType.SECRET_TYPE_DOCKER_CONFIG_JSON,
+    "secret-two": SecretType.SECRET_TYPE_OPAQUE_UNSPECIFIED,
+    "secret-three": SecretType.SECRET_TYPE_DOCKER_CONFIG_JSON,
+  }
+  // Create a real client, but we'll stub out the function we're interested in.
+  const client = new KubeappsGrpcClient().getResourcesServiceClientImpl();
+  let mockClientGetSecretNames: jest.MockedFunction<typeof client.GetSecretNames>;
+  beforeEach(() => {
+    mockClientGetSecretNames = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({
+        secretNames: expectedSecretNames,
+      } as GetSecretNamesResponse));
+
+    jest.spyOn(client, "GetSecretNames").mockImplementation(mockClientGetSecretNames);
+    jest.spyOn(Secret, "resourcesClient").mockImplementation(() => client);
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns the map of secret names with types", async () => {
+    const result = await Secret.getDockerConfigSecretNames("default", "default");
+
+    expect(result).toEqual(["secret-one", "secret-three"]);
+  });
+});
 
 it("gets a secret", async () => {
   axiosWithAuth.get = jest.fn().mockReturnValue({ data: "ok" });

--- a/dashboard/src/shared/Secret.test.ts
+++ b/dashboard/src/shared/Secret.test.ts
@@ -1,4 +1,3 @@
-import { axiosWithAuth } from "./AxiosInstance";
 import Secret from "./Secret";
 import {
   CreateSecretRequest,

--- a/dashboard/src/shared/Secret.test.ts
+++ b/dashboard/src/shared/Secret.test.ts
@@ -38,22 +38,6 @@ describe("getSecretNames", () => {
   });
 });
 
-it("gets a secret", async () => {
-  axiosWithAuth.get = jest.fn().mockReturnValue({ data: "ok" });
-  await Secret.get("default", "bar", "foo");
-  expect(axiosWithAuth.get).toHaveBeenCalledWith(
-    "api/clusters/default/api/v1/namespaces/bar/secrets/foo",
-  );
-});
-
-it("lists secrets", async () => {
-  axiosWithAuth.get = jest.fn().mockReturnValue({ data: "ok" });
-  await Secret.list("default", "foo");
-  expect(axiosWithAuth.get).toHaveBeenCalledWith(
-    "api/clusters/default/api/v1/namespaces/foo/secrets",
-  );
-});
-
 describe("createSecret", () => {
   // Create a real client, but we'll stub out the function we're interested in.
   const client = new KubeappsGrpcClient().getResourcesServiceClientImpl();

--- a/dashboard/src/shared/Secret.test.ts
+++ b/dashboard/src/shared/Secret.test.ts
@@ -13,16 +13,16 @@ describe("getSecretNames", () => {
     "secret-one": SecretType.SECRET_TYPE_DOCKER_CONFIG_JSON,
     "secret-two": SecretType.SECRET_TYPE_OPAQUE_UNSPECIFIED,
     "secret-three": SecretType.SECRET_TYPE_DOCKER_CONFIG_JSON,
-  }
+  };
   // Create a real client, but we'll stub out the function we're interested in.
   const client = new KubeappsGrpcClient().getResourcesServiceClientImpl();
   let mockClientGetSecretNames: jest.MockedFunction<typeof client.GetSecretNames>;
   beforeEach(() => {
-    mockClientGetSecretNames = jest
-      .fn()
-      .mockImplementation(() => Promise.resolve({
+    mockClientGetSecretNames = jest.fn().mockImplementation(() =>
+      Promise.resolve({
         secretNames: expectedSecretNames,
-      } as GetSecretNamesResponse));
+      } as GetSecretNamesResponse),
+    );
 
     jest.spyOn(client, "GetSecretNames").mockImplementation(mockClientGetSecretNames);
     jest.spyOn(Secret, "resourcesClient").mockImplementation(() => client);

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -1,6 +1,3 @@
-import { axiosWithAuth } from "./AxiosInstance";
-import { IK8sList, ISecret } from "./types";
-import * as url from "./url";
 import { KubeappsGrpcClient } from "./KubeappsGrpcClient";
 import {
   CreateSecretRequest,

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -9,11 +9,6 @@ import {
 
 export default class Secret {
   public static resourcesClient = () => new KubeappsGrpcClient().getResourcesServiceClientImpl();
-  public static async get(cluster: string, namespace: string, name: string) {
-    const u = url.api.k8s.secret(cluster, namespace, name);
-    const { data } = await axiosWithAuth.get<ISecret>(u);
-    return data;
-  }
 
   public static async getDockerConfigSecretNames(cluster: string, namespace: string) {
     const result = await this.resourcesClient().GetSecretNames({
@@ -30,12 +25,6 @@ export default class Secret {
       }
     }
     return secretNames;
-  }
-
-  public static async list(cluster: string, namespace: string, fieldSelector?: string) {
-    const u = url.api.k8s.secrets(cluster, namespace, fieldSelector);
-    const { data } = await axiosWithAuth.get<IK8sList<ISecret, {}>>(u);
-    return data;
   }
 
   public static async createPullSecret(

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -15,9 +15,9 @@ export default class Secret {
       },
     });
 
-    let secretNames = [];
+    const secretNames = [];
     for (const [name, type] of Object.entries(result.secretNames)) {
-      if (type == SecretType.SECRET_TYPE_DOCKER_CONFIG_JSON) {
+      if (type === SecretType.SECRET_TYPE_DOCKER_CONFIG_JSON) {
         secretNames.push(name);
       }
     }

--- a/dashboard/src/shared/Secret.ts
+++ b/dashboard/src/shared/Secret.ts
@@ -15,6 +15,23 @@ export default class Secret {
     return data;
   }
 
+  public static async getDockerConfigSecretNames(cluster: string, namespace: string) {
+    const result = await this.resourcesClient().GetSecretNames({
+      context: {
+        cluster,
+        namespace,
+      },
+    });
+
+    let secretNames = [];
+    for (const [name, type] of Object.entries(result.secretNames)) {
+      if (type == SecretType.SECRET_TYPE_DOCKER_CONFIG_JSON) {
+        secretNames.push(name);
+      }
+    }
+    return secretNames;
+  }
+
   public static async list(cluster: string, namespace: string, fieldSelector?: string) {
     const u = url.api.k8s.secrets(cluster, namespace, fieldSelector);
     const { data } = await axiosWithAuth.get<IK8sList<ISecret, {}>>(u);

--- a/dashboard/src/shared/url.ts
+++ b/dashboard/src/shared/url.ts
@@ -170,12 +170,6 @@ export const api = {
           cluster,
         )}/apis/operators.coreos.com/v1alpha1/namespaces/${namespace}/subscriptions/${name}`,
     },
-    secrets: (cluster: string, namespace: string, fieldSelector?: string) =>
-      `${api.k8s.namespace(cluster, namespace)}/secrets${
-        fieldSelector ? `?fieldSelector=${encodeURIComponent(fieldSelector)}` : ""
-      }`,
-    secret: (cluster: string, namespace: string, name: string) =>
-      `${api.k8s.secrets(cluster, namespace)}/${name}`,
   },
 
   operators: {


### PR DESCRIPTION
### Description of the change

This PR follows on from #4028, updating the AppRepoForm so that it fetches the image pull secret *names* only (from the resources API), rather than fetching (and storing in global state) the image pull secrets for a namespace. Also updated, while there, to no longer use global state for these, but rather just local state on the form.

It also does some cleaning up, so that `shared/Secret.ts` no longer has any references to the k8s API, as well as removing the urls from `shared/urls` etc.

Tested IRL.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Kubeapps no longer hits the k8s API for secrets, nor does it expose any method for fetching secrets generally.

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3896 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
