### PR TITLE
Update dashboard's validateToken not to use k8s api server.

### DIFF
--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -415,14 +415,18 @@ func resourceRefsEqual(r1, r2 *pkgsGRPCv1alpha1.ResourceRef) bool {
 }
 
 // errorByStatus generates a meaningful error message
+// TODO(minelson): Move to a shared helper for plugins interacting
+// with the k8s cluster.
 func errorByStatus(verb, resource, identifier string, err error) error {
 	if identifier == "" {
 		identifier = "all"
 	}
 	if errors.IsNotFound(err) {
 		return status.Errorf(codes.NotFound, "unable to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
-	} else if errors.IsForbidden(err) || errors.IsUnauthorized(err) {
-		return status.Errorf(codes.PermissionDenied, "Unauthorized to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+	} else if errors.IsForbidden(err) {
+		return status.Errorf(codes.PermissionDenied, "Forbidden to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+	} else if errors.IsUnauthorized(err) {
+		return status.Errorf(codes.Unauthenticated, "Authorization required to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
 	} else if errors.IsAlreadyExists(err) {
 		return status.Errorf(codes.AlreadyExists, "Cannot %s the %s '%s' due to '%v' as it already exists", verb, resource, identifier, err)
 	}

--- a/dashboard/src/components/LoginForm/LoginForm.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.test.tsx
@@ -2,7 +2,7 @@ import LoadingWrapper from "components/LoadingWrapper";
 import { Location } from "history";
 import { act } from "react-dom/test-utils";
 import { Redirect } from "react-router";
-import { defaultStore, mountWrapper } from "shared/specs/mountWrapper";
+import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
 import LoginForm from "./LoginForm";
 import OAuthLogin from "./OauthLogin";
 import TokenLogin from "./TokenLogin";
@@ -145,21 +145,33 @@ describe("oauth login form", () => {
     expect(wrapper.find("input#token").exists()).toBe(false);
   });
 
-  it("displays the oauth login if oauthLoginURI provided", () => {
-    const wrapper = mountWrapper(defaultStore, <LoginForm {...props} />);
+  it("displays the oauth login if authProxyEnabled", () => {
+    const state = {
+      ...defaultStore,
+      config: {
+        authProxyEnabled: true,
+      },
+    };
+    const wrapper = mountWrapper(getStore({ ...state }), <LoginForm {...props} />);
     expect(props.checkCookieAuthentication).toHaveBeenCalled();
     expect(wrapper.find(OAuthLogin)).toExist();
     expect(wrapper.find("a").findWhere(a => a.prop("href") === props.oauthLoginURI)).toExist();
   });
 
   it("doesn't render the login form if the cookie has not been checked yet", () => {
+    const state = {
+      ...defaultStore,
+      config: {
+        authProxyEnabled: true,
+      },
+    };
     const props2 = {
       ...props,
       checkCookieAuthentication: jest.fn().mockReturnValue({
         then: jest.fn(() => false),
       }),
     };
-    const wrapper = mountWrapper(defaultStore, <LoginForm {...props2} />);
+    const wrapper = mountWrapper(getStore({ ...state }), <LoginForm {...props2} />);
     expect(wrapper.find(LoadingWrapper)).toExist();
     expect(wrapper.find(OAuthLogin)).not.toExist();
   });

--- a/dashboard/src/components/LoginForm/LoginForm.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.tsx
@@ -7,6 +7,8 @@ import LoadingWrapper from "../../components/LoadingWrapper";
 import "./LoginForm.css";
 import OAuthLogin from "./OauthLogin";
 import TokenLogin from "./TokenLogin";
+import { useSelector } from "react-redux";
+import { IStoreState } from "shared/types";
 
 export interface ILoginFormProps {
   cluster: string;
@@ -26,8 +28,13 @@ function LoginForm(props: ILoginFormProps) {
   const [token, setToken] = useState("");
   const [cookieChecked, setCookieChecked] = useState(false);
   const { oauthLoginURI, checkCookieAuthentication } = props;
+
+  const {
+    config: { authProxyEnabled },
+  } = useSelector((state: IStoreState) => state);
+
   useEffect(() => {
-    if (oauthLoginURI) {
+    if (authProxyEnabled) {
       checkCookieAuthentication(props.cluster).then(() => setCookieChecked(true));
     } else {
       setCookieChecked(true);

--- a/dashboard/src/components/LoginForm/LoginForm.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.tsx
@@ -27,7 +27,7 @@ function LoginForm(props: ILoginFormProps) {
   const intl = useIntl();
   const [token, setToken] = useState("");
   const [cookieChecked, setCookieChecked] = useState(false);
-  const { oauthLoginURI, checkCookieAuthentication } = props;
+  const { checkCookieAuthentication } = props;
 
   const {
     config: { authProxyEnabled },
@@ -39,7 +39,7 @@ function LoginForm(props: ILoginFormProps) {
     } else {
       setCookieChecked(true);
     }
-  }, [oauthLoginURI, checkCookieAuthentication, props.cluster]);
+  }, [authProxyEnabled, checkCookieAuthentication, props.cluster]);
 
   if (props.authenticating || !cookieChecked) {
     return (

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -1,23 +1,38 @@
+import { grpc } from "@improbable-eng/grpc-web";
 import Axios, { AxiosResponse } from "axios";
+import { CheckNamespaceExistsRequest } from "gen/kubeappsapis/plugins/resources/v1alpha1/resources";
 import * as jwt from "jsonwebtoken";
 import { Auth } from "./Auth";
 import { SupportedThemes } from "./Config";
+import { KubeappsGrpcClient } from "./KubeappsGrpcClient";
 
 describe("Auth", () => {
+  // Create a real client, but we'll stub out the function we're interested in.
+  const client = new KubeappsGrpcClient().getResourcesServiceClientImpl();
+  let mockClientCheckNamespaceExists: jest.MockedFunction<typeof client.CheckNamespaceExists>;
+
   beforeEach(() => {
     Axios.get = jest.fn();
+    mockClientCheckNamespaceExists = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ exists: true } as CheckNamespaceExistsRequest));
+    jest.spyOn(client, "CheckNamespaceExists").mockImplementation(mockClientCheckNamespaceExists);
+    jest.spyOn(Auth, "resourcesClient").mockImplementation(() => client);
   });
   afterEach(() => {
     jest.resetAllMocks();
   });
+
   it("should get an URL with the given token", async () => {
-    const mock = jest.fn();
-    Axios.get = mock;
     await Auth.validateToken("othercluster", "foo");
-    expect(mock.mock.calls[0]).toEqual([
-      "api/clusters/othercluster/",
-      { headers: { Authorization: "Bearer foo" } },
-    ]);
+
+    expect(Auth.resourcesClient).toHaveBeenCalledWith("foo");
+    expect(mockClientCheckNamespaceExists).toHaveBeenCalledWith({
+      context: {
+        cluster: "othercluster",
+        namespace: "default",
+      },
+    });
   });
 
   describe("when there is an error", () => {
@@ -25,29 +40,32 @@ describe("Auth", () => {
       {
         name: "should throw an invalid token error for 401 responses",
         response: { status: 401, data: "ignored anyway" },
+        grpcCode: grpc.Code.Unauthenticated,
         expectedError: new Error("invalid token"),
       },
       {
         name: "should throw a standard error for a 404 response",
-        response: { status: 404, data: "Not found" },
-        expectedError: new Error("404: Not found"),
+        grpcCode: grpc.Code.NotFound,
+        expectedError: new Error("not found"),
       },
       {
         name: "should throw a standard error for a 500 response",
-        response: { status: 500, data: "Server exception" },
-        expectedError: new Error("500: Server exception"),
+        grpcCode: grpc.Code.Internal,
+        expectedError: new Error("internal error"),
       },
       {
         name: "should succeed for a 403 response",
-        response: { status: 403, data: "Not Allowed" },
+        grpcCode: grpc.Code.PermissionDenied,
         expectedError: null,
       },
     ].forEach(testCase => {
       it(testCase.name, async () => {
-        const mock = jest.fn(() => {
-          return Promise.reject({ response: testCase.response });
-        });
-        Axios.get = mock;
+        mockClientCheckNamespaceExists = jest
+          .fn()
+          .mockImplementation(() => Promise.reject({ code: testCase.grpcCode }));
+        jest
+          .spyOn(client, "CheckNamespaceExists")
+          .mockImplementation(mockClientCheckNamespaceExists);
         // TODO(absoludity): tried using `expect(fn()).rejects.toThrow()` but it seems we need
         // to upgrade jest for `toThrow()` to work with async.
         let err = null;

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -65,13 +65,9 @@ export class Auth {
   // Throws an error if the token is invalid
   public static async validateToken(cluster: string, token: string) {
     try {
-      const response = await this.resourcesClient(token).CheckNamespaceExists({
+      await this.resourcesClient(token).CheckNamespaceExists({
         context: { cluster, namespace: "default" },
       });
-      if (response.exists) {
-        return;
-      }
-      return;
     } catch (e: any) {
       if (e.code === grpc.Code.Unauthenticated) {
         throw new Error("invalid token");

--- a/dashboard/src/shared/KubeappsGrpcClient.test.ts
+++ b/dashboard/src/shared/KubeappsGrpcClient.test.ts
@@ -90,7 +90,7 @@ describe("kubeapps grpc core plugin service", () => {
   // More details: https://github.com/kubeapps/kubeapps/issues/3165#issuecomment-882944035
 });
 
-describe("kubeapps grpc core plugin service", () => {
+describe("kubeapps grpc resources plugin service", () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/dashboard/src/shared/KubeappsGrpcClient.test.ts
+++ b/dashboard/src/shared/KubeappsGrpcClient.test.ts
@@ -89,3 +89,45 @@ describe("kubeapps grpc core plugin service", () => {
   // TODO(agamez): try to also mock the messages ussing the new FakeTransportBuilder().withMessages([])
   // More details: https://github.com/kubeapps/kubeapps/issues/3165#issuecomment-882944035
 });
+
+describe("kubeapps grpc core plugin service", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const fakeAuthTransport = new FakeTransportBuilder()
+    .withHeaders(new grpc.Metadata({ authorization: "Bearer topsecret" }))
+    .build();
+
+  it("it set the metadata if using token auth", async () => {
+    const kubeappsGrpcClient = new KubeappsGrpcClient(fakeAuthTransport);
+    jest.spyOn(window.localStorage.__proto__, "getItem").mockReturnValue("topsecret");
+
+    const getClientMetadataMock = jest.spyOn(KubeappsGrpcClient.prototype, "getClientMetadata");
+    kubeappsGrpcClient.getResourcesServiceClientImpl();
+
+    const expectedMetadata = new grpc.Metadata({ authorization: "Bearer topsecret" });
+    expect(getClientMetadataMock.mock.results[0].value).toEqual(expectedMetadata);
+  });
+
+  it("it doesn't set the metadata if not using token auth", async () => {
+    const kubeappsGrpcClient = new KubeappsGrpcClient(fakeAuthTransport);
+    jest.spyOn(window.localStorage.__proto__, "getItem").mockReturnValue(null);
+    const getClientMetadataMock = jest.spyOn(KubeappsGrpcClient.prototype, "getClientMetadata");
+
+    kubeappsGrpcClient.getResourcesServiceClientImpl();
+
+    expect(getClientMetadataMock.mock.results[0].value).toBeUndefined();
+  });
+
+  it("it sets the metadata if passed an explicit token", async () => {
+    const kubeappsGrpcClient = new KubeappsGrpcClient(fakeAuthTransport);
+    jest.spyOn(window.localStorage.__proto__, "getItem").mockReturnValue(null);
+    const getClientMetadataMock = jest.spyOn(KubeappsGrpcClient.prototype, "getClientMetadata");
+
+    kubeappsGrpcClient.getResourcesServiceClientImpl("topsecret");
+
+    const expectedMetadata = new grpc.Metadata({ authorization: "Bearer topsecret" });
+    expect(getClientMetadataMock.mock.results[0].value).toEqual(expectedMetadata);
+  });
+});


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Part one of removing `shared/Auth`'s use of the k8s API server, this PR updates the `validateToken` check, used when Kubeapps is configured with token authentication, so that it hits the resources API (`checkNamespace`), rather than hitting the k8s API server directly.

To do so, I had to correct the error handling in the resources plugin to differentiate between 401s and 403s (and will later follow up as per the TODO there).

I also fixed an issue where the dashboard was checking cookie auth based only on the loginURL being set, which it is by default anyway (which resulted in an extra error being displayed when token login failed).
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

One more action no longer hitting k8s API.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3896

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
