### PR TITLE
Update cookie auth check to no longer use axios/k8s api server

### DIFF
--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -132,6 +132,23 @@ describe("Auth", () => {
       expect(isAuthed).toBe(true);
     });
 
+    it("returns true if the request to api root results in a 403 with another grpc protocol", async () => {
+      mockClientCheckNamespaceExists = jest.fn().mockImplementation(() =>
+        Promise.reject({
+          code: grpc.Code.PermissionDenied,
+          metadata: {
+            headersMap: {
+              "content-type": ["application/grpc-web+thrift"],
+            },
+          },
+        }),
+      );
+      jest.spyOn(client, "CheckNamespaceExists").mockImplementation(mockClientCheckNamespaceExists);
+
+      const isAuthed = await Auth.isAuthenticatedWithCookie("somecluster");
+
+      expect(isAuthed).toBe(true);
+    });
     it("returns false if the request results in a 401", async () => {
       mockClientCheckNamespaceExists = jest.fn().mockImplementation(() =>
         Promise.reject({

--- a/dashboard/src/shared/Auth.test.ts
+++ b/dashboard/src/shared/Auth.test.ts
@@ -1,5 +1,5 @@
 import { grpc } from "@improbable-eng/grpc-web";
-import Axios, { AxiosResponse } from "axios";
+import { AxiosResponse } from "axios";
 import { CheckNamespaceExistsRequest } from "gen/kubeappsapis/plugins/resources/v1alpha1/resources";
 import * as jwt from "jsonwebtoken";
 import { Auth } from "./Auth";
@@ -12,7 +12,6 @@ describe("Auth", () => {
   let mockClientCheckNamespaceExists: jest.MockedFunction<typeof client.CheckNamespaceExists>;
 
   beforeEach(() => {
-    Axios.get = jest.fn();
     mockClientCheckNamespaceExists = jest
       .fn()
       .mockImplementation(() => Promise.resolve({ exists: true } as CheckNamespaceExistsRequest));
@@ -85,52 +84,69 @@ describe("Auth", () => {
 
   describe("isAuthenticatedWithCookie", () => {
     it("returns true if request to API root succeeds", async () => {
-      Axios.get = jest.fn().mockReturnValue(Promise.resolve({ headers: { status: 200 } }));
       const isAuthed = await Auth.isAuthenticatedWithCookie("somecluster");
 
-      expect(Axios.get).toBeCalledWith("api/clusters/somecluster/");
+      expect(Auth.resourcesClient).toHaveBeenCalledWith();
+      expect(mockClientCheckNamespaceExists).toHaveBeenCalledWith({
+        context: {
+          cluster: "somecluster",
+          namespace: "default",
+        },
+      });
       expect(isAuthed).toBe(true);
     });
-    it("returns false if the request to api root results in a 403 for an anonymous request", async () => {
-      Axios.get = jest.fn(() => {
-        return Promise.reject({
-          response: {
-            status: 403,
-            data: { message: "Something with system:anonymous in there" },
+
+    it("returns false if the request results in a non-grpc-web response", async () => {
+      mockClientCheckNamespaceExists = jest.fn().mockImplementation(() =>
+        Promise.reject({
+          code: grpc.Code.PermissionDenied,
+          metadata: {
+            headersMap: {
+              "content-type": ["not-grpc-content-type"],
+            },
           },
-        });
-      });
+        }),
+      );
+      jest.spyOn(client, "CheckNamespaceExists").mockImplementation(mockClientCheckNamespaceExists);
+
       const isAuthed = await Auth.isAuthenticatedWithCookie("somecluster");
+
       expect(isAuthed).toBe(false);
     });
-    it("returns false if the request to api root results in a non-json response (ie. without data.message)", async () => {
-      Axios.get = jest.fn(() => {
-        return Promise.reject({
-          response: {
-            status: 403,
+
+    it("returns true if the request to api root results in a 403", async () => {
+      mockClientCheckNamespaceExists = jest.fn().mockImplementation(() =>
+        Promise.reject({
+          code: grpc.Code.PermissionDenied,
+          metadata: {
+            headersMap: {
+              "content-type": ["application/grpc-web+proto"],
+            },
           },
-        });
-      });
+        }),
+      );
+      jest.spyOn(client, "CheckNamespaceExists").mockImplementation(mockClientCheckNamespaceExists);
+
       const isAuthed = await Auth.isAuthenticatedWithCookie("somecluster");
-      expect(isAuthed).toBe(false);
-    });
-    it("returns true if the request to api root results in a 403 (but not anonymous)", async () => {
-      Axios.get = jest.fn(() => {
-        return Promise.reject({
-          response: {
-            status: 403,
-            data: { message: "some message for other-user" },
-          },
-        });
-      });
-      const isAuthed = await Auth.isAuthenticatedWithCookie("somecluster");
+
       expect(isAuthed).toBe(true);
     });
-    it("should return false if the request results in a 401", async () => {
-      Axios.get = jest.fn(() => {
-        return Promise.reject({ response: { status: 401 } });
-      });
+
+    it("returns false if the request results in a 401", async () => {
+      mockClientCheckNamespaceExists = jest.fn().mockImplementation(() =>
+        Promise.reject({
+          code: grpc.Code.Unauthenticated,
+          metadata: {
+            headersMap: {
+              "content-type": ["not-grpc-content-type"],
+            },
+          },
+        }),
+      );
+      jest.spyOn(client, "CheckNamespaceExists").mockImplementation(mockClientCheckNamespaceExists);
+
       const isAuthed = await Auth.isAuthenticatedWithCookie("somecluster");
+
       expect(isAuthed).toBe(false);
     });
   });

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -1,7 +1,6 @@
-import Axios, { AxiosResponse } from "axios";
+import { AxiosResponse } from "axios";
 import * as jwt from "jsonwebtoken";
 import { get } from "lodash";
-import * as url from "shared/url";
 import { IConfig } from "./Config";
 import { KubeappsGrpcClient } from "./KubeappsGrpcClient";
 import { grpc } from "@improbable-eng/grpc-web";
@@ -90,6 +89,16 @@ export class Auth {
     }
   }
 
+  // is403FromAPIsServer returns true if the response is a 403 determined to have originated
+  // from the grpc-web APIs server, rather than the auth proxy.
+  public static is403FromAPIsServer(e: any): boolean {
+    const contentType = e.metadata?.headersMap["content-type"] as string[];
+    if (contentType.some(v => v === "application/grpc-web+proto")) {
+      return true;
+    }
+    return false;
+  }
+
   // is403FromAuthProxy returns true if the response is a 403 determined to have originated
   // from the auth proxy itself, rather than upstream.
   //
@@ -99,6 +108,8 @@ export class Auth {
   // upstream result). Hence encapsulating this ugliness here so we can fix
   // it in the one spot. We may need to query `/oauth2/info` to avoid potential
   // false positives.
+  // Note: This function is only used now by AxiosInstance which
+  // in turn is only used for operators support.
   public static is403FromAuthProxy(r: AxiosResponse<any>): boolean {
     if (r.data && typeof r.data === "string" && r.data.match("system:serviceaccount")) {
       // If the error message is related to a service account is not from the auth proxy
@@ -112,39 +123,43 @@ export class Auth {
   // the k8s api server nowadays defaults to allowing anonymous
   // requests, so that rather than returning a 401, a 403 is returned if
   // RBAC does not allow the anonymous user access.
+  //
+  // Note: This function is only used now by AxiosInstance which
+  // in turn is only used for operators support.
   public static isAnonymous(response: AxiosResponse<any>): boolean {
     const msg = get(response, "data.message") || get(response, "data");
     return typeof msg === "string" && msg.includes("system:anonymous");
   }
 
-  // isAuthenticatedWithCookie() does an anonymous GET request to determine if
+  // isAuthenticatedWithCookie() does a GET request to determine if
   // the request is authenticated with an http-only cookie (there is, by design,
   // no way to determine via client JS whether an http-only cookie is present).
+  //
+  // Note that when using the auth-proxy, anonymous requests never
+  // get to the backend since the auth-proxy requires authentication.
+  // But if this function is incorrectly called when the auth-proxy
+  // is not in use, with a cluster that supports anonymous requests,
+  // it could potentially return a false positive.
   public static async isAuthenticatedWithCookie(cluster: string): Promise<boolean> {
     try {
-      await Axios.get(url.api.k8s.base(cluster) + "/");
+      await this.resourcesClient().CheckNamespaceExists({
+        context: { cluster, namespace: "default" },
+      });
     } catch (e: any) {
-      const response = e.response as AxiosResponse<any>;
       // The only error response which can possibly mean we did authenticate is
       // a 403 from the k8s api server (ie. we got through to k8s api server
       // but RBAC doesn't authorize us).
-      // See note below about anonymous requests.
-      if (response.status !== 403) {
+      if (e.code !== grpc.Code.PermissionDenied) {
         return false;
       }
 
-      // A 403 error response from the auth proxy itself means we did not get
-      // through to the API server but instead were rejected by the auth
-      // proxy (ie. no http-only cookie).
-      // TODO(mnelson): Check why doesn't the auth proxy return a 401 for a request without auth?
-      if (this.is403FromAuthProxy(response)) {
-        return false;
+      // A 403 error response from our APIs server, rather than the
+      // auth proxy, means we are authenticated and did get
+      // through to the API server but were rejected by RBAC.
+      if (this.is403FromAPIsServer(e)) {
+        return true;
       }
-      // Finally, the k8s api server nowadays defaults to allowing anonymous
-      // requests, so that rather than returning a 401, a 403 is returned if
-      // RBAC does not allow the anonymous user access. An http-only cookie
-      // will not result in an anonymous request, so...
-      return !this.isAnonymous(response);
+      return false;
     }
     return true;
   }

--- a/dashboard/src/shared/Auth.ts
+++ b/dashboard/src/shared/Auth.ts
@@ -89,11 +89,11 @@ export class Auth {
     }
   }
 
-  // is403FromAPIsServer returns true if the response is a 403 determined to have originated
+  // isErrorFromAPIsServer returns true if the response is a 403 determined to have originated
   // from the grpc-web APIs server, rather than the auth proxy.
-  public static is403FromAPIsServer(e: any): boolean {
+  public static isErrorFromAPIsServer(e: any): boolean {
     const contentType = e.metadata?.headersMap["content-type"] as string[];
-    if (contentType.some(v => v === "application/grpc-web+proto")) {
+    if (contentType.some(v => v.startsWith("application/grpc-web"))) {
       return true;
     }
     return false;
@@ -156,7 +156,7 @@ export class Auth {
       // A 403 error response from our APIs server, rather than the
       // auth proxy, means we are authenticated and did get
       // through to the API server but were rejected by RBAC.
-      if (this.is403FromAPIsServer(e)) {
+      if (this.isErrorFromAPIsServer(e)) {
         return true;
       }
       return false;


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Follows on from #4043, this time updating the cookie-based authentication so that it no longer uses a request to the k8s API server to determine the authentication status.

I'd originally planned to remove axios from `shared/Auth` (with the `isAnonymous` and `is403FromAuthProxy` functions), but then found they are still used in `shared/AxiosInstance` which is still used by the operator support (which will continue for now to query the k8s API directly).

As with the previous PR the pain here was testing IRL locally the various possibilities to find the best solution.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

Hopefully no more requests to the k8s api server, outside of the operator support (though I'll do a proper audit and test tomorrow).

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3896 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
