### PR TITLE
Use another yaml dep to unmarshall the schema

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -27,11 +27,11 @@ import (
 	datapackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"gopkg.in/yaml.v3"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/yaml"
 )
 
 type pkgSemver struct {

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
@@ -14,7 +14,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -292,12 +291,31 @@ valueWithDefault: 80
 			`# missingDefaultObject: {}
 # valueWithDefault: 80
 `, nil},
-		{"bad schema", true, []byte(`properties:
-  fluent_bit:
-    description: fluent-bit Kubernetes configuration.
+		{"good schema (w/ additionalProperties: true, as per jsonschema draft 4)", true, []byte(`properties:
+  myAdditionalPropertiesProp:
+    type: object
+    additionalProperties: true
+`,
+		),
+			`# myAdditionalPropertiesProp: {}
+`, nil},
+		{"good schema (w/ additionalProperties: <schema>)", true, []byte(`properties:
+  myAdditionalPropertiesProp:
+    type: object
+    additionalProperties:
+      type: string
+`,
+		),
+			`# myAdditionalPropertiesProp: {}
+`, nil},
+		{"bad schema (w/ additionalProperties: string)", true, []byte(`properties:
+  myAdditionalPropertiesProp:
+    type: object
     additionalProperties: string
 `,
-		), "", fmt.Errorf("error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field JSONSchemaProps.Properties.AdditionalProperties of type apiextensions.JSONSchemaPropsOrBool")},
+		),
+			`# myAdditionalPropertiesProp: {}
+`, nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -102,7 +102,7 @@ function UpgradeForm(props: IUpgradeFormProps) {
   useEffect(() => {
     if (installedAppAvailablePackageDetail?.defaultValues && !modifications) {
       // Calculate modifications from the default values
-      const defaultValuesObj = yaml.load(installedAppAvailablePackageDetail?.defaultValues);
+      const defaultValuesObj = yaml.load(installedAppAvailablePackageDetail?.defaultValues) || {};
       const deployedValuesObj = yaml.load(installedAppInstalledPackageDetail?.valuesApplied || "");
       const newModifications = jsonpatch.compare(defaultValuesObj as any, deployedValuesObj as any);
       const values = applyModifications(


### PR DESCRIPTION
### Description of the change

Follow-up PR of #4023. 

After giving a try to the repo that the TCE folks so kindly created (https://github.com/vmware-tanzu/community-edition/pull/2775#issuecomment-1006784759)), I noticed it still failed in Kubeapps. The unmarshaller was returning an error even if the `addtionalProperties` prop was properly being set (according to the JSONSchema Spec). 
I guess it has something to do with the `JSONSchemaPropsOrBool` (from k8s) field it tries to unmarshall to, but I don't know the root cause yet.

Anyway, it gets sorted out when using another `yaml` dependency, which in case of failures, it seems to be using the default value in `JSONSchemaPropsOrBool` (which is `true`).

This PR replaces this yaml dep and updates the test cases accordingly.

### Benefits

Kubeapps will be able to set default values for all the TCE packages (and any other with the same issue in the schema)

### Possible drawbacks

Perhaps it can influence #3848.

### Applicable issues


- rel #3853

### Additional information

![image](https://user-images.githubusercontent.com/11535726/148772962-90833e33-364e-4416-a283-90ef90cfbf54.png)
