### PR TITLE
Test running without k8s api proxying.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,7 +686,7 @@ jobs:
       DEFAULT_DEX_IP: "172.18.0.2"
       TEST_UPGRADE: "1"
       USE_MULTICLUSTER_OIDC_ENV: "true"
-      TEST_OPERATORS: ""
+      TEST_OPERATORS: "1"
       <<: *common_envars
     parameters:
       number:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,6 +686,7 @@ jobs:
       DEFAULT_DEX_IP: "172.18.0.2"
       TEST_UPGRADE: "1"
       USE_MULTICLUSTER_OIDC_ENV: "true"
+      TEST_OPERATORS: ""
       <<: *common_envars
     parameters:
       number:

--- a/chart/kubeapps/templates/frontend/configmap.yaml
+++ b/chart/kubeapps/templates/frontend/configmap.yaml
@@ -61,19 +61,13 @@ data:
         return 200 "healthy\n";
       }
 
+      # Only proxy to k8s API endpoints if operators are enabled.
+    {{- if $.Values.featureFlags.operators }}
+
       # Ensure each cluster can be reached (should only be
       # used with an auth-proxy where k8s credentials never leave
       # the cluster). See clusters option.
     {{- range .Values.clusters }}
-      
-    {{- if not $.Values.featureFlags.operators }}
-
-      # Operators support disabled
-      location ~* /api/clusters/{{ .name }}/.*operators.coreos.com.* {
-        access_log off;
-        return 403;
-      }
-    {{- end }}
 
       location ~* /api/clusters/{{ .name }} {
     {{/* We need to split the API service URL(s) into the base url and the path segment so
@@ -111,6 +105,7 @@ data:
     {{- end }}
         include "./server_blocks/k8s-api-proxy.conf";
       }
+    {{- end }}
     {{- end }}
 
       location ~* /apis {

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -48,53 +48,8 @@ describe("getResourceKinds", () => {
   });
 
   it("retrieves resource kinds", async () => {
-    const groups = [{ name: "foo" }];
+    const groups = [{ name: "foo" }, { name: "operators.coreos.com" }];
     const kinds = { test: "data" };
-    Kube.getAPIGroups = jest.fn().mockResolvedValue(groups);
-    Kube.getResourceKinds = jest.fn().mockResolvedValue(kinds);
-    const expectedActions = [
-      {
-        type: getType(actions.kube.requestResourceKinds),
-      },
-      {
-        type: getType(actions.kube.receiveResourceKinds),
-        payload: kinds,
-      },
-    ];
-    await store.dispatch(actions.kube.getResourceKinds("cluster-1"));
-
-    const testActions = store.getActions();
-    expect(testActions).toEqual(expectedActions);
-    expect(Kube.getAPIGroups).toHaveBeenCalledWith("cluster-1");
-    expect(Kube.getResourceKinds).toHaveBeenCalledWith("cluster-1", groups);
-  });
-
-  it("retrieves filtered out resource kinds with operators disabled", async () => {
-    const groups = [{ name: "foo" }, { name: "operators.coreos.com" }];
-    const kinds = { testoperator: "data" };
-    Kube.getAPIGroups = jest.fn().mockResolvedValue(groups);
-    Kube.getResourceKinds = jest.fn().mockResolvedValue(kinds);
-    const expectedActions = [
-      {
-        type: getType(actions.kube.requestResourceKinds),
-      },
-      {
-        type: getType(actions.kube.receiveResourceKinds),
-        payload: kinds,
-      },
-    ];
-    await store.dispatch(actions.kube.getResourceKinds("cluster-1"));
-
-    const testActions = store.getActions();
-    expect(testActions).toEqual(expectedActions);
-    expect(Kube.getAPIGroups).toHaveBeenCalledWith("cluster-1");
-    expect(Kube.getResourceKinds).toHaveBeenCalledWith("cluster-1", [{ name: "foo" }]);
-  });
-
-  it("retrieves operators resource kinds with operators enabled", async () => {
-    store = makeStore(true);
-    const groups = [{ name: "foo" }, { name: "operators.coreos.com" }];
-    const kinds = { testoperator: "data" };
     Kube.getAPIGroups = jest.fn().mockResolvedValue(groups);
     Kube.getResourceKinds = jest.fn().mockResolvedValue(kinds);
     const expectedActions = [

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -8,7 +8,6 @@ import {
   InstalledPackageReference,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { GetResourcesResponse } from "gen/kubeappsapis/plugins/resources/v1alpha1/resources";
-import Config from "shared/Config";
 
 const { createAction } = deprecated;
 
@@ -68,17 +67,10 @@ export type KubeAction = ActionType<typeof allActions[number]>;
 export function getResourceKinds(
   cluster: string,
 ): ThunkAction<Promise<void>, IStoreState, null, KubeAction> {
-  return async (dispatch, getStore) => {
+  return async dispatch => {
     dispatch(requestResourceKinds());
     try {
-      let groups = await Kube.getAPIGroups(cluster);
-      // Ignore APIs for operators if specified
-      const operatorsEnabled = getStore().config.featureFlags?.operators === true;
-      if (!operatorsEnabled) {
-        groups = groups.filter(
-          (group: any) => !(group.name as string).includes(Config.OperatorsApi),
-        );
-      }
+      const groups = await Kube.getAPIGroups(cluster);
       const kinds = await Kube.getResourceKinds(cluster, groups);
       dispatch(receiveResourceKinds(kinds));
     } catch (e: any) {

--- a/dashboard/src/components/Layout/Layout.test.tsx
+++ b/dashboard/src/components/Layout/Layout.test.tsx
@@ -33,7 +33,23 @@ const defaultState = {
   auth: { authenticated: true },
 };
 
-it("fetch resource kinds", () => {
-  mountWrapper(getStore(defaultState), <Layout />);
+it("fetches resource kinds when operators enabled", () => {
+  const state = {
+    ...defaultState,
+    config: {
+      featureFlags: {
+        operators: true,
+      },
+    },
+  };
+
+  mountWrapper(getStore(state), <Layout />);
+
   expect(actions.kube.getResourceKinds).toHaveBeenCalled();
+});
+
+it("does not fetch resource kinds when operators disaabled", () => {
+  mountWrapper(getStore(defaultState), <Layout />);
+
+  expect(actions.kube.getResourceKinds).not.toHaveBeenCalled();
 });

--- a/dashboard/src/components/Layout/Layout.tsx
+++ b/dashboard/src/components/Layout/Layout.tsx
@@ -16,14 +16,17 @@ function Layout({ children }: any) {
   const {
     auth: { authenticated },
     kube: { kindsError },
+    config: {
+      featureFlags: { operators },
+    },
     clusters,
   } = useSelector((state: IStoreState) => state);
 
   React.useEffect(() => {
-    if (authenticated && clusters.currentCluster) {
+    if (authenticated && clusters.currentCluster && operators) {
       dispatch(actions.kube.getResourceKinds(clusters.currentCluster));
     }
-  }, [dispatch, authenticated, clusters.currentCluster]);
+  }, [dispatch, authenticated, operators, clusters.currentCluster]);
 
   return (
     <section className="layout">

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -396,7 +396,7 @@ testsToIgnore=()
 # Also skip the multicluster scenario
 if [[ -n "${GKE_BRANCH-}" ]]; then
   testsToIgnore=("operator-deployment.js" "add-multicluster-deployment.js" "${testsToIgnore[@]}")
-elif [[ -z "${TEST_OPERATORS}"  ]]; then
+elif [[ -z "${TEST_OPERATORS-}" ]]; then
   testsToIgnore=("operator-deployment.js" "${testsToIgnore[@]}")
 fi
 ignoreFlag=""

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -199,7 +199,7 @@ installOrUpgradeKubeapps() {
     --set apprepository.initialRepos[0].basicAuth.user=admin
     --set apprepository.initialRepos[0].basicAuth.password=password
     --set globalReposNamespaceSuffix=-repos-global
-    "${operatorFlags[@]"
+    "${operatorFlags[@]}"
     --wait)
 
   echo "${cmd[@]}"
@@ -207,7 +207,7 @@ installOrUpgradeKubeapps() {
 }
 
 # Operators are not supported in GKE 1.14 and flaky in 1.15
-if [[ -z "${GKE_BRANCH-}${TEST_OPERATORS-}" ]]; then
+if [[ -z "${GKE_BRANCH-}" ]] && [[ -n "${TEST_OPERATORS-}" ]]; then
   installOLM $OLM_VERSION
 fi
 
@@ -275,7 +275,7 @@ if [ "$USE_MULTICLUSTER_OIDC_ENV" = true ]; then
   )
 fi
 
-if [ -n "$TEST_OPERATORS" ]; then
+if [ -n "${TEST_OPERATORS-}" ]; then
   operatorFlags=(
     "--set" "featureFlags.operators=true"
   )
@@ -375,7 +375,7 @@ if [[ -z "${TEST_LATEST_RELEASE:-}" ]]; then
 fi
 
 # Operators are not supported in GKE 1.14 and flaky in 1.15
-if [[ -z "${GKE_BRANCH-}${TEST_OPERATORS-}" ]]; then
+if [[ -z "${GKE_BRANCH-}" ]] && [[ -n "${TEST_OPERATORS-}" ]]; then
   ## Wait for the Operator catalog to be populated
   info "Waiting for the OperatorHub Catalog to be ready ..."
   retry_while isOperatorHubCatalogRunning 24
@@ -393,8 +393,10 @@ done
 testsToIgnore=()
 # Operators are not supported in GKE 1.14 and flaky in 1.15, skipping test
 # Also skip the multicluster scenario
-if [[ -n "${GKE_BRANCH-}${TEST_OPERATORS-}" ]]; then
+if [[ -n "${GKE_BRANCH-}" ]]; then
   testsToIgnore=("operator-deployment.js" "add-multicluster-deployment.js" "${testsToIgnore[@]}")
+elif [[ -z "${TEST_OPERATORS}"  ]]; then
+  testsToIgnore=("operator-deployment.js" "${testsToIgnore[@]}")
 fi
 ignoreFlag=""
 if [[ "${#testsToIgnore[@]}" > "0" ]]; then

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -395,9 +395,9 @@ testsToIgnore=()
 # Operators are not supported in GKE 1.14 and flaky in 1.15, skipping test
 # Also skip the multicluster scenario
 if [[ -n "${GKE_BRANCH-}" ]]; then
-  testsToIgnore=("operator-deployment.js" "add-multicluster-deployment.js" "${testsToIgnore[@]}")
+  testsToIgnore=("operator-deployment.js" "add-multicluster-deployment.js")
 elif [[ -z "${TEST_OPERATORS-}" ]]; then
-  testsToIgnore=("operator-deployment.js" "${testsToIgnore[@]}")
+  testsToIgnore=("operator-deployment.js")
 fi
 ignoreFlag=""
 if [[ "${#testsToIgnore[@]}" > "0" ]]; then

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -199,7 +199,7 @@ installOrUpgradeKubeapps() {
     --set apprepository.initialRepos[0].basicAuth.user=admin
     --set apprepository.initialRepos[0].basicAuth.password=password
     --set globalReposNamespaceSuffix=-repos-global
-    --set featureFlags.operators=true
+    "${operatorFlags[@]"
     --wait)
 
   echo "${cmd[@]}"
@@ -207,7 +207,7 @@ installOrUpgradeKubeapps() {
 }
 
 # Operators are not supported in GKE 1.14 and flaky in 1.15
-if [[ -z "${GKE_BRANCH-}" ]]; then
+if [[ -z "${GKE_BRANCH-}${TEST_OPERATORS-}" ]]; then
   installOLM $OLM_VERSION
 fi
 
@@ -272,6 +272,12 @@ if [ "$USE_MULTICLUSTER_OIDC_ENV" = true ]; then
     "--set" "clusters[1].apiServiceURL=https://${ADDITIONAL_CLUSTER_IP}:6443"
     "--set" "clusters[1].insecure=true"
     "--set" "clusters[1].serviceToken=ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklsbHpiSEp5TlZwM1QwaG9WSE5PYkhVdE5GQkRablY2TW0wd05rUmtMVmxFWVV4MlZEazNaeTEyUmxFaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbXQxWW1WaGNIQnpMVzVoYldWemNHRmpaUzFrYVhOamIzWmxjbmt0ZEc5clpXNHRjV295Ym1naUxDSnJkV0psY201bGRHVnpMbWx2TDNObGNuWnBZMlZoWTJOdmRXNTBMM05sY25acFkyVXRZV05qYjNWdWRDNXVZVzFsSWpvaWEzVmlaV0Z3Y0hNdGJtRnRaWE53WVdObExXUnBjMk52ZG1WeWVTSXNJbXQxWW1WeWJtVjBaWE11YVc4dmMyVnlkbWxqWldGalkyOTFiblF2YzJWeWRtbGpaUzFoWTJOdmRXNTBMblZwWkNJNkltVXhaakE1WmpSakxUTTRNemt0TkRJME15MWhZbUptTFRKaU5HWm1OREZrWW1RMllTSXNJbk4xWWlJNkluTjVjM1JsYlRwelpYSjJhV05sWVdOamIzVnVkRHBrWldaaGRXeDBPbXQxWW1WaGNIQnpMVzVoYldWemNHRmpaUzFrYVhOamIzWmxjbmtpZlEuTnh6V2dsUGlrVWpROVQ1NkpWM2xJN1VWTUVSR3J2bklPSHJENkh4dUVwR0luLWFUUzV5Q0pDa3Z0cTF6S3Z3b05sc2MyX0YxaTdFOUxWRGFwbC1UQlhleUN5Rl92S1B1TDF4dTdqZFBMZ1dKT1pQX3JMcXppaDV4ZlkxalFoOHNhdTRZclFJLUtqb3U1UkRRZ0tOQS1BaS1lRlFOZVh2bmlUNlBKYWVkc184V0t3dHRMMC1wdHpYRnBnOFl5dkx6N0U1UWdTR2tjNWpDVXlsS0RvZVRUaVRSOEc2RHFHYkFQQUYwREt0b3MybU9Geno4SlJYNHhoQmdvaUcxVTVmR1g4Z3hnTU1SV0VHRE9kaGMyeXRvcFdRUkRpYmhvaldNS3VDZlNua09zMDRGYTBkYmEwQ0NTbld2a29LZ3Z4QVR5aVVrWm9wV3VpZ1JJNFd5dDkzbXhR"
+  )
+fi
+
+if [ -n "$TEST_OPERATORS" ]; then
+  operatorFlags=(
+    "--set" "featureFlags.operators=true"
   )
 fi
 
@@ -369,7 +375,7 @@ if [[ -z "${TEST_LATEST_RELEASE:-}" ]]; then
 fi
 
 # Operators are not supported in GKE 1.14 and flaky in 1.15
-if [[ -z "${GKE_BRANCH-}" ]]; then
+if [[ -z "${GKE_BRANCH-}${TEST_OPERATORS-}" ]]; then
   ## Wait for the Operator catalog to be populated
   info "Waiting for the OperatorHub Catalog to be ready ..."
   retry_while isOperatorHubCatalogRunning 24
@@ -387,7 +393,7 @@ done
 testsToIgnore=()
 # Operators are not supported in GKE 1.14 and flaky in 1.15, skipping test
 # Also skip the multicluster scenario
-if [[ -n "${GKE_BRANCH-}" ]]; then
+if [[ -n "${GKE_BRANCH-}${TEST_OPERATORS-}" ]]; then
   testsToIgnore=("operator-deployment.js" "add-multicluster-deployment.js" "${testsToIgnore[@]}")
 fi
 ignoreFlag=""

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -182,6 +182,7 @@ installOrUpgradeKubeapps() {
   info "Installing Kubeapps from ${chartSource}..."
   kubectl -n kubeapps delete secret localhost-tls || true
 
+  # See https://stackoverflow.com/a/36296000 for "${arr[@]+"${arr[@]}"}" notation.
   cmd=(helm upgrade --install kubeapps-ci --namespace kubeapps "${chartSource}"
     "${img_flags[@]}"
     "${@:2}"
@@ -199,7 +200,7 @@ installOrUpgradeKubeapps() {
     --set apprepository.initialRepos[0].basicAuth.user=admin
     --set apprepository.initialRepos[0].basicAuth.password=password
     --set globalReposNamespaceSuffix=-repos-global
-    "${operatorFlags[@]-}"
+    "${operatorFlags[@]+"${operatorFlags[@]}"}"
     --wait)
 
   echo "${cmd[@]}"

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -275,6 +275,7 @@ if [ "$USE_MULTICLUSTER_OIDC_ENV" = true ]; then
   )
 fi
 
+operatorFlags=()
 if [ -n "${TEST_OPERATORS-}" ]; then
   operatorFlags=(
     "--set" "featureFlags.operators=true"

--- a/script/e2e-test.sh
+++ b/script/e2e-test.sh
@@ -199,7 +199,7 @@ installOrUpgradeKubeapps() {
     --set apprepository.initialRepos[0].basicAuth.user=admin
     --set apprepository.initialRepos[0].basicAuth.password=password
     --set globalReposNamespaceSuffix=-repos-global
-    "${operatorFlags[@]}"
+    "${operatorFlags[@]-}"
     --wait)
 
   echo "${cmd[@]}"
@@ -275,7 +275,6 @@ if [ "$USE_MULTICLUSTER_OIDC_ENV" = true ]; then
   )
 fi
 
-operatorFlags=()
 if [ -n "${TEST_OPERATORS-}" ]; then
   operatorFlags=(
     "--set" "featureFlags.operators=true"


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

Follows on from both the work on #3896 as well as @castelblanque 's work in the recent #4051 . Since the latter isn't yet landed, I've targeted a branch that I created which is just an updated master with Rafa's changes. I'll retarget to master once Rafa's PR lands. (Edit: done)

This PR updates the frontend config so that it no longer proxies to the k8s API server, unless operators are enabled.

It also updates ci so that the operator switch (and hence whether Kubeapps proxies to the k8s api server) can be configured via the env. I set it to disable operators and the k8s api proxying to [verify that it passed](https://circleci.com/gh/kubeapps/kubeapps/70321?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link), and am now updating it to re-enable the operators in CI for now. 

Finally, it also updates the dashboard so that we no longer request api groups and api endpoints at all, when operators are not enabled.

### Benefits

No more proxying of k8s api server! (unless operator support is enabled).

### Possible drawbacks

<!-- Describe any known limitations with your change -->
Some yet-to-be discovered place where we still depend on the k8s API being accessible, that is not used in e2e, causing a failure (but should be easy to fix, if so)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #3896 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

I've tested this IRL and haven't hit any issues. Let's see what CI says.