### PR TITLE
Fix namespace when watching (rather than getting) resources.

### DIFF
--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -226,7 +226,7 @@ func (s *Server) GetResources(r *v1alpha1.GetResourcesRequest, stream v1alpha1.R
 		}
 		var watcher watch.Interface
 		if scopeName == meta.RESTScopeNameNamespace {
-			watcher, err = dynamicClient.Resource(gvr).Namespace(namespace).Watch(stream.Context(), listOptions)
+			watcher, err = dynamicClient.Resource(gvr).Namespace(ref.Namespace).Watch(stream.Context(), listOptions)
 		} else {
 			watcher, err = dynamicClient.Resource(gvr).Watch(stream.Context(), listOptions)
 		}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

I just took a brief look at this issue after you mentioned @antgamdia it in the standup:

- The [ResourceRef message](https://github.com/kubeapps/kubeapps/blob/master/cmd/kubeapps-apis/proto/kubeappsapis/core/packages/v1alpha1/packages.proto#L924-L928) already explicitly supports references for resources that are in other namespaces than the installed package context.
- The tests for the [resources plugin already have a case for this](https://github.com/kubeapps/kubeapps/blob/master/cmd/kubeapps-apis/plugins/resources/v1alpha1/server_test.go#L318).

but, that said, I wasn't able (yet) to test the streaming requests and as it turns out, it was using the installed package context namespace, rather than that of the resource.

This one-liner should fix it, though I'm keen to get the tests working for streaming requests to the fake k8s client too (need to add a watch reactor or something, which I think Greg may have done in some of his code already).
