### PR TITLE
3854 get resources

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -16,13 +16,20 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/scheme"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 )
 
 type clientGetter func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error)
@@ -43,11 +50,48 @@ type Server struct {
 	clientGetter             clientGetter
 	globalPackagingNamespace string
 	globalPackagingCluster   string
+
+	// We keep a restmapper to cache discovery of REST mappings from GVK->GVR.
+	restMapper meta.RESTMapper
+
+	// kindToResource is a function to convert a GVK to GVR with
+	// namespace/cluster scope information. Can be replaced in tests with a
+	// dummy version using the unsafe helpers while the real implementation
+	// queries the k8s API for a REST mapper.
+	kindToResource func(meta.RESTMapper, schema.GroupVersionKind) (schema.GroupVersionResource, meta.RESTScopeName, error)
+}
+
+// createRESTMapper returns a rest mapper configured with the APIs of the
+// local k8s API server. This is used to convert between the GroupVersionKinds
+// of the resource references to the GroupVersionResource used by the API server.
+func createRESTMapper() (meta.RESTMapper, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	// To use the config with RESTClientFor, extra fields are required.
+	// See https://github.com/kubernetes/client-go/issues/657#issuecomment-842960258
+	config.GroupVersion = &schema.GroupVersion{Group: "", Version: "v1"}
+	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs}
+	client, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+	discoveryClient := discovery.NewDiscoveryClient(client)
+	groupResources, err := restmapper.GetAPIGroupResources(discoveryClient)
+	if err != nil {
+		return nil, err
+	}
+	return restmapper.NewDiscoveryRESTMapper(groupResources), nil
 }
 
 // NewServer returns a Server automatically configured with a function to obtain
 // the k8s client config.
 func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster string) *Server {
+	mapper, err := createRESTMapper()
+	if err != nil {
+		return nil
+	}
 	return &Server{
 		clientGetter: func(ctx context.Context, cluster string) (kubernetes.Interface, dynamic.Interface, error) {
 			if configGetter == nil {
@@ -69,6 +113,14 @@ func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster 
 		},
 		globalPackagingNamespace: globalPackagingNamespace,
 		globalPackagingCluster:   globalPackagingCluster,
+		restMapper:               mapper,
+		kindToResource: func(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVersionResource, meta.RESTScopeName, error) {
+			mapping, err := mapper.RESTMapping(gvk.GroupKind())
+			if err != nil {
+				return schema.GroupVersionResource{}, "", err
+			}
+			return mapping.Resource, mapping.Scope.Name(), nil
+		},
 	}
 }
 

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -724,93 +724,23 @@ func (s *Server) GetInstalledPackageResourceRefs(ctx context.Context, request *c
 		cluster = s.globalPackagingCluster
 	}
 
-	typedClient, _, err := s.GetClients(ctx, cluster)
+	// get the app id and build the label selector
+	appLabelValue, err := s.appLabelIdentifier(ctx, cluster, namespace, installedPackageRefId)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
+		return nil, err
 	}
+	appLabelSelector := fmt.Sprintf("%s=%s", appLabelKey, appLabelValue)
+	listOptions := metav1.ListOptions{LabelSelector: appLabelSelector}
 
-	refs := []*corev1.ResourceRef{}
-
-	// TODO(agamez): apparently, App CRs not being created by a "kapp deploy"
-	// don't have the proper annotations. So, in order to retrieve the annotation value,
-	// we have to get the ConfigMap <AppName>-ctrl and, then, fetch the
-	// vaulue of the key "labelValue" in data.spec.
-	// See https://kubernetes.slack.com/archives/CH8KCCKA5/p1637842398026700
-
-	// the ConfigMap name is, by convention, "<appname>-ctrl", but it will change in the near future
-	cmName := fmt.Sprintf("%s-ctrl", installedPackageRefId)
-	cm, err := typedClient.CoreV1().ConfigMaps(namespace).Get(ctx, cmName, metav1.GetOptions{})
-	if err == nil && cm.Data["spec"] != "" {
-
-		appLabelValue := extractValue(cm.Data["spec"], "labelValue")
-		appLabelSelector := fmt.Sprintf("%s=%s", appLabelKey, appLabelValue)
-		listOptions := metav1.ListOptions{LabelSelector: appLabelSelector}
-
-		// TODO(agamez): perform an actual query over all the resources available in the cluster
-		// this is currently just a PoC getting the bare minimum: pods, deployments, services and secrets.
-		// Also, the xxx.Items[i] are not populating the Kind and APIVersion fields. Check why.
-
-		// Fetching all the matching pods
-		pods, err := typedClient.CoreV1().Pods(namespace).List(ctx, listOptions)
-		if err != nil {
-			return nil, errorByStatus("get", "Pods", "", err)
-		}
-		for _, resource := range pods.Items {
-			refs = append(refs, &corev1.ResourceRef{
-				ApiVersion: "core/v1",
-				Kind:       "Pod",
-				Name:       resource.Name,
-				Namespace:  resource.Namespace,
-			})
-		}
-
-		// Fetching all the matching deployments
-		deployments, err := typedClient.AppsV1().Deployments(namespace).List(ctx, listOptions)
-		if err != nil {
-			return nil, errorByStatus("get", "Deployments", "", err)
-		}
-		for _, resource := range deployments.Items {
-			refs = append(refs, &corev1.ResourceRef{
-				ApiVersion: "apps/v1",
-				Kind:       "Deployment",
-				Name:       resource.ObjectMeta.Name,
-				Namespace:  resource.ObjectMeta.Namespace,
-			})
-		}
-
-		// Fetching all the matching services
-		services, err := typedClient.CoreV1().Services(namespace).List(ctx, listOptions)
-		if err != nil {
-			return nil, errorByStatus("get", "services", "", err)
-		}
-		for _, resource := range services.Items {
-			refs = append(refs, &corev1.ResourceRef{
-				ApiVersion: "core/v1",
-				Kind:       "Service",
-				Name:       resource.ObjectMeta.Name,
-				Namespace:  resource.ObjectMeta.Namespace,
-			})
-		}
-
-		// Fetching all the matching secrets
-		secrets, err := typedClient.CoreV1().Secrets(namespace).List(ctx, listOptions)
-		if err != nil {
-			return nil, errorByStatus("get", "Secrets", "", err)
-		}
-		for _, resource := range secrets.Items {
-			refs = append(refs, &corev1.ResourceRef{
-				ApiVersion: "core/v1",
-				Kind:       "Secret",
-				Name:       resource.ObjectMeta.Name,
-				Namespace:  resource.ObjectMeta.Namespace,
-			})
-		}
-	} else {
-		log.Warning(errorByStatus("get", "ConfigMap", cmName, err))
+	// get the list of every k8s resource matching ResourceRef
+	refs, err := s.findMatchingK8sResources(ctx, cluster, listOptions)
+	if err != nil {
+		return nil, err
 	}
 
 	return &corev1.GetInstalledPackageResourceRefsResponse{
 		Context:      request.GetInstalledPackageRef().GetContext(),
 		ResourceRefs: refs,
 	}, nil
+
 }

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -31,12 +31,20 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type pkgSemver struct {
 	pkg     *datapackagingv1alpha1.Package
 	version *semver.Version
+}
+
+type resourceAndGvk struct {
+	resource *unstructured.Unstructured
+	gvk      *schema.GroupVersionKind
+	err      error
 }
 
 // pkgVersionsMap recturns a map of packages keyed by the packagemetadataName.

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -127,7 +127,7 @@ func pageOffsetFromPageToken(pageToken string) (int, error) {
 // key - the key for which the value should be extracted
 // returns - the value for the given key
 // https://stackoverflow.com/questions/17452722/how-to-get-the-key-value-from-a-json-string-in-go/37332972
-func extractValue(body string, key string) string {
+func extractValueFromJson(body string, key string) string {
 	keystr := "\"" + key + "\":[^,;\\]}]*"
 	r, _ := regexp.Compile(keystr)
 	match := r.FindString(body)

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
@@ -201,7 +201,7 @@ func TestExtractValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			values := extractValue(tt.body, tt.key)
+			values := extractValueFromJson(tt.body, tt.key)
 			if !cmp.Equal(tt.expected, values) {
 				t.Errorf("mismatch in '%s': %s", tt.name, cmp.Diff(tt.expected, values))
 			}


### PR DESCRIPTION
### Description of the change

This PR removes the workaround we implemented when we released it last time and implements a generic way to retrieve all the kubernetes resources matching a certain label. This way we can fetch every k8s resource created as a result of a Carvel PackageInstall.

### Benefits

The retrieved resources for a carvel package will now include every possible one, not a fixed list of pods, svc and deployments.

### Possible drawbacks

Hitting the k8s APIs for querying every possible available resource is expensive in time. I guess it is also due to my Kubelet config in kind with limited resources, but I'm still worried about it. 

* Example: an app with 97 resources (in a cluster with  88 different resource types) takes around 15 seconds to retrieve the resource refs.
  * With plenty of ` Waited for <some time> ms due to client-side throttling, not priority and fairness, request: GET:https://10.96.0.1:443/apis/<api resource>?labelSelector=kapp.k14s.io%2Fapp%3D<my-id>` console messages 

Note that the `kapp` CLI is already is able to fetch its generated resources; however, solely using a Kubernetes client (not the `kapp` binary), there is no CR holding this information. 
See how the `kapp inspect` command under the hood here: https://github.com/vmware-tanzu/carvel-kapp/blob/v0.44.0/pkg/kapp/cmd/app/inspect.go#L76

### Applicable issues

- fixes #3854
- requires https://github.com/kubeapps/kubeapps/pull/4057 for the UI to be fully working.

### Additional information

Some resources from a Habor installation: 
![image](https://user-images.githubusercontent.com/11535726/148979604-393ed593-53b2-4e04-85b1-92e42034efb9.png)


Created as a draft as the tests are still misisng.
