### PR TITLE
Error alert component

### DIFF
--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -159,7 +159,13 @@ export function fetchApps(
       dispatch(receiveAppList(installedPackageSummaries));
       return installedPackageSummaries;
     } catch (e: any) {
-      dispatch(errorApp(new FetchError(e.message)));
+      dispatch(
+        errorApp(
+          e instanceof Error
+            ? new FetchError("Unable to list apps", [e])
+            : new FetchError("Unable to list apps: " + e.message),
+        ),
+      );
       return [];
     }
   };

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -2,7 +2,7 @@ import { CdsButton } from "@cds/react/button";
 import { CdsIcon } from "@cds/react/icon";
 import { CdsToggle, CdsToggleGroup } from "@cds/react/toggle";
 import actions from "actions";
-import Alert from "components/js/Alert";
+import ErrorAlert from "components/ErrorAlert";
 import LoadingWrapper from "components/LoadingWrapper/LoadingWrapper";
 import { push } from "connected-react-router";
 import qs from "qs";
@@ -131,7 +131,7 @@ function AppList() {
         className="margin-t-xl"
       >
         {error ? (
-          <Alert theme="danger">Unable to list apps: {error.message}</Alert>
+          <ErrorAlert>{error}</ErrorAlert>
         ) : (
           <AppListGrid
             appList={listOverview}

--- a/dashboard/src/components/ErrorAlert/ErrorAlert.scss
+++ b/dashboard/src/components/ErrorAlert/ErrorAlert.scss
@@ -1,0 +1,4 @@
+.error-alert-indent {
+  padding-left: 0.6rem;
+  padding-top: 0.3rem;
+}

--- a/dashboard/src/components/ErrorAlert/ErrorAlert.scss
+++ b/dashboard/src/components/ErrorAlert/ErrorAlert.scss
@@ -1,4 +1,4 @@
 .error-alert-indent {
-  padding-left: 0.6rem;
   padding-top: 0.3rem;
+  padding-left: 0.6rem;
 }

--- a/dashboard/src/components/ErrorAlert/ErrorAlert.test.tsx
+++ b/dashboard/src/components/ErrorAlert/ErrorAlert.test.tsx
@@ -1,0 +1,68 @@
+import Alert from "components/js/Alert";
+import { mount } from "enzyme";
+import ErrorAlert from "./ErrorAlert";
+import { CustomError } from "shared/types";
+
+describe("Error Alert", () => {
+  it("should render string messages", () => {
+    const wrapper = mount(<ErrorAlert>foo</ErrorAlert>);
+    expect(wrapper.text()).toContain("foo");
+  });
+
+  it("should render string messages without breaklines", () => {
+    const wrapper = mount(
+      <ErrorAlert>Error ocurred: Another error message. Yet another msg.</ErrorAlert>,
+    );
+    expect(wrapper.find(Alert)).toExist();
+    expect(wrapper.text()).toContain("Error ocurred: Another error message. Yet another msg.");
+  });
+
+  it("should render custom errors with plain messages", () => {
+    const error = new CustomError(
+      "An error occurred for tests: cause of the error. Another cause.",
+    );
+    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
+    const alertTag = wrapper.find(Alert);
+    expect(alertTag).toExist();
+    expect(alertTag.text()).toContain(
+      "An error occurred for tests: cause of the error. Another cause.",
+    );
+  });
+
+  it("should render custom errors with error causes", () => {
+    const error = new CustomError("An error occurred for tests", [
+      new Error("The first cause"),
+      new Error("Second cause"),
+    ]);
+    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
+    const alertTag = wrapper.find(Alert);
+    expect(alertTag).toExist();
+    expect(alertTag.find("div.error-alert")).toHaveLength(1);
+    expect(alertTag.find("div.error-alert").text()).toBe("An error occurred for tests");
+    expect(alertTag.find("div.error-alert-indent")).toHaveLength(2);
+    expect(alertTag.find("div.error-alert-indent").at(0).text()).toBe("The first cause");
+    expect(alertTag.find("div.error-alert-indent").at(1).text()).toBe("Second cause");
+  });
+
+  it("should render custom errors with error causes including rpc messages", () => {
+    const error = new CustomError("An error occurred for tests", [
+      new Error("The first cause"),
+      new Error(
+        "An error occurred when performing request: rpc error: code = Testing desc = The description of the RPC error",
+      ),
+      new Error("Even a third cause"),
+    ]);
+    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
+    const alertTag = wrapper.find(Alert);
+    expect(alertTag).toExist();
+    expect(alertTag.find("div.error-alert")).toHaveLength(1);
+    expect(alertTag.find("div.error-alert").text()).toBe("An error occurred for tests");
+    expect(alertTag.find("div.error-alert-indent")).toHaveLength(3);
+    expect(alertTag.find("div.error-alert-indent").at(0).text()).toBe("The first cause");
+    expect(alertTag.find("div.error-alert-indent .error-alert-rpc")).toExist();
+    expect(alertTag.find("div.error-alert-indent .error-alert-rpc .rpc-message").text()).toBe(
+      "An error occurred when performing request: ",
+    );
+    expect(alertTag.find("div.error-alert-indent").at(2).text()).toBe("Even a third cause");
+  });
+});

--- a/dashboard/src/components/ErrorAlert/ErrorAlert.test.tsx
+++ b/dashboard/src/components/ErrorAlert/ErrorAlert.test.tsx
@@ -9,6 +9,24 @@ describe("Error Alert", () => {
     expect(wrapper.text()).toContain("foo");
   });
 
+  it("should handle empty strings", () => {
+    const error = "";
+    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
+    expect(wrapper.text()).toContain("");
+  });
+
+  it("should handle empty string Error", () => {
+    const error = new Error("");
+    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
+    expect(wrapper.text()).toContain("");
+  });
+
+  it("should handle empty Error", () => {
+    const error = new Error();
+    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
+    expect(wrapper.text()).toContain("");
+  });
+
   it("should render string messages without breaklines", () => {
     const wrapper = mount(
       <ErrorAlert>Error ocurred: Another error message. Yet another msg.</ErrorAlert>,

--- a/dashboard/src/components/ErrorAlert/ErrorAlert.test.tsx
+++ b/dashboard/src/components/ErrorAlert/ErrorAlert.test.tsx
@@ -17,6 +17,13 @@ describe("Error Alert", () => {
     expect(wrapper.text()).toContain("Error ocurred: Another error message. Yet another msg.");
   });
 
+  it("should render regular errors", () => {
+    const error = new Error("Error ocurred");
+    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
+    expect(wrapper.find(Alert)).toExist();
+    expect(wrapper.text()).toContain("Error ocurred");
+  });
+
   it("should render custom errors with plain messages", () => {
     const error = new CustomError(
       "An error occurred for tests: cause of the error. Another cause.",

--- a/dashboard/src/components/ErrorAlert/ErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/ErrorAlert.tsx
@@ -5,7 +5,7 @@ import { CustomError } from "shared/types";
 import "./ErrorAlert.css";
 
 export interface IErrorAlert {
-  children: CustomError | string;
+  children: CustomError | Error | string;
 }
 
 function createWrap(message: any, index: number, indented: boolean): JSX.Element {
@@ -34,6 +34,8 @@ export default function ErrorAlert({ children }: IErrorAlert) {
     if (children.causes) {
       messages.push(buildMessages(children.causes));
     }
+  } else if (children instanceof Error) {
+    messages = [createWrap(children.message, 0, false)];
   } else {
     messages = [children];
   }

--- a/dashboard/src/components/ErrorAlert/ErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/ErrorAlert.tsx
@@ -1,0 +1,41 @@
+import Alert from "components/js/Alert";
+import RpcErrorMessage from "components/RpcErrorMessage";
+import { RpcError } from "shared/RpcError";
+import { CustomError } from "shared/types";
+import "./ErrorAlert.css";
+
+export interface IErrorAlert {
+  children: CustomError | string;
+}
+
+function createWrap(message: any, index: number, indented: boolean): JSX.Element {
+  return (
+    <div className={indented ? "error-alert-indent" : "error-alert"} key={index}>
+      {message}
+    </div>
+  );
+}
+
+function buildMessages(errors: Error[]): JSX.Element[] {
+  return errors.map((cause, index) => {
+    if (cause instanceof RpcError) {
+      return createWrap(<RpcErrorMessage>{cause}</RpcErrorMessage>, index + 1, true);
+    } else {
+      return createWrap(cause.message, index + 1, true);
+    }
+  });
+}
+
+// Extension of Alert component for showing more meaningful Errors
+export default function ErrorAlert({ children }: IErrorAlert) {
+  let messages: any[];
+  if (children instanceof CustomError) {
+    messages = [createWrap(children.message, 0, false)];
+    if (children.causes) {
+      messages.push(buildMessages(children.causes));
+    }
+  } else {
+    messages = [children];
+  }
+  return <Alert theme="danger">{messages}</Alert>;
+}

--- a/dashboard/src/components/ErrorAlert/index.tsx
+++ b/dashboard/src/components/ErrorAlert/index.tsx
@@ -1,0 +1,3 @@
+import ErrorAlert from "./ErrorAlert";
+
+export default ErrorAlert;

--- a/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.scss
+++ b/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.scss
@@ -1,9 +1,9 @@
 .error-alert-rpc {
   ul > li {
-    font-weight: bolder;
+    font-weight: 700;
 
     span.rpc-value {
-      font-weight: normal;
+      font-weight: 400;
     }
   }
 }

--- a/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.scss
+++ b/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.scss
@@ -1,6 +1,7 @@
 .error-alert-rpc {
   ul > li {
     font-weight: bolder;
+    
     span.rpc-value {
       font-weight: normal;
     }

--- a/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.scss
+++ b/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.scss
@@ -1,0 +1,8 @@
+.error-alert-rpc {
+  ul > li {
+    font-weight: bolder;
+    span.rpc-value {
+      font-weight: normal;
+    }
+  }
+}

--- a/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.scss
+++ b/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.scss
@@ -1,7 +1,7 @@
 .error-alert-rpc {
   ul > li {
     font-weight: bolder;
-    
+
     span.rpc-value {
       font-weight: normal;
     }

--- a/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.test.tsx
+++ b/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.test.tsx
@@ -1,0 +1,27 @@
+import { mount } from "enzyme";
+import { RpcError } from "shared/RpcError";
+import RpcErrorMessage from ".";
+
+describe("RPC Error message", () => {
+  it("should render rpc error", () => {
+    const error = new RpcError(
+      new Error(
+        "An error occurred for tests: rpc error: code = Testing desc = The description of the RPC error",
+      ),
+    );
+    const wrapper = mount(<RpcErrorMessage>{error}</RpcErrorMessage>);
+    expect(wrapper.find("span.rpc-message").text()).toContain("An error occurred for tests: ");
+    expect(wrapper.find("li.rpc-code .rpc-value").text()).toContain("Testing");
+    expect(wrapper.find("li.rpc-desc .rpc-value").text()).toContain(
+      "The description of the RPC error",
+    );
+  });
+
+  it("should render message with empty details", () => {
+    const error = new RpcError(new Error("Non RPC error message text"));
+    const wrapper = mount(<RpcErrorMessage>{error}</RpcErrorMessage>);
+    expect(wrapper.find("span.rpc-message").text()).toContain("Non RPC error message text");
+    expect(wrapper.find("li.rpc-code .rpc-value").text()).toContain("");
+    expect(wrapper.find("li.rpc-desc .rpc-value").text()).toContain("");
+  });
+});

--- a/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.tsx
+++ b/dashboard/src/components/RpcErrorMessage/RpcErrorMessage.tsx
@@ -1,0 +1,22 @@
+import { RpcError } from "shared/RpcError";
+import "./RpcErrorMessage.css";
+
+export interface IRpcErrorMessage {
+  children: RpcError;
+}
+
+export default function RpcErrorMessage({ children }: IRpcErrorMessage) {
+  return (
+    <div className="error-alert-rpc">
+      <span className="rpc-message">{children.message}</span>
+      <ul>
+        <li className="rpc-code">
+          Code: <span className="rpc-value">{children.code}</span>
+        </li>
+        <li className="rpc-desc">
+          Description: <span className="rpc-value">{children.desc}</span>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/dashboard/src/components/RpcErrorMessage/index.tsx
+++ b/dashboard/src/components/RpcErrorMessage/index.tsx
@@ -1,0 +1,3 @@
+import RpcErrorMessage from "./RpcErrorMessage";
+
+export default RpcErrorMessage;

--- a/dashboard/src/shared/RpcError.test.ts
+++ b/dashboard/src/shared/RpcError.test.ts
@@ -18,4 +18,18 @@ describe("RpcError", () => {
     expect(rpcError.code).toBe("");
     expect(rpcError.desc).toBe("");
   });
+
+  it("handles correctly an empty string as param", () => {
+    const rpcError = new RpcError(new Error(""));
+    expect(rpcError.message).toBe("");
+    expect(rpcError.code).toBe("");
+    expect(rpcError.desc).toBe("");
+  });
+
+  it("handles correctly undefined param", () => {
+    const rpcError = new RpcError(new Error(undefined));
+    expect(rpcError.message).toBe("");
+    expect(rpcError.code).toBe("");
+    expect(rpcError.desc).toBe("");
+  });
 });

--- a/dashboard/src/shared/RpcError.test.ts
+++ b/dashboard/src/shared/RpcError.test.ts
@@ -1,0 +1,21 @@
+import { RpcError } from "./RpcError";
+
+describe("RpcError", () => {
+  it("parses correctly an Error", () => {
+    const rpcError = new RpcError(
+      new Error(
+        "An error occurred for tests: rpc error: code = Testing desc = The description of the RPC error",
+      ),
+    );
+    expect(rpcError.message).toBe("An error occurred for tests: ");
+    expect(rpcError.code).toBe("Testing");
+    expect(rpcError.desc).toBe("The description of the RPC error");
+  });
+
+  it("parses correctly a normal error", () => {
+    const rpcError = new RpcError(new Error("An error occurred for tests: reason."));
+    expect(rpcError.message).toBe("An error occurred for tests: reason.");
+    expect(rpcError.code).toBe("");
+    expect(rpcError.desc).toBe("");
+  });
+});

--- a/dashboard/src/shared/RpcError.ts
+++ b/dashboard/src/shared/RpcError.ts
@@ -1,0 +1,24 @@
+export class RpcError extends Error {
+  // Following https://github.com/grpc/grpc-go/blob/master/internal/status/status.go#L140
+  static RPC_ERROR_REGEX = /rpc error: code = (\w+) desc = (.*)/;
+  static RPC_ERROR_CHECK = "rpc error:";
+
+  readonly code: string;
+  readonly desc: string;
+  readonly message: string;
+
+  constructor(error: Error) {
+    super(error.message);
+    Object.setPrototypeOf(this, new.target.prototype);
+    [this.code, this.desc, this.message] = this.extractData(error.message);
+  }
+  public static isRpcError(error: Error) {
+    return error.message.trim().indexOf(this.RPC_ERROR_CHECK) > -1;
+  }
+  private extractData(message: string): [string, string, string] {
+    const found = message.trim().match(RpcError.RPC_ERROR_REGEX);
+    return found
+      ? [found[1], found[2], message.substring(0, message.indexOf(found[0]))]
+      : ["", "", message];
+  }
+}

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -15,13 +15,28 @@ import { IAuthState } from "../reducers/auth";
 import { IClustersState } from "../reducers/cluster";
 import { IConfigState } from "../reducers/config";
 import { IAppRepositoryState } from "../reducers/repos";
+import { RpcError } from "./RpcError";
 
-class CustomError extends Error {
+export class CustomError extends Error {
+  public causes: Error[] | undefined;
   // The constructor is defined so we can later on compare the returned object
-  // via err.contructor  == FOO
-  constructor(message?: string) {
+  // via err.constructor  == FOO
+  constructor(message?: string, causes?: Error[]) {
     super(message);
     Object.setPrototypeOf(this, new.target.prototype);
+    this.causes = causes;
+    this.checkCauses();
+  }
+  // Workaround used until RPC code (unary) throws a custom rpc error
+  // Check if any RPC error is among the causes
+  private checkCauses() {
+    if (!this.causes) return;
+    for (let i = 0; i < this.causes.length; i++) {
+      const cause = this.causes[i];
+      if (RpcError.isRpcError(cause)) {
+        this.causes[i] = new RpcError(cause);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Introduces a React `ErrorAlert` component aimed at improving readability of UI errors and that could replace existing `<Alert>` usages. 

It is able to turn this kind of UI error:

![image](https://user-images.githubusercontent.com/67455978/149508523-d0c22163-66d0-4808-8576-275aabbf6d89.png)

into this:

![image](https://user-images.githubusercontent.com/67455978/149508557-2e2d4aa9-3457-47ab-8bae-cce0c5a6a7f3.png)

It can detect RPC errors and show them indented while not affecting existing plain text errors.
The change also allows to specify a stack of errors when creating a custom error (or an extension of it).

### Benefits

Better error readability on UI

### Possible drawbacks

None that I can think of.


