### PR TITLE
Wait until CM is created when installing a carvel pkg

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server.go
@@ -75,6 +75,8 @@ func parsePluginConfig(pluginConfigPath string) (*kappControllerPluginParsedConf
 	}
 
 	// override the defaults with the loaded configuration
+	config.timeoutSeconds = pluginConfig.Core.Packages.V1alpha1.TimeoutSeconds
+	config.versionsInSummary = pluginConfig.Core.Packages.V1alpha1.VersionsInSummary
 	config.defaultUpgradePolicy = upgradePolicyMapping[pluginConfig.KappController.Packages.V1alpha1.DefaultUpgradePolicy]
 	config.defaultPrereleasesVersionSelection = pluginConfig.KappController.Packages.V1alpha1.DefaultPrereleasesVersionSelection
 	config.defaultAllowDowngrades = pluginConfig.KappController.Packages.V1alpha1.DefaultAllowDowngrades

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -530,8 +530,9 @@ func (s *Server) CreateInstalledPackage(ctx context.Context, request *corev1.Cre
 		return nil, statuserror.FromK8sError("create", "PackageInstall", newPkgInstall.Name, err)
 	}
 
-	// TODO(agamez): some seconds should be enough, however, make it configurable
-	err = wait.PollImmediateWithContext(ctx, time.Second*1, time.Second*5, func(ctx context.Context) (bool, error) {
+	// The package is considered as created once the kapp App gets created,
+	// so we actively wait for the App CR to be present in the cluster before returning OK
+	err = wait.PollImmediateWithContext(ctx, time.Second*1, time.Duration(s.pluginConfig.timeoutSeconds), func(ctx context.Context) (bool, error) {
 		_, err := s.getApp(ctx, targetCluster, targetNamespace, newPkgInstall.Name)
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_resources.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_resources.go
@@ -6,12 +6,15 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	kappctrlv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	packagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	datapackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -398,6 +401,22 @@ func (s *Server) updatePkgInstall(ctx context.Context, cluster, namespace string
 func (s *Server) inspectKappK8sResources(ctx context.Context, cluster, namespace, packageId string) ([]*corev1.ResourceRef, error) {
 	// As per https://github.com/vmware-tanzu/carvel-kapp-controller/blob/v0.32.0/pkg/deploy/kapp.go#L151
 	appName := fmt.Sprintf("%s-ctrl", packageId)
+
+	_, dynClient, err := s.GetClients(ctx, cluster)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to get the k8s client: '%v'", err)
+	}
+
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	resource := dynClient.Resource(gvr).Namespace(namespace)
+
+	// In order to be able to fetch the resources created by the kapp-controller, we need to fetch a ConfigMap
+	// that contains the label (the application id) used for query the k8s resources.
+	// We actively wait for this ConfigMap to be present in the cluster before returning the list of resources
+	err = WaitForResource(ctx, resource, appName, time.Second*1, time.Second*time.Duration(s.pluginConfig.timeoutSeconds))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "timeout exceeded (%v s) waiting for resource to be installed: '%v'", s.pluginConfig.timeoutSeconds, err)
+	}
 
 	refs := []*corev1.ResourceRef{}
 

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -2306,6 +2306,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 		request                *corev1.CreateInstalledPackageRequest
 		pluginConfig           *kappControllerPluginParsedConfig
 		existingObjects        []runtime.Object
+		existingTypedObjects   []runtime.Object
 		expectedStatusCode     codes.Code
 		expectedResponse       *corev1.CreateInstalledPackageResponse
 		expectedPackageInstall *packagingv1alpha1.PackageInstall
@@ -2398,6 +2399,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 							Stdout: "inspectStdout",
 							Stderr: "inspectStderr",
 						},
+					},
+				},
+			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
 					},
 				},
 			},
@@ -2513,6 +2529,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
+					},
+				},
+			},
 			expectedStatusCode: codes.Internal,
 		},
 		{
@@ -2604,6 +2635,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 							Stdout: "inspectStdout",
 							Stderr: "inspectStderr",
 						},
+					},
+				},
+			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
 					},
 				},
 			},
@@ -2748,6 +2794,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
+					},
+				},
+			},
 			expectedStatusCode: codes.OK,
 			expectedResponse: &corev1.CreateInstalledPackageResponse{
 				InstalledPackageRef: &corev1.InstalledPackageReference{
@@ -2888,6 +2949,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 							Stdout: "inspectStdout",
 							Stderr: "inspectStderr",
 						},
+					},
+				},
+			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
 					},
 				},
 			},
@@ -3035,6 +3111,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
+					},
+				},
+			},
 			expectedStatusCode: codes.OK,
 			expectedResponse: &corev1.CreateInstalledPackageResponse{
 				InstalledPackageRef: &corev1.InstalledPackageReference{
@@ -3179,6 +3270,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
+					},
+				},
+			},
 			expectedStatusCode: codes.OK,
 			expectedResponse: &corev1.CreateInstalledPackageResponse{
 				InstalledPackageRef: &corev1.InstalledPackageReference{
@@ -3316,6 +3422,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 							Stdout: "inspectStdout",
 							Stderr: "inspectStderr",
 						},
+					},
+				},
+			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
 					},
 				},
 			},
@@ -3462,6 +3583,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
+					},
+				},
+			},
 			expectedStatusCode: codes.OK,
 			expectedResponse: &corev1.CreateInstalledPackageResponse{
 				InstalledPackageRef: &corev1.InstalledPackageReference{
@@ -3602,6 +3738,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 							Stdout: "inspectStdout",
 							Stderr: "inspectStderr",
 						},
+					},
+				},
+			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
 					},
 				},
 			},
@@ -3748,6 +3899,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
+					},
+				},
+			},
 			expectedStatusCode: codes.OK,
 			expectedResponse: &corev1.CreateInstalledPackageResponse{
 				InstalledPackageRef: &corev1.InstalledPackageReference{
@@ -3891,6 +4057,21 @@ func TestCreateInstalledPackage(t *testing.T) {
 					},
 				},
 			},
+			existingTypedObjects: []runtime.Object{
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
+					},
+				},
+			},
 			expectedStatusCode: codes.OK,
 			expectedResponse: &corev1.CreateInstalledPackageResponse{
 				InstalledPackageRef: &corev1.InstalledPackageReference{
@@ -3963,7 +4144,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 			s := Server{
 				pluginConfig: tc.pluginConfig,
 				clientGetter: func(ctx context.Context, cluster string) (clientgetter.ClientInterfaces, error) {
-					return clientgetter.NewClientInterfaces(typfake.NewSimpleClientset(), dynamicClient, nil), nil
+					return clientgetter.NewClientInterfaces(typfake.NewSimpleClientset(tc.existingTypedObjects...), dynamicClient, nil), nil
 				},
 			}
 
@@ -4497,6 +4678,20 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 						}},
 					},
 				},
+				// Although it's a typical k8s object, it is retrieved with the dynamic client
+				&k8scorev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "my-installation-ctrl",
+					},
+					Data: map[string]string{
+						"spec": "{\"labelKey\":\"kapp.k14s.io/app\",\"labelValue\":\"my-id\"}",
+					},
+				},
 			},
 			existingTypedObjects: []runtime.Object{
 				&k8scorev1.ConfigMap{
@@ -4541,6 +4736,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 					GroupVersion: "v1",
 					APIResources: []metav1.APIResource{
 						{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: []string{"list", "get"}},
+						{Name: "configmaps", Namespaced: true, Kind: "ConfigMap", Verbs: []string{"list", "get"}},
 					},
 				},
 			}
@@ -4558,7 +4754,8 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 					{Group: datapackagingv1alpha1.SchemeGroupVersion.Group, Version: datapackagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgMetadatasResource}: pkgMetadataResource + "List",
 					{Group: packagingv1alpha1.SchemeGroupVersion.Group, Version: packagingv1alpha1.SchemeGroupVersion.Version, Resource: pkgInstallsResource}:          pkgInstallResource + "List",
 					// If more resources types are added, this will need to be updated accordingly
-					{Group: "", Version: "v1", Resource: "pods"}: "Pod" + "List",
+					{Group: "", Version: "v1", Resource: "pods"}:       "Pod" + "List",
+					{Group: "", Version: "v1", Resource: "configmaps"}: "ConfigMap" + "List",
 				},
 				unstructuredObjects...,
 			)

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -16,13 +17,18 @@ import (
 	kappcmdcore "github.com/k14s/kapp/pkg/kapp/cmd/core"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
 	kappctrlv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	datapackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	vendirversions "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1"
 	"gopkg.in/yaml.v3" // The usual "sigs.k8s.io/yaml" doesn't work: https://github.com/kubeapps/kubeapps/pull/4050
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
 
@@ -458,4 +464,22 @@ func (f *ConfigurableConfigFactoryImpl) ConfigureRESTConfig(config *rest.Config)
 
 func (f *ConfigurableConfigFactoryImpl) RESTConfig() (*rest.Config, error) {
 	return f.config, nil
+}
+
+func WaitForResource(ctx context.Context, ri dynamic.ResourceInterface, name string, interval, timeout time.Duration) error {
+	err := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+		_, err := ri.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// the resource hasn't been created yet
+				return false, nil
+			} else {
+				// any other real error
+				return false, statuserror.FromK8sError("wait", "resource", name, err)
+			}
+		}
+		// the resource is created now
+		return true, nil
+	})
+	return err
 }

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	kappcmdcore "github.com/k14s/kapp/pkg/kapp/cmd/core"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
 	kappctrlv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	datapackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	vendirversions "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1"
@@ -321,6 +322,15 @@ func isKindInt(src interface{}) bool {
 
 type (
 	kappControllerPluginConfig struct {
+		Core struct {
+			Packages struct {
+				V1alpha1 struct {
+					VersionsInSummary pkgutils.VersionsInSummary
+					TimeoutSeconds    int32 `json:"timeoutSeconds"`
+				} `json:"v1alpha1"`
+			} `json:"packages"`
+		} `json:"core"`
+
 		KappController struct {
 			Packages struct {
 				V1alpha1 struct {
@@ -332,6 +342,8 @@ type (
 		} `json:"kappController"`
 	}
 	kappControllerPluginParsedConfig struct {
+		versionsInSummary                  pkgutils.VersionsInSummary
+		timeoutSeconds                     int32
 		defaultUpgradePolicy               upgradePolicy
 		defaultPrereleasesVersionSelection []string
 		defaultAllowDowngrades             bool
@@ -339,6 +351,8 @@ type (
 )
 
 var defaultPluginConfig = &kappControllerPluginParsedConfig{
+	versionsInSummary:                  pkgutils.GetDefaultVersionsInSummary(),
+	timeoutSeconds:                     300,
 	defaultUpgradePolicy:               fallbackDefaultUpgradePolicy,
 	defaultPrereleasesVersionSelection: fallbackDefaultPrereleasesVersionSelection(),
 	defaultAllowDowngrades:             fallbackDefaultAllowDowngrades,


### PR DESCRIPTION
### Description of the change

After merging #4068, I've noticed there was an error every time you installed a package. This is because right after a successful install, you get redirected to the details view, meaning that every expected resource is supposed to be available.

We had that problem in the past (we needed the `App` CR to be created, something that happens a few seconds after creating the `PackageInstall`). However, now we are watching the generated resources, we need to query a `ConfigMap` to get the App ID (something generated by `kapp-ctrl` ); therefore, we need to wait until the CM is created. The thorny thing here is it takes up to 30s.

This PR just follows the similar approach we did for querying  the existence of an`App`, but I'm open to any other suggestions you may have.

### Benefits

No ugly error when the user got redirected to the installed app view.

### Possible drawbacks

The installation process will take longer (meaning that the user will see the spinner for 10-30 seconds).

### Applicable issues

- related #3849

### Additional information

N/A
