### PR TITLE
Fix failing test after previous PR merge

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -2212,10 +2212,6 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 %s
 
 
-### Inspect:
-%s
-
-
 ## Errors
 
 
@@ -2227,10 +2223,7 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 %s
 
 
-### Inspect:
-%s
-
-`, "deployStdout", "fetchStdout", "inspectStdout", "deployStderr", "fetchStderr", "inspectStderr"),
+`, "deployStdout", "fetchStdout", "deployStderr", "fetchStderr"),
 				LatestVersion: &corev1.PackageAppVersion{
 					PkgVersion: "1.2.3",
 					AppVersion: "1.2.3",


### PR DESCRIPTION
### Description of the change

This trivial PR addresses a failure in a test case due to a wrong test assert introduced in a merged PR.

### Benefits

CI will pass again

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

I'll rubber-stamp this PR as soon as it passes in CI
