### PR TITLE
Rename `MasterURL` to `APIServerURL`

### DIFF
--- a/cmd/apprepository-controller/cmd/root.go
+++ b/cmd/apprepository-controller/cmd/root.go
@@ -73,7 +73,7 @@ func init() {
 
 func setFlags(c *cobra.Command) {
 	c.Flags().StringVar(&serveOpts.Kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	c.Flags().StringVar(&serveOpts.MasterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	c.Flags().StringVar(&serveOpts.APIServerURL, "apiserver", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	c.Flags().StringVar(&serveOpts.RepoSyncImage, "repo-sync-image", "docker.io/kubeapps/asset-syncer:latest", "container repo/image to use in CronJobs")
 	c.Flags().StringSliceVar(&serveOpts.RepoSyncImagePullSecrets, "repo-sync-image-pullsecrets", nil, "optional reference to secrets in the same namespace to use for pulling the image used by this pod")
 	c.Flags().StringVar(&serveOpts.RepoSyncCommand, "repo-sync-cmd", "/chart-repo", "command used to sync/delete repos for repo-sync-image")

--- a/cmd/apprepository-controller/cmd/root_test.go
+++ b/cmd/apprepository-controller/cmd/root_test.go
@@ -38,7 +38,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 			[]string{},
 			server.Config{
 				Kubeconfig:               "",
-				MasterURL:                "",
+				APIServerURL:             "",
 				RepoSyncImage:            "docker.io/kubeapps/asset-syncer:latest",
 				RepoSyncImagePullSecrets: nil,
 				RepoSyncCommand:          "/chart-repo",
@@ -67,7 +67,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 			},
 			server.Config{
 				Kubeconfig:               "",
-				MasterURL:                "",
+				APIServerURL:             "",
 				RepoSyncImage:            "docker.io/kubeapps/asset-syncer:latest",
 				RepoSyncImagePullSecrets: []string{"s1", " s2", " s3"},
 				ImagePullSecretsRefs:     []v1.LocalObjectReference{{Name: "s1"}, {Name: " s2"}, {Name: " s3"}},
@@ -93,7 +93,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 			"all arguments are captured",
 			[]string{
 				"--kubeconfig", "foo01",
-				"--master", "foo02",
+				"--apiserver", "foo02",
 				"--repo-sync-image", "foo03",
 				"--repo-sync-image-pullsecrets", "s1,s2",
 				"--repo-sync-image-pullsecrets", "s3",
@@ -114,7 +114,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 			},
 			server.Config{
 				Kubeconfig:               "foo01",
-				MasterURL:                "foo02",
+				APIServerURL:             "foo02",
 				RepoSyncImage:            "foo03",
 				RepoSyncImagePullSecrets: []string{"s1", "s2", "s3"},
 				ImagePullSecretsRefs:     []v1.LocalObjectReference{{Name: "s1"}, {Name: "s2"}, {Name: "s3"}},

--- a/cmd/apprepository-controller/server/controller_test.go
+++ b/cmd/apprepository-controller/server/controller_test.go
@@ -1483,7 +1483,7 @@ func TestObjectBelongsTo(t *testing.T) {
 func makeDefaultConfig() Config {
 	return Config{
 		Kubeconfig:               "",
-		MasterURL:                "",
+		APIServerURL:             "",
 		RepoSyncImage:            repoSyncImage,
 		RepoSyncImagePullSecrets: []string{},
 		RepoSyncCommand:          "/chart-repo",

--- a/cmd/apprepository-controller/server/server.go
+++ b/cmd/apprepository-controller/server/server.go
@@ -29,7 +29,7 @@ import (
 )
 
 type Config struct {
-	MasterURL                string
+	APIServerURL             string
 	Kubeconfig               string
 	RepoSyncImage            string
 	RepoSyncImagePullSecrets []string
@@ -53,7 +53,7 @@ type Config struct {
 }
 
 func Serve(serveOpts Config) error {
-	cfg, err := clientcmd.BuildConfigFromFlags(serveOpts.MasterURL, serveOpts.Kubeconfig)
+	cfg, err := clientcmd.BuildConfigFromFlags(serveOpts.APIServerURL, serveOpts.Kubeconfig)
 	if err != nil {
 		return fmt.Errorf("Error building kubeconfig: %s", err.Error())
 	}


### PR DESCRIPTION
### Description of the change

This PR simply addresses an intentional leftover in  #4101 as it is an actual change in the code.
However, as far as I'm concerned, this param is not being used in our chart or ci scripts.

I've used `--apiserver` as the param name, but happy to change it to any other better alternative you think of.

### Benefits

The param name won't point to an outdated name in kubernetes (`master` nodes were renamed to `control plane` long time ago).

### Possible drawbacks

Unnoticed uses of this param elsewhere? 

### Applicable issues

- rel #4075 

### Additional information

N/A