### PR TITLE
Allow changing the k8s target version in Cargo

### DIFF
--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -18,7 +18,7 @@ hyper-tls = "0.5"
 kube = { version = "0.67.0" }
 kube-derive = { version = "0.67.0"}
 kube-runtime = "0.67.0"
-k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_22"] }
+k8s-openapi = { version = "0.14.0", default-features = false}
 log = "0.4"
 native-tls = "0.2"
 openssl = "0.10"
@@ -32,6 +32,15 @@ tokio = { version = "1", features = ["full"] }
 tokio-native-tls = "0.3"
 url = "2.2"
 http = "0.2.6"
+
+[features]
+default = ["v1_22"]
+
+# k8s target version when compiling k8s-openapi
+v1_20 = ["k8s-openapi/v1_20"]
+v1_21 = ["k8s-openapi/v1_21"]
+v1_22 = ["k8s-openapi/v1_22"]
+v1_23 = ["k8s-openapi/v1_23"]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/cmd/pinniped-proxy/Cargo.toml
+++ b/cmd/pinniped-proxy/Cargo.toml
@@ -37,6 +37,7 @@ http = "0.2.6"
 default = ["v1_22"]
 
 # k8s target version when compiling k8s-openapi
+# See https://doc.rust-lang.org/cargo/reference/features.html#dependency-features
 v1_20 = ["k8s-openapi/v1_20"]
 v1_21 = ["k8s-openapi/v1_21"]
 v1_22 = ["k8s-openapi/v1_22"]

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -44,6 +44,8 @@ The versions used there _must_ match the ones used for building the container im
 
 Besides, the `GKE_STABLE_VERSION_XX` and the `GKE_REGULAR_VERSION_XX` might have to be updated if the _Stable_ and _Regular_ Kubernetes versions in GKE have changed. Check this information on [this GKE release notes website](https://cloud.google.com/kubernetes-engine/docs/release-notes).
 
+> **NOTE**: at least one of those `GKE_STABLE_VERSION_XX` or `GKE_REGULAR_VERSION_XX` versions _must_ match the Kubernetes-related dependencies in [Go](../../go.mod) and [Rust](../../cmd/pinniped-proxy/Cargo.toml).
+
 > As part of this release process, these variables _must_ be updated accordingly. Other variable changes _should_ be tracked in a separate PR.
 
 #### 0.2.2 - CI integration image and dependencies


### PR DESCRIPTION
### Description of the change

This trivial PR just extracts the version used in the `k8s-openapi` dependency apart into a Cargo feature. This way any piece of code depending on `pinniped-proxy` can modify the target k8s platform simply compiling it with a `feature`.
Defaulting to the same value it has.

### Benefits

Pinniped-proxy will be simpler to configure when used as a dependency.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

I've added also a note in the release docs talking about then kubernetes-related deps.
