### PR TITLE
Update circleci imgs to the latest ones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,13 @@ version: 2.1
 parameters:
   GOLANG_VERSION:
     type: string
-    default: "1.17.5"
+    default: "1.17.6"
   NODE_VERSION:
     type: string
-    default: "16"
+    default: "16.13.2"
   RUST_VERSION:
     type: string
-    default: "1.57.0"
+    default: "1.58.1"
   DOCKER_VERSION:
     type: string
     default: "20.10.11"
@@ -496,7 +496,7 @@ run_e2e_tests: &run_e2e_tests
       fi
 gke_test: &gke_test
   docker:
-    - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+    - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
   steps:
     - checkout
     - run:
@@ -587,7 +587,7 @@ jobs:
       CGO_ENABLED: "0"
       <<: *common_envars
     docker:
-      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+      - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
     steps:
       - checkout
       - <<: *exports
@@ -600,7 +600,7 @@ jobs:
           name: Run go integration tests for DB
           command: |
             docker run -d --name postgresql --rm --publish 5432:5432 -e ALLOW_EMPTY_PASSWORD=yes bitnami/postgresql:${POSTGRESQL_VERSION}
-            docker run --network container:postgresql -d --name tests circleci/golang:${GOLANG_VERSION} tail -f /dev/null
+            docker run --network container:postgresql -d --name tests cimg/go:${GOLANG_VERSION} tail -f /dev/null
             docker cp /go tests:/
             docker exec -it tests /bin/sh -c "cd /go/src/github.com/kubeapps/kubeapps/ && make test-db"
   test_dashboard:
@@ -610,7 +610,7 @@ jobs:
       # garbage collection to start earlier with 512M per worker.
       NODE_OPTIONS: "--max-old-space-size=512"
     docker:
-      - image: circleci/node:<< pipeline.parameters.NODE_VERSION >>
+      - image: cimg/node:<< pipeline.parameters.NODE_VERSION >>
     steps:
       - checkout
       - run:
@@ -627,7 +627,7 @@ jobs:
             yarn --cwd=dashboard run test --maxWorkers=4 --coverage --logHeapUsage
   test_pinniped_proxy:
     docker:
-      - image: circleci/rust:<< pipeline.parameters.RUST_VERSION >>
+      - image: cimg/rust:<< pipeline.parameters.RUST_VERSION >>
     steps:
       - checkout
       - run:
@@ -638,7 +638,7 @@ jobs:
     environment:
       <<: *common_envars
     docker:
-      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+      - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
     steps:
       - <<: *exports
       - checkout
@@ -649,7 +649,7 @@ jobs:
             ./script/chart-template-test.sh
   build_go_images:
     docker:
-      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+      - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
     working_directory: /go/src/github.com/kubeapps/kubeapps
     environment:
       GOPATH: ${HOME}/.go_workspace
@@ -657,14 +657,14 @@ jobs:
     <<: *build_images
   build_dashboard:
     docker:
-      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+      - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
     environment:
       IMAGES: "dashboard"
     <<: *build_images
   build_pinniped_proxy:
     docker:
       # We're building the image in a docker container anyway so just re-use the golang image already in use.
-      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+      - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
     environment:
       IMAGES: "pinniped-proxy"
     <<: *build_images
@@ -672,7 +672,7 @@ jobs:
     environment:
       <<: *common_envars
     docker:
-      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+      - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
     steps:
       - checkout
       - <<: *install_github
@@ -725,7 +725,7 @@ jobs:
     environment:
       <<: *common_envars
     docker:
-      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+      - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
     steps:
       - checkout
       - <<: *install_github
@@ -757,7 +757,7 @@ jobs:
     environment:
       <<: *common_envars
     docker:
-      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+      - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
     steps:
       - checkout
       - <<: *install_github
@@ -790,7 +790,7 @@ jobs:
             ./script/chart_upstream_checker.sh << pipeline.parameters.CI_BOT_USERNAME >> << pipeline.parameters.CI_BOT_EMAIL >> << pipeline.parameters.CI_BOT_GPG >> << pipeline.parameters.CI_BOT_FORKED_CHARTS_DEPLOYKEY_FILENAME >> << pipeline.parameters.CHARTS_REPO_ORIGINAL >> << pipeline.parameters.BRANCH_CHARTS_REPO_ORIGINAL >> << pipeline.parameters.CHARTS_REPO_FORKED >> << pipeline.parameters.BRANCH_CHARTS_REPO_FORKED >> << pipeline.parameters.KUBEAPPS_REPO >> << pipeline.parameters.BRANCH_KUBEAPPS_REPO >>
   push_images:
     docker:
-      - image: circleci/golang:<< pipeline.parameters.GOLANG_VERSION >>
+      - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
     steps:
       - setup_remote_docker
       - <<: *exports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -604,7 +604,7 @@ jobs:
             docker run -d --name postgresql --rm --publish 5432:5432 -e ALLOW_EMPTY_PASSWORD=yes bitnami/postgresql:${POSTGRESQL_VERSION}
             docker run --network container:postgresql -d --name tests cimg/go:${GOLANG_VERSION} tail -f /dev/null
             docker cp /home/circleci/go tests:/
-            docker exec -it tests /bin/sh -c "cd /home/circleci/go/src/github.com/kubeapps/kubeapps/ && make test-db"
+            docker exec -it tests /bin/sh -c "cd /go/src/github.com/kubeapps/kubeapps/ && make test-db"
   test_dashboard:
     environment:
       # Note that the max old space setting is per worker, so running the tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,7 +582,7 @@ local_e2e_steps: &local_e2e_steps
 
 jobs:
   test_go:
-    working_directory: /go/src/github.com/kubeapps/kubeapps
+    working_directory: /home/circleci/go/src/github.com/kubeapps/kubeapps
     environment:
       CGO_ENABLED: "0"
       <<: *common_envars
@@ -650,7 +650,7 @@ jobs:
   build_go_images:
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
-    working_directory: /go/src/github.com/kubeapps/kubeapps
+    working_directory: /home/circleci/go/src/github.com/kubeapps/kubeapps
     environment:
       GOPATH: ${HOME}/.go_workspace
       IMAGES: "kubeops apprepository-controller asset-syncer assetsvc kubeapps-apis"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -603,8 +603,8 @@ jobs:
           command: |
             docker run -d --name postgresql --rm --publish 5432:5432 -e ALLOW_EMPTY_PASSWORD=yes bitnami/postgresql:${POSTGRESQL_VERSION}
             docker run --network container:postgresql -d --name tests cimg/go:${GOLANG_VERSION} tail -f /dev/null
-            docker cp /go tests:/
-            docker exec -it tests /bin/sh -c "cd /go/src/github.com/kubeapps/kubeapps/ && make test-db"
+            docker cp /home/circleci/go tests:/
+            docker exec -it tests /bin/sh -c "cd /home/circleci/go/src/github.com/kubeapps/kubeapps/ && make test-db"
   test_dashboard:
     environment:
       # Note that the max old space setting is per worker, so running the tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,7 +519,8 @@ gke_test: &gke_test
           fi
     - <<: *exports
     - <<: *install_gcloud_sdk
-    - setup_remote_docker
+    - setup_remote_docker:
+          version: << pipeline.parameters.DOCKER_VERSION >>
     - run:
         name: Configure Google Cloud
         command: |
@@ -595,7 +596,8 @@ jobs:
           name: Run go unit tests
           command: |
             make test
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: << pipeline.parameters.DOCKER_VERSION >>
       - run:
           name: Run go integration tests for DB
           command: |
@@ -792,7 +794,8 @@ jobs:
     docker:
       - image: cimg/go:<< pipeline.parameters.GOLANG_VERSION >>
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: << pipeline.parameters.DOCKER_VERSION >>
       - <<: *exports
       - run:
           name: Push images

--- a/cmd/pinniped-proxy/Dockerfile
+++ b/cmd/pinniped-proxy/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax = docker/dockerfile:1
 
-FROM rust:1.58.0 as builder
+FROM rust:1.58.1 as builder
 
 WORKDIR /pinniped-proxy
 ARG VERSION


### PR DESCRIPTION
### Description of the change

As part of the circleci [image deprecations](https://circleci.com/docs/2.0/circleci-images/), this PR is simply to update the container images used for running the steps.

### Benefits

We'll continue to have image upgrades (`circleci/xxxx` images were deprecated in 2021)

### Possible drawbacks

Let's see if the CI think otherwise

### Applicable issues

N/A

### Additional information

N/A