### PR TITLE
Don't set explicit targetNamespace for HelmRelease.

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release.go
@@ -520,7 +520,6 @@ func (s *Server) newFluxHelmRelease(chart *models.Chart, targetName types.Namesp
 						},
 					},
 				},
-				"targetNamespace": targetName.Namespace,
 			},
 		},
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/release_test.go
@@ -1675,8 +1675,7 @@ var (
 					},
 				},
 			},
-			"interval":        "1m",
-			"targetNamespace": "test",
+			"interval": "1m",
 		},
 	}
 
@@ -1699,8 +1698,7 @@ var (
 					"version": "> 5",
 				},
 			},
-			"interval":        "1m",
-			"targetNamespace": "test",
+			"interval": "1m",
 		},
 	}
 
@@ -1725,7 +1723,6 @@ var (
 			"interval":           "1m0s",
 			"serviceAccountName": "foo",
 			"suspend":            false,
-			"targetNamespace":    "test",
 		},
 	}
 
@@ -1747,8 +1744,7 @@ var (
 					},
 				},
 			},
-			"interval":        "1m",
-			"targetNamespace": "test",
+			"interval": "1m",
 			"values": map[string]interface{}{
 				"ui": map[string]interface{}{"message": "what we do in the shadows"},
 			},


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

When creating a fluxv2 helm release via Kubeapps, the plugin explicitly sets both the HelmRelease's `metadata.namespace` and the `spec.targetNamespace` field to the same target namespace value. The first is obviously correct and necessary, the second is redundant because Flux automatically defaults to using the HelmRelease's `metadata.namespace` as the target namespace when it is not set.

As a result, [as per the docs](https://fluxcd.io/docs/components/helm/helmreleases/#specification) when the `targetNamespace` is set, the actual name of the helm release (not the HelmRelease) defaults to `[TargetNamespace-]Name`:

```
helm ls -n kubeapps-user-namespace
NAME                                    NAMESPACE               REVISION        UPDATED                                 STATUS  CHART           APP VERSION
kubeapps-user-namespace-test-apache-2   kubeapps-user-namespace 1               2022-01-27 00:23:28.749271732 +0000 UTC failed  apache-9.0.1    2.4.52     

```

So when the UX then calls `GetInstalledPackageDetail`, it fails with:

```
Application not found: Unable to get the resource refs for the package "test-apache-2" using the plugin "fluxv2.packages": rpc error: code = NotFound desc = Unable to find Helm release "test-apache-2" in namespace "kubeapps-user-namespace": release: not found
```
since that code assumes the helm release name is the same as the `HelmRelease` name.

The solution here for now is to simply not set the `targetNamespace` redundantly with the same value as the `HelmRelease.metadata.namespace`, which means that flux itself defaults to using the `HelmRelease.metadata.namespace` for the actual helm release (ie. no change), but importantly, flux creates the helm release with the same name as the flux `HelmRelease`, and the UX just works.

<!-- Describe the scope of your change - i.e. what the change does. -->

It's not the only solution. Another would be to instead additionally explicitly set the `HelmRelease.Spec.ReleaseName` with the same value used for `HelmRelease.metadata.name`, or, later when we actually need support for helm releases in different target contexts, update the code to get (or derive) the name based on the flux2 rules.

But for now, given that we don't need support, I'm not sure there's a reason to not just use the flux default by removing the redundant `targetNamespace`.

Thoughts?

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #3695 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
