### PR TITLE
Unify import aliases

### DIFF
--- a/cmd/apprepository-controller/cmd/root.go
+++ b/cmd/apprepository-controller/cmd/root.go
@@ -8,17 +8,16 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/server"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
-	corev1 "k8s.io/api/core/v1"
+	apprepoctrlserver "github.com/kubeapps/kubeapps/cmd/apprepository-controller/server"
+	cobra "github.com/spf13/cobra"
+	viper "github.com/spf13/viper"
+	k8scorev1 "k8s.io/api/core/v1"
 	log "k8s.io/klog/v2"
 )
 
 var (
 	cfgFile   string
-	serveOpts server.Config
+	serveOpts apprepoctrlserver.Config
 	// This Version var is updated during the build
 	// see the -ldflags option in the cmd/apprepository-controller/Dockerfile
 	version = "devel"
@@ -36,7 +35,7 @@ func newRootCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			return server.Serve(serveOpts)
+			return apprepoctrlserver.Serve(serveOpts)
 		},
 		Version: "devel",
 	}
@@ -108,12 +107,12 @@ func initConfig() {
 
 // getImagePullSecretsRefs gets the []string of Secrets names from the
 // StringSliceVar flag list passed in the repoSyncImagePullSecrets arg
-func getImagePullSecretsRefs(imagePullSecretsRefsArr []string) []corev1.LocalObjectReference {
-	var imagePullSecretsRefs []corev1.LocalObjectReference
+func getImagePullSecretsRefs(imagePullSecretsRefsArr []string) []k8scorev1.LocalObjectReference {
+	var imagePullSecretsRefs []k8scorev1.LocalObjectReference
 
 	// getting and appending a []LocalObjectReference for each ImagePullSecret passed
 	for _, imagePullSecretName := range imagePullSecretsRefsArr {
-		imagePullSecretsRefs = append(imagePullSecretsRefs, corev1.LocalObjectReference{Name: imagePullSecretName})
+		imagePullSecretsRefs = append(imagePullSecretsRefs, k8scorev1.LocalObjectReference{Name: imagePullSecretName})
 	}
 	return imagePullSecretsRefs
 }

--- a/cmd/apprepository-controller/cmd/root_test.go
+++ b/cmd/apprepository-controller/cmd/root_test.go
@@ -6,24 +6,23 @@ package cmd
 import (
 	"bytes"
 	"strings"
-
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/server"
-	v1 "k8s.io/api/core/v1"
+	cmp "github.com/google/go-cmp/cmp"
+	apprepoctrlserver "github.com/kubeapps/kubeapps/cmd/apprepository-controller/server"
+	k8scorev1 "k8s.io/api/core/v1"
 )
 
 func TestParseFlagsCorrect(t *testing.T) {
 	var tests = []struct {
 		name string
 		args []string
-		conf server.Config
+		conf apprepoctrlserver.Config
 	}{
 		{
 			"no arguments returns default flag values",
 			[]string{},
-			server.Config{
+			apprepoctrlserver.Config{
 				Kubeconfig:               "",
 				APIServerURL:             "",
 				RepoSyncImage:            "docker.io/kubeapps/asset-syncer:latest",
@@ -52,12 +51,12 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--repo-sync-image-pullsecrets=s1, s2",
 				"--repo-sync-image-pullsecrets= s3",
 			},
-			server.Config{
+			apprepoctrlserver.Config{
 				Kubeconfig:               "",
 				APIServerURL:             "",
 				RepoSyncImage:            "docker.io/kubeapps/asset-syncer:latest",
 				RepoSyncImagePullSecrets: []string{"s1", " s2", " s3"},
-				ImagePullSecretsRefs:     []v1.LocalObjectReference{{Name: "s1"}, {Name: " s2"}, {Name: " s3"}},
+				ImagePullSecretsRefs:     []k8scorev1.LocalObjectReference{{Name: "s1"}, {Name: " s2"}, {Name: " s3"}},
 				RepoSyncCommand:          "/chart-repo",
 				KubeappsNamespace:        "kubeapps",
 				GlobalReposNamespace:     "kubeapps",
@@ -99,12 +98,12 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--custom-annotations", "extra13=extra13",
 				"--custom-labels", "foo14=bar14,foo14x=bar14x",
 			},
-			server.Config{
+			apprepoctrlserver.Config{
 				Kubeconfig:               "foo01",
 				APIServerURL:             "foo02",
 				RepoSyncImage:            "foo03",
 				RepoSyncImagePullSecrets: []string{"s1", "s2", "s3"},
-				ImagePullSecretsRefs:     []v1.LocalObjectReference{{Name: "s1"}, {Name: "s2"}, {Name: "s3"}},
+				ImagePullSecretsRefs:     []k8scorev1.LocalObjectReference{{Name: "s1"}, {Name: "s2"}, {Name: "s3"}},
 				RepoSyncCommand:          "foo04",
 				KubeappsNamespace:        "foo05",
 				GlobalReposNamespace:     "kubeapps-repos-global",

--- a/cmd/apprepository-controller/main.go
+++ b/cmd/apprepository-controller/main.go
@@ -3,8 +3,10 @@
 
 package main
 
-import "github.com/kubeapps/kubeapps/cmd/apprepository-controller/cmd"
+import (
+	apprepoctrlcmd "github.com/kubeapps/kubeapps/cmd/apprepository-controller/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	apprepoctrlcmd.Execute()
 }

--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/register.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/register.go
@@ -4,39 +4,38 @@
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository"
+	apprepo "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = schema.GroupVersion{Group: apprepository.GroupName, Version: "v1alpha1"}
+var SchemeGroupVersion = k8sschema.GroupVersion{Group: apprepo.GroupName, Version: "v1alpha1"}
 
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
-func Kind(kind string) schema.GroupKind {
+func Kind(kind string) k8sschema.GroupKind {
 	return SchemeGroupVersion.WithKind(kind).GroupKind()
 }
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
-func Resource(resource string) schema.GroupResource {
+func Resource(resource string) k8sschema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
 var (
 	// SchemeBuilder is the SchemeBuilder for AppRepository
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	SchemeBuilder = k8sruntime.NewSchemeBuilder(addKnownTypes)
 	// AddToScheme is the function to add to the scheme for AppRepository
 	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 // Adds the list of known types to Scheme.
-func addKnownTypes(scheme *runtime.Scheme) error {
+func addKnownTypes(scheme *k8sruntime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&AppRepository{},
 		&AppRepositoryList{},
 	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	k8smetav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }

--- a/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
+++ b/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1/types.go
@@ -4,8 +4,8 @@
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scorev1 "k8s.io/api/core/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +genclient
@@ -14,8 +14,8 @@ import (
 
 // AppRepository is a specification for an AppRepository resource
 type AppRepository struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	k8smetav1.TypeMeta   `json:",inline"`
+	k8smetav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   AppRepositorySpec   `json:"spec"`
 	Status AppRepositoryStatus `json:"status"`
@@ -23,11 +23,11 @@ type AppRepository struct {
 
 // AppRepositorySpec is the spec for an AppRepository resource
 type AppRepositorySpec struct {
-	Type               string                 `json:"type"`
-	URL                string                 `json:"url"`
-	Auth               AppRepositoryAuth      `json:"auth,omitempty"`
-	ResyncRequests     uint                   `json:"resyncRequests"`
-	SyncJobPodTemplate corev1.PodTemplateSpec `json:"syncJobPodTemplate"`
+	Type               string                    `json:"type"`
+	URL                string                    `json:"url"`
+	Auth               AppRepositoryAuth         `json:"auth,omitempty"`
+	ResyncRequests     uint                      `json:"resyncRequests"`
+	SyncJobPodTemplate k8scorev1.PodTemplateSpec `json:"syncJobPodTemplate"`
 	// DockerRegistrySecrets is a list of dockerconfigjson secrets which exist
 	// in the same namespace as the AppRepository and should be included
 	// automatically for matching images.
@@ -54,13 +54,13 @@ type AppRepositoryAuth struct {
 // AppRepositoryAuthHeader secret-key reference
 type AppRepositoryAuthHeader struct {
 	// Selects a key of a secret in the pod's namespace
-	SecretKeyRef corev1.SecretKeySelector `json:"secretKeyRef,omitempty"`
+	SecretKeyRef k8scorev1.SecretKeySelector `json:"secretKeyRef,omitempty"`
 }
 
 // AppRepositoryCustomCA secret-key reference
 type AppRepositoryCustomCA struct {
 	// Selects a key of a secret in the pod's namespace
-	SecretKeyRef corev1.SecretKeySelector `json:"secretKeyRef,omitempty"`
+	SecretKeyRef k8scorev1.SecretKeySelector `json:"secretKeyRef,omitempty"`
 }
 
 // FilterRuleSpec defines a set of rules and aggreagation logic
@@ -78,8 +78,8 @@ type AppRepositoryStatus struct {
 
 // AppRepositoryList is a list of AppRepository resources
 type AppRepositoryList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	k8smetav1.TypeMeta `json:",inline"`
+	k8smetav1.ListMeta `json:"metadata"`
 
 	Items []AppRepository `json:"items"`
 }

--- a/cmd/apprepository-controller/pkg/client/informers/externalversions/apprepository/v1alpha1/apprepository.go
+++ b/cmd/apprepository-controller/pkg/client/informers/externalversions/apprepository/v1alpha1/apprepository.go
@@ -7,7 +7,7 @@ package v1alpha1
 
 import (
 	"context"
-	time "time"
+	"time"
 
 	apprepositoryv1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	versioned "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"

--- a/cmd/apprepository-controller/pkg/client/informers/externalversions/factory.go
+++ b/cmd/apprepository-controller/pkg/client/informers/externalversions/factory.go
@@ -6,9 +6,9 @@
 package externalversions
 
 import (
-	reflect "reflect"
-	sync "sync"
-	time "time"
+	"reflect"
+	"sync"
+	"time"
 
 	versioned "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
 	apprepository "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/informers/externalversions/apprepository"

--- a/cmd/apprepository-controller/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/cmd/apprepository-controller/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -6,7 +6,7 @@
 package internalinterfaces
 
 import (
-	time "time"
+	"time"
 
 	versioned "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/apprepository-controller/server/controller.go
+++ b/cmd/apprepository-controller/server/controller.go
@@ -12,28 +12,28 @@ import (
 	"time"
 
 	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	clientset "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
+	apprepoclient "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
 	appreposcheme "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/scheme"
-	informers "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/informers/externalversions"
-	listers "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/listers/apprepository/v1alpha1"
-	"github.com/kubeapps/kubeapps/pkg/kube"
+	apprepoinformers "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/informers/externalversions"
+	apprepolisters "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/listers/apprepository/v1alpha1"
+	kubeutils "github.com/kubeapps/kubeapps/pkg/kube"
 	log "github.com/sirupsen/logrus"
-	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	k8sbatchv1 "k8s.io/api/batch/v1"
+	k8sbatchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	kubeinformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	batchlisters "k8s.io/client-go/listers/batch/v1beta1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/workqueue"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8sruntimeutil "k8s.io/apimachinery/pkg/util/runtime"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+	k8sinformers "k8s.io/client-go/informers"
+	k8stypedclient "k8s.io/client-go/kubernetes"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	k8stypedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	k8sbatchlistersv1 "k8s.io/client-go/listers/batch/v1beta1"
+	k8stoolscache "k8s.io/client-go/tools/cache"
+	k8stoolsrecord "k8s.io/client-go/tools/record"
+	k8workqueue "k8s.io/client-go/util/workqueue"
 )
 
 const controllerAgentName = "apprepository-controller"
@@ -63,34 +63,34 @@ const (
 // Controller is the controller implementation for AppRepository resources
 type Controller struct {
 	// kubeclientset is a standard kubernetes clientset
-	kubeclientset kubernetes.Interface
+	kubeclientset k8stypedclient.Interface
 	// apprepoclientset is the clientset for AppRepository resources
-	apprepoclientset clientset.Interface
+	apprepoclientset apprepoclient.Interface
 
-	cronjobsLister batchlisters.CronJobLister
-	cronjobsSynced cache.InformerSynced
-	appreposLister listers.AppRepositoryLister
-	appreposSynced cache.InformerSynced
+	cronjobsLister k8sbatchlistersv1.CronJobLister
+	cronjobsSynced k8stoolscache.InformerSynced
+	appreposLister apprepolisters.AppRepositoryLister
+	appreposSynced k8stoolscache.InformerSynced
 
 	// workqueue is a rate limited work queue. This is used to queue work to be
 	// processed instead of performing it as soon as a change happens. This
 	// means we can ensure we only process a fixed amount of resources at a
 	// time, and makes it easy to ensure we are never processing the same item
 	// simultaneously in two different workers.
-	workqueue workqueue.RateLimitingInterface
+	workqueue k8workqueue.RateLimitingInterface
 	// recorder is an event recorder for recording Event resources to the
 	// Kubernetes API.
-	recorder record.EventRecorder
+	recorder k8stoolsrecord.EventRecorder
 
 	conf Config
 }
 
 // NewController returns a new sample controller
 func NewController(
-	kubeclientset kubernetes.Interface,
-	apprepoclientset clientset.Interface,
-	kubeInformerFactory kubeinformers.SharedInformerFactory,
-	apprepoInformerFactory informers.SharedInformerFactory,
+	kubeclientset k8stypedclient.Interface,
+	apprepoclientset apprepoclient.Interface,
+	kubeInformerFactory k8sinformers.SharedInformerFactory,
+	apprepoInformerFactory apprepoinformers.SharedInformerFactory,
 	conf *Config) *Controller {
 
 	// obtain references to shared index informers for the CronJob and
@@ -101,12 +101,12 @@ func NewController(
 	// Create event broadcaster
 	// Add apprepository-controller types to the default Kubernetes Scheme so
 	// Events can be logged for apprepository-controller types.
-	appreposcheme.AddToScheme(scheme.Scheme)
+	appreposcheme.AddToScheme(k8sscheme.Scheme)
 	log.Info("Creating event broadcaster")
-	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster := k8stoolsrecord.NewBroadcaster()
 	eventBroadcaster.StartLogging(log.Infof)
-	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
-	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
+	eventBroadcaster.StartRecordingToSink(&k8stypedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(k8sscheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 
 	controller := &Controller{
 		kubeclientset:    kubeclientset,
@@ -115,14 +115,14 @@ func NewController(
 		cronjobsSynced:   cronjobInformer.Informer().HasSynced,
 		appreposLister:   apprepoInformer.Lister(),
 		appreposSynced:   apprepoInformer.Informer().HasSynced,
-		workqueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AppRepositories"),
+		workqueue:        k8workqueue.NewNamedRateLimitingQueue(k8workqueue.DefaultControllerRateLimiter(), "AppRepositories"),
 		recorder:         recorder,
 		conf:             *conf,
 	}
 
 	log.Info("Setting up event handlers")
 	// Set up an event handler for when AppRepository resources change
-	apprepoInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	apprepoInformer.Informer().AddEventHandler(k8stoolscache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueAppRepo,
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			oldApp := oldObj.(*apprepov1alpha1.AppRepository)
@@ -132,7 +132,7 @@ func NewController(
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			key, err := k8stoolscache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err == nil {
 				controller.workqueue.AddRateLimited(key)
 			}
@@ -146,7 +146,7 @@ func NewController(
 	// to implement custom logic for handling CronJob resources. More info on this
 	// pattern:
 	// https://github.com/kubernetes/community/blob/8cafef897a22026d42f5e5bb3f104febe7e29830/contributors/devel/controllers.md
-	cronjobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	cronjobInformer.Informer().AddEventHandler(k8stoolscache.ResourceEventHandlerFuncs{
 		DeleteFunc: controller.handleObject,
 	})
 
@@ -158,7 +158,7 @@ func NewController(
 // is closed, at which point it will shutdown the workqueue and wait for
 // workers to finish processing their current work items.
 func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
-	defer runtime.HandleCrash()
+	defer k8sruntimeutil.HandleCrash()
 	defer c.workqueue.ShutDown()
 
 	// Start the informer factories to begin populating the informer caches
@@ -166,14 +166,14 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 
 	// Wait for the caches to be synced before starting workers
 	log.Info("Waiting for informer caches to sync")
-	if ok := cache.WaitForCacheSync(stopCh, c.cronjobsSynced, c.appreposSynced); !ok {
+	if ok := k8stoolscache.WaitForCacheSync(stopCh, c.cronjobsSynced, c.appreposSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
 	log.Info("Starting workers")
 	// Launch two workers to process AppRepository resources
 	for i := 0; i < threadiness; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
+		go k8swait.Until(c.runWorker, time.Second, stopCh)
 	}
 
 	log.Info("Started workers")
@@ -221,7 +221,7 @@ func (c *Controller) processNextWorkItem() bool {
 			// Forget here else we'd go into a loop of attempting to
 			// process a work item that is invalid.
 			c.workqueue.Forget(obj)
-			runtime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			k8sruntimeutil.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
 			return nil
 		}
 		// Run the syncHandler, passing it the namespace/name string of the
@@ -237,7 +237,7 @@ func (c *Controller) processNextWorkItem() bool {
 	}(obj)
 
 	if err != nil {
-		runtime.HandleError(err)
+		k8sruntimeutil.HandleError(err)
 		return true
 	}
 
@@ -249,9 +249,9 @@ func (c *Controller) processNextWorkItem() bool {
 // resource with the current status of the resource.
 func (c *Controller) syncHandler(key string) error {
 	// Convert the namespace/name string into a distinct namespace and name
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	namespace, name, err := k8stoolscache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		k8sruntimeutil.HandleError(fmt.Errorf("invalid resource key: %s", key))
 		return nil
 	}
 
@@ -260,10 +260,10 @@ func (c *Controller) syncHandler(key string) error {
 	if err != nil {
 		// The AppRepository resource may no longer exist, in which case we stop
 		// processing.
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			log.Infof("AppRepository '%s' no longer exists so performing cleanup of charts from the DB", key)
 			// Trigger a Job to perfrom the cleanup of the charts in the DB corresponding to deleted AppRepository
-			_, err = c.kubeclientset.BatchV1().Jobs(c.conf.KubeappsNamespace).Create(context.TODO(), newCleanupJob(c.conf.KubeappsNamespace, namespace, name, c.conf), metav1.CreateOptions{})
+			_, err = c.kubeclientset.BatchV1().Jobs(c.conf.KubeappsNamespace).Create(context.TODO(), newCleanupJob(c.conf.KubeappsNamespace, namespace, name, c.conf), k8smetav1.CreateOptions{})
 			if err != nil {
 				log.Errorf("Unable to create cleanup job: %v", err)
 				return err
@@ -271,8 +271,8 @@ func (c *Controller) syncHandler(key string) error {
 
 			// TODO: Workaround until the sync jobs are moved to the repoNamespace (#1647)
 			// Delete the cronjob in the Kubeapps namespace to avoid re-syncing the repository
-			err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Delete(context.TODO(), cronJobName(namespace, name), metav1.DeleteOptions{})
-			if err != nil && !errors.IsNotFound(err) {
+			err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Delete(context.TODO(), cronJobName(namespace, name), k8smetav1.DeleteOptions{})
+			if err != nil && !k8serrors.IsNotFound(err) {
 				log.Errorf("Unable to delete sync cronjob: %v", err)
 				return err
 			}
@@ -285,25 +285,25 @@ func (c *Controller) syncHandler(key string) error {
 	cronjobName := cronJobName(namespace, name)
 	cronjob, err := c.cronjobsLister.CronJobs(c.conf.KubeappsNamespace).Get(cronjobName)
 	// If the resource doesn't exist, we'll create it
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		log.Infof("Creating CronJob %q for AppRepository %q", cronjobName, apprepo.GetName())
-		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Create(context.TODO(), newCronJob(apprepo, c.conf), metav1.CreateOptions{})
+		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Create(context.TODO(), newCronJob(apprepo, c.conf), k8smetav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
 
 		// Trigger a manual Job for the initial sync
-		_, err = c.kubeclientset.BatchV1().Jobs(c.conf.KubeappsNamespace).Create(context.TODO(), newSyncJob(apprepo, c.conf), metav1.CreateOptions{})
+		_, err = c.kubeclientset.BatchV1().Jobs(c.conf.KubeappsNamespace).Create(context.TODO(), newSyncJob(apprepo, c.conf), k8smetav1.CreateOptions{})
 	} else if err == nil {
 		// If the resource already exists, we'll update it
 		log.Infof("Updating CronJob %q in namespace %q for AppRepository %q in namespace %q", cronjobName, c.conf.KubeappsNamespace, apprepo.GetName(), apprepo.GetNamespace())
-		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Update(context.TODO(), newCronJob(apprepo, c.conf), metav1.UpdateOptions{})
+		cronjob, err = c.kubeclientset.BatchV1beta1().CronJobs(c.conf.KubeappsNamespace).Update(context.TODO(), newCronJob(apprepo, c.conf), k8smetav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
 
 		// The AppRepository has changed, launch a manual Job
-		_, err = c.kubeclientset.BatchV1().Jobs(c.conf.KubeappsNamespace).Create(context.TODO(), newSyncJob(apprepo, c.conf), metav1.CreateOptions{})
+		_, err = c.kubeclientset.BatchV1().Jobs(c.conf.KubeappsNamespace).Create(context.TODO(), newSyncJob(apprepo, c.conf), k8smetav1.CreateOptions{})
 	}
 
 	// If an error occurs during Get/Create, we'll requeue the item so we can
@@ -316,7 +316,7 @@ func (c *Controller) syncHandler(key string) error {
 	// If the CronJob is not controlled by this AppRepository resource and it is not a
 	// cronjob for an app repo in another namespace, then we should
 	// log a warning to the event recorder and return it.
-	if !metav1.IsControlledBy(cronjob, apprepo) && !objectBelongsTo(cronjob, apprepo) {
+	if !k8smetav1.IsControlledBy(cronjob, apprepo) && !objectBelongsTo(cronjob, apprepo) {
 		msg := fmt.Sprintf(MessageResourceExists, cronjob.Name)
 		c.recorder.Event(apprepo, corev1.EventTypeWarning, ErrResourceExists, msg)
 		return fmt.Errorf(msg)
@@ -330,7 +330,7 @@ func (c *Controller) syncHandler(key string) error {
 
 // belongsTo is similar to IsControlledBy, but enables us to establish a relationship
 // between cronjobs and app repositories in different namespaces.
-func objectBelongsTo(object, parent metav1.Object) bool {
+func objectBelongsTo(object, parent k8smetav1.Object) bool {
 	labels := object.GetLabels()
 	return labels[LabelRepoName] == parent.GetName() && labels[LabelRepoNamespace] == parent.GetNamespace()
 }
@@ -341,8 +341,8 @@ func objectBelongsTo(object, parent metav1.Object) bool {
 func (c *Controller) enqueueAppRepo(obj interface{}) {
 	var key string
 	var err error
-	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
-		runtime.HandleError(err)
+	if key, err = k8stoolscache.MetaNamespaceKeyFunc(obj); err != nil {
+		k8sruntimeutil.HandleError(err)
 		return
 	}
 	c.workqueue.AddRateLimited(key)
@@ -354,23 +354,23 @@ func (c *Controller) enqueueAppRepo(obj interface{}) {
 // It then enqueues that AppRepository resource to be processed. If the object
 // does not have an appropriate OwnerReference, it will simply be skipped.
 func (c *Controller) handleObject(obj interface{}) {
-	var object metav1.Object
+	var object k8smetav1.Object
 	var ok bool
-	if object, ok = obj.(metav1.Object); !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if object, ok = obj.(k8smetav1.Object); !ok {
+		tombstone, ok := obj.(k8stoolscache.DeletedFinalStateUnknown)
 		if !ok {
-			runtime.HandleError(fmt.Errorf("error decoding object, invalid type"))
+			k8sruntimeutil.HandleError(fmt.Errorf("error decoding object, invalid type"))
 			return
 		}
-		object, ok = tombstone.Obj.(metav1.Object)
+		object, ok = tombstone.Obj.(k8smetav1.Object)
 		if !ok {
-			runtime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
+			k8sruntimeutil.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
 			return
 		}
 		log.Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 	}
 	log.Infof("Processing object: %s", object.GetName())
-	if ownerRef := metav1.GetControllerOf(object); ownerRef != nil {
+	if ownerRef := k8smetav1.GetControllerOf(object); ownerRef != nil {
 		// If this object is not owned by an AppRepository, we should not do
 		// anything more with it.
 		if ownerRef.Kind != "AppRepository" {
@@ -395,10 +395,10 @@ func (c *Controller) handleObject(obj interface{}) {
 
 // ownerReferencesForAppRepo returns populated owner references for app repos in the same namespace
 // as the cronjob and nil otherwise.
-func ownerReferencesForAppRepo(apprepo *apprepov1alpha1.AppRepository, childNamespace string) []metav1.OwnerReference {
+func ownerReferencesForAppRepo(apprepo *apprepov1alpha1.AppRepository, childNamespace string) []k8smetav1.OwnerReference {
 	if apprepo.GetNamespace() == childNamespace {
-		return []metav1.OwnerReference{
-			*metav1.NewControllerRef(apprepo, schema.GroupVersionKind{
+		return []k8smetav1.OwnerReference{
+			*k8smetav1.NewControllerRef(apprepo, k8sschema.GroupVersionKind{
 				Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 				Version: apprepov1alpha1.SchemeGroupVersion.Version,
 				Kind:    "AppRepository",
@@ -411,21 +411,21 @@ func ownerReferencesForAppRepo(apprepo *apprepov1alpha1.AppRepository, childName
 // newCronJob creates a new CronJob for a AppRepository resource. It also sets
 // the appropriate OwnerReferences on the resource so handleObject can discover
 // the AppRepository resource that 'owns' it.
-func newCronJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1beta1.CronJob {
-	return &batchv1beta1.CronJob{
-		ObjectMeta: metav1.ObjectMeta{
+func newCronJob(apprepo *apprepov1alpha1.AppRepository, config Config) *k8sbatchv1beta1.CronJob {
+	return &k8sbatchv1beta1.CronJob{
+		ObjectMeta: k8smetav1.ObjectMeta{
 			Name:            cronJobName(apprepo.Namespace, apprepo.Name),
 			OwnerReferences: ownerReferencesForAppRepo(apprepo, config.KubeappsNamespace),
 			Labels:          jobLabels(apprepo, config),
 			Annotations:     config.ParsedCustomAnnotations,
 		},
-		Spec: batchv1beta1.CronJobSpec{
+		Spec: k8sbatchv1beta1.CronJobSpec{
 			Schedule: config.Crontab,
 			// Set to replace as short-circuit in k8s <1.12
 			// TODO re-evaluate ConcurrentPolicy when 1.12+ is mainstream (i.e 1.14)
 			// https://github.com/kubernetes/kubernetes/issues/54870
 			ConcurrencyPolicy: "Replace",
-			JobTemplate: batchv1beta1.JobTemplateSpec{
+			JobTemplate: k8sbatchv1beta1.JobTemplateSpec{
 				Spec: syncJobSpec(apprepo, config),
 			},
 		},
@@ -434,9 +434,9 @@ func newCronJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1b
 
 // newSyncJob triggers a job for the AppRepository resource. It also sets the
 // appropriate OwnerReferences on the resource
-func newSyncJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1.Job {
-	return &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+func newSyncJob(apprepo *apprepov1alpha1.AppRepository, config Config) *k8sbatchv1.Job {
+	return &k8sbatchv1.Job{
+		ObjectMeta: k8smetav1.ObjectMeta{
 			GenerateName:    cronJobName(apprepo.Namespace, apprepo.Name) + "-",
 			OwnerReferences: ownerReferencesForAppRepo(apprepo, config.KubeappsNamespace),
 			Annotations:     config.ParsedCustomLabels,
@@ -447,7 +447,7 @@ func newSyncJob(apprepo *apprepov1alpha1.AppRepository, config Config) *batchv1.
 }
 
 // jobSpec returns a batchv1.JobSpec for running the chart-repo sync job
-func syncJobSpec(apprepo *apprepov1alpha1.AppRepository, config Config) batchv1.JobSpec {
+func syncJobSpec(apprepo *apprepov1alpha1.AppRepository, config Config) k8sbatchv1.JobSpec {
 	volumes := []corev1.Volume{}
 	volumeMounts := []corev1.VolumeMount{}
 	if apprepo.Spec.Auth.CustomCA != nil {
@@ -499,7 +499,7 @@ func syncJobSpec(apprepo *apprepov1alpha1.AppRepository, config Config) batchv1.
 	// Add volumes
 	podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, volumes...)
 
-	return batchv1.JobSpec{
+	return k8sbatchv1.JobSpec{
 		TTLSecondsAfterFinished: ttlLifetimeJobs(config),
 		Template:                podTemplateSpec,
 	}
@@ -507,9 +507,9 @@ func syncJobSpec(apprepo *apprepov1alpha1.AppRepository, config Config) batchv1.
 
 // newCleanupJob triggers a job for the AppRepository resource. It also sets the
 // appropriate OwnerReferences on the resource
-func newCleanupJob(kubeappsNamespace, repoNamespace, name string, config Config) *batchv1.Job {
-	return &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
+func newCleanupJob(kubeappsNamespace, repoNamespace, name string, config Config) *k8sbatchv1.Job {
+	return &k8sbatchv1.Job{
+		ObjectMeta: k8smetav1.ObjectMeta{
 			GenerateName: deleteJobName(repoNamespace, name) + "-",
 			Namespace:    kubeappsNamespace,
 			Annotations:  config.ParsedCustomAnnotations,
@@ -520,8 +520,8 @@ func newCleanupJob(kubeappsNamespace, repoNamespace, name string, config Config)
 }
 
 // cleanupJobSpec returns a batchv1.JobSpec for running the chart-repo delete job
-func cleanupJobSpec(namespace, name string, config Config) batchv1.JobSpec {
-	return batchv1.JobSpec{
+func cleanupJobSpec(namespace, name string, config Config) k8sbatchv1.JobSpec {
+	return k8sbatchv1.JobSpec{
 		TTLSecondsAfterFinished: ttlLifetimeJobs(config),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
@@ -664,7 +664,7 @@ func secretKeyRefForRepo(keyRef corev1.SecretKeySelector, apprepo *apprepov1alph
 	if apprepo.ObjectMeta.Namespace == config.KubeappsNamespace {
 		return &keyRef
 	}
-	keyRef.LocalObjectReference.Name = kube.KubeappsSecretNameForRepo(apprepo.ObjectMeta.Name, apprepo.ObjectMeta.Namespace)
+	keyRef.LocalObjectReference.Name = kubeutils.KubeappsSecretNameForRepo(apprepo.ObjectMeta.Name, apprepo.ObjectMeta.Namespace)
 	return &keyRef
 }
 

--- a/cmd/apprepository-controller/server/controller_test.go
+++ b/cmd/apprepository-controller/server/controller_test.go
@@ -6,13 +6,13 @@ package server
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	cmp "github.com/google/go-cmp/cmp"
 	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sbatchv1 "k8s.io/api/batch/v1"
+	k8sbatchv1beta1 "k8s.io/api/batch/v1beta1"
+	k8scorev1 "k8s.io/api/core/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const repoSyncImage = "bitnami/kubeapps-asset-syncer:2.0.0-scratch-r2"
@@ -25,18 +25,18 @@ func Test_newCronJob(t *testing.T) {
 		crontab          string
 		userAgentComment string
 		apprepo          *apprepov1alpha1.AppRepository
-		expected         batchv1beta1.CronJob
+		expected         k8sbatchv1beta1.CronJob
 	}{
 		{
 			"my-charts",
 			"*/10 * * * *",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -49,13 +49,13 @@ func Test_newCronJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 				},
 			},
-			batchv1beta1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1beta1.CronJob{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: "apprepo-kubeapps-sync-my-charts",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -67,23 +67,23 @@ func Test_newCronJob(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: k8sbatchv1beta1.CronJobSpec{
 					Schedule:          "*/10 * * * *",
 					ConcurrencyPolicy: "Replace",
-					JobTemplate: batchv1beta1.JobTemplateSpec{
-						Spec: batchv1.JobSpec{
+					JobTemplate: k8sbatchv1beta1.JobTemplateSpec{
+						Spec: k8sbatchv1.JobSpec{
 							TTLSecondsAfterFinished: &defaultTTL,
-							Template: corev1.PodTemplateSpec{
-								ObjectMeta: metav1.ObjectMeta{
+							Template: k8scorev1.PodTemplateSpec{
+								ObjectMeta: k8smetav1.ObjectMeta{
 									Labels: map[string]string{
 										LabelRepoName:      "my-charts",
 										LabelRepoNamespace: "kubeapps",
 									},
 									Annotations: map[string]string{},
 								},
-								Spec: corev1.PodSpec{
+								Spec: k8scorev1.PodSpec{
 									RestartPolicy: "OnFailure",
-									Containers: []corev1.Container{
+									Containers: []k8scorev1.Container{
 										{
 											Name:            "sync",
 											Image:           repoSyncImage,
@@ -100,11 +100,11 @@ func Test_newCronJob(t *testing.T) {
 												"https://charts.acme.com/my-charts",
 												"helm",
 											},
-											Env: []corev1.EnvVar{
+											Env: []k8scorev1.EnvVar{
 												{
 													Name: "DB_PASSWORD",
-													ValueFrom: &corev1.EnvVarSource{
-														SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+													ValueFrom: &k8scorev1.EnvVarSource{
+														SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 												},
 											},
 											VolumeMounts: nil,
@@ -123,11 +123,11 @@ func Test_newCronJob(t *testing.T) {
 			"*/20 * * * *",
 			"kubeapps/v2.3",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -140,17 +140,17 @@ func Test_newCronJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 					Auth: apprepov1alpha1.AppRepositoryAuth{
 						Header: &apprepov1alpha1.AppRepositoryAuthHeader{
-							SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"}},
+							SecretKeyRef: k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"}},
 					},
 				},
 			},
-			batchv1beta1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1beta1.CronJob{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: "apprepo-kubeapps-sync-my-charts",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -162,23 +162,23 @@ func Test_newCronJob(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: k8sbatchv1beta1.CronJobSpec{
 					Schedule:          "*/20 * * * *",
 					ConcurrencyPolicy: "Replace",
-					JobTemplate: batchv1beta1.JobTemplateSpec{
-						Spec: batchv1.JobSpec{
+					JobTemplate: k8sbatchv1beta1.JobTemplateSpec{
+						Spec: k8sbatchv1.JobSpec{
 							TTLSecondsAfterFinished: &defaultTTL,
-							Template: corev1.PodTemplateSpec{
-								ObjectMeta: metav1.ObjectMeta{
+							Template: k8scorev1.PodTemplateSpec{
+								ObjectMeta: k8smetav1.ObjectMeta{
 									Labels: map[string]string{
 										LabelRepoName:      "my-charts",
 										LabelRepoNamespace: "kubeapps",
 									},
 									Annotations: map[string]string{},
 								},
-								Spec: corev1.PodSpec{
+								Spec: k8scorev1.PodSpec{
 									RestartPolicy: "OnFailure",
-									Containers: []corev1.Container{
+									Containers: []k8scorev1.Container{
 										{
 											Name:            "sync",
 											Image:           repoSyncImage,
@@ -196,16 +196,16 @@ func Test_newCronJob(t *testing.T) {
 												"https://charts.acme.com/my-charts",
 												"helm",
 											},
-											Env: []corev1.EnvVar{
+											Env: []k8scorev1.EnvVar{
 												{
 													Name: "DB_PASSWORD",
-													ValueFrom: &corev1.EnvVarSource{
-														SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+													ValueFrom: &k8scorev1.EnvVarSource{
+														SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 												},
 												{
 													Name: "AUTHORIZATION_HEADER",
-													ValueFrom: &corev1.EnvVarSource{
-														SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"}},
+													ValueFrom: &k8scorev1.EnvVarSource{
+														SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"}},
 												},
 											},
 											VolumeMounts: nil,
@@ -224,11 +224,11 @@ func Test_newCronJob(t *testing.T) {
 			"*/20 * * * *",
 			"kubeapps/v2.3",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts-in-otherns",
 					Namespace: "otherns",
 					Labels: map[string]string{
@@ -241,12 +241,12 @@ func Test_newCronJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 					Auth: apprepov1alpha1.AppRepositoryAuth{
 						Header: &apprepov1alpha1.AppRepositoryAuthHeader{
-							SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "apprepo-my-charts-in-otherns"}, Key: "AuthorizationHeader"}},
+							SecretKeyRef: k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "apprepo-my-charts-in-otherns"}, Key: "AuthorizationHeader"}},
 					},
 				},
 			},
-			batchv1beta1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1beta1.CronJob{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: "apprepo-otherns-sync-my-charts-in-otherns",
 					Labels: map[string]string{
 						LabelRepoName:      "my-charts-in-otherns",
@@ -254,23 +254,23 @@ func Test_newCronJob(t *testing.T) {
 					},
 					Annotations: map[string]string{},
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: k8sbatchv1beta1.CronJobSpec{
 					Schedule:          "*/20 * * * *",
 					ConcurrencyPolicy: "Replace",
-					JobTemplate: batchv1beta1.JobTemplateSpec{
-						Spec: batchv1.JobSpec{
+					JobTemplate: k8sbatchv1beta1.JobTemplateSpec{
+						Spec: k8sbatchv1.JobSpec{
 							TTLSecondsAfterFinished: &defaultTTL,
-							Template: corev1.PodTemplateSpec{
-								ObjectMeta: metav1.ObjectMeta{
+							Template: k8scorev1.PodTemplateSpec{
+								ObjectMeta: k8smetav1.ObjectMeta{
 									Labels: map[string]string{
 										LabelRepoName:      "my-charts-in-otherns",
 										LabelRepoNamespace: "otherns",
 									},
 									Annotations: map[string]string{},
 								},
-								Spec: corev1.PodSpec{
+								Spec: k8scorev1.PodSpec{
 									RestartPolicy: "OnFailure",
-									Containers: []corev1.Container{
+									Containers: []k8scorev1.Container{
 										{
 											Name:            "sync",
 											Image:           repoSyncImage,
@@ -288,16 +288,16 @@ func Test_newCronJob(t *testing.T) {
 												"https://charts.acme.com/my-charts",
 												"helm",
 											},
-											Env: []corev1.EnvVar{
+											Env: []k8scorev1.EnvVar{
 												{
 													Name: "DB_PASSWORD",
-													ValueFrom: &corev1.EnvVarSource{
-														SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+													ValueFrom: &k8scorev1.EnvVarSource{
+														SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 												},
 												{
 													Name: "AUTHORIZATION_HEADER",
-													ValueFrom: &corev1.EnvVarSource{
-														SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "otherns-apprepo-my-charts-in-otherns"}, Key: "AuthorizationHeader"}},
+													ValueFrom: &k8scorev1.EnvVarSource{
+														SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "otherns-apprepo-my-charts-in-otherns"}, Key: "AuthorizationHeader"}},
 												},
 											},
 											VolumeMounts: nil,
@@ -332,17 +332,17 @@ func Test_newSyncJob(t *testing.T) {
 		name             string
 		userAgentComment string
 		apprepo          *apprepov1alpha1.AppRepository
-		expected         batchv1.Job
+		expected         k8sbatchv1.Job
 	}{
 		{
 			"my-charts",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -355,13 +355,13 @@ func Test_newSyncJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-sync-my-charts-",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -371,19 +371,19 @@ func Test_newSyncJob(t *testing.T) {
 					Annotations: map[string]string{},
 					Labels:      map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "kubeapps",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -400,11 +400,11 @@ func Test_newSyncJob(t *testing.T) {
 										"https://charts.acme.com/my-charts",
 										"helm",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 									},
 									VolumeMounts: nil,
@@ -420,11 +420,11 @@ func Test_newSyncJob(t *testing.T) {
 			"an app repository in another namespace results in jobs without owner references",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "my-other-namespace",
 					Labels: map[string]string{
@@ -437,25 +437,25 @@ func Test_newSyncJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-my-other-namespace-sync-my-charts-",
 					Annotations:  map[string]string{},
 					Labels:       map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "my-other-namespace",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -472,11 +472,11 @@ func Test_newSyncJob(t *testing.T) {
 										"https://charts.acme.com/my-charts",
 										"helm",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 									},
 									VolumeMounts: nil,
@@ -492,11 +492,11 @@ func Test_newSyncJob(t *testing.T) {
 			"my-charts with auth and userAgent comment",
 			"kubeapps/v2.3",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -509,17 +509,17 @@ func Test_newSyncJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 					Auth: apprepov1alpha1.AppRepositoryAuth{
 						Header: &apprepov1alpha1.AppRepositoryAuthHeader{
-							SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"}},
+							SecretKeyRef: k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"}},
 					},
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-sync-my-charts-",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -529,19 +529,19 @@ func Test_newSyncJob(t *testing.T) {
 					Annotations: map[string]string{},
 					Labels:      map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "kubeapps",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -559,16 +559,16 @@ func Test_newSyncJob(t *testing.T) {
 										"https://charts.acme.com/my-charts",
 										"helm",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 										{
 											Name: "AUTHORIZATION_HEADER",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"}},
 										},
 									},
 									VolumeMounts: nil,
@@ -584,11 +584,11 @@ func Test_newSyncJob(t *testing.T) {
 			"my-charts with a customCA",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -601,18 +601,18 @@ func Test_newSyncJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 					Auth: apprepov1alpha1.AppRepositoryAuth{
 						CustomCA: &apprepov1alpha1.AppRepositoryCustomCA{
-							SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "ca-cert-test"}, Key: "foo"},
+							SecretKeyRef: k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "ca-cert-test"}, Key: "foo"},
 						},
 					},
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-sync-my-charts-",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -622,19 +622,19 @@ func Test_newSyncJob(t *testing.T) {
 					Annotations: map[string]string{},
 					Labels:      map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "kubeapps",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -651,26 +651,26 @@ func Test_newSyncJob(t *testing.T) {
 										"https://charts.acme.com/my-charts",
 										"helm",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 									},
-									VolumeMounts: []corev1.VolumeMount{{
+									VolumeMounts: []k8scorev1.VolumeMount{{
 										Name:      "ca-cert-test",
 										ReadOnly:  true,
 										MountPath: "/usr/local/share/ca-certificates",
 									}},
 								},
 							},
-							Volumes: []corev1.Volume{{
+							Volumes: []k8scorev1.Volume{{
 								Name: "ca-cert-test",
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{
+								VolumeSource: k8scorev1.VolumeSource{
+									Secret: &k8scorev1.SecretVolumeSource{
 										SecretName: "ca-cert-test",
-										Items: []corev1.KeyToPath{
+										Items: []k8scorev1.KeyToPath{
 											{Key: "foo", Path: "ca.crt"},
 										},
 									},
@@ -685,11 +685,11 @@ func Test_newSyncJob(t *testing.T) {
 			"my-charts with a customCA and auth header",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -702,21 +702,21 @@ func Test_newSyncJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 					Auth: apprepov1alpha1.AppRepositoryAuth{
 						CustomCA: &apprepov1alpha1.AppRepositoryCustomCA{
-							SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "ca-cert-test"}, Key: "foo"},
+							SecretKeyRef: k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "ca-cert-test"}, Key: "foo"},
 						},
 						Header: &apprepov1alpha1.AppRepositoryAuthHeader{
-							SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"},
+							SecretKeyRef: k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"},
 						},
 					},
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-sync-my-charts-",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -726,19 +726,19 @@ func Test_newSyncJob(t *testing.T) {
 					Annotations: map[string]string{},
 					Labels:      map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "kubeapps",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -755,31 +755,31 @@ func Test_newSyncJob(t *testing.T) {
 										"https://charts.acme.com/my-charts",
 										"helm",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 										{
 											Name: "AUTHORIZATION_HEADER",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: "AuthorizationHeader"}},
 										},
 									},
-									VolumeMounts: []corev1.VolumeMount{{
+									VolumeMounts: []k8scorev1.VolumeMount{{
 										Name:      "ca-cert-test",
 										ReadOnly:  true,
 										MountPath: "/usr/local/share/ca-certificates",
 									}},
 								},
 							},
-							Volumes: []corev1.Volume{{
+							Volumes: []k8scorev1.Volume{{
 								Name: "ca-cert-test",
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{
+								VolumeSource: k8scorev1.VolumeSource{
+									Secret: &k8scorev1.SecretVolumeSource{
 										SecretName: "ca-cert-test",
-										Items: []corev1.KeyToPath{
+										Items: []k8scorev1.KeyToPath{
 											{Key: "foo", Path: "ca.crt"},
 										},
 									},
@@ -794,11 +794,11 @@ func Test_newSyncJob(t *testing.T) {
 			"my-charts linked to docker registry creds",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -811,18 +811,18 @@ func Test_newSyncJob(t *testing.T) {
 					URL:  "https://charts.acme.com/my-charts",
 					Auth: apprepov1alpha1.AppRepositoryAuth{
 						Header: &apprepov1alpha1.AppRepositoryAuthHeader{
-							SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: ".dockerconfigjson"},
+							SecretKeyRef: k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: ".dockerconfigjson"},
 						},
 					},
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-sync-my-charts-",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -832,19 +832,19 @@ func Test_newSyncJob(t *testing.T) {
 					Annotations: map[string]string{},
 					Labels:      map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "kubeapps",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -861,16 +861,16 @@ func Test_newSyncJob(t *testing.T) {
 										"https://charts.acme.com/my-charts",
 										"helm",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 										{
 											Name: "DOCKER_CONFIG_JSON",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: ".dockerconfigjson"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "apprepo-my-charts-secrets"}, Key: ".dockerconfigjson"}},
 										},
 									},
 								},
@@ -884,11 +884,11 @@ func Test_newSyncJob(t *testing.T) {
 			"my-charts with a custom pod template",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -899,35 +899,35 @@ func Test_newSyncJob(t *testing.T) {
 				Spec: apprepov1alpha1.AppRepositorySpec{
 					Type: "helm",
 					URL:  "https://charts.acme.com/my-charts",
-					SyncJobPodTemplate: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					SyncJobPodTemplate: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								"foo": "bar",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
-							Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{}}},
-							Containers: []corev1.Container{
+						Spec: k8scorev1.PodSpec{
+							Affinity: &k8scorev1.Affinity{NodeAffinity: &k8scorev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &k8scorev1.NodeSelector{}}},
+							Containers: []k8scorev1.Container{
 								{
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{Name: "FOO", Value: "BAR"},
 									},
-									VolumeMounts: []corev1.VolumeMount{{Name: "foo", MountPath: "/bar"}},
+									VolumeMounts: []k8scorev1.VolumeMount{{Name: "foo", MountPath: "/bar"}},
 								},
 							},
-							Volumes: []corev1.Volume{{Name: "foo", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+							Volumes: []k8scorev1.Volume{{Name: "foo", VolumeSource: k8scorev1.VolumeSource{EmptyDir: &k8scorev1.EmptyDirVolumeSource{}}}},
 						},
 					},
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-sync-my-charts-",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -937,10 +937,10 @@ func Test_newSyncJob(t *testing.T) {
 					Annotations: map[string]string{},
 					Labels:      map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "kubeapps",
@@ -948,10 +948,10 @@ func Test_newSyncJob(t *testing.T) {
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
-							Affinity:      &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{}}},
+						Spec: k8scorev1.PodSpec{
+							Affinity:      &k8scorev1.Affinity{NodeAffinity: &k8scorev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &k8scorev1.NodeSelector{}}},
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -968,18 +968,18 @@ func Test_newSyncJob(t *testing.T) {
 										"https://charts.acme.com/my-charts",
 										"helm",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{Name: "FOO", Value: "BAR"},
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 									},
-									VolumeMounts: []corev1.VolumeMount{{Name: "foo", MountPath: "/bar"}},
+									VolumeMounts: []k8scorev1.VolumeMount{{Name: "foo", MountPath: "/bar"}},
 								},
 							},
-							Volumes: []corev1.Volume{{Name: "foo", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+							Volumes: []k8scorev1.Volume{{Name: "foo", VolumeSource: k8scorev1.VolumeSource{EmptyDir: &k8scorev1.EmptyDirVolumeSource{}}}},
 						},
 					},
 				},
@@ -989,11 +989,11 @@ func Test_newSyncJob(t *testing.T) {
 			"OCI registry with repositories",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -1007,13 +1007,13 @@ func Test_newSyncJob(t *testing.T) {
 					OCIRepositories: []string{"apache", "jenkins"},
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-sync-my-charts-",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -1023,19 +1023,19 @@ func Test_newSyncJob(t *testing.T) {
 					Annotations: map[string]string{},
 					Labels:      map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "kubeapps",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -1054,11 +1054,11 @@ func Test_newSyncJob(t *testing.T) {
 										"--oci-repositories",
 										"apache,jenkins",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 									},
 									VolumeMounts: nil,
@@ -1074,11 +1074,11 @@ func Test_newSyncJob(t *testing.T) {
 			"Skip TLS verification",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -1093,13 +1093,13 @@ func Test_newSyncJob(t *testing.T) {
 					TLSInsecureSkipVerify: true,
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-sync-my-charts-",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -1109,19 +1109,19 @@ func Test_newSyncJob(t *testing.T) {
 					Annotations: map[string]string{},
 					Labels:      map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "kubeapps",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -1141,11 +1141,11 @@ func Test_newSyncJob(t *testing.T) {
 										"apache,jenkins",
 										"--tls-insecure-skip-verify",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 									},
 									VolumeMounts: nil,
@@ -1161,11 +1161,11 @@ func Test_newSyncJob(t *testing.T) {
 			"Paas credentials",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -1180,13 +1180,13 @@ func Test_newSyncJob(t *testing.T) {
 					PassCredentials: true,
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-sync-my-charts-",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -1196,19 +1196,19 @@ func Test_newSyncJob(t *testing.T) {
 					Annotations: map[string]string{},
 					Labels:      map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "kubeapps",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -1228,11 +1228,11 @@ func Test_newSyncJob(t *testing.T) {
 										"apache,jenkins",
 										"--pass-credentials",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 									},
 									VolumeMounts: nil,
@@ -1248,11 +1248,11 @@ func Test_newSyncJob(t *testing.T) {
 			"Repository with filters",
 			"",
 			&apprepov1alpha1.AppRepository{
-				TypeMeta: metav1.TypeMeta{
+				TypeMeta: k8smetav1.TypeMeta{
 					Kind:       "AppRepository",
 					APIVersion: "kubeapps.com/v1alpha1",
 				},
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -1268,13 +1268,13 @@ func Test_newSyncJob(t *testing.T) {
 					},
 				},
 			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-sync-my-charts-",
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(
-							&apprepov1alpha1.AppRepository{ObjectMeta: metav1.ObjectMeta{Name: "my-charts"}},
-							schema.GroupVersionKind{
+					OwnerReferences: []k8smetav1.OwnerReference{
+						*k8smetav1.NewControllerRef(
+							&apprepov1alpha1.AppRepository{ObjectMeta: k8smetav1.ObjectMeta{Name: "my-charts"}},
+							k8sschema.GroupVersionKind{
 								Group:   apprepov1alpha1.SchemeGroupVersion.Group,
 								Version: apprepov1alpha1.SchemeGroupVersion.Version,
 								Kind:    "AppRepository",
@@ -1284,19 +1284,19 @@ func Test_newSyncJob(t *testing.T) {
 					Annotations: map[string]string{},
 					Labels:      map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
+					Template: k8scorev1.PodTemplateSpec{
+						ObjectMeta: k8smetav1.ObjectMeta{
 							Labels: map[string]string{
 								LabelRepoName:      "my-charts",
 								LabelRepoNamespace: "kubeapps",
 							},
 							Annotations: map[string]string{},
 						},
-						Spec: corev1.PodSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "OnFailure",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "sync",
 									Image:           repoSyncImage,
@@ -1315,11 +1315,11 @@ func Test_newSyncJob(t *testing.T) {
 										"--filter-rules",
 										`{"jq":".name == $var1","variables":{"$var1":"wordpress"}}`,
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 									},
 									VolumeMounts: nil,
@@ -1351,25 +1351,25 @@ func Test_newCleanupJob(t *testing.T) {
 		name          string
 		repoName      string
 		repoNamespace string
-		expected      batchv1.Job
+		expected      k8sbatchv1.Job
 	}{
 		{
 			"my-charts",
 			"my-charts",
 			"kubeapps",
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
+			k8sbatchv1.Job{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					GenerateName: "apprepo-kubeapps-cleanup-my-charts-",
 					Namespace:    "kubeapps",
 					Annotations:  map[string]string{},
 					Labels:       map[string]string{},
 				},
-				Spec: batchv1.JobSpec{
+				Spec: k8sbatchv1.JobSpec{
 					TTLSecondsAfterFinished: &defaultTTL,
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
+					Template: k8scorev1.PodTemplateSpec{
+						Spec: k8scorev1.PodSpec{
 							RestartPolicy: "Never",
-							Containers: []corev1.Container{
+							Containers: []k8scorev1.Container{
 								{
 									Name:            "delete",
 									Image:           repoSyncImage,
@@ -1383,11 +1383,11 @@ func Test_newCleanupJob(t *testing.T) {
 										"--database-user=admin",
 										"--database-name=assets",
 									},
-									Env: []corev1.EnvVar{
+									Env: []k8scorev1.EnvVar{
 										{
 											Name: "DB_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
+											ValueFrom: &k8scorev1.EnvVarSource{
+												SecretKeyRef: &k8scorev1.SecretKeySelector{LocalObjectReference: k8scorev1.LocalObjectReference{Name: "postgresql"}, Key: "postgresql-root-password"}},
 										},
 									},
 								},
@@ -1412,14 +1412,14 @@ func Test_newCleanupJob(t *testing.T) {
 func TestObjectBelongsTo(t *testing.T) {
 	testCases := []struct {
 		name   string
-		object metav1.Object
-		parent metav1.Object
+		object k8smetav1.Object
+		parent k8smetav1.Object
 		expect bool
 	}{
 		{
 			name: "it recognises a cronjob belonging to an app repository in another namespace",
-			object: &batchv1beta1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
+			object: &k8sbatchv1beta1.CronJob{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "apprepo-kubeapps-sync-my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -1429,7 +1429,7 @@ func TestObjectBelongsTo(t *testing.T) {
 				},
 			},
 			parent: &apprepov1alpha1.AppRepository{
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "my-namespace",
 				},
@@ -1438,8 +1438,8 @@ func TestObjectBelongsTo(t *testing.T) {
 		},
 		{
 			name: "it returns false if the namespace does not match",
-			object: &batchv1beta1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
+			object: &k8sbatchv1beta1.CronJob{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "apprepo-kubeapps-sync-my-charts",
 					Namespace: "kubeapps",
 					Labels: map[string]string{
@@ -1449,7 +1449,7 @@ func TestObjectBelongsTo(t *testing.T) {
 				},
 			},
 			parent: &apprepov1alpha1.AppRepository{
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "my-charts",
 					Namespace: "my-namespace2",
 				},

--- a/cmd/asset-syncer/cmd/root.go
+++ b/cmd/asset-syncer/cmd/root.go
@@ -7,16 +7,15 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubeapps/kubeapps/cmd/asset-syncer/server"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
+	assetsyncerserver "github.com/kubeapps/kubeapps/cmd/asset-syncer/server"
+	cobra "github.com/spf13/cobra"
+	viper "github.com/spf13/viper"
 	log "k8s.io/klog/v2"
 )
 
 var (
 	cfgFile   string
-	serveOpts server.Config
+	serveOpts assetsyncerserver.Config
 	// This Version var is updated during the build
 	// see the -ldflags option in the cmd/asset-syncer/Dockerfile
 	version = "devel"
@@ -45,7 +44,7 @@ func newSyncCmd() *cobra.Command {
 		Use:   "sync [REPO NAME] [REPO URL] [REPO TYPE]",
 		Short: "Add a new chart repository, and resync its charts periodically",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return server.Sync(serveOpts, version, args)
+			return assetsyncerserver.Sync(serveOpts, version, args)
 		},
 		Version: "devel",
 	}
@@ -57,7 +56,7 @@ func newDeleteCmd() *cobra.Command {
 		Use:   "delete [REPO NAME]",
 		Short: "delete a package repository",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return server.Delete(serveOpts, args)
+			return assetsyncerserver.Delete(serveOpts, args)
 		},
 		Version: "devel",
 	}
@@ -69,7 +68,7 @@ func newInvalidateCacheCmd() *cobra.Command {
 		Use:   "invalidate-cache",
 		Short: "removes all data so the cache can be rebuilt",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return server.InvalidateCache(serveOpts, args)
+			return assetsyncerserver.InvalidateCache(serveOpts, args)
 		},
 		Version: "devel",
 	}
@@ -102,7 +101,7 @@ func init() {
 	serveOpts.KubeappsNamespace = os.Getenv("POD_NAMESPACE")
 	serveOpts.AuthorizationHeader = os.Getenv("AUTHORIZATION_HEADER")
 	serveOpts.DockerConfigJson = os.Getenv("DOCKER_CONFIG_JSON")
-	serveOpts.UserAgent = server.GetUserAgent(version, serveOpts.UserAgent)
+	serveOpts.UserAgent = assetsyncerserver.GetUserAgent(version, serveOpts.UserAgent)
 
 	// Register each command to the root cmd
 	cmds := []*cobra.Command{syncCmd, deleteCmd, invalidateCacheCmd}

--- a/cmd/asset-syncer/cmd/root_test.go
+++ b/cmd/asset-syncer/cmd/root_test.go
@@ -7,15 +7,15 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/cmd/asset-syncer/server"
+	cmp "github.com/google/go-cmp/cmp"
+	assetsyncerserver "github.com/kubeapps/kubeapps/cmd/asset-syncer/server"
 )
 
 func TestParseFlagsCorrect(t *testing.T) {
 	var tests = []struct {
 		name string
 		args []string
-		conf server.Config
+		conf assetsyncerserver.Config
 	}{
 		{
 			"all arguments are captured (root command)",
@@ -32,7 +32,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--pass-credentials", "true",
 				"--oci-repositories", "foo07",
 			},
-			server.Config{
+			assetsyncerserver.Config{
 				DatabaseURL:           "foo01",
 				DatabaseName:          "foo02",
 				DatabaseUser:          "foo03",
@@ -62,7 +62,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--pass-credentials", "true",
 				"--oci-repositories", "foo07",
 			},
-			server.Config{
+			assetsyncerserver.Config{
 				DatabaseURL:           "foo01",
 				DatabaseName:          "foo02",
 				DatabaseUser:          "foo03",
@@ -92,7 +92,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--pass-credentials", "true",
 				"--oci-repositories", "foo07",
 			},
-			server.Config{
+			assetsyncerserver.Config{
 				DatabaseURL:           "foo01",
 				DatabaseName:          "foo02",
 				DatabaseUser:          "foo03",
@@ -118,7 +118,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 			setSyncFlags(cmd)
 			cmd.SetArgs(tt.args)
 			cmd.Execute()
-			serveOpts.UserAgent = server.GetUserAgent(version, serveOpts.UserAgent)
+			serveOpts.UserAgent = assetsyncerserver.GetUserAgent(version, serveOpts.UserAgent)
 			if got, want := serveOpts, tt.conf; !cmp.Equal(want, got) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 			}

--- a/cmd/asset-syncer/main.go
+++ b/cmd/asset-syncer/main.go
@@ -3,8 +3,10 @@
 
 package main
 
-import "github.com/kubeapps/kubeapps/cmd/asset-syncer/cmd"
+import (
+	assetsyncercmd "github.com/kubeapps/kubeapps/cmd/asset-syncer/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	assetsyncercmd.Execute()
 }

--- a/cmd/asset-syncer/server/delete.go
+++ b/cmd/asset-syncer/server/delete.go
@@ -6,8 +6,8 @@ package server
 import (
 	"fmt"
 
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
 	log "k8s.io/klog/v2"
 )
 
@@ -27,7 +27,7 @@ func Delete(serveOpts Config, args []string) error {
 	}
 	defer manager.Close()
 
-	repo := models.Repo{Name: args[0], Namespace: serveOpts.Namespace}
+	repo := chartmodels.Repo{Name: args[0], Namespace: serveOpts.Namespace}
 	if err = manager.Delete(repo); err != nil {
 		return fmt.Errorf("Can't delete chart repository %s from database: %v", args[0], err)
 	}

--- a/cmd/asset-syncer/server/invalidate-cache.go
+++ b/cmd/asset-syncer/server/invalidate-cache.go
@@ -6,7 +6,7 @@ package server
 import (
 	"fmt"
 
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
+	dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
 	log "k8s.io/klog/v2"
 )
 

--- a/cmd/asset-syncer/server/postgresql_utils_test.go
+++ b/cmd/asset-syncer/server/postgresql_utils_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
 )
 
 func getMockManager(t *testing.T) (*postgresAssetManager, sqlmock.Sqlmock, func()) {
@@ -29,7 +29,7 @@ func Test_DeletePGRepo(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
-	repo := models.Repo{Name: "testrepo", Namespace: "testnamespace"}
+	repo := chartmodels.Repo{Name: "testrepo", Namespace: "testnamespace"}
 	mock.ExpectQuery(`DELETE FROM repos WHERE name = \$1 AND namespace = \$2`).
 		WithArgs(repo.Name, repo.Namespace).
 		WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
@@ -48,7 +48,7 @@ func Test_PGRepoLastChecksum(t *testing.T) {
 		WithArgs("foo", "repo-namespace").
 		WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("123"))
 
-	got := pgManager.LastChecksum(models.Repo{Namespace: "repo-namespace", Name: "foo"})
+	got := pgManager.LastChecksum(chartmodels.Repo{Namespace: "repo-namespace", Name: "foo"})
 	if got != "123" {
 		t.Errorf("got: %s, want: %s", got, "123")
 	}
@@ -79,8 +79,8 @@ func Test_PGremoveMissingCharts(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
-	repo := models.Repo{Name: "repo"}
-	charts := []models.Chart{{ID: "foo", Repo: &repo}, {ID: "bar"}}
+	repo := chartmodels.Repo{Name: "repo"}
+	charts := []chartmodels.Chart{{ID: "foo", Repo: &repo}, {ID: "bar"}}
 	mock.ExpectQuery(`^DELETE FROM charts WHERE chart_id NOT IN \('foo', 'bar'\) AND repo_name = \$1 AND repo_namespace = \$2`).
 		WithArgs(repo.Name, repo.Namespace).
 		WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1).AddRow(2))
@@ -103,7 +103,7 @@ func Test_PGupdateIcon(t *testing.T) {
 			WithArgs("stable/wordpress", "repo-namespace", "repo-name").
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1))
 
-		err := pgManager.updateIcon(models.Repo{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
+		err := pgManager.updateIcon(chartmodels.Repo{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
 
 		if err != nil {
 			t.Errorf("%+v", err)
@@ -117,7 +117,7 @@ func Test_PGupdateIcon(t *testing.T) {
 			WithArgs("stable/wordpress", "repo-namespace", "repo-name").
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}))
 
-		err := pgManager.updateIcon(models.Repo{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
+		err := pgManager.updateIcon(chartmodels.Repo{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
 
 		if got, want := err, sql.ErrNoRows; got != want {
 			t.Errorf("got: %+v, want: %+v", got, want)
@@ -131,7 +131,7 @@ func Test_PGupdateIcon(t *testing.T) {
 			WithArgs("stable/wordpress", "repo-namespace", "repo-name").
 			WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow(1).AddRow(2))
 
-		err := pgManager.updateIcon(models.Repo{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
+		err := pgManager.updateIcon(chartmodels.Repo{Namespace: "repo-namespace", Name: "repo-name"}, data, contentType, id)
 
 		if got, want := errors.Is(err, ErrMultipleRows), true; got != want {
 			t.Errorf("got: %t, want: %t", got, want)
@@ -147,7 +147,7 @@ func Test_PGfilesExist(t *testing.T) {
 		id     = "stable/wordpress"
 		digest = "foo"
 	)
-	repo := models.Repo{Namespace: "namespace", Name: "repo-name"}
+	repo := chartmodels.Repo{Namespace: "namespace", Name: "repo-name"}
 
 	rows := sqlmock.NewRows([]string{"info"}).AddRow(`true`)
 	mock.ExpectQuery(`^SELECT EXISTS\(
@@ -175,7 +175,7 @@ func Test_PGinsertFiles(t *testing.T) {
 		chartID   string = repoName + "/wordpress"
 		filesID   string = chartID + "-2.1.3"
 	)
-	files := models.ChartFiles{ID: filesID, Readme: "foo", Values: "bar", Repo: &models.Repo{Namespace: namespace, Name: repoName}}
+	files := chartmodels.ChartFiles{ID: filesID, Readme: "foo", Values: "bar", Repo: &chartmodels.Repo{Namespace: namespace, Name: repoName}}
 	mock.ExpectQuery(`INSERT INTO files \(chart_id, repo_name, repo_namespace, chart_files_ID, info\)*`).
 		WithArgs(chartID, repoName, namespace, filesID, files).
 		WillReturnRows(sqlmock.NewRows([]string{"ID"}).AddRow("3"))

--- a/cmd/assetsvc/cmd/root.go
+++ b/cmd/assetsvc/cmd/root.go
@@ -7,15 +7,15 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubeapps/kubeapps/cmd/assetsvc/server"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	assetsvcserver "github.com/kubeapps/kubeapps/cmd/assetsvc/server"
+	cobra "github.com/spf13/cobra"
+	viper "github.com/spf13/viper"
 	log "k8s.io/klog/v2"
 )
 
 var (
 	cfgFile   string
-	serveOpts server.ServeOptions
+	serveOpts assetsvcserver.ServeOptions
 	// This Version var is updated during the build
 	// see the -ldflags option in the cmd/kubeops/Dockerfile
 	version = "devel"
@@ -32,7 +32,7 @@ func newRootCmd() *cobra.Command {
 			log.Infof("assetsvc has been configured with: %#v", serveOpts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return server.Serve(serveOpts)
+			return assetsvcserver.Serve(serveOpts)
 		},
 		Version: "devel",
 	}

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -3,8 +3,10 @@
 
 package main
 
-import "github.com/kubeapps/kubeapps/cmd/assetsvc/cmd"
+import (
+	assetsvccmd "github.com/kubeapps/kubeapps/cmd/assetsvc/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	assetsvccmd.Execute()
 }

--- a/cmd/assetsvc/pkg/utils/postgres_db_test.go
+++ b/cmd/assetsvc/pkg/utils/postgres_db_test.go
@@ -13,10 +13,10 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest"
-	"github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest/pgtest"
+	cmp "github.com/google/go-cmp/cmp"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	dbutilstest "github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest"
+	pgtest "github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest/pgtest"
 	_ "github.com/lib/pq"
 )
 
@@ -32,7 +32,7 @@ func TestGetChart(t *testing.T) {
 	testCases := []struct {
 		name string
 		// existingCharts is a map of charts per namespace
-		existingCharts map[string][]models.Chart
+		existingCharts map[string][]chartmodels.Chart
 		chartId        string
 		namespace      string
 		expectedChart  string
@@ -46,9 +46,9 @@ func TestGetChart(t *testing.T) {
 		},
 		{
 			name: "it returns an error if the chart does not exist in that repo",
-			existingCharts: map[string][]models.Chart{
-				"namespace-1": []models.Chart{
-					models.Chart{ID: "chart-1", Name: "my-chart"},
+			existingCharts: map[string][]chartmodels.Chart{
+				"namespace-1": []chartmodels.Chart{
+					chartmodels.Chart{ID: "chart-1", Name: "my-chart"},
 				},
 			},
 			chartId:     "chart-1",
@@ -57,9 +57,9 @@ func TestGetChart(t *testing.T) {
 		},
 		{
 			name: "it returns the chart matching the chartid",
-			existingCharts: map[string][]models.Chart{
-				"namespace-1": []models.Chart{
-					models.Chart{ID: "chart-1", Name: "my-chart"},
+			existingCharts: map[string][]chartmodels.Chart{
+				"namespace-1": []chartmodels.Chart{
+					chartmodels.Chart{ID: "chart-1", Name: "my-chart"},
 				},
 			},
 			chartId:       "chart-1",
@@ -74,7 +74,7 @@ func TestGetChart(t *testing.T) {
 			pam, cleanup := getInitializedManager(t)
 			defer cleanup()
 			for namespace, charts := range tc.existingCharts {
-				pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repoName, Namespace: namespace})
+				pgtest.EnsureChartsExist(t, pam, charts, chartmodels.Repo{Name: repoName, Namespace: namespace})
 			}
 
 			chart, err := pam.GetChart(tc.namespace, tc.chartId)
@@ -96,7 +96,7 @@ func TestGetVersion(t *testing.T) {
 	testCases := []struct {
 		name string
 		// existingCharts is a map of charts per namespace
-		existingCharts   map[string][]models.Chart
+		existingCharts   map[string][]chartmodels.Chart
 		chartId          string
 		namespace        string
 		requestedVersion string
@@ -111,10 +111,10 @@ func TestGetVersion(t *testing.T) {
 		},
 		{
 			name: "it returns an error if the chart version does not exist",
-			existingCharts: map[string][]models.Chart{
-				"namespace-1": []models.Chart{
-					models.Chart{ID: "chart-1", ChartVersions: []models.ChartVersion{
-						models.ChartVersion{Version: "1.2.3"},
+			existingCharts: map[string][]chartmodels.Chart{
+				"namespace-1": []chartmodels.Chart{
+					chartmodels.Chart{ID: "chart-1", ChartVersions: []chartmodels.ChartVersion{
+						chartmodels.ChartVersion{Version: "1.2.3"},
 					}},
 				},
 			},
@@ -125,10 +125,10 @@ func TestGetVersion(t *testing.T) {
 		},
 		{
 			name: "it returns an error if the chart version does not exist in that namespace",
-			existingCharts: map[string][]models.Chart{
-				"namespace-1": []models.Chart{
-					models.Chart{ID: "chart-1", ChartVersions: []models.ChartVersion{
-						models.ChartVersion{Version: "1.2.3"},
+			existingCharts: map[string][]chartmodels.Chart{
+				"namespace-1": []chartmodels.Chart{
+					chartmodels.Chart{ID: "chart-1", ChartVersions: []chartmodels.ChartVersion{
+						chartmodels.ChartVersion{Version: "1.2.3"},
 					}},
 				},
 			},
@@ -139,11 +139,11 @@ func TestGetVersion(t *testing.T) {
 		},
 		{
 			name: "it returns the chart version matching the chartid and version",
-			existingCharts: map[string][]models.Chart{
-				"namespace-1": []models.Chart{
-					models.Chart{ID: "chart-1", ChartVersions: []models.ChartVersion{
-						models.ChartVersion{Version: "1.2.3"},
-						models.ChartVersion{Version: "4.5.6"},
+			existingCharts: map[string][]chartmodels.Chart{
+				"namespace-1": []chartmodels.Chart{
+					chartmodels.Chart{ID: "chart-1", ChartVersions: []chartmodels.ChartVersion{
+						chartmodels.ChartVersion{Version: "1.2.3"},
+						chartmodels.ChartVersion{Version: "4.5.6"},
 					}},
 				},
 			},
@@ -159,7 +159,7 @@ func TestGetVersion(t *testing.T) {
 			pam, cleanup := getInitializedManager(t)
 			defer cleanup()
 			for namespace, charts := range tc.existingCharts {
-				pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repoName, Namespace: namespace})
+				pgtest.EnsureChartsExist(t, pam, charts, chartmodels.Repo{Name: repoName, Namespace: namespace})
 			}
 
 			chart, err := pam.GetChartVersion(tc.namespace, tc.chartId, tc.requestedVersion)
@@ -188,8 +188,8 @@ func TestGetPaginatedChartList(t *testing.T) {
 		namespaceName = "namespace-name"
 	)
 
-	chartVersions := []models.ChartVersion{
-		models.ChartVersion{
+	chartVersions := []chartmodels.ChartVersion{
+		chartmodels.ChartVersion{
 			Digest: "abc-123",
 		},
 	}
@@ -197,10 +197,10 @@ func TestGetPaginatedChartList(t *testing.T) {
 	testCases := []struct {
 		name string
 		// existingCharts is a map of charts per namespace and repo
-		existingCharts   map[string]map[string][]models.Chart
+		existingCharts   map[string]map[string][]chartmodels.Chart
 		namespace        string
 		repo             string
-		expectedCharts   []*models.Chart
+		expectedCharts   []*chartmodels.Chart
 		expectedErr      error
 		expectedNumPages int
 	}{
@@ -208,157 +208,157 @@ func TestGetPaginatedChartList(t *testing.T) {
 			name:             "it returns an empty list if the repo or namespace do not exist",
 			repo:             "repo-doesnt-exist",
 			namespace:        "doesnt-exist",
-			expectedCharts:   []*models.Chart{},
+			expectedCharts:   []*chartmodels.Chart{},
 			expectedNumPages: 0,
 		},
 		{
 			name:      "it returns charts from a specific repo in a specific namespace",
 			repo:      repoName,
 			namespace: namespaceName,
-			existingCharts: map[string]map[string][]models.Chart{
-				namespaceName: map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
+			existingCharts: map[string]map[string][]chartmodels.Chart{
+				namespaceName: map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 					},
-					"other-repo": []models.Chart{
-						models.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
+					"other-repo": []chartmodels.Chart{
+						chartmodels.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
 					},
 				},
-				"other-namespace": map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
+				"other-namespace": map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
 					},
 				},
 			},
-			expectedCharts: []*models.Chart{
-				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
+			expectedCharts: []*chartmodels.Chart{
+				&chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 			},
 			expectedNumPages: 1,
 		},
 		{
 			name: "it returns charts from multiple repos in a specific namespace",
-			existingCharts: map[string]map[string][]models.Chart{
-				namespaceName: map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
+			existingCharts: map[string]map[string][]chartmodels.Chart{
+				namespaceName: map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 					},
-					"other-repo": []models.Chart{
-						models.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
+					"other-repo": []chartmodels.Chart{
+						chartmodels.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
 					},
 				},
-				"other-namespace": map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
+				"other-namespace": map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
 					},
 				},
 			},
 			repo:      "",
 			namespace: namespaceName,
-			expectedCharts: []*models.Chart{
-				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
-				&models.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
+			expectedCharts: []*chartmodels.Chart{
+				&chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
+				&chartmodels.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
 			},
 			expectedNumPages: 1,
 		},
 		{
 			name: "it includes charts from global repositories and the specific namespace",
-			existingCharts: map[string]map[string][]models.Chart{
-				namespaceName: map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
+			existingCharts: map[string]map[string][]chartmodels.Chart{
+				namespaceName: map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 					},
-					"other-repo": []models.Chart{
-						models.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
-					},
-				},
-				"other-namespace": map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
+					"other-repo": []chartmodels.Chart{
+						chartmodels.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
 					},
 				},
-				dbutilstest.KubeappsTestNamespace: map[string][]models.Chart{
-					"global-repo": []models.Chart{
-						models.Chart{ID: "global-repo/global-chart", Name: "global-chart"},
+				"other-namespace": map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
+					},
+				},
+				dbutilstest.KubeappsTestNamespace: map[string][]chartmodels.Chart{
+					"global-repo": []chartmodels.Chart{
+						chartmodels.Chart{ID: "global-repo/global-chart", Name: "global-chart"},
 					},
 				},
 			},
 			repo:      "",
 			namespace: namespaceName,
-			expectedCharts: []*models.Chart{
-				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
-				&models.Chart{ID: "global-repo/global-chart", Name: "global-chart"},
-				&models.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
+			expectedCharts: []*chartmodels.Chart{
+				&chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
+				&chartmodels.Chart{ID: "global-repo/global-chart", Name: "global-chart"},
+				&chartmodels.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
 			},
 			expectedNumPages: 1,
 		},
 		{
 			name: "it returns charts from multiple repos across all namespaces",
-			existingCharts: map[string]map[string][]models.Chart{
-				namespaceName: map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
+			existingCharts: map[string]map[string][]chartmodels.Chart{
+				namespaceName: map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 					},
-					"other-repo": []models.Chart{
-						models.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
+					"other-repo": []chartmodels.Chart{
+						chartmodels.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
 					},
 				},
-				"other-namespace": map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
+				"other-namespace": map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
 					},
 				},
 			},
 			repo:      "",
 			namespace: "_all",
-			expectedCharts: []*models.Chart{
-				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
-				&models.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
-				&models.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
+			expectedCharts: []*chartmodels.Chart{
+				&chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
+				&chartmodels.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
+				&chartmodels.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
 			},
 			expectedNumPages: 1,
 		},
 		{
 			name: "it returns charts from a single repo across all namespaces",
-			existingCharts: map[string]map[string][]models.Chart{
-				namespaceName: map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
+			existingCharts: map[string]map[string][]chartmodels.Chart{
+				namespaceName: map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
 					},
-					"other-repo": []models.Chart{
-						models.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
+					"other-repo": []chartmodels.Chart{
+						chartmodels.Chart{ID: "other-repo/other-chart", Name: "other-chart"},
 					},
 				},
-				"other-namespace": map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
+				"other-namespace": map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
 					},
 				},
 			},
 			repo:      repoName,
 			namespace: "_all",
-			expectedCharts: []*models.Chart{
-				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
-				&models.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
+			expectedCharts: []*chartmodels.Chart{
+				&chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1"},
+				&chartmodels.Chart{ID: repoName + "/chart-in-other-namespace", Name: "chart-in-other-namespace"},
 			},
 			expectedNumPages: 1,
 		},
 		{
 			name: "it does not remove duplicates",
-			existingCharts: map[string]map[string][]models.Chart{
-				namespaceName: map[string][]models.Chart{
-					repoName: []models.Chart{
-						models.Chart{ID: repoName + "/chart-1", Name: "chart-1", ChartVersions: chartVersions},
+			existingCharts: map[string]map[string][]chartmodels.Chart{
+				namespaceName: map[string][]chartmodels.Chart{
+					repoName: []chartmodels.Chart{
+						chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1", ChartVersions: chartVersions},
 					},
-					"other-repo": []models.Chart{
-						models.Chart{ID: "other-repo/same-chart-different-repo", Name: "same-chart-different-repo", ChartVersions: chartVersions},
+					"other-repo": []chartmodels.Chart{
+						chartmodels.Chart{ID: "other-repo/same-chart-different-repo", Name: "same-chart-different-repo", ChartVersions: chartVersions},
 					},
 				},
 			},
 			repo:      "",
 			namespace: namespaceName,
-			expectedCharts: []*models.Chart{
-				&models.Chart{ID: repoName + "/chart-1", Name: "chart-1", ChartVersions: chartVersions},
-				&models.Chart{ID: "other-repo/same-chart-different-repo", Name: "same-chart-different-repo", ChartVersions: chartVersions},
+			expectedCharts: []*chartmodels.Chart{
+				&chartmodels.Chart{ID: repoName + "/chart-1", Name: "chart-1", ChartVersions: chartVersions},
+				&chartmodels.Chart{ID: "other-repo/same-chart-different-repo", Name: "same-chart-different-repo", ChartVersions: chartVersions},
 			},
 			expectedNumPages: 1,
 		},
@@ -370,7 +370,7 @@ func TestGetPaginatedChartList(t *testing.T) {
 			defer cleanup()
 			for namespace, chartsPerRepo := range tc.existingCharts {
 				for repo, charts := range chartsPerRepo {
-					pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repo, Namespace: namespace})
+					pgtest.EnsureChartsExist(t, pam, charts, chartmodels.Repo{Name: repo, Namespace: namespace})
 				}
 			}
 
@@ -389,9 +389,9 @@ func TestGetPaginatedChartList(t *testing.T) {
 	}
 }
 
-// ByID implements sort.Interface for []models.Chart based on
+// ByID implements sort.Interface for []chartmodels.Chart based on
 // the ID field.
-type byID []*models.Chart
+type byID []*chartmodels.Chart
 
 func (a byID) Len() int           { return len(a) }
 func (a byID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
@@ -405,34 +405,34 @@ func TestGetChartsWithFilters(t *testing.T) {
 		namespaceName = "namespace-name"
 	)
 
-	chartVersion := models.ChartVersion{
+	chartVersion := chartmodels.ChartVersion{
 		Digest:     "abc-123",
 		Version:    "1.0chart",
 		AppVersion: "2.0app",
 	}
 
-	chartVersions := []models.ChartVersion{chartVersion}
+	chartVersions := []chartmodels.ChartVersion{chartVersion}
 
-	chartWithVersionRepo1 := models.Chart{ID: repoName1 + "/chart-1", Name: "chart-1", ChartVersions: chartVersions}
-	chartWithVersionRepo2 := models.Chart{ID: repoName2 + "/chart-1", Name: "chart-1", ChartVersions: chartVersions}
+	chartWithVersionRepo1 := chartmodels.Chart{ID: repoName1 + "/chart-1", Name: "chart-1", ChartVersions: chartVersions}
+	chartWithVersionRepo2 := chartmodels.Chart{ID: repoName2 + "/chart-1", Name: "chart-1", ChartVersions: chartVersions}
 
 	testCases := []struct {
 		name string
 		// existingCharts is a map of charts per namespace and repo
-		existingCharts map[string]map[string][]models.Chart
+		existingCharts map[string]map[string][]chartmodels.Chart
 		namespace      string
 		chartName      string
 		chartVersion   string
 		appVersion     string
-		expectedCharts []*models.Chart
+		expectedCharts []*chartmodels.Chart
 		expectedErr    error
 	}{
 		{
 			name: "returns charts in the specific namespace",
-			existingCharts: map[string]map[string][]models.Chart{
+			existingCharts: map[string]map[string][]chartmodels.Chart{
 				namespaceName: {
 					repoName1: {chartWithVersionRepo1},
-					"other-repo": []models.Chart{
+					"other-repo": []chartmodels.Chart{
 						{ID: "other-repo/other-chart", Name: "other-chart"},
 					},
 				},
@@ -444,13 +444,13 @@ func TestGetChartsWithFilters(t *testing.T) {
 			chartName:    chartWithVersionRepo1.Name,
 			chartVersion: chartWithVersionRepo1.ChartVersions[0].Version,
 			appVersion:   chartWithVersionRepo1.ChartVersions[0].AppVersion,
-			expectedCharts: []*models.Chart{
+			expectedCharts: []*chartmodels.Chart{
 				&chartWithVersionRepo1,
 			},
 		},
 		{
 			name: "returns charts from different repos in the specific namespace",
-			existingCharts: map[string]map[string][]models.Chart{
+			existingCharts: map[string]map[string][]chartmodels.Chart{
 				namespaceName: {
 					repoName1:    {chartWithVersionRepo1},
 					"other-repo": {chartWithVersionRepo2},
@@ -460,14 +460,14 @@ func TestGetChartsWithFilters(t *testing.T) {
 			chartName:    chartWithVersionRepo1.Name,
 			chartVersion: chartWithVersionRepo1.ChartVersions[0].Version,
 			appVersion:   chartWithVersionRepo1.ChartVersions[0].AppVersion,
-			expectedCharts: []*models.Chart{
+			expectedCharts: []*chartmodels.Chart{
 				&chartWithVersionRepo1,
 				&chartWithVersionRepo2,
 			},
 		},
 		{
 			name: "includes charts from global repositories",
-			existingCharts: map[string]map[string][]models.Chart{
+			existingCharts: map[string]map[string][]chartmodels.Chart{
 				namespaceName: {
 					repoName1: {chartWithVersionRepo1},
 				},
@@ -479,7 +479,7 @@ func TestGetChartsWithFilters(t *testing.T) {
 			chartName:    chartWithVersionRepo1.Name,
 			chartVersion: chartWithVersionRepo1.ChartVersions[0].Version,
 			appVersion:   chartWithVersionRepo1.ChartVersions[0].AppVersion,
-			expectedCharts: []*models.Chart{
+			expectedCharts: []*chartmodels.Chart{
 				&chartWithVersionRepo1,
 				&chartWithVersionRepo2,
 			},
@@ -492,7 +492,7 @@ func TestGetChartsWithFilters(t *testing.T) {
 			defer cleanup()
 			for namespace, chartsPerRepo := range tc.existingCharts {
 				for repo, charts := range chartsPerRepo {
-					pgtest.EnsureChartsExist(t, pam, charts, models.Repo{Name: repo, Namespace: namespace})
+					pgtest.EnsureChartsExist(t, pam, charts, chartmodels.Repo{Name: repo, Namespace: namespace})
 				}
 			}
 

--- a/cmd/assetsvc/pkg/utils/postgresql_utils_test.go
+++ b/cmd/assetsvc/pkg/utils/postgresql_utils_test.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	cmp "github.com/google/go-cmp/cmp"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
 )
 
 func getMockManager(t *testing.T) (*PostgresAssetManager, sqlmock.Sqlmock, func()) {
@@ -33,8 +33,8 @@ func Test_PGGetChart(t *testing.T) {
 
 	icon := []byte("test")
 	iconB64 := base64.StdEncoding.EncodeToString(icon)
-	dbChart := models.ChartIconString{
-		Chart:   models.Chart{ID: "foo"},
+	dbChart := chartmodels.ChartIconString{
+		Chart:   chartmodels.Chart{ID: "foo"},
 		RawIcon: iconB64,
 	}
 	dbChartJSON, err := json.Marshal(dbChart)
@@ -49,7 +49,7 @@ func Test_PGGetChart(t *testing.T) {
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}
-	expectedChart := models.Chart{
+	expectedChart := chartmodels.Chart{
 		ID:      "foo",
 		RawIcon: icon,
 	}
@@ -62,9 +62,9 @@ func Test_PGGetChartVersion(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
-	dbChart := models.Chart{
+	dbChart := chartmodels.Chart{
 		ID: "foo",
-		ChartVersions: []models.ChartVersion{
+		ChartVersions: []chartmodels.ChartVersion{
 			{Version: "1.0.0"},
 			{Version: "2.0.0"},
 		},
@@ -81,9 +81,9 @@ func Test_PGGetChartVersion(t *testing.T) {
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}
-	expectedChart := models.Chart{
+	expectedChart := chartmodels.Chart{
 		ID: "foo",
-		ChartVersions: []models.ChartVersion{
+		ChartVersions: []chartmodels.ChartVersion{
 			{Version: "1.0.0"},
 		},
 	}
@@ -96,7 +96,7 @@ func Test_GetChartFiles(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
-	expectedFiles := models.ChartFiles{ID: "foo"}
+	expectedFiles := chartmodels.ChartFiles{ID: "foo"}
 	filesJSON, err := json.Marshal(expectedFiles)
 	if err != nil {
 		t.Fatalf("%+v", err)
@@ -118,7 +118,7 @@ func Test_GetChartFiles_withSlashes(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
-	expectedFiles := models.ChartFiles{ID: "fo%2Fo"}
+	expectedFiles := chartmodels.ChartFiles{ID: "fo%2Fo"}
 	filesJSON, err := json.Marshal(expectedFiles)
 	if err != nil {
 		t.Fatalf("%+v", err)
@@ -140,9 +140,9 @@ func Test_GetChartsWithFilters(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
-	dbChart := models.Chart{
+	dbChart := chartmodels.Chart{
 		Name: "foo",
-		ChartVersions: []models.ChartVersion{
+		ChartVersions: []chartmodels.ChartVersion{
 			{Version: "2.0.0", AppVersion: "2.0.2"},
 			{Version: "1.0.0", AppVersion: "1.0.1"},
 		},
@@ -164,9 +164,9 @@ func Test_GetChartsWithFilters(t *testing.T) {
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}
-	expectedCharts := []*models.Chart{&models.Chart{
+	expectedCharts := []*chartmodels.Chart{&chartmodels.Chart{
 		Name: "foo",
-		ChartVersions: []models.ChartVersion{
+		ChartVersions: []chartmodels.ChartVersion{
 			{Version: "2.0.0", AppVersion: "2.0.2"},
 			{Version: "1.0.0", AppVersion: "1.0.1"},
 		},
@@ -180,9 +180,9 @@ func Test_GetChartsWithFilters_withSlashes(t *testing.T) {
 	pgManager, mock, cleanup := getMockManager(t)
 	defer cleanup()
 
-	dbChart := models.Chart{
+	dbChart := chartmodels.Chart{
 		Name: "fo%2Fo",
-		ChartVersions: []models.ChartVersion{
+		ChartVersions: []chartmodels.ChartVersion{
 			{Version: "2.0.0", AppVersion: "2.0.2"},
 			{Version: "1.0.0", AppVersion: "1.0.1"},
 		},
@@ -204,9 +204,9 @@ func Test_GetChartsWithFilters_withSlashes(t *testing.T) {
 	if err != nil {
 		t.Errorf("Found error %v", err)
 	}
-	expectedCharts := []*models.Chart{&models.Chart{
+	expectedCharts := []*chartmodels.Chart{&chartmodels.Chart{
 		Name: "fo%2Fo",
-		ChartVersions: []models.ChartVersion{
+		ChartVersions: []chartmodels.ChartVersion{
 			{Version: "2.0.0", AppVersion: "2.0.2"},
 			{Version: "1.0.0", AppVersion: "1.0.1"},
 		},
@@ -222,13 +222,13 @@ func Test_GetAllChartCategories(t *testing.T) {
 		name                    string
 		namespace               string
 		repo                    string
-		expectedChartCategories []*models.ChartCategory
+		expectedChartCategories []*chartmodels.ChartCategory
 	}{
 		{
 			name:      "without repo",
 			namespace: "other-namespace",
 			repo:      "",
-			expectedChartCategories: []*models.ChartCategory{
+			expectedChartCategories: []*chartmodels.ChartCategory{
 				{Name: "cat1", Count: 1},
 				{Name: "cat2", Count: 2},
 				{Name: "cat3", Count: 3},
@@ -238,7 +238,7 @@ func Test_GetAllChartCategories(t *testing.T) {
 			name:      "with repo",
 			namespace: "other-namespace",
 			repo:      "bitnami",
-			expectedChartCategories: []*models.ChartCategory{
+			expectedChartCategories: []*chartmodels.ChartCategory{
 				{Name: "cat1", Count: 1},
 				{Name: "cat2", Count: 2},
 				{Name: "cat3", Count: 3},
@@ -274,11 +274,11 @@ func Test_GetAllChartCategories(t *testing.T) {
 	}
 }
 func Test_GetPaginatedChartList(t *testing.T) {
-	availableCharts := []*models.Chart{
-		{ID: "bar", ChartVersions: []models.ChartVersion{{Digest: "456"}}},
-		{ID: "copyFoo", ChartVersions: []models.ChartVersion{{Digest: "123"}}},
-		{ID: "foo", ChartVersions: []models.ChartVersion{{Digest: "123"}}},
-		{ID: "fo%2Fo", ChartVersions: []models.ChartVersion{{Digest: "321"}}},
+	availableCharts := []*chartmodels.Chart{
+		{ID: "bar", ChartVersions: []chartmodels.ChartVersion{{Digest: "456"}}},
+		{ID: "copyFoo", ChartVersions: []chartmodels.ChartVersion{{Digest: "123"}}},
+		{ID: "foo", ChartVersions: []chartmodels.ChartVersion{{Digest: "123"}}},
+		{ID: "fo%2Fo", ChartVersions: []chartmodels.ChartVersion{{Digest: "321"}}},
 	}
 	tests := []struct {
 		name               string
@@ -286,7 +286,7 @@ func Test_GetPaginatedChartList(t *testing.T) {
 		repo               string
 		pageNumber         int
 		pageSize           int
-		expectedCharts     []*models.Chart
+		expectedCharts     []*chartmodels.Chart
 		expectedTotalPages int
 	}{
 		{
@@ -313,7 +313,7 @@ func Test_GetPaginatedChartList(t *testing.T) {
 			repo:               "",
 			pageNumber:         2,
 			pageSize:           2,
-			expectedCharts:     []*models.Chart{availableCharts[2], availableCharts[3]},
+			expectedCharts:     []*chartmodels.Chart{availableCharts[2], availableCharts[3]},
 			expectedTotalPages: 2,
 		},
 		{
@@ -322,7 +322,7 @@ func Test_GetPaginatedChartList(t *testing.T) {
 			repo:               "",
 			pageNumber:         3,
 			pageSize:           2,
-			expectedCharts:     []*models.Chart{},
+			expectedCharts:     []*chartmodels.Chart{},
 			expectedTotalPages: 2,
 		},
 		{
@@ -339,7 +339,7 @@ func Test_GetPaginatedChartList(t *testing.T) {
 			namespace:          "other-namespace",
 			repo:               "",
 			pageSize:           3,
-			expectedCharts:     []*models.Chart{availableCharts[0], availableCharts[1], availableCharts[2]},
+			expectedCharts:     []*chartmodels.Chart{availableCharts[0], availableCharts[1], availableCharts[2]},
 			expectedTotalPages: 2,
 		},
 		{
@@ -357,7 +357,7 @@ func Test_GetPaginatedChartList(t *testing.T) {
 			repo:               "",
 			pageNumber:         -2,
 			pageSize:           2,
-			expectedCharts:     []*models.Chart{availableCharts[0], availableCharts[1]},
+			expectedCharts:     []*chartmodels.Chart{availableCharts[0], availableCharts[1]},
 			expectedTotalPages: 2,
 		},
 		{
@@ -373,7 +373,7 @@ func Test_GetPaginatedChartList(t *testing.T) {
 			namespace:          "other-namespace",
 			repo:               "",
 			pageSize:           2,
-			expectedCharts:     []*models.Chart{availableCharts[0], availableCharts[1]},
+			expectedCharts:     []*chartmodels.Chart{availableCharts[0], availableCharts[1]},
 			expectedTotalPages: 2,
 		},
 		{

--- a/cmd/assetsvc/pkg/utils/utils.go
+++ b/cmd/assetsvc/pkg/utils/utils.go
@@ -4,18 +4,18 @@
 package utils
 
 import (
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
 )
 
 type AssetManager interface {
 	Init() error
 	Close() error
-	GetChart(namespace, chartID string) (models.Chart, error)
-	GetChartVersion(namespace, chartID, version string) (models.Chart, error)
-	GetChartFiles(namespace, filesID string) (models.ChartFiles, error)
-	GetPaginatedChartListWithFilters(cq ChartQuery, pageNumber, pageSize int) ([]*models.Chart, int, error)
-	GetAllChartCategories(cq ChartQuery) ([]*models.ChartCategory, error)
+	GetChart(namespace, chartID string) (chartmodels.Chart, error)
+	GetChartVersion(namespace, chartID, version string) (chartmodels.Chart, error)
+	GetChartFiles(namespace, filesID string) (chartmodels.ChartFiles, error)
+	GetPaginatedChartListWithFilters(cq ChartQuery, pageNumber, pageSize int) ([]*chartmodels.Chart, int, error)
+	GetAllChartCategories(cq ChartQuery) ([]*chartmodels.ChartCategory, error)
 }
 
 // ChartQuery is a container for passing the supported query parameters for generating the WHERE query

--- a/cmd/assetsvc/server/handler_test.go
+++ b/cmd/assetsvc/server/handler_test.go
@@ -17,12 +17,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/disintegration/imaging"
-	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
-	"github.com/stretchr/testify/assert"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	imaging "github.com/disintegration/imaging"
+	assetmanager "github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
+	assert "github.com/stretchr/testify/assert"
 )
 
 type bodyAPIListResponse struct {
@@ -34,7 +34,7 @@ type bodyAPIResponse struct {
 	Data apiResponse `json:"data"`
 }
 
-var chartsList []*models.Chart
+var chartsList []*chartmodels.Chart
 var cc count
 
 const (
@@ -47,7 +47,7 @@ const (
 	testRepoName         = "my-repo"
 )
 
-var testRepo *models.Repo = &models.Repo{Name: testRepoName, Namespace: namespace}
+var testRepo *chartmodels.Repo = &chartmodels.Repo{Name: testRepoName, Namespace: namespace}
 
 func iconBytes() []byte {
 	var b bytes.Buffer
@@ -65,7 +65,7 @@ func setMockManager(t *testing.T) (sqlmock.Sqlmock, func()) {
 	// TODO(absoludity): Let's not use globals for storing state like this.
 	origManager := manager
 
-	manager = &utils.PostgresAssetManager{&dbutils.PostgresAssetManager{DB: db, GlobalReposNamespace: globalReposNamespace}}
+	manager = &assetmanager.PostgresAssetManager{&dbutils.PostgresAssetManager{DB: db, GlobalReposNamespace: globalReposNamespace}}
 
 	return mock, func() { db.Close(); manager = origManager }
 }
@@ -147,15 +147,15 @@ func Test_extractChartQueryFromRequest(t *testing.T) {
 func Test_chartAttributes(t *testing.T) {
 	tests := []struct {
 		name  string
-		chart models.Chart
+		chart chartmodels.Chart
 	}{
-		{"chart enconded has no icon", models.Chart{
+		{"chart enconded has no icon", chartmodels.Chart{
 			Repo: testRepo, Name: "foo%2Fwordpress", ID: "my-repo/foo%2Fwordpress",
 		}},
-		{"chart has no icon", models.Chart{
+		{"chart has no icon", chartmodels.Chart{
 			Repo: testRepo, Name: "wordpress", ID: "my-repo/wordpress",
 		}},
-		{"chart has a icon", models.Chart{
+		{"chart has a icon", chartmodels.Chart{
 			Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", RawIcon: iconBytes(), IconContentType: "image/svg",
 		}},
 	}
@@ -178,13 +178,13 @@ func Test_chartAttributes(t *testing.T) {
 func Test_chartVersionAttributes(t *testing.T) {
 	tests := []struct {
 		name  string
-		chart models.Chart
+		chart chartmodels.Chart
 	}{
-		{"my-chart", models.Chart{
-			Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}},
+		{"my-chart", chartmodels.Chart{
+			Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}},
 		}},
-		{"foo%2Fmy-chart", models.Chart{
-			Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}},
+		{"foo%2Fmy-chart", chartmodels.Chart{
+			Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}},
 		}},
 	}
 	for _, tt := range tests {
@@ -201,19 +201,19 @@ func Test_newChartResponse(t *testing.T) {
 	tests := []struct {
 		name      string
 		chartName string
-		chart     models.Chart
+		chart     chartmodels.Chart
 	}{
-		{"chart has only one version", "my-chart", models.Chart{
-			Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "1.2.3"}}},
+		{"chart has only one version", "my-chart", chartmodels.Chart{
+			Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3"}}},
 		},
-		{"chart encoded has only one version", "foo%2Fmy-chart", models.Chart{
-			Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "1.2.3"}}},
+		{"chart encoded has only one version", "foo%2Fmy-chart", chartmodels.Chart{
+			Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3"}}},
 		},
-		{"chart has many versions", "my-chart", models.Chart{
-			Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.2"}, {Version: "0.1.0"}},
+		{"chart has many versions", "my-chart", chartmodels.Chart{
+			Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.2"}, {Version: "0.1.0"}},
 		}},
-		{"raw_icon is never sent down the wire", "my-chart", models.Chart{
-			Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "1.2.3"}}, RawIcon: iconBytes(), IconContentType: "image/svg",
+		{"raw_icon is never sent down the wire", "my-chart", chartmodels.Chart{
+			Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3"}}, RawIcon: iconBytes(), IconContentType: "image/svg",
 		}},
 	}
 	for _, tt := range tests {
@@ -221,10 +221,10 @@ func Test_newChartResponse(t *testing.T) {
 			cResponse := newChartResponse(&tt.chart)
 			assert.Equal(t, cResponse.Type, "chart", "response type is chart")
 			assert.Equal(t, cResponse.ID, tt.chart.ID, "chart ID should be the same")
-			assert.Equal(t, cResponse.Relationships["latestChartVersion"].Data.(models.ChartVersion).Version, tt.chart.ChartVersions[0].Version, "latestChartVersion should match version at index 0")
+			assert.Equal(t, cResponse.Relationships["latestChartVersion"].Data.(chartmodels.ChartVersion).Version, tt.chart.ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 			assert.Equal(t, cResponse.Links.(selfLink).Self, pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID, "self link should be the same")
 			// We don't send the raw icon down the wire.
-			assert.Nil(t, cResponse.Attributes.(models.Chart).RawIcon)
+			assert.Nil(t, cResponse.Attributes.(chartmodels.Chart).RawIcon)
 		})
 	}
 }
@@ -232,28 +232,28 @@ func Test_newChartResponse(t *testing.T) {
 func Test_newChartListResponse(t *testing.T) {
 	tests := []struct {
 		name   string
-		input  []*models.Chart
-		result []*models.Chart
+		input  []*chartmodels.Chart
+		result []*chartmodels.Chart
 	}{
-		{"no charts", []*models.Chart{}, []*models.Chart{}},
-		{"has one chart", []*models.Chart{
-			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-		}, []*models.Chart{
-			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+		{"no charts", []*chartmodels.Chart{}, []*chartmodels.Chart{}},
+		{"has one chart", []*chartmodels.Chart{
+			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+		}, []*chartmodels.Chart{
+			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 		}},
-		{"has two charts", []*models.Chart{
-			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, Name: "wordpress", ID: "my-repo/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
-		}, []*models.Chart{
-			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, Name: "wordpress", ID: "my-repo/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		{"has two charts", []*chartmodels.Chart{
+			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, Name: "wordpress", ID: "my-repo/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		}, []*chartmodels.Chart{
+			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, Name: "wordpress", ID: "my-repo/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}},
-		{"has two encoded charts", []*models.Chart{
-			{Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, Name: "foo%2Fwordpress", ID: "my-repo/foo%2Fwordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
-		}, []*models.Chart{
-			{Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, Name: "foo%2Fwordpress", ID: "my-repo/foo%2Fwordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		{"has two encoded charts", []*chartmodels.Chart{
+			{Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, Name: "foo%2Fwordpress", ID: "my-repo/foo%2Fwordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		}, []*chartmodels.Chart{
+			{Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, Name: "foo%2Fwordpress", ID: "my-repo/foo%2Fwordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}},
 	}
 
@@ -264,7 +264,7 @@ func Test_newChartListResponse(t *testing.T) {
 			for i := range tt.result {
 				assert.Equal(t, "chart", clResponse[i].Type, "response type is chart")
 				assert.Equal(t, tt.result[i].ID, clResponse[i].ID, "chart ID should be the same")
-				assert.Equal(t, tt.result[i].ChartVersions[0].Version, clResponse[i].Relationships["latestChartVersion"].Data.(models.ChartVersion).Version, "latestChartVersion should match version at index 0")
+				assert.Equal(t, tt.result[i].ChartVersions[0].Version, clResponse[i].Relationships["latestChartVersion"].Data.(chartmodels.ChartVersion).Version, "latestChartVersion should match version at index 0")
 				assert.Equal(t, pathPrefix+"/ns/"+namespace+"/charts/"+tt.result[i].ID, clResponse[i].Links.(selfLink).Self, "self link should be the same")
 			}
 		})
@@ -274,25 +274,25 @@ func Test_newChartListResponse(t *testing.T) {
 func Test_newChartVersionResponse(t *testing.T) {
 	tests := []struct {
 		name         string
-		chart        models.Chart
+		chart        chartmodels.Chart
 		expectedIcon string
 	}{
 		{
 			name: "my-chart",
-			chart: models.Chart{
-				Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.2.3"}},
+			chart: chartmodels.Chart{
+				Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}, {Version: "0.2.3"}},
 			},
 		},
 		{
 			name: "foo%2Fmy-chart",
-			chart: models.Chart{
-				Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.2.3"}},
+			chart: chartmodels.Chart{
+				Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}, {Version: "0.2.3"}},
 			},
 		},
 		{
 			name: "RawIcon is never sent down the wire",
-			chart: models.Chart{
-				Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "1.2.3"}}, RawIcon: iconBytes(), IconContentType: "image/svg",
+			chart: chartmodels.Chart{
+				Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3"}}, RawIcon: iconBytes(), IconContentType: "image/svg",
 			},
 			expectedIcon: "/v1/ns/" + namespace + "/assets/my-repo/my-chart/logo",
 		},
@@ -305,14 +305,14 @@ func Test_newChartVersionResponse(t *testing.T) {
 				assert.Equal(t, "chartVersion", cvResponse.Type, "response type is chartVersion")
 				assert.Equal(t, tt.chart.Repo.Name+"/"+tt.chart.Name+"-"+tt.chart.ChartVersions[i].Version, cvResponse.ID, "response id should have chart version suffix")
 				assert.Equal(t, pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[i].Version, cvResponse.Links.(interface{}).(selfLink).Self, "self link should be the same")
-				assert.Equal(t, tt.chart.ChartVersions[i].Version, cvResponse.Attributes.(models.ChartVersion).Version, "chart version in the response should be the same")
+				assert.Equal(t, tt.chart.ChartVersions[i].Version, cvResponse.Attributes.(chartmodels.ChartVersion).Version, "chart version in the response should be the same")
 
 				// The chart should have had its icon url set and raw icon data removed.
 				expectedChart := tt.chart
 				expectedChart.RawIcon = nil
 				expectedChart.Icon = tt.expectedIcon
-				expectedChart.ChartVersions = []models.ChartVersion{}
-				assert.Equal(t, cvResponse.Relationships["chart"].Data.(interface{}).(models.Chart), expectedChart, "chart in relatioship matches")
+				expectedChart.ChartVersions = []chartmodels.ChartVersion{}
+				assert.Equal(t, cvResponse.Relationships["chart"].Data.(interface{}).(chartmodels.Chart), expectedChart, "chart in relatioship matches")
 			}
 		})
 	}
@@ -321,19 +321,19 @@ func Test_newChartVersionResponse(t *testing.T) {
 func Test_newChartVersionListResponse(t *testing.T) {
 	tests := []struct {
 		name  string
-		chart models.Chart
+		chart chartmodels.Chart
 	}{
-		{"chart has no versions", models.Chart{
-			Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{},
+		{"chart has no versions", chartmodels.Chart{
+			Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{},
 		}},
-		{"chart has one version", models.Chart{
-			Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1"}},
+		{"chart has one version", chartmodels.Chart{
+			Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1"}},
 		}},
-		{"chart has many versions", models.Chart{
-			Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1"}, {Version: "0.0.2"}},
+		{"chart has many versions", chartmodels.Chart{
+			Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1"}, {Version: "0.0.2"}},
 		}},
-		{"chart encoded has many versions", models.Chart{
-			Repo: testRepo, ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1"}, {Version: "0.0.2"}},
+		{"chart encoded has many versions", chartmodels.Chart{
+			Repo: testRepo, ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1"}, {Version: "0.0.2"}},
 		}},
 	}
 
@@ -345,7 +345,7 @@ func Test_newChartVersionListResponse(t *testing.T) {
 				assert.Equal(t, "chartVersion", cvListResponse[i].Type, "response type is chartVersion")
 				assert.Equal(t, tt.chart.ID+"-"+tt.chart.ChartVersions[i].Version, cvListResponse[i].ID, "response id should have chart version suffix")
 				assert.Equal(t, pathPrefix+"/ns/"+namespace+"/charts/"+tt.chart.ID+"/versions/"+tt.chart.ChartVersions[i].Version, cvListResponse[i].Links.(interface{}).(selfLink).Self, "self link should be the same")
-				assert.Equal(t, tt.chart.ChartVersions[i].Version, cvListResponse[i].Attributes.(models.ChartVersion).Version, "chart version in the response should be the same")
+				assert.Equal(t, tt.chart.ChartVersions[i].Version, cvListResponse[i].Attributes.(chartmodels.ChartVersion).Version, "chart version in the response should be the same")
 			}
 		})
 	}
@@ -354,26 +354,26 @@ func Test_newChartVersionListResponse(t *testing.T) {
 func Test_listCharts(t *testing.T) {
 	tests := []struct {
 		name   string
-		charts []*models.Chart
+		charts []*chartmodels.Chart
 		meta   meta
 	}{
-		{"no charts", []*models.Chart{}, meta{TotalPages: 1}},
-		{"one chart", []*models.Chart{
-			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+		{"no charts", []*chartmodels.Chart{}, meta{TotalPages: 1}},
+		{"one chart", []*chartmodels.Chart{
+			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 		}, meta{TotalPages: 1}},
-		{"two charts", []*models.Chart{
-			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, Name: "dokuwiki", ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		{"two charts", []*chartmodels.Chart{
+			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, Name: "dokuwiki", ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}, meta{TotalPages: 1}},
-		{"two charts, one encoded", []*models.Chart{
-			{Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, Name: "dokuwiki", ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		{"two charts, one encoded", []*chartmodels.Chart{
+			{Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, Name: "dokuwiki", ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}, meta{TotalPages: 1}},
-		{"four charts", []*models.Chart{
-			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, Name: "dokuwiki", ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, Name: "drupal", ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, Name: "wordpress", ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"four charts", []*chartmodels.Chart{
+			{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, Name: "dokuwiki", ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, Name: "drupal", ID: "stable/drupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, Name: "wordpress", ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 1}},
 	}
 
@@ -428,76 +428,76 @@ func Test_listRepoCharts(t *testing.T) {
 		name   string
 		repo   string
 		query  string
-		charts []*models.Chart
+		charts []*chartmodels.Chart
 		meta   meta
 	}{
-		{"repo has no charts", "my-repo", "", []*models.Chart{}, meta{TotalPages: 1}},
-		{"repo has one chart", "my-repo", "", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+		{"repo has no charts", "my-repo", "", []*chartmodels.Chart{}, meta{TotalPages: 1}},
+		{"repo has one chart", "my-repo", "", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 		}, meta{TotalPages: 1}},
-		{"repo has many charts", "my-repo", "", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		{"repo has many charts", "my-repo", "", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "my-repo/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}, meta{TotalPages: 1}},
-		{"repo has many encoded charts with pagination", "my-repo", "?page=1&size=2", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "stable/foo%2Fdokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, ID: "stable/foo%2Fdrupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"repo has many encoded charts with pagination", "my-repo", "?page=1&size=2", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "stable/foo%2Fdokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, ID: "stable/foo%2Fdrupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 2}},
-		{"repo has many charts with pagination (2 pages)", "my-repo", "?page=2&size=2", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"repo has many charts with pagination (2 pages)", "my-repo", "?page=2&size=2", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 2}},
-		{"repo has many charts with pagination (non existing page)", "my-repo", "?page=3&size=2", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"repo has many charts with pagination (non existing page)", "my-repo", "?page=3&size=2", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 2}},
-		{"repo has many charts with pagination (out of range size)", "my-repo", "?page=1&size=100", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"repo has many charts with pagination (out of range size)", "my-repo", "?page=1&size=100", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 1}},
-		{"repo has many charts with pagination (w/ page, w size)", "my-repo", "?page=2size=3", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"repo has many charts with pagination (w/ page, w size)", "my-repo", "?page=2size=3", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 1}},
-		{"repo has many charts with pagination (w/ page, w zero size)", "my-repo", "?page=2size=0", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"repo has many charts with pagination (w/ page, w zero size)", "my-repo", "?page=2size=0", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 1}},
-		{"repo has many charts with pagination (w/ wrong page, w/ size)", "my-repo", "?page=-2size=2", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"repo has many charts with pagination (w/ wrong page, w/ size)", "my-repo", "?page=-2size=2", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 1}},
-		{"repo has many charts with pagination (w/ page, w/o size)", "my-repo", "?page=2", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"repo has many charts with pagination (w/ page, w/o size)", "my-repo", "?page=2", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 1}},
-		{"repo has many charts with pagination (w/o page, w/ size)", "my-repo", "?size=2", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"repo has many charts with pagination (w/o page, w/ size)", "my-repo", "?size=2", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 2}},
-		{"repo has many charts with pagination (w/o page, w/o size)", "my-repo", "", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		{"repo has many charts with pagination (w/o page, w/o size)", "my-repo", "", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "stable/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{Repo: testRepo, ID: "stable/drupal", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{Repo: testRepo, ID: "stable/wordpress", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{TotalPages: 1}},
 	}
 
@@ -561,37 +561,37 @@ func Test_getChart(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
-		chart    models.Chart
+		chart    chartmodels.Chart
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart"},
+			chartmodels.Chart{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart encoded does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart"},
+			chartmodels.Chart{Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart encoded exists",
 			nil,
-			models.Chart{Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, Name: "foo%2Fmy-chart", ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			chartmodels.Chart{Repo: testRepo, Name: "my-chart", ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}
@@ -643,37 +643,37 @@ func Test_listChartVersions(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
-		chart    models.Chart
+		chart    chartmodels.Chart
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart"},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart encoded does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{Repo: testRepo, ID: "my-repo/foo%2Fmy-chart"},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/foo%2Fmy-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart encoded exists",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}
@@ -727,37 +727,37 @@ func Test_getChartVersion(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
-		chart    models.Chart
+		chart    chartmodels.Chart
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusNotFound,
 		},
 		{
 			"chart encoded does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{Repo: testRepo, ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart encoded exists",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/foo%2Fmy-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/foo%2Fmy-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}
@@ -809,49 +809,49 @@ func Test_getChartIcon(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
-		chart    models.Chart
+		chart    chartmodels.Chart
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{ID: "my-repo/my-chart"},
+			chartmodels.Chart{ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart encoded does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{ID: "my-repo/foo%2Fmy-chart"},
+			chartmodels.Chart{ID: "my-repo/foo%2Fmy-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart has icon",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", RawIcon: iconBytes(), IconContentType: "image/png"},
+			chartmodels.Chart{ID: "my-repo/my-chart", RawIcon: iconBytes(), IconContentType: "image/png"},
 			http.StatusOK,
 		},
 		{
 			"chart encoded has icon",
 			nil,
-			models.Chart{ID: "my-repo/foo%2Fmy-chart", RawIcon: iconBytes(), IconContentType: "image/png"},
+			chartmodels.Chart{ID: "my-repo/foo%2Fmy-chart", RawIcon: iconBytes(), IconContentType: "image/png"},
 			http.StatusOK,
 		},
 		{
 			"chart does not have a icon",
 			nil,
-			models.Chart{ID: "my-repo/my-chart"},
+			chartmodels.Chart{ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart encoded does not have a icon",
 			nil,
-			models.Chart{ID: "my-repo/foo%2Fmy-chart"},
+			chartmodels.Chart{ID: "my-repo/foo%2Fmy-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart has icon with custom type",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", RawIcon: iconBytes(), IconContentType: "image/svg"},
+			chartmodels.Chart{ID: "my-repo/my-chart", RawIcon: iconBytes(), IconContentType: "image/svg"},
 			http.StatusOK,
 		},
 	}
@@ -902,42 +902,42 @@ func Test_getChartVersionReadme(t *testing.T) {
 		name     string
 		version  string
 		err      error
-		files    models.ChartFiles
+		files    chartmodels.ChartFiles
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			"0.1.0",
 			errors.New("return an error when checking if chart exists"),
-			models.ChartFiles{ID: "my-repo/" + chartName},
+			chartmodels.ChartFiles{ID: "my-repo/" + chartName},
 			http.StatusNotFound,
 		},
 		{
 			"chart encoded does not exist",
 			"0.1.0",
 			errors.New("return an error when checking if chart exists"),
-			models.ChartFiles{ID: "my-repo/" + chartEncodedName},
+			chartmodels.ChartFiles{ID: "my-repo/" + chartEncodedName},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			"1.2.3",
 			nil,
-			models.ChartFiles{ID: "my-repo/" + chartName, Readme: testChartReadme},
+			chartmodels.ChartFiles{ID: "my-repo/" + chartName, Readme: testChartReadme},
 			http.StatusOK,
 		},
 		{
 			"chart encoded exists",
 			"1.2.3",
 			nil,
-			models.ChartFiles{ID: "my-repo/" + chartEncodedName, Readme: testChartReadme},
+			chartmodels.ChartFiles{ID: "my-repo/" + chartEncodedName, Readme: testChartReadme},
 			http.StatusOK,
 		},
 		{
 			"chart does not have a readme",
 			"1.1.1",
 			nil,
-			models.ChartFiles{ID: "my-repo/" + chartName},
+			chartmodels.ChartFiles{ID: "my-repo/" + chartName},
 			http.StatusNotFound,
 		},
 	}
@@ -986,42 +986,42 @@ func Test_getChartVersionValues(t *testing.T) {
 		name     string
 		version  string
 		err      error
-		files    models.ChartFiles
+		files    chartmodels.ChartFiles
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			"0.1.0",
 			errors.New("return an error when checking if chart exists"),
-			models.ChartFiles{ID: "my-repo/my-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart encoded does not exist",
 			"0.1.0",
 			errors.New("return an error when checking if chart exists"),
-			models.ChartFiles{ID: "my-repo/foo%2Fmy-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/foo%2Fmy-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			"3.2.1",
 			nil,
-			models.ChartFiles{ID: "my-repo/my-chart", Values: testChartValues},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart", Values: testChartValues},
 			http.StatusOK,
 		},
 		{
 			"chart encoded exists",
 			"3.2.1",
 			nil,
-			models.ChartFiles{ID: "my-repo/foo%2Fmy-chart", Values: testChartValues},
+			chartmodels.ChartFiles{ID: "my-repo/foo%2Fmy-chart", Values: testChartValues},
 			http.StatusOK,
 		},
 		{
 			"chart does not have values.yaml",
 			"2.2.2",
 			nil,
-			models.ChartFiles{ID: "my-repo/my-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart"},
 			http.StatusOK,
 		},
 	}
@@ -1070,42 +1070,42 @@ func Test_getChartVersionSchema(t *testing.T) {
 		name     string
 		version  string
 		err      error
-		files    models.ChartFiles
+		files    chartmodels.ChartFiles
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			"0.1.0",
 			errors.New("return an error when checking if chart exists"),
-			models.ChartFiles{ID: "my-repo/my-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart encoded not exist",
 			"0.1.0",
 			errors.New("return an error when checking if chart exists"),
-			models.ChartFiles{ID: "my-repo/foo%2Fmy-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/foo%2Fmy-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			"3.2.1",
 			nil,
-			models.ChartFiles{ID: "my-repo/my-chart", Schema: testChartSchema},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart", Schema: testChartSchema},
 			http.StatusOK,
 		},
 		{
 			"chart encoded exists",
 			"3.2.1",
 			nil,
-			models.ChartFiles{ID: "my-repo/foo%2Fmy-chart", Schema: testChartSchema},
+			chartmodels.ChartFiles{ID: "my-repo/foo%2Fmy-chart", Schema: testChartSchema},
 			http.StatusOK,
 		},
 		{
 			"chart does not have values.yaml",
 			"2.2.2",
 			nil,
-			models.ChartFiles{ID: "my-repo/my-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart"},
 			http.StatusOK,
 		},
 	}
@@ -1150,51 +1150,51 @@ func Test_getChartVersionSchema(t *testing.T) {
 }
 
 func Test_findLatestChart(t *testing.T) {
-	chart1 := &models.Chart{
+	chart1 := &chartmodels.Chart{
 		Name:        "foo",
 		ID:          "foo",
 		Category:    "cat1",
 		Description: "best chart",
-		Repo: &models.Repo{
+		Repo: &chartmodels.Repo{
 			Name:      "bar",
 			Namespace: kubeappsNamespace,
 		},
-		ChartVersions: []models.ChartVersion{
+		ChartVersions: []chartmodels.ChartVersion{
 			{Version: "1.0.0", AppVersion: "0.1.0"},
 			{Version: "1.0.0", AppVersion: "whatever"},
 			{Version: "whatever", AppVersion: "1.0.0"},
 		},
 	}
-	chart2 := &models.Chart{
+	chart2 := &chartmodels.Chart{
 		Name:        "no-name",
 		ID:          "no-id",
 		Category:    "no-category",
 		Description: "no-description",
-		Repo: &models.Repo{
+		Repo: &chartmodels.Repo{
 			Name:      "no-repo",
 			Namespace: kubeappsNamespace,
 		},
-		ChartVersions: []models.ChartVersion{
+		ChartVersions: []chartmodels.ChartVersion{
 			{Version: "1.0.0", AppVersion: "whatever"},
 			{Version: "whatever", AppVersion: "1.0.0"},
 		},
 	}
-	chartDup1 := &models.Chart{
+	chartDup1 := &chartmodels.Chart{
 		Name: "foo",
 		ID:   "stable/foo",
-		Repo: &models.Repo{Name: "bar"},
-		ChartVersions: []models.ChartVersion{
+		Repo: &chartmodels.Repo{Name: "bar"},
+		ChartVersions: []chartmodels.ChartVersion{
 			{Version: "1.0.0",
 				AppVersion: "0.1.0",
 				Digest:     "123",
 			},
 		},
 	}
-	chartDup2 := &models.Chart{
+	chartDup2 := &chartmodels.Chart{
 		Name: "foo",
 		ID:   "bitnami/foo",
-		Repo: &models.Repo{Name: "bar"},
-		ChartVersions: []models.ChartVersion{
+		Repo: &chartmodels.Repo{Name: "bar"},
+		ChartVersions: []chartmodels.ChartVersion{
 			{Version: "1.0.0",
 				AppVersion: "0.1.0",
 				Digest:     "123",
@@ -1203,18 +1203,18 @@ func Test_findLatestChart(t *testing.T) {
 	}
 	tests := []struct {
 		name           string
-		charts         []*models.Chart
+		charts         []*chartmodels.Chart
 		chartName      string
 		version        string
 		appVersion     string
 		repos          string
 		categories     string
 		query          string
-		expectedCharts []*models.Chart
+		expectedCharts []*chartmodels.Chart
 	}{
 		{
 			name: "returns no charts (by name)",
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				chart1,
 			},
 			chartName:      "nothing",
@@ -1223,11 +1223,11 @@ func Test_findLatestChart(t *testing.T) {
 			repos:          "",
 			categories:     "",
 			query:          "",
-			expectedCharts: []*models.Chart{},
+			expectedCharts: []*chartmodels.Chart{},
 		},
 		{
 			name: "returns mocked chart (by name)",
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				chart1,
 				chart2,
 			},
@@ -1237,13 +1237,13 @@ func Test_findLatestChart(t *testing.T) {
 			repos:      "",
 			categories: "",
 			query:      "",
-			expectedCharts: []*models.Chart{
+			expectedCharts: []*chartmodels.Chart{
 				chart1,
 			},
 		},
 		{
 			name: "returns mocked chart (by version and appversion)",
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				chart1,
 				chart2,
 			},
@@ -1253,13 +1253,13 @@ func Test_findLatestChart(t *testing.T) {
 			repos:      "",
 			categories: "",
 			query:      "",
-			expectedCharts: []*models.Chart{
+			expectedCharts: []*chartmodels.Chart{
 				chart1,
 			},
 		},
 		{
 			name: "returns mocked chart (by repos)",
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				chart1,
 				chart2,
 			},
@@ -1269,13 +1269,13 @@ func Test_findLatestChart(t *testing.T) {
 			repos:      "bar",
 			categories: "",
 			query:      "",
-			expectedCharts: []*models.Chart{
+			expectedCharts: []*chartmodels.Chart{
 				chart1,
 			},
 		},
 		{
 			name: "returns mocked chart (by category)",
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				chart1,
 				chart2,
 			},
@@ -1285,13 +1285,13 @@ func Test_findLatestChart(t *testing.T) {
 			repos:      "",
 			categories: "cat1",
 			query:      "",
-			expectedCharts: []*models.Chart{
+			expectedCharts: []*chartmodels.Chart{
 				chart1,
 			},
 		},
 		{
 			name: "returns mocked chart (by query)",
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				chart1,
 				chart2,
 			},
@@ -1301,13 +1301,13 @@ func Test_findLatestChart(t *testing.T) {
 			repos:      "",
 			categories: "",
 			query:      "best",
-			expectedCharts: []*models.Chart{
+			expectedCharts: []*chartmodels.Chart{
 				chart1,
 			},
 		},
 		{
 			name: "includes duplicated charts",
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				chartDup1,
 				chartDup2,
 			},
@@ -1317,7 +1317,7 @@ func Test_findLatestChart(t *testing.T) {
 			repos:      "",
 			categories: "",
 			query:      "",
-			expectedCharts: []*models.Chart{
+			expectedCharts: []*chartmodels.Chart{
 				chartDup1,
 				chartDup2,
 			},

--- a/cmd/assetsvc/server/server.go
+++ b/cmd/assetsvc/server/server.go
@@ -8,16 +8,16 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/gorilla/mux"
-	"github.com/heptiolabs/healthcheck"
-	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
+	mux "github.com/gorilla/mux"
+	healthcheck "github.com/heptiolabs/healthcheck"
+	assetmanager "github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
+	dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
 	negroni "github.com/urfave/negroni/v2"
 	log "k8s.io/klog/v2"
 )
 
 type ServeOptions struct {
-	Manager              utils.AssetManager
+	Manager              assetmanager.AssetManager
 	DbURL                string
 	DbName               string
 	DbUsername           string
@@ -27,7 +27,7 @@ type ServeOptions struct {
 }
 
 // TODO(absoludity): Let's not use globals for storing state like this.
-var manager utils.AssetManager
+var manager assetmanager.AssetManager
 
 const pathPrefix = "/v1"
 
@@ -66,7 +66,7 @@ func Serve(serveOpts ServeOptions) error {
 	dbConfig := dbutils.Config{URL: *&serveOpts.DbURL, Database: *&serveOpts.DbName, Username: *&serveOpts.DbUsername, Password: serveOpts.DbPassword}
 
 	var err error
-	manager, err = utils.NewManager("postgresql", dbConfig, serveOpts.GlobalReposNamespace)
+	manager, err = assetmanager.NewManager("postgresql", dbConfig, serveOpts.GlobalReposNamespace)
 	if err != nil {
 		return fmt.Errorf("Error: %v", err)
 	}

--- a/cmd/assetsvc/server/server_test.go
+++ b/cmd/assetsvc/server/server_test.go
@@ -10,9 +10,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/stretchr/testify/assert"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	assert "github.com/stretchr/testify/assert"
 )
 
 // tests the GET /live endpoint
@@ -50,15 +50,15 @@ func Test_GetCharts(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		charts []*models.Chart
+		charts []*chartmodels.Chart
 	}{
-		{"no charts", []*models.Chart{}},
-		{"one chart", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1"}}}},
+		{"no charts", []*chartmodels.Chart{}},
+		{"one chart", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1"}}}},
 		},
-		{"two charts", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		{"two charts", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "my-repo/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}},
 	}
 
@@ -105,21 +105,21 @@ func Test_GetChartCategories(t *testing.T) {
 
 	tests := []struct {
 		name                    string
-		expectedChartCategories []*models.ChartCategory
+		expectedChartCategories []*chartmodels.ChartCategory
 	}{
 		{
 			"no charts",
-			[]*models.ChartCategory{},
+			[]*chartmodels.ChartCategory{},
 		},
 		{
 			"two charts - same category",
-			[]*models.ChartCategory{
+			[]*chartmodels.ChartCategory{
 				{Name: "cat1", Count: 2},
 			},
 		},
 		{
 			"two charts - different category",
-			[]*models.ChartCategory{
+			[]*chartmodels.ChartCategory{
 				{Name: "cat1", Count: 1},
 				{Name: "cat2", Count: 1},
 			},
@@ -161,17 +161,17 @@ func Test_GetChartCategoriesRepo(t *testing.T) {
 	tests := []struct {
 		name                    string
 		repo                    string
-		expectedChartCategories []*models.ChartCategory
+		expectedChartCategories []*chartmodels.ChartCategory
 	}{
 		{
 			"no charts",
 			"my-repo",
-			[]*models.ChartCategory{},
+			[]*chartmodels.ChartCategory{},
 		},
 		{
 			"two charts - same category",
 			"my-repo",
-			[]*models.ChartCategory{
+			[]*chartmodels.ChartCategory{
 				{Name: "cat1", Count: 1},
 				{Name: "cat2", Count: 2},
 				{Name: "cat3", Count: 3},
@@ -180,7 +180,7 @@ func Test_GetChartCategoriesRepo(t *testing.T) {
 		{
 			"two charts - different category",
 			"my-repo",
-			[]*models.ChartCategory{
+			[]*chartmodels.ChartCategory{
 				{Name: "cat1", Count: 1},
 				{Name: "cat2", Count: 2},
 				{Name: "cat3", Count: 3},
@@ -222,15 +222,15 @@ func Test_GetChartsInRepo(t *testing.T) {
 	tests := []struct {
 		name   string
 		repo   string
-		charts []*models.Chart
+		charts []*chartmodels.Chart
 	}{
-		{"repo has no charts", "my-repo", []*models.Chart{}},
-		{"repo has one chart", "my-repo", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+		{"repo has no charts", "my-repo", []*chartmodels.Chart{}},
+		{"repo has one chart", "my-repo", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 		}},
-		{"repo has many charts", "my-repo", []*models.Chart{
-			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{Repo: testRepo, ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		{"repo has many charts", "my-repo", []*chartmodels.Chart{
+			{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{Repo: testRepo, ID: "my-repo/dokuwiki", ChartVersions: []chartmodels.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}},
 	}
 
@@ -277,25 +277,25 @@ func Test_GetChartInRepo(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
-		chart    models.Chart
+		chart    chartmodels.Chart
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart"},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}
@@ -335,25 +335,25 @@ func Test_ListChartVersions(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
-		chart    models.Chart
+		chart    chartmodels.Chart
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart"},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}
@@ -393,25 +393,25 @@ func Test_GetChartVersion(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
-		chart    models.Chart
+		chart    chartmodels.Chart
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}}},
 			http.StatusOK,
 		},
 		{
 			"chart has multiple versions",
 			nil,
-			models.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
+			chartmodels.Chart{Repo: testRepo, ID: "my-repo/my-chart", ChartVersions: []chartmodels.ChartVersion{{Version: "0.1.0"}, {Version: "0.0.1"}}},
 			http.StatusOK,
 		},
 	}
@@ -453,25 +453,25 @@ func Test_GetChartIcon(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
-		chart    models.Chart
+		chart    chartmodels.Chart
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			errors.New("return an error when checking if chart exists"),
-			models.Chart{ID: "my-repo/my-chart"},
+			chartmodels.Chart{ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart has icon",
 			nil,
-			models.Chart{ID: "my-repo/my-chart", RawIcon: iconBytes()},
+			chartmodels.Chart{ID: "my-repo/my-chart", RawIcon: iconBytes()},
 			http.StatusOK,
 		},
 		{
 			"chart does not have a icon",
 			nil,
-			models.Chart{ID: "my-repo/my-chart"},
+			chartmodels.Chart{ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 	}
@@ -513,28 +513,28 @@ func Test_GetChartReadme(t *testing.T) {
 		name     string
 		version  string
 		err      error
-		files    models.ChartFiles
+		files    chartmodels.ChartFiles
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			"0.1.0",
 			errors.New("return an error when checking if chart exists"),
-			models.ChartFiles{ID: "my-repo/my-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			"1.2.3",
 			nil,
-			models.ChartFiles{ID: "my-repo/my-chart", Readme: testChartReadme},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart", Readme: testChartReadme},
 			http.StatusOK,
 		},
 		{
 			"chart does not have a readme",
 			"1.1.1",
 			nil,
-			models.ChartFiles{ID: "my-repo/my-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 	}
@@ -575,28 +575,28 @@ func Test_GetChartValues(t *testing.T) {
 		name     string
 		version  string
 		err      error
-		files    models.ChartFiles
+		files    chartmodels.ChartFiles
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			"0.1.0",
 			errors.New("return an error when checking if chart exists"),
-			models.ChartFiles{ID: "my-repo/my-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			"3.2.1",
 			nil,
-			models.ChartFiles{ID: "my-repo/my-chart", Values: testChartValues},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart", Values: testChartValues},
 			http.StatusOK,
 		},
 		{
 			"chart does not have values.yaml",
 			"2.2.2",
 			nil,
-			models.ChartFiles{ID: "my-repo/my-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart"},
 			http.StatusOK,
 		},
 	}
@@ -637,28 +637,28 @@ func Test_GetChartSchema(t *testing.T) {
 		name     string
 		version  string
 		err      error
-		files    models.ChartFiles
+		files    chartmodels.ChartFiles
 		wantCode int
 	}{
 		{
 			"chart does not exist",
 			"0.1.0",
 			errors.New("return an error when checking if chart exists"),
-			models.ChartFiles{ID: "my-repo/my-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart"},
 			http.StatusNotFound,
 		},
 		{
 			"chart exists",
 			"3.2.1",
 			nil,
-			models.ChartFiles{ID: "my-repo/my-chart", Schema: testChartSchema},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart", Schema: testChartSchema},
 			http.StatusOK,
 		},
 		{
 			"chart does not have values.schema.json",
 			"2.2.2",
 			nil,
-			models.ChartFiles{ID: "my-repo/my-chart"},
+			chartmodels.ChartFiles{ID: "my-repo/my-chart"},
 			http.StatusOK,
 		},
 	}

--- a/cmd/kubeapps-apis/cmd/root.go
+++ b/cmd/kubeapps-apis/cmd/root.go
@@ -4,22 +4,22 @@
 package cmd
 
 import (
-	goflag "flag"
+	"flag"
 	"fmt"
 	"os"
 
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
+	apiscore "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
+	apisserver "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
-	"github.com/spf13/viper"
+	cobra "github.com/spf13/cobra"
+	pflag "github.com/spf13/pflag"
+	viper "github.com/spf13/viper"
 	log "k8s.io/klog/v2"
 )
 
 var (
 	cfgFile   string
-	serveOpts core.ServeOptions
+	serveOpts apiscore.ServeOptions
 	// This version var is updated during the build
 	// see the -ldflags option in the Dockerfile
 	version = "devel"
@@ -40,7 +40,7 @@ The api service serves both gRPC and HTTP requests for the configured APIs.`,
 			log.Infof("kubeapps-apis has been configured with: %#v", serveOpts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return server.Serve(serveOpts)
+			return apisserver.Serve(serveOpts)
 		},
 		Version: "devel",
 	}
@@ -59,8 +59,8 @@ func init() {
 	rootCmd.SetVersionTemplate(version)
 	setFlags(rootCmd)
 	//set initial value of verbosity
-	goflag.Set("v", "3")
-	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	flag.Set("v", "3")
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
 
 func setFlags(c *cobra.Command) {

--- a/cmd/kubeapps-apis/cmd/root_test.go
+++ b/cmd/kubeapps-apis/cmd/root_test.go
@@ -7,15 +7,15 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
+	cmp "github.com/google/go-cmp/cmp"
+	apiscore "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 )
 
 func TestParseFlagsCorrect(t *testing.T) {
 	var tests = []struct {
 		name string
 		args []string
-		conf core.ServeOptions
+		conf apiscore.ServeOptions
 	}{
 		{
 			"all arguments are captured",
@@ -31,7 +31,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--kube-api-qps", "1.0",
 				"--kube-api-burst", "1",
 			},
-			core.ServeOptions{
+			apiscore.ServeOptions{
 				Port:                     901,
 				PluginDirs:               []string{"foo01"},
 				ClustersConfigPath:       "foo02",

--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages.go
@@ -8,24 +8,24 @@ import (
 	"fmt"
 	"strconv"
 
-	. "github.com/ahmetb/go-linq/v3"
+	linq "github.com/ahmetb/go-linq/v3"
 	pluginsv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core/plugins/v1alpha1"
-	packages "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	log "k8s.io/klog/v2"
 )
 
 // pkgPluginsWithServer stores the plugin detail together with its implementation.
 type pkgPluginsWithServer struct {
-	plugin *v1alpha1.Plugin
-	server packages.PackagesServiceServer
+	plugin *pluginsGRPCv1alpha1.Plugin
+	server pkgsGRPCv1alpha1.PackagesServiceServer
 }
 
 // packagesServer implements the API defined in proto/kubeappsapis/core/packages/v1alpha1/packages.proto
 type packagesServer struct {
-	packages.UnimplementedPackagesServiceServer
+	pkgsGRPCv1alpha1.UnimplementedPackagesServiceServer
 
 	// pluginsWithServers is a slice of all registered pluginsWithServers which satisfy the core.packages.v1alpha1
 	// interface.
@@ -37,7 +37,7 @@ func NewPackagesServer(pkgingPlugins []pluginsv1alpha1.PluginWithServer) (*packa
 	// casting.
 	pluginsWithServer := make([]pkgPluginsWithServer, len(pkgingPlugins))
 	for i, p := range pkgingPlugins {
-		pkgsSrv, ok := p.Server.(packages.PackagesServiceServer)
+		pkgsSrv, ok := p.Server.(pkgsGRPCv1alpha1.PackagesServiceServer)
 		if !ok {
 			return nil, fmt.Errorf("Unable to convert plugin %v to core PackagesServicesServer", p)
 		}
@@ -53,25 +53,25 @@ func NewPackagesServer(pkgingPlugins []pluginsv1alpha1.PluginWithServer) (*packa
 }
 
 // GetAvailablePackages returns the packages based on the request.
-func (s packagesServer) GetAvailablePackageSummaries(ctx context.Context, request *packages.GetAvailablePackageSummariesRequest) (*packages.GetAvailablePackageSummariesResponse, error) {
+func (s packagesServer) GetAvailablePackageSummaries(ctx context.Context, request *pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest) (*pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetContext().GetCluster(), request.GetContext().GetNamespace())
 	log.Infof("+core GetAvailablePackageSummaries %s", contextMsg)
 
 	pageOffset, err := pageOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
 	pageSize := request.GetPaginationOptions().GetPageSize()
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Unable to intepret page token %q: %v", request.GetPaginationOptions().GetPageToken(), err)
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Unable to intepret page token %q: %v", request.GetPaginationOptions().GetPageToken(), err)
 	}
 
 	// TODO(agamez): temporarily fetching all the results (size=0) and then paginate them
 	// ideally, paginate each plugin request and then aggregate results.
 	requestN := request
-	requestN.PaginationOptions = &packages.PaginationOptions{
+	requestN.PaginationOptions = &pkgsGRPCv1alpha1.PaginationOptions{
 		PageToken: "0",
 		PageSize:  0,
 	}
 
-	pkgs := []*packages.AvailablePackageSummary{}
+	pkgs := []*pkgsGRPCv1alpha1.AvailablePackageSummary{}
 	categories := []string{}
 
 	// TODO: We can do these in parallel in separate go routines.
@@ -82,7 +82,7 @@ func (s packagesServer) GetAvailablePackageSummaries(ctx context.Context, reques
 
 			response, err := p.server.GetAvailablePackageSummaries(ctx, requestN)
 			if err != nil {
-				return nil, status.Errorf(status.Convert(err).Code(), "Invalid GetAvailablePackageSummaries response from the plugin %v: %v", p.plugin.Name, err)
+				return nil, grpcstatus.Errorf(grpcstatus.Convert(err).Code(), "Invalid GetAvailablePackageSummaries response from the plugin %v: %v", p.plugin.Name, err)
 			}
 
 			categories = append(categories, response.Categories...)
@@ -91,7 +91,7 @@ func (s packagesServer) GetAvailablePackageSummaries(ctx context.Context, reques
 			pluginPkgs := response.AvailablePackageSummaries
 			for _, r := range pluginPkgs {
 				if r.AvailablePackageRef == nil {
-					r.AvailablePackageRef = &packages.AvailablePackageReference{}
+					r.AvailablePackageRef = &pkgsGRPCv1alpha1.AvailablePackageReference{}
 				}
 				r.AvailablePackageRef.Plugin = p.plugin
 			}
@@ -99,17 +99,17 @@ func (s packagesServer) GetAvailablePackageSummaries(ctx context.Context, reques
 		}
 	}
 	// Delete duplicate categories and sort by name
-	From(categories).Distinct().OrderBy(func(i interface{}) interface{} { return i }).ToSlice(&categories)
+	linq.From(categories).Distinct().OrderBy(func(i interface{}) interface{} { return i }).ToSlice(&categories)
 
 	// Only return a next page token if the request was for pagination and
 	// the results are a full page.
 	nextPageToken := ""
 	if pageSize > 0 {
 		// Using https://github.com/ahmetb/go-linq for simplicity
-		From(pkgs).
+		linq.From(pkgs).
 			// Order by package name, regardless of the plugin
 			OrderBy(func(pkg interface{}) interface{} {
-				return pkg.(*packages.AvailablePackageSummary).Name + pkg.(*packages.AvailablePackageSummary).AvailablePackageRef.Plugin.Name
+				return pkg.(*pkgsGRPCv1alpha1.AvailablePackageSummary).Name + pkg.(*pkgsGRPCv1alpha1.AvailablePackageSummary).AvailablePackageRef.Plugin.Name
 			}).
 			Skip(pageOffset * int(pageSize)).
 			Take(int(pageSize)).
@@ -119,14 +119,14 @@ func (s packagesServer) GetAvailablePackageSummaries(ctx context.Context, reques
 			nextPageToken = fmt.Sprintf("%d", pageOffset+1)
 		}
 	} else {
-		From(pkgs).
+		linq.From(pkgs).
 			// Order by package name, regardless of the plugin
 			OrderBy(func(pkg interface{}) interface{} {
-				return pkg.(*packages.AvailablePackageSummary).Name + pkg.(*packages.AvailablePackageSummary).AvailablePackageRef.Plugin.Name
+				return pkg.(*pkgsGRPCv1alpha1.AvailablePackageSummary).Name + pkg.(*pkgsGRPCv1alpha1.AvailablePackageSummary).AvailablePackageRef.Plugin.Name
 			}).ToSlice(&pkgs)
 	}
 
-	return &packages.GetAvailablePackageSummariesResponse{
+	return &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
 		AvailablePackageSummaries: pkgs,
 		Categories:                categories,
 		NextPageToken:             nextPageToken,
@@ -134,243 +134,243 @@ func (s packagesServer) GetAvailablePackageSummaries(ctx context.Context, reques
 }
 
 // GetAvailablePackageDetail returns the package details based on the request.
-func (s packagesServer) GetAvailablePackageDetail(ctx context.Context, request *packages.GetAvailablePackageDetailRequest) (*packages.GetAvailablePackageDetailResponse, error) {
+func (s packagesServer) GetAvailablePackageDetail(ctx context.Context, request *pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest) (*pkgsGRPCv1alpha1.GetAvailablePackageDetailResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetAvailablePackageRef().GetContext().GetCluster(), request.GetAvailablePackageRef().GetContext().GetNamespace())
 	log.Infof("+core GetAvailablePackageDetail %s", contextMsg)
 
 	if request.GetAvailablePackageRef().GetPlugin() == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Unable to retrieve the plugin (missing AvailablePackageRef.Plugin)")
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Unable to retrieve the plugin (missing AvailablePackageRef.Plugin)")
 	}
 
 	// Retrieve the plugin with server matching the requested plugin name
 	pluginWithServer := s.getPluginWithServer(request.AvailablePackageRef.Plugin)
 	if pluginWithServer == nil {
-		return nil, status.Errorf(codes.Internal, "Unable to get the plugin %v", request.AvailablePackageRef.Plugin)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to get the plugin %v", request.AvailablePackageRef.Plugin)
 	}
 
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.GetAvailablePackageDetail(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to get the available package detail for the package %q using the plugin %q: %v", request.AvailablePackageRef.Identifier, request.AvailablePackageRef.Plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpcstatus.Convert(err).Code(), "Unable to get the available package detail for the package %q using the plugin %q: %v", request.AvailablePackageRef.Identifier, request.AvailablePackageRef.Plugin.Name, err)
 	}
 
 	// Validate the plugin response
 	if response.GetAvailablePackageDetail().GetAvailablePackageRef() == nil {
-		return nil, status.Errorf(codes.Internal, "Invalid available package detail response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Invalid available package detail response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	// Build the response
-	return &packages.GetAvailablePackageDetailResponse{
+	return &pkgsGRPCv1alpha1.GetAvailablePackageDetailResponse{
 		AvailablePackageDetail: response.AvailablePackageDetail,
 	}, nil
 }
 
 // GetInstalledPackageSummaries returns the installed package summaries based on the request.
-func (s packagesServer) GetInstalledPackageSummaries(ctx context.Context, request *packages.GetInstalledPackageSummariesRequest) (*packages.GetInstalledPackageSummariesResponse, error) {
+func (s packagesServer) GetInstalledPackageSummaries(ctx context.Context, request *pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest) (*pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetContext().GetCluster(), request.GetContext().GetNamespace())
 	log.Infof("+core GetInstalledPackageSummaries %s", contextMsg)
 
 	// Aggregate the response for each plugin
-	pkgs := []*packages.InstalledPackageSummary{}
+	pkgs := []*pkgsGRPCv1alpha1.InstalledPackageSummary{}
 	// TODO: We can do these in parallel in separate go routines.
 	for _, p := range s.pluginsWithServers {
 		response, err := p.server.GetInstalledPackageSummaries(ctx, request)
 		if err != nil {
-			return nil, status.Errorf(status.Convert(err).Code(), "Invalid GetInstalledPackageSummaries response from the plugin %v: %v", p.plugin.Name, err)
+			return nil, grpcstatus.Errorf(grpcstatus.Convert(err).Code(), "Invalid GetInstalledPackageSummaries response from the plugin %v: %v", p.plugin.Name, err)
 		}
 
 		// Add the plugin for the pkgs
 		pluginPkgs := response.InstalledPackageSummaries
 		for _, r := range pluginPkgs {
 			if r.InstalledPackageRef == nil {
-				r.InstalledPackageRef = &packages.InstalledPackageReference{}
+				r.InstalledPackageRef = &pkgsGRPCv1alpha1.InstalledPackageReference{}
 			}
 			r.InstalledPackageRef.Plugin = p.plugin
 		}
 		pkgs = append(pkgs, pluginPkgs...)
 	}
 
-	From(pkgs).
+	linq.From(pkgs).
 		// Order by package name, regardless of the plugin
 		OrderBy(func(pkg interface{}) interface{} {
-			return pkg.(*packages.InstalledPackageSummary).Name + pkg.(*packages.InstalledPackageSummary).InstalledPackageRef.Plugin.Name
+			return pkg.(*pkgsGRPCv1alpha1.InstalledPackageSummary).Name + pkg.(*pkgsGRPCv1alpha1.InstalledPackageSummary).InstalledPackageRef.Plugin.Name
 		}).
 		ToSlice(&pkgs)
 
 	// Build the response
-	return &packages.GetInstalledPackageSummariesResponse{
+	return &pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{
 		InstalledPackageSummaries: pkgs,
 	}, nil
 }
 
 // GetInstalledPackageDetail returns the package versions based on the request.
-func (s packagesServer) GetInstalledPackageDetail(ctx context.Context, request *packages.GetInstalledPackageDetailRequest) (*packages.GetInstalledPackageDetailResponse, error) {
+func (s packagesServer) GetInstalledPackageDetail(ctx context.Context, request *pkgsGRPCv1alpha1.GetInstalledPackageDetailRequest) (*pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetInstalledPackageRef().GetContext().GetCluster(), request.GetInstalledPackageRef().GetContext().GetNamespace())
 	log.Infof("+core GetInstalledPackageDetail %s", contextMsg)
 
 	if request.GetInstalledPackageRef().GetPlugin() == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Unable to retrieve the plugin (missing InstalledPackageRef.Plugin)")
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Unable to retrieve the plugin (missing InstalledPackageRef.Plugin)")
 	}
 
 	// Retrieve the plugin with server matching the requested plugin name
 	pluginWithServer := s.getPluginWithServer(request.InstalledPackageRef.Plugin)
 	if pluginWithServer == nil {
-		return nil, status.Errorf(codes.Internal, "Unable to get the plugin %v", request.InstalledPackageRef.Plugin)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to get the plugin %v", request.InstalledPackageRef.Plugin)
 	}
 
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.GetInstalledPackageDetail(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to get the installed package detail for the package %q using the plugin %q: %v", request.InstalledPackageRef.Identifier, request.InstalledPackageRef.Plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpcstatus.Convert(err).Code(), "Unable to get the installed package detail for the package %q using the plugin %q: %v", request.InstalledPackageRef.Identifier, request.InstalledPackageRef.Plugin.Name, err)
 	}
 
 	// Validate the plugin response
 	if response.GetInstalledPackageDetail() == nil {
-		return nil, status.Errorf(codes.Internal, "Invalid GetInstalledPackageDetail response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Invalid GetInstalledPackageDetail response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	// Build the response
-	return &packages.GetInstalledPackageDetailResponse{
+	return &pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse{
 		InstalledPackageDetail: response.InstalledPackageDetail,
 	}, nil
 }
 
 // GetAvailablePackageVersions returns the package versions based on the request.
-func (s packagesServer) GetAvailablePackageVersions(ctx context.Context, request *packages.GetAvailablePackageVersionsRequest) (*packages.GetAvailablePackageVersionsResponse, error) {
+func (s packagesServer) GetAvailablePackageVersions(ctx context.Context, request *pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest) (*pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetAvailablePackageRef().GetContext().GetCluster(), request.GetAvailablePackageRef().GetContext().GetNamespace())
 	log.Infof("+core GetAvailablePackageVersions %s", contextMsg)
 
 	if request.GetAvailablePackageRef().GetPlugin() == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Unable to retrieve the plugin (missing AvailablePackageRef.Plugin)")
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Unable to retrieve the plugin (missing AvailablePackageRef.Plugin)")
 	}
 
 	// Retrieve the plugin with server matching the requested plugin name
 	pluginWithServer := s.getPluginWithServer(request.AvailablePackageRef.Plugin)
 	if pluginWithServer == nil {
-		return nil, status.Errorf(codes.Internal, "Unable to get the plugin %v", request.AvailablePackageRef.Plugin)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to get the plugin %v", request.AvailablePackageRef.Plugin)
 	}
 
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.GetAvailablePackageVersions(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to get the available package versions for the package %q using the plugin %q: %v", request.AvailablePackageRef.Identifier, request.AvailablePackageRef.Plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpcstatus.Convert(err).Code(), "Unable to get the available package versions for the package %q using the plugin %q: %v", request.AvailablePackageRef.Identifier, request.AvailablePackageRef.Plugin.Name, err)
 	}
 
 	// Validate the plugin response
 	if response.PackageAppVersions == nil {
-		return nil, status.Errorf(codes.Internal, "Invalid GetAvailablePackageVersions response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Invalid GetAvailablePackageVersions response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	// Build the response
-	return &packages.GetAvailablePackageVersionsResponse{
+	return &pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{
 		PackageAppVersions: response.PackageAppVersions,
 	}, nil
 }
 
 // GetInstalledPackageResourceRefs returns the references for the Kubernetes resources created by
 // an installed package.
-func (s *packagesServer) GetInstalledPackageResourceRefs(ctx context.Context, request *packages.GetInstalledPackageResourceRefsRequest) (*packages.GetInstalledPackageResourceRefsResponse, error) {
+func (s *packagesServer) GetInstalledPackageResourceRefs(ctx context.Context, request *pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest) (*pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsResponse, error) {
 	pkgRef := request.GetInstalledPackageRef()
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", pkgRef.GetContext().GetCluster(), pkgRef.GetContext().GetNamespace())
 	identifier := pkgRef.GetIdentifier()
 	log.Infof("+core GetInstalledPackageResourceRefs %s %s", contextMsg, identifier)
 
 	if request.GetInstalledPackageRef().GetPlugin() == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Unable to retrieve the plugin (missing InstalledPackageRef.Plugin)")
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Unable to retrieve the plugin (missing InstalledPackageRef.Plugin)")
 	}
 
 	// Retrieve the plugin with server matching the requested plugin name
 	pluginWithServer := s.getPluginWithServer(request.InstalledPackageRef.Plugin)
 	if pluginWithServer == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Unable to retrieve the plugin %v", request.InstalledPackageRef.Plugin)
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Unable to retrieve the plugin %v", request.InstalledPackageRef.Plugin)
 	}
 
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.GetInstalledPackageResourceRefs(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to get the resource refs for the package %q using the plugin %q: %v", request.InstalledPackageRef.Identifier, request.InstalledPackageRef.Plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpcstatus.Convert(err).Code(), "Unable to get the resource refs for the package %q using the plugin %q: %v", request.InstalledPackageRef.Identifier, request.InstalledPackageRef.Plugin.Name, err)
 	}
 
 	return response, nil
 }
 
 // CreateInstalledPackage creates an installed package using configured plugins.
-func (s packagesServer) CreateInstalledPackage(ctx context.Context, request *packages.CreateInstalledPackageRequest) (*packages.CreateInstalledPackageResponse, error) {
+func (s packagesServer) CreateInstalledPackage(ctx context.Context, request *pkgsGRPCv1alpha1.CreateInstalledPackageRequest) (*pkgsGRPCv1alpha1.CreateInstalledPackageResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetTargetContext().GetCluster(), request.GetTargetContext().GetNamespace())
 	log.Infof("+core CreateInstalledPackage %s", contextMsg)
 
 	if request.GetAvailablePackageRef().GetPlugin() == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Unable to retrieve the plugin (missing AvailablePackageRef.Plugin)")
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Unable to retrieve the plugin (missing AvailablePackageRef.Plugin)")
 	}
 
 	// Retrieve the plugin with server matching the requested plugin name
 	pluginWithServer := s.getPluginWithServer(request.AvailablePackageRef.Plugin)
 	if pluginWithServer == nil {
-		return nil, status.Errorf(codes.Internal, "Unable to get the plugin %v", request.AvailablePackageRef.Plugin)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to get the plugin %v", request.AvailablePackageRef.Plugin)
 	}
 
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.CreateInstalledPackage(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to create the installed package for the package %q using the plugin %q: %v", request.AvailablePackageRef.Identifier, request.AvailablePackageRef.Plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpcstatus.Convert(err).Code(), "Unable to create the installed package for the package %q using the plugin %q: %v", request.AvailablePackageRef.Identifier, request.AvailablePackageRef.Plugin.Name, err)
 	}
 
 	// Validate the plugin response
 	if response.InstalledPackageRef == nil {
-		return nil, status.Errorf(codes.Internal, "Invalid CreateInstalledPackage response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Invalid CreateInstalledPackage response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	return response, nil
 }
 
 // UpdateInstalledPackage updates an installed package using configured plugins.
-func (s packagesServer) UpdateInstalledPackage(ctx context.Context, request *packages.UpdateInstalledPackageRequest) (*packages.UpdateInstalledPackageResponse, error) {
+func (s packagesServer) UpdateInstalledPackage(ctx context.Context, request *pkgsGRPCv1alpha1.UpdateInstalledPackageRequest) (*pkgsGRPCv1alpha1.UpdateInstalledPackageResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetInstalledPackageRef().GetContext().GetCluster(), request.GetInstalledPackageRef().GetContext().GetNamespace())
 	log.Infof("+core UpdateInstalledPackage %s", contextMsg)
 
 	if request.GetInstalledPackageRef().GetPlugin() == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Unable to retrieve the plugin (missing InstalledPackageRef.Plugin)")
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Unable to retrieve the plugin (missing InstalledPackageRef.Plugin)")
 	}
 
 	// Retrieve the plugin with server matching the requested plugin name
 	pluginWithServer := s.getPluginWithServer(request.InstalledPackageRef.Plugin)
 	if pluginWithServer == nil {
-		return nil, status.Errorf(codes.Internal, "Unable to get the plugin %v", request.InstalledPackageRef.Plugin)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to get the plugin %v", request.InstalledPackageRef.Plugin)
 	}
 
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.UpdateInstalledPackage(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to update the installed package for the package %q using the plugin %q: %v", request.InstalledPackageRef.Identifier, request.InstalledPackageRef.Plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpcstatus.Convert(err).Code(), "Unable to update the installed package for the package %q using the plugin %q: %v", request.InstalledPackageRef.Identifier, request.InstalledPackageRef.Plugin.Name, err)
 	}
 
 	// Validate the plugin response
 	if response.InstalledPackageRef == nil {
-		return nil, status.Errorf(codes.Internal, "Invalid UpdateInstalledPackage response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Invalid UpdateInstalledPackage response from the plugin %v: %v", pluginWithServer.plugin.Name, err)
 	}
 
 	return response, nil
 }
 
 // DeleteInstalledPackage deletes an installed package using configured plugins.
-func (s packagesServer) DeleteInstalledPackage(ctx context.Context, request *packages.DeleteInstalledPackageRequest) (*packages.DeleteInstalledPackageResponse, error) {
+func (s packagesServer) DeleteInstalledPackage(ctx context.Context, request *pkgsGRPCv1alpha1.DeleteInstalledPackageRequest) (*pkgsGRPCv1alpha1.DeleteInstalledPackageResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetInstalledPackageRef().GetContext().GetCluster(), request.GetInstalledPackageRef().GetContext().GetNamespace())
 	log.Infof("+core DeleteInstalledPackage %s", contextMsg)
 
 	if request.GetInstalledPackageRef().GetPlugin() == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Unable to retrieve the plugin (missing InstalledPackageRef.Plugin)")
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Unable to retrieve the plugin (missing InstalledPackageRef.Plugin)")
 	}
 
 	// Retrieve the plugin with server matching the requested plugin name
 	pluginWithServer := s.getPluginWithServer(request.InstalledPackageRef.Plugin)
 	if pluginWithServer == nil {
-		return nil, status.Errorf(codes.Internal, "Unable to get the plugin %v", request.InstalledPackageRef.Plugin)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to get the plugin %v", request.InstalledPackageRef.Plugin)
 	}
 
 	// Get the response from the requested plugin
 	response, err := pluginWithServer.server.DeleteInstalledPackage(ctx, request)
 	if err != nil {
-		return nil, status.Errorf(status.Convert(err).Code(), "Unable to delete the installed packagefor the package %q using the plugin %q: %v", request.InstalledPackageRef.Identifier, request.InstalledPackageRef.Plugin.Name, err)
+		return nil, grpcstatus.Errorf(grpcstatus.Convert(err).Code(), "Unable to delete the installed packagefor the package %q using the plugin %q: %v", request.InstalledPackageRef.Identifier, request.InstalledPackageRef.Plugin.Name, err)
 	}
 
 	return response, nil
@@ -378,7 +378,7 @@ func (s packagesServer) DeleteInstalledPackage(ctx context.Context, request *pac
 
 // getPluginWithServer returns the *pkgPluginsWithServer from a given packagesServer
 // matching the plugin name
-func (s packagesServer) getPluginWithServer(plugin *v1alpha1.Plugin) *pkgPluginsWithServer {
+func (s packagesServer) getPluginWithServer(plugin *pluginsGRPCv1alpha1.Plugin) *pkgPluginsWithServer {
 	for _, p := range s.pluginsWithServers {
 		if plugin.Name == p.plugin.Name {
 			return &p

--- a/cmd/kubeapps-apis/core/packages/v1alpha1/packages_test.go
+++ b/cmd/kubeapps-apis/core/packages/v1alpha1/packages_test.go
@@ -7,14 +7,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugin_test"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	cmp "github.com/google/go-cmp/cmp"
+	cmpopts "github.com/google/go-cmp/cmp/cmpopts"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	plugintest "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugin_test"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 const (
@@ -23,52 +22,52 @@ const (
 
 var mockedPackagingPlugin1 = makeDefaultTestPackagingPlugin("mock1")
 var mockedPackagingPlugin2 = makeDefaultTestPackagingPlugin("mock2")
-var mockedNotFoundPackagingPlugin = makeOnlyStatusTestPackagingPlugin("bad-plugin", codes.NotFound)
+var mockedNotFoundPackagingPlugin = makeOnlyStatusTestPackagingPlugin("bad-plugin", grpccodes.NotFound)
 
 var ignoreUnexportedOpts = cmpopts.IgnoreUnexported(
-	corev1.AvailablePackageDetail{},
-	corev1.AvailablePackageReference{},
-	corev1.AvailablePackageSummary{},
-	corev1.Context{},
-	corev1.GetAvailablePackageDetailResponse{},
-	corev1.GetAvailablePackageSummariesResponse{},
-	corev1.GetAvailablePackageVersionsResponse{},
-	corev1.GetInstalledPackageResourceRefsResponse{},
-	corev1.GetInstalledPackageDetailResponse{},
-	corev1.GetInstalledPackageSummariesResponse{},
-	corev1.CreateInstalledPackageResponse{},
-	corev1.UpdateInstalledPackageResponse{},
-	corev1.InstalledPackageDetail{},
-	corev1.InstalledPackageReference{},
-	corev1.InstalledPackageStatus{},
-	corev1.InstalledPackageSummary{},
-	corev1.Maintainer{},
-	corev1.PackageAppVersion{},
-	corev1.VersionReference{},
-	corev1.ResourceRef{},
-	plugins.Plugin{},
+	pkgsGRPCv1alpha1.AvailablePackageDetail{},
+	pkgsGRPCv1alpha1.AvailablePackageReference{},
+	pkgsGRPCv1alpha1.AvailablePackageSummary{},
+	pkgsGRPCv1alpha1.Context{},
+	pkgsGRPCv1alpha1.GetAvailablePackageDetailResponse{},
+	pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{},
+	pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{},
+	pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsResponse{},
+	pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse{},
+	pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{},
+	pkgsGRPCv1alpha1.CreateInstalledPackageResponse{},
+	pkgsGRPCv1alpha1.UpdateInstalledPackageResponse{},
+	pkgsGRPCv1alpha1.InstalledPackageDetail{},
+	pkgsGRPCv1alpha1.InstalledPackageReference{},
+	pkgsGRPCv1alpha1.InstalledPackageStatus{},
+	pkgsGRPCv1alpha1.InstalledPackageSummary{},
+	pkgsGRPCv1alpha1.Maintainer{},
+	pkgsGRPCv1alpha1.PackageAppVersion{},
+	pkgsGRPCv1alpha1.VersionReference{},
+	pkgsGRPCv1alpha1.ResourceRef{},
+	pluginsGRPCv1alpha1.Plugin{},
 )
 
 func makeDefaultTestPackagingPlugin(pluginName string) pkgPluginsWithServer {
-	pluginDetails := &plugins.Plugin{Name: pluginName, Version: "v1alpha1"}
-	packagingPluginServer := &plugin_test.TestPackagingPluginServer{Plugin: pluginDetails}
+	pluginDetails := &pluginsGRPCv1alpha1.Plugin{Name: pluginName, Version: "v1alpha1"}
+	packagingPluginServer := &plugintest.TestPackagingPluginServer{Plugin: pluginDetails}
 
-	packagingPluginServer.AvailablePackageSummaries = []*corev1.AvailablePackageSummary{
-		plugin_test.MakeAvailablePackageSummary("pkg-2", pluginDetails),
-		plugin_test.MakeAvailablePackageSummary("pkg-1", pluginDetails),
+	packagingPluginServer.AvailablePackageSummaries = []*pkgsGRPCv1alpha1.AvailablePackageSummary{
+		plugintest.MakeAvailablePackageSummary("pkg-2", pluginDetails),
+		plugintest.MakeAvailablePackageSummary("pkg-1", pluginDetails),
 	}
-	packagingPluginServer.AvailablePackageDetail = plugin_test.MakeAvailablePackageDetail("pkg-1", pluginDetails)
-	packagingPluginServer.InstalledPackageSummaries = []*corev1.InstalledPackageSummary{
-		plugin_test.MakeInstalledPackageSummary("pkg-2", pluginDetails),
-		plugin_test.MakeInstalledPackageSummary("pkg-1", pluginDetails),
+	packagingPluginServer.AvailablePackageDetail = plugintest.MakeAvailablePackageDetail("pkg-1", pluginDetails)
+	packagingPluginServer.InstalledPackageSummaries = []*pkgsGRPCv1alpha1.InstalledPackageSummary{
+		plugintest.MakeInstalledPackageSummary("pkg-2", pluginDetails),
+		plugintest.MakeInstalledPackageSummary("pkg-1", pluginDetails),
 	}
-	packagingPluginServer.InstalledPackageDetail = plugin_test.MakeInstalledPackageDetail("pkg-1", pluginDetails)
-	packagingPluginServer.PackageAppVersions = []*corev1.PackageAppVersion{
-		plugin_test.MakePackageAppVersion(plugin_test.DefaultAppVersion, plugin_test.DefaultPkgUpdateVersion),
-		plugin_test.MakePackageAppVersion(plugin_test.DefaultAppVersion, plugin_test.DefaultPkgVersion),
+	packagingPluginServer.InstalledPackageDetail = plugintest.MakeInstalledPackageDetail("pkg-1", pluginDetails)
+	packagingPluginServer.PackageAppVersions = []*pkgsGRPCv1alpha1.PackageAppVersion{
+		plugintest.MakePackageAppVersion(plugintest.DefaultAppVersion, plugintest.DefaultPkgUpdateVersion),
+		plugintest.MakePackageAppVersion(plugintest.DefaultAppVersion, plugintest.DefaultPkgVersion),
 	}
 	packagingPluginServer.NextPageToken = "1"
-	packagingPluginServer.Categories = []string{plugin_test.DefaultCategory}
+	packagingPluginServer.Categories = []string{plugintest.DefaultCategory}
 
 	return pkgPluginsWithServer{
 		plugin: pluginDetails,
@@ -76,9 +75,9 @@ func makeDefaultTestPackagingPlugin(pluginName string) pkgPluginsWithServer {
 	}
 }
 
-func makeOnlyStatusTestPackagingPlugin(pluginName string, statusCode codes.Code) pkgPluginsWithServer {
-	pluginDetails := &plugins.Plugin{Name: pluginName, Version: "v1alpha1"}
-	packagingPluginServer := &plugin_test.TestPackagingPluginServer{Plugin: pluginDetails}
+func makeOnlyStatusTestPackagingPlugin(pluginName string, statusCode grpccodes.Code) pkgPluginsWithServer {
+	pluginDetails := &pluginsGRPCv1alpha1.Plugin{Name: pluginName, Version: "v1alpha1"}
+	packagingPluginServer := &plugintest.TestPackagingPluginServer{Plugin: pluginDetails}
 
 	packagingPluginServer.Status = statusCode
 
@@ -92,9 +91,9 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 	testCases := []struct {
 		name              string
 		configuredPlugins []pkgPluginsWithServer
-		statusCode        codes.Code
-		request           *corev1.GetAvailablePackageSummariesRequest
-		expectedResponse  *corev1.GetAvailablePackageSummariesResponse
+		statusCode        grpccodes.Code
+		request           *pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest
+		expectedResponse  *pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse
 	}{
 		{
 			name: "it should successfully call the core GetAvailablePackageSummaries operation",
@@ -102,23 +101,23 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
-					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
-					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin2.plugin),
-					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin1.plugin),
-					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
+					plugintest.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
+					plugintest.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin2.plugin),
+					plugintest.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin1.plugin),
+					plugintest.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
 				},
 				Categories: []string{"cat-1"},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should successfully call and paginate (first page) the core GetAvailablePackageSummaries operation",
@@ -126,22 +125,22 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{PageToken: "0", PageSize: 1},
+				PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{PageToken: "0", PageSize: 1},
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
-					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
+					plugintest.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
 				},
 				Categories:    []string{"cat-1"},
 				NextPageToken: "1",
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should successfully call and paginate (proper PageSize) the core GetAvailablePackageSummaries operation",
@@ -149,25 +148,25 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{PageToken: "0", PageSize: 4},
+				PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{PageToken: "0", PageSize: 4},
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
-					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
-					plugin_test.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin2.plugin),
-					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin1.plugin),
-					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
+					plugintest.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
+					plugintest.MakeAvailablePackageSummary("pkg-1", mockedPackagingPlugin2.plugin),
+					plugintest.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin1.plugin),
+					plugintest.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
 				},
 				Categories:    []string{"cat-1"},
 				NextPageToken: "1",
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should successfully call and paginate (last page - 1) the core GetAvailablePackageSummaries operation",
@@ -175,22 +174,22 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{PageToken: "3", PageSize: 1},
+				PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{PageToken: "3", PageSize: 1},
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
-					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
+					plugintest.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
 				},
 				Categories:    []string{"cat-1"},
 				NextPageToken: "4",
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should successfully call and paginate (last page) the core GetAvailablePackageSummaries operation",
@@ -198,22 +197,22 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{PageToken: "3", PageSize: 1},
+				PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{PageToken: "3", PageSize: 1},
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
-					plugin_test.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
+					plugintest.MakeAvailablePackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
 				},
 				Categories:    []string{"cat-1"},
 				NextPageToken: "4",
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should successfully call and paginate (last page + 1) the core GetAvailablePackageSummaries operation",
@@ -221,20 +220,20 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{PageToken: "4", PageSize: 1},
+				PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{PageToken: "4", PageSize: 1},
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{},
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{},
 				Categories:                []string{"cat-1"},
 				NextPageToken:             "",
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should fail when calling the core GetAvailablePackageSummaries operation when the package is not present in a plugin",
@@ -242,18 +241,18 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{},
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{},
 				Categories:                []string{""},
 			},
-			statusCode: codes.NotFound,
+			statusCode: grpccodes.NotFound,
 		},
 	}
 
@@ -264,11 +263,11 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 			}
 			availablePackageSummaries, err := server.GetAvailablePackageSummaries(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				if got, want := availablePackageSummaries, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
@@ -281,9 +280,9 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 	testCases := []struct {
 		name              string
 		configuredPlugins []pkgPluginsWithServer
-		statusCode        codes.Code
-		request           *corev1.GetAvailablePackageDetailRequest
-		expectedResponse  *corev1.GetAvailablePackageDetailResponse
+		statusCode        grpccodes.Code
+		request           *pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest
+		expectedResponse  *pkgsGRPCv1alpha1.GetAvailablePackageDetailResponse
 	}{
 		{
 			name: "it should successfully call the core GetAvailablePackageDetail operation",
@@ -291,9 +290,9 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
-			request: &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Cluster:   "",
 						Namespace: globalPackagingNamespace,
 					},
@@ -303,10 +302,10 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				PkgVersion: "",
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageDetailResponse{
-				AvailablePackageDetail: plugin_test.MakeAvailablePackageDetail("pkg-1", mockedPackagingPlugin1.plugin),
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageDetailResponse{
+				AvailablePackageDetail: plugintest.MakeAvailablePackageDetail("pkg-1", mockedPackagingPlugin1.plugin),
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should fail when calling the core GetAvailablePackageDetail operation when the package is not present in a plugin",
@@ -314,9 +313,9 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
-			request: &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Cluster:   "",
 						Namespace: globalPackagingNamespace,
 					},
@@ -326,8 +325,8 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				PkgVersion: "",
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageDetailResponse{},
-			statusCode:       codes.NotFound,
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageDetailResponse{},
+			statusCode:       grpccodes.NotFound,
 		},
 	}
 
@@ -338,11 +337,11 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 			}
 			availablePackageDetail, err := server.GetAvailablePackageDetail(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				if got, want := availablePackageDetail, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
@@ -355,9 +354,9 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 	testCases := []struct {
 		name              string
 		configuredPlugins []pkgPluginsWithServer
-		statusCode        codes.Code
-		request           *corev1.GetInstalledPackageSummariesRequest
-		expectedResponse  *corev1.GetInstalledPackageSummariesResponse
+		statusCode        grpccodes.Code
+		request           *pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest
+		expectedResponse  *pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse
 	}{
 		{
 			name: "it should successfully call the core GetInstalledPackageSummaries operation",
@@ -365,22 +364,22 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
-			request: &corev1.GetInstalledPackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
 			},
 
-			expectedResponse: &corev1.GetInstalledPackageSummariesResponse{
-				InstalledPackageSummaries: []*corev1.InstalledPackageSummary{
-					plugin_test.MakeInstalledPackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
-					plugin_test.MakeInstalledPackageSummary("pkg-1", mockedPackagingPlugin2.plugin),
-					plugin_test.MakeInstalledPackageSummary("pkg-2", mockedPackagingPlugin1.plugin),
-					plugin_test.MakeInstalledPackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{
+				InstalledPackageSummaries: []*pkgsGRPCv1alpha1.InstalledPackageSummary{
+					plugintest.MakeInstalledPackageSummary("pkg-1", mockedPackagingPlugin1.plugin),
+					plugintest.MakeInstalledPackageSummary("pkg-1", mockedPackagingPlugin2.plugin),
+					plugintest.MakeInstalledPackageSummary("pkg-2", mockedPackagingPlugin1.plugin),
+					plugintest.MakeInstalledPackageSummary("pkg-2", mockedPackagingPlugin2.plugin),
 				},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should fail when calling the core GetInstalledPackageSummaries operation when the package is not present in a plugin",
@@ -388,17 +387,17 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
-			request: &corev1.GetInstalledPackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
 			},
 
-			expectedResponse: &corev1.GetInstalledPackageSummariesResponse{
-				InstalledPackageSummaries: []*corev1.InstalledPackageSummary{},
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{
+				InstalledPackageSummaries: []*pkgsGRPCv1alpha1.InstalledPackageSummary{},
 			},
-			statusCode: codes.NotFound,
+			statusCode: grpccodes.NotFound,
 		},
 	}
 
@@ -409,11 +408,11 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 			}
 			installedPackageSummaries, err := server.GetInstalledPackageSummaries(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				if got, want := installedPackageSummaries, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
@@ -426,9 +425,9 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 	testCases := []struct {
 		name              string
 		configuredPlugins []pkgPluginsWithServer
-		statusCode        codes.Code
-		request           *corev1.GetInstalledPackageDetailRequest
-		expectedResponse  *corev1.GetInstalledPackageDetailResponse
+		statusCode        grpccodes.Code
+		request           *pkgsGRPCv1alpha1.GetInstalledPackageDetailRequest
+		expectedResponse  *pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse
 	}{
 		{
 			name: "it should successfully call the core GetInstalledPackageDetail operation",
@@ -436,9 +435,9 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
-			request: &corev1.GetInstalledPackageDetailRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageDetailRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Cluster:   "",
 						Namespace: globalPackagingNamespace,
 					},
@@ -447,10 +446,10 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 				},
 			},
 
-			expectedResponse: &corev1.GetInstalledPackageDetailResponse{
-				InstalledPackageDetail: plugin_test.MakeInstalledPackageDetail("pkg-1", mockedPackagingPlugin1.plugin),
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse{
+				InstalledPackageDetail: plugintest.MakeInstalledPackageDetail("pkg-1", mockedPackagingPlugin1.plugin),
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should fail when calling the core GetInstalledPackageDetail operation when the package is not present in a plugin",
@@ -458,9 +457,9 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
-			request: &corev1.GetInstalledPackageDetailRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageDetailRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Cluster:   "",
 						Namespace: globalPackagingNamespace,
 					},
@@ -469,8 +468,8 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 				},
 			},
 
-			expectedResponse: &corev1.GetInstalledPackageDetailResponse{},
-			statusCode:       codes.NotFound,
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse{},
+			statusCode:       grpccodes.NotFound,
 		},
 	}
 
@@ -481,11 +480,11 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 			}
 			installedPackageDetail, err := server.GetInstalledPackageDetail(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				if got, want := installedPackageDetail, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
@@ -498,9 +497,9 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 	testCases := []struct {
 		name              string
 		configuredPlugins []pkgPluginsWithServer
-		statusCode        codes.Code
-		request           *corev1.GetAvailablePackageVersionsRequest
-		expectedResponse  *corev1.GetAvailablePackageVersionsResponse
+		statusCode        grpccodes.Code
+		request           *pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest
+		expectedResponse  *pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse
 	}{
 		{
 			name: "it should successfully call the core GetAvailablePackageVersions operation",
@@ -508,9 +507,9 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedPackagingPlugin2,
 			},
-			request: &corev1.GetAvailablePackageVersionsRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Cluster:   "",
 						Namespace: globalPackagingNamespace,
 					},
@@ -519,13 +518,13 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 				},
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageVersionsResponse{
-				PackageAppVersions: []*corev1.PackageAppVersion{
-					plugin_test.MakePackageAppVersion(plugin_test.DefaultAppVersion, plugin_test.DefaultPkgUpdateVersion),
-					plugin_test.MakePackageAppVersion(plugin_test.DefaultAppVersion, plugin_test.DefaultPkgVersion),
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{
+				PackageAppVersions: []*pkgsGRPCv1alpha1.PackageAppVersion{
+					plugintest.MakePackageAppVersion(plugintest.DefaultAppVersion, plugintest.DefaultPkgUpdateVersion),
+					plugintest.MakePackageAppVersion(plugintest.DefaultAppVersion, plugintest.DefaultPkgVersion),
 				},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should fail when calling the core GetAvailablePackageVersions operation when the package is not present in a plugin",
@@ -533,9 +532,9 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 				mockedPackagingPlugin1,
 				mockedNotFoundPackagingPlugin,
 			},
-			request: &corev1.GetAvailablePackageVersionsRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Cluster:   "",
 						Namespace: globalPackagingNamespace,
 					},
@@ -544,10 +543,10 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 				},
 			},
 
-			expectedResponse: &corev1.GetAvailablePackageVersionsResponse{
-				PackageAppVersions: []*corev1.PackageAppVersion{},
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{
+				PackageAppVersions: []*pkgsGRPCv1alpha1.PackageAppVersion{},
 			},
-			statusCode: codes.NotFound,
+			statusCode: grpccodes.NotFound,
 		},
 	}
 
@@ -558,11 +557,11 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 			}
 			AvailablePackageVersions, err := server.GetAvailablePackageVersions(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				if got, want := AvailablePackageVersions, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
@@ -575,45 +574,45 @@ func TestCreateInstalledPackage(t *testing.T) {
 
 	testCases := []struct {
 		name              string
-		configuredPlugins []*plugins.Plugin
-		statusCode        codes.Code
-		request           *corev1.CreateInstalledPackageRequest
-		expectedResponse  *corev1.CreateInstalledPackageResponse
+		configuredPlugins []*pluginsGRPCv1alpha1.Plugin
+		statusCode        grpccodes.Code
+		request           *pkgsGRPCv1alpha1.CreateInstalledPackageRequest
+		expectedResponse  *pkgsGRPCv1alpha1.CreateInstalledPackageResponse
 	}{
 		{
 			name: "installs the package using the correct plugin",
-			configuredPlugins: []*plugins.Plugin{
+			configuredPlugins: []*pluginsGRPCv1alpha1.Plugin{
 				{Name: "plugin-1", Version: "v1alpha1"},
 				{Name: "plugin-1", Version: "v1alpha2"},
 			},
-			statusCode: codes.OK,
-			request: &corev1.CreateInstalledPackageRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
+			statusCode: grpccodes.OK,
+			request: &pkgsGRPCv1alpha1.CreateInstalledPackageRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
 					Identifier: "available-pkg-1",
-					Plugin:     &plugins.Plugin{Name: "plugin-1", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "plugin-1", Version: "v1alpha1"},
 				},
-				TargetContext: &corev1.Context{
+				TargetContext: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "my-ns",
 				},
 				Name: "installed-pkg-1",
 			},
-			expectedResponse: &corev1.CreateInstalledPackageResponse{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context:    &corev1.Context{Cluster: "default", Namespace: "my-ns"},
+			expectedResponse: &pkgsGRPCv1alpha1.CreateInstalledPackageResponse{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Cluster: "default", Namespace: "my-ns"},
 					Identifier: "installed-pkg-1",
-					Plugin:     &plugins.Plugin{Name: "plugin-1", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "plugin-1", Version: "v1alpha1"},
 				},
 			},
 		},
 		{
 			name:       "returns invalid argument if plugin not specified in request",
-			statusCode: codes.InvalidArgument,
-			request: &corev1.CreateInstalledPackageRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
+			statusCode: grpccodes.InvalidArgument,
+			request: &pkgsGRPCv1alpha1.CreateInstalledPackageRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
 					Identifier: "available-pkg-1",
 				},
-				TargetContext: &corev1.Context{
+				TargetContext: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "my-ns",
 				},
@@ -622,13 +621,13 @@ func TestCreateInstalledPackage(t *testing.T) {
 		},
 		{
 			name:       "returns internal error if unable to find the plugin",
-			statusCode: codes.Internal,
-			request: &corev1.CreateInstalledPackageRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
+			statusCode: grpccodes.Internal,
+			request: &pkgsGRPCv1alpha1.CreateInstalledPackageRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
 					Identifier: "available-pkg-1",
-					Plugin:     &plugins.Plugin{Name: "plugin-1", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "plugin-1", Version: "v1alpha1"},
 				},
-				TargetContext: &corev1.Context{
+				TargetContext: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "my-ns",
 				},
@@ -643,7 +642,7 @@ func TestCreateInstalledPackage(t *testing.T) {
 			for _, p := range tc.configuredPlugins {
 				configuredPluginServers = append(configuredPluginServers, pkgPluginsWithServer{
 					plugin: p,
-					server: plugin_test.TestPackagingPluginServer{Plugin: p},
+					server: plugintest.TestPackagingPluginServer{Plugin: p},
 				})
 			}
 
@@ -653,11 +652,11 @@ func TestCreateInstalledPackage(t *testing.T) {
 
 			installedPkgResponse, err := server.CreateInstalledPackage(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				if got, want := installedPkgResponse, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
@@ -670,49 +669,49 @@ func TestUpdateInstalledPackage(t *testing.T) {
 
 	testCases := []struct {
 		name              string
-		configuredPlugins []*plugins.Plugin
-		statusCode        codes.Code
-		request           *corev1.UpdateInstalledPackageRequest
-		expectedResponse  *corev1.UpdateInstalledPackageResponse
+		configuredPlugins []*pluginsGRPCv1alpha1.Plugin
+		statusCode        grpccodes.Code
+		request           *pkgsGRPCv1alpha1.UpdateInstalledPackageRequest
+		expectedResponse  *pkgsGRPCv1alpha1.UpdateInstalledPackageResponse
 	}{
 		{
 			name: "updates the package using the correct plugin",
-			configuredPlugins: []*plugins.Plugin{
+			configuredPlugins: []*pluginsGRPCv1alpha1.Plugin{
 				{Name: "plugin-1", Version: "v1alpha1"},
 				{Name: "plugin-1", Version: "v1alpha2"},
 			},
-			statusCode: codes.OK,
-			request: &corev1.UpdateInstalledPackageRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context:    &corev1.Context{Cluster: "default", Namespace: "my-ns"},
+			statusCode: grpccodes.OK,
+			request: &pkgsGRPCv1alpha1.UpdateInstalledPackageRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Cluster: "default", Namespace: "my-ns"},
 					Identifier: "installed-pkg-1",
-					Plugin:     &plugins.Plugin{Name: "plugin-1", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "plugin-1", Version: "v1alpha1"},
 				},
 			},
-			expectedResponse: &corev1.UpdateInstalledPackageResponse{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context:    &corev1.Context{Cluster: "default", Namespace: "my-ns"},
+			expectedResponse: &pkgsGRPCv1alpha1.UpdateInstalledPackageResponse{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Cluster: "default", Namespace: "my-ns"},
 					Identifier: "installed-pkg-1",
-					Plugin:     &plugins.Plugin{Name: "plugin-1", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "plugin-1", Version: "v1alpha1"},
 				},
 			},
 		},
 		{
 			name:       "returns invalid argument if plugin not specified in request",
-			statusCode: codes.InvalidArgument,
-			request: &corev1.UpdateInstalledPackageRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
+			statusCode: grpccodes.InvalidArgument,
+			request: &pkgsGRPCv1alpha1.UpdateInstalledPackageRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
 					Identifier: "available-pkg-1",
 				},
 			},
 		},
 		{
 			name:       "returns internal error if unable to find the plugin",
-			statusCode: codes.Internal,
-			request: &corev1.UpdateInstalledPackageRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
+			statusCode: grpccodes.Internal,
+			request: &pkgsGRPCv1alpha1.UpdateInstalledPackageRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
 					Identifier: "available-pkg-1",
-					Plugin:     &plugins.Plugin{Name: "plugin-1", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "plugin-1", Version: "v1alpha1"},
 				},
 			},
 		},
@@ -724,7 +723,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 			for _, p := range tc.configuredPlugins {
 				configuredPluginServers = append(configuredPluginServers, pkgPluginsWithServer{
 					plugin: p,
-					server: plugin_test.TestPackagingPluginServer{Plugin: p},
+					server: plugintest.TestPackagingPluginServer{Plugin: p},
 				})
 			}
 
@@ -734,11 +733,11 @@ func TestUpdateInstalledPackage(t *testing.T) {
 
 			updatedPkgResponse, err := server.UpdateInstalledPackage(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				if got, want := updatedPkgResponse, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}
@@ -751,41 +750,41 @@ func TestDeleteInstalledPackage(t *testing.T) {
 
 	testCases := []struct {
 		name              string
-		configuredPlugins []*plugins.Plugin
-		statusCode        codes.Code
-		request           *corev1.DeleteInstalledPackageRequest
+		configuredPlugins []*pluginsGRPCv1alpha1.Plugin
+		statusCode        grpccodes.Code
+		request           *pkgsGRPCv1alpha1.DeleteInstalledPackageRequest
 	}{
 		{
 			name: "deletes the package",
-			configuredPlugins: []*plugins.Plugin{
+			configuredPlugins: []*pluginsGRPCv1alpha1.Plugin{
 				{Name: "plugin-1", Version: "v1alpha1"},
 				{Name: "plugin-1", Version: "v1alpha2"},
 			},
-			statusCode: codes.OK,
-			request: &corev1.DeleteInstalledPackageRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context:    &corev1.Context{Cluster: "default", Namespace: "my-ns"},
+			statusCode: grpccodes.OK,
+			request: &pkgsGRPCv1alpha1.DeleteInstalledPackageRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Cluster: "default", Namespace: "my-ns"},
 					Identifier: "installed-pkg-1",
-					Plugin:     &plugins.Plugin{Name: "plugin-1", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "plugin-1", Version: "v1alpha1"},
 				},
 			},
 		},
 		{
 			name:       "returns invalid argument if plugin not specified in request",
-			statusCode: codes.InvalidArgument,
-			request: &corev1.DeleteInstalledPackageRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
+			statusCode: grpccodes.InvalidArgument,
+			request: &pkgsGRPCv1alpha1.DeleteInstalledPackageRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
 					Identifier: "available-pkg-1",
 				},
 			},
 		},
 		{
 			name:       "returns internal error if unable to find the plugin",
-			statusCode: codes.Internal,
-			request: &corev1.DeleteInstalledPackageRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
+			statusCode: grpccodes.Internal,
+			request: &pkgsGRPCv1alpha1.DeleteInstalledPackageRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
 					Identifier: "available-pkg-1",
-					Plugin:     &plugins.Plugin{Name: "plugin-1", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "plugin-1", Version: "v1alpha1"},
 				},
 			},
 		},
@@ -797,7 +796,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 			for _, p := range tc.configuredPlugins {
 				configuredPluginServers = append(configuredPluginServers, pkgPluginsWithServer{
 					plugin: p,
-					server: plugin_test.TestPackagingPluginServer{Plugin: p},
+					server: plugintest.TestPackagingPluginServer{Plugin: p},
 				})
 			}
 
@@ -807,7 +806,7 @@ func TestDeleteInstalledPackage(t *testing.T) {
 
 			_, err := server.DeleteInstalledPackage(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 		})
@@ -815,34 +814,34 @@ func TestDeleteInstalledPackage(t *testing.T) {
 }
 
 func TestGetInstalledPackageResourceRefs(t *testing.T) {
-	installedPlugin := &plugins.Plugin{Name: "plugin-1", Version: "v1alpha1"}
+	installedPlugin := &pluginsGRPCv1alpha1.Plugin{Name: "plugin-1", Version: "v1alpha1"}
 
 	testCases := []struct {
 		name               string
-		statusCode         codes.Code
-		pluginResourceRefs []*corev1.ResourceRef
-		request            *corev1.GetInstalledPackageResourceRefsRequest
-		expectedResponse   *corev1.GetInstalledPackageResourceRefsResponse
+		statusCode         grpccodes.Code
+		pluginResourceRefs []*pkgsGRPCv1alpha1.ResourceRef
+		request            *pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest
+		expectedResponse   *pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsResponse
 	}{
 		{
 			name: "it should successfully call the plugins GetInstalledPackageResourceRefs endpoint",
-			pluginResourceRefs: []*corev1.ResourceRef{
+			pluginResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "apps/v1",
 					Kind:       "Deployment",
 					Name:       "some-deployment",
 				},
 			},
-			request: &corev1.GetInstalledPackageResourceRefsRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context:    &corev1.Context{Cluster: "default", Namespace: "my-ns"},
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Cluster: "default", Namespace: "my-ns"},
 					Identifier: "installed-pkg-1",
 					Plugin:     installedPlugin,
 				},
 			},
-			expectedResponse: &corev1.GetInstalledPackageResourceRefsResponse{
-				Context: &corev1.Context{Cluster: "default", Namespace: "my-ns"},
-				ResourceRefs: []*corev1.ResourceRef{
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsResponse{
+				Context: &pkgsGRPCv1alpha1.Context{Cluster: "default", Namespace: "my-ns"},
+				ResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 					{
 						ApiVersion: "apps/v1",
 						Kind:       "Deployment",
@@ -850,28 +849,28 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 					},
 				},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it should return an invalid argument if the plugin is not specified",
-			request: &corev1.GetInstalledPackageResourceRefsRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context:    &corev1.Context{Cluster: "default", Namespace: "my-ns"},
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Cluster: "default", Namespace: "my-ns"},
 					Identifier: "installed-pkg-1",
 				},
 			},
-			statusCode: codes.InvalidArgument,
+			statusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name: "it should return an invalid argument if the plugin cannot be found",
-			request: &corev1.GetInstalledPackageResourceRefsRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context:    &corev1.Context{Cluster: "default", Namespace: "my-ns"},
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Cluster: "default", Namespace: "my-ns"},
 					Identifier: "installed-pkg-1",
-					Plugin:     &plugins.Plugin{Name: "other-plugin.packages", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "other-plugin.packages", Version: "v1alpha1"},
 				},
 			},
-			statusCode: codes.InvalidArgument,
+			statusCode: grpccodes.InvalidArgument,
 		},
 	}
 
@@ -881,7 +880,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 				pluginsWithServers: []pkgPluginsWithServer{
 					{
 						plugin: installedPlugin,
-						server: &plugin_test.TestPackagingPluginServer{
+						server: &plugintest.TestPackagingPluginServer{
 							Plugin:       installedPlugin,
 							ResourceRefs: tc.pluginResourceRefs,
 						},
@@ -891,11 +890,11 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 
 			resourceRefs, err := server.GetInstalledPackageResourceRefs(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				if got, want := resourceRefs, tc.expectedResponse; !cmp.Equal(got, want, ignoreUnexportedOpts) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoreUnexportedOpts))
 				}

--- a/cmd/kubeapps-apis/core/serveopts.go
+++ b/cmd/kubeapps-apis/core/serveopts.go
@@ -6,9 +6,9 @@ package core
 import (
 	"context"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"google.golang.org/grpc"
-	"k8s.io/client-go/rest"
+	grpcgwruntime "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	grpc "google.golang.org/grpc"
+	k8srest "k8s.io/client-go/rest"
 )
 
 // ServeOptions encapsulates the available command-line options.
@@ -28,7 +28,7 @@ type ServeOptions struct {
 // required when registering an HTTP handler for the gateway.
 type GatewayHandlerArgs struct {
 	Ctx         context.Context
-	Mux         *runtime.ServeMux
+	Mux         *grpcgwruntime.ServeMux
 	Addr        string
 	DialOptions []grpc.DialOption
 }
@@ -36,4 +36,4 @@ type GatewayHandlerArgs struct {
 // KubernetesConfigGetter is a function type used throughout the apis server so
 // that call-sites don't need to know how to obtain an authenticated client, but
 // rather can just pass the request context and the cluster to get one.
-type KubernetesConfigGetter func(ctx context.Context, cluster string) (*rest.Config, error)
+type KubernetesConfigGetter func(ctx context.Context, cluster string) (*k8srest.Config, error)

--- a/cmd/kubeapps-apis/main.go
+++ b/cmd/kubeapps-apis/main.go
@@ -3,11 +3,13 @@
 
 package main
 
-import "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/cmd"
+import (
+	apiscmd "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/cmd"
+)
 
 // This cobra command was initially generated together with the cmd/root with the command
 // cobra init --pkg-name github.com/kubeapps/kubeapps/cmd/kubeapps-apis
 
 func main() {
-	cmd.Execute()
+	apiscmd.Execute()
 }

--- a/cmd/kubeapps-apis/plugin_test/mock_plugin.go
+++ b/cmd/kubeapps-apis/plugin_test/mock_plugin.go
@@ -6,39 +6,38 @@ package plugin_test
 import (
 	"context"
 
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	packages "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 type TestPackagingPluginServer struct {
-	packages.UnimplementedPackagesServiceServer
-	Plugin                    *plugins.Plugin
-	AvailablePackageSummaries []*corev1.AvailablePackageSummary
-	AvailablePackageDetail    *corev1.AvailablePackageDetail
-	InstalledPackageSummaries []*corev1.InstalledPackageSummary
-	InstalledPackageDetail    *corev1.InstalledPackageDetail
-	PackageAppVersions        []*corev1.PackageAppVersion
-	ResourceRefs              []*corev1.ResourceRef
+	pkgsGRPCv1alpha1.UnimplementedPackagesServiceServer
+	Plugin                    *pluginsGRPCv1alpha1.Plugin
+	AvailablePackageSummaries []*pkgsGRPCv1alpha1.AvailablePackageSummary
+	AvailablePackageDetail    *pkgsGRPCv1alpha1.AvailablePackageDetail
+	InstalledPackageSummaries []*pkgsGRPCv1alpha1.InstalledPackageSummary
+	InstalledPackageDetail    *pkgsGRPCv1alpha1.InstalledPackageDetail
+	PackageAppVersions        []*pkgsGRPCv1alpha1.PackageAppVersion
+	ResourceRefs              []*pkgsGRPCv1alpha1.ResourceRef
 	Categories                []string
 	NextPageToken             string
-	Status                    codes.Code
+	Status                    grpccodes.Code
 }
 
-func NewTestPackagingPlugin(plugin *plugins.Plugin) *TestPackagingPluginServer {
+func NewTestPackagingPlugin(plugin *pluginsGRPCv1alpha1.Plugin) *TestPackagingPluginServer {
 	return &TestPackagingPluginServer{
 		Plugin: plugin,
 	}
 }
 
 // GetAvailablePackages returns the packages based on the request.
-func (s TestPackagingPluginServer) GetAvailablePackageSummaries(ctx context.Context, request *packages.GetAvailablePackageSummariesRequest) (*packages.GetAvailablePackageSummariesResponse, error) {
-	if s.Status != codes.OK {
-		return nil, status.Errorf(s.Status, "Non-OK response")
+func (s TestPackagingPluginServer) GetAvailablePackageSummaries(ctx context.Context, request *pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest) (*pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse, error) {
+	if s.Status != grpccodes.OK {
+		return nil, grpcstatus.Errorf(s.Status, "Non-OK response")
 	}
-	return &packages.GetAvailablePackageSummariesResponse{
+	return &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
 		AvailablePackageSummaries: s.AvailablePackageSummaries,
 		Categories:                s.Categories,
 		NextPageToken:             s.NextPageToken,
@@ -46,63 +45,63 @@ func (s TestPackagingPluginServer) GetAvailablePackageSummaries(ctx context.Cont
 }
 
 // GetAvailablePackageDetail returns the package details based on the request.
-func (s TestPackagingPluginServer) GetAvailablePackageDetail(ctx context.Context, request *packages.GetAvailablePackageDetailRequest) (*packages.GetAvailablePackageDetailResponse, error) {
-	if s.Status != codes.OK {
-		return nil, status.Errorf(s.Status, "Non-OK response")
+func (s TestPackagingPluginServer) GetAvailablePackageDetail(ctx context.Context, request *pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest) (*pkgsGRPCv1alpha1.GetAvailablePackageDetailResponse, error) {
+	if s.Status != grpccodes.OK {
+		return nil, grpcstatus.Errorf(s.Status, "Non-OK response")
 	}
-	return &packages.GetAvailablePackageDetailResponse{
+	return &pkgsGRPCv1alpha1.GetAvailablePackageDetailResponse{
 		AvailablePackageDetail: s.AvailablePackageDetail,
 	}, nil
 }
 
 // GetInstalledPackageSummaries returns the installed package summaries based on the request.
-func (s TestPackagingPluginServer) GetInstalledPackageSummaries(ctx context.Context, request *packages.GetInstalledPackageSummariesRequest) (*packages.GetInstalledPackageSummariesResponse, error) {
-	if s.Status != codes.OK {
-		return nil, status.Errorf(s.Status, "Non-OK response")
+func (s TestPackagingPluginServer) GetInstalledPackageSummaries(ctx context.Context, request *pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest) (*pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse, error) {
+	if s.Status != grpccodes.OK {
+		return nil, grpcstatus.Errorf(s.Status, "Non-OK response")
 	}
-	return &packages.GetInstalledPackageSummariesResponse{
+	return &pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{
 		InstalledPackageSummaries: s.InstalledPackageSummaries,
 		NextPageToken:             s.NextPageToken,
 	}, nil
 }
 
 // GetInstalledPackageDetail returns the package versions based on the request.
-func (s TestPackagingPluginServer) GetInstalledPackageDetail(ctx context.Context, request *packages.GetInstalledPackageDetailRequest) (*packages.GetInstalledPackageDetailResponse, error) {
-	if s.Status != codes.OK {
-		return nil, status.Errorf(s.Status, "Non-OK response")
+func (s TestPackagingPluginServer) GetInstalledPackageDetail(ctx context.Context, request *pkgsGRPCv1alpha1.GetInstalledPackageDetailRequest) (*pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse, error) {
+	if s.Status != grpccodes.OK {
+		return nil, grpcstatus.Errorf(s.Status, "Non-OK response")
 	}
-	return &packages.GetInstalledPackageDetailResponse{
+	return &pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse{
 		InstalledPackageDetail: s.InstalledPackageDetail,
 	}, nil
 }
 
 // GetAvailablePackageVersions returns the package versions based on the request.
-func (s TestPackagingPluginServer) GetAvailablePackageVersions(ctx context.Context, request *packages.GetAvailablePackageVersionsRequest) (*packages.GetAvailablePackageVersionsResponse, error) {
-	if s.Status != codes.OK {
-		return nil, status.Errorf(s.Status, "Non-OK response")
+func (s TestPackagingPluginServer) GetAvailablePackageVersions(ctx context.Context, request *pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest) (*pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse, error) {
+	if s.Status != grpccodes.OK {
+		return nil, grpcstatus.Errorf(s.Status, "Non-OK response")
 	}
-	return &packages.GetAvailablePackageVersionsResponse{
+	return &pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{
 		PackageAppVersions: s.PackageAppVersions,
 	}, nil
 }
 
 // GetInstalledPackageResourceRefs returns the resource references based on the request.
-func (s TestPackagingPluginServer) GetInstalledPackageResourceRefs(ctx context.Context, request *packages.GetInstalledPackageResourceRefsRequest) (*packages.GetInstalledPackageResourceRefsResponse, error) {
-	if s.Status != codes.OK {
-		return nil, status.Errorf(s.Status, "Non-OK response")
+func (s TestPackagingPluginServer) GetInstalledPackageResourceRefs(ctx context.Context, request *pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest) (*pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsResponse, error) {
+	if s.Status != grpccodes.OK {
+		return nil, grpcstatus.Errorf(s.Status, "Non-OK response")
 	}
-	return &packages.GetInstalledPackageResourceRefsResponse{
+	return &pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsResponse{
 		Context:      request.GetInstalledPackageRef().GetContext(),
 		ResourceRefs: s.ResourceRefs,
 	}, nil
 }
 
-func (s TestPackagingPluginServer) CreateInstalledPackage(ctx context.Context, request *packages.CreateInstalledPackageRequest) (*packages.CreateInstalledPackageResponse, error) {
-	if s.Status != codes.OK {
-		return nil, status.Errorf(s.Status, "Non-OK response")
+func (s TestPackagingPluginServer) CreateInstalledPackage(ctx context.Context, request *pkgsGRPCv1alpha1.CreateInstalledPackageRequest) (*pkgsGRPCv1alpha1.CreateInstalledPackageResponse, error) {
+	if s.Status != grpccodes.OK {
+		return nil, grpcstatus.Errorf(s.Status, "Non-OK response")
 	}
-	return &packages.CreateInstalledPackageResponse{
-		InstalledPackageRef: &packages.InstalledPackageReference{
+	return &pkgsGRPCv1alpha1.CreateInstalledPackageResponse{
+		InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
 			Context:    request.GetTargetContext(),
 			Identifier: request.GetName(),
 			Plugin:     s.Plugin,
@@ -110,12 +109,12 @@ func (s TestPackagingPluginServer) CreateInstalledPackage(ctx context.Context, r
 	}, nil
 }
 
-func (s TestPackagingPluginServer) UpdateInstalledPackage(ctx context.Context, request *packages.UpdateInstalledPackageRequest) (*packages.UpdateInstalledPackageResponse, error) {
-	if s.Status != codes.OK {
-		return nil, status.Errorf(s.Status, "Non-OK response")
+func (s TestPackagingPluginServer) UpdateInstalledPackage(ctx context.Context, request *pkgsGRPCv1alpha1.UpdateInstalledPackageRequest) (*pkgsGRPCv1alpha1.UpdateInstalledPackageResponse, error) {
+	if s.Status != grpccodes.OK {
+		return nil, grpcstatus.Errorf(s.Status, "Non-OK response")
 	}
-	return &packages.UpdateInstalledPackageResponse{
-		InstalledPackageRef: &packages.InstalledPackageReference{
+	return &pkgsGRPCv1alpha1.UpdateInstalledPackageResponse{
+		InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
 			Context:    request.GetInstalledPackageRef().GetContext(),
 			Identifier: request.GetInstalledPackageRef().GetIdentifier(),
 			Plugin:     s.Plugin,
@@ -123,9 +122,9 @@ func (s TestPackagingPluginServer) UpdateInstalledPackage(ctx context.Context, r
 	}, nil
 }
 
-func (s TestPackagingPluginServer) DeleteInstalledPackage(ctx context.Context, request *packages.DeleteInstalledPackageRequest) (*packages.DeleteInstalledPackageResponse, error) {
-	if s.Status != codes.OK {
-		return nil, status.Errorf(s.Status, "Non-OK response")
+func (s TestPackagingPluginServer) DeleteInstalledPackage(ctx context.Context, request *pkgsGRPCv1alpha1.DeleteInstalledPackageRequest) (*pkgsGRPCv1alpha1.DeleteInstalledPackageResponse, error) {
+	if s.Status != grpccodes.OK {
+		return nil, grpcstatus.Errorf(s.Status, "Non-OK response")
 	}
-	return &packages.DeleteInstalledPackageResponse{}, nil
+	return &pkgsGRPCv1alpha1.DeleteInstalledPackageResponse{}, nil
 }

--- a/cmd/kubeapps-apis/plugin_test/utils.go
+++ b/cmd/kubeapps-apis/plugin_test/utils.go
@@ -4,8 +4,8 @@
 package plugin_test
 
 import (
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 )
 
 const (
@@ -32,35 +32,35 @@ const (
 	DefaultMaintainerEmail  = "me@example.com"
 )
 
-var defaultInstalledPackageStatus = &corev1.InstalledPackageStatus{
+var defaultInstalledPackageStatus = &pkgsGRPCv1alpha1.InstalledPackageStatus{
 	Ready:      true,
-	Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+	Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 	UserReason: "ReconciliationSucceeded",
 }
 
-func MakeAvailablePackageSummary(name string, plugin *plugins.Plugin) *corev1.AvailablePackageSummary {
-	return &corev1.AvailablePackageSummary{
+func MakeAvailablePackageSummary(name string, plugin *pluginsGRPCv1alpha1.Plugin) *pkgsGRPCv1alpha1.AvailablePackageSummary {
+	return &pkgsGRPCv1alpha1.AvailablePackageSummary{
 		Name:        name,
 		DisplayName: name,
-		LatestVersion: &corev1.PackageAppVersion{
+		LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 			PkgVersion: DefaultPkgVersion,
 			AppVersion: DefaultAppVersion,
 		},
 		IconUrl:          DefaultIconURL,
 		Categories:       []string{DefaultCategory},
 		ShortDescription: DefaultDescription,
-		AvailablePackageRef: &corev1.AvailablePackageReference{
-			Context:    &corev1.Context{Cluster: GlobalPackagingCluster, Namespace: DefaultNamespace},
+		AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+			Context:    &pkgsGRPCv1alpha1.Context{Cluster: GlobalPackagingCluster, Namespace: DefaultNamespace},
 			Identifier: DefaultId,
 			Plugin:     plugin,
 		},
 	}
 }
 
-func MakeInstalledPackageSummary(name string, plugin *plugins.Plugin) *corev1.InstalledPackageSummary {
-	return &corev1.InstalledPackageSummary{
-		InstalledPackageRef: &corev1.InstalledPackageReference{
-			Context: &corev1.Context{
+func MakeInstalledPackageSummary(name string, plugin *pluginsGRPCv1alpha1.Plugin) *pkgsGRPCv1alpha1.InstalledPackageSummary {
+	return &pkgsGRPCv1alpha1.InstalledPackageSummary{
+		InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+			Context: &pkgsGRPCv1alpha1.Context{
 				Namespace: DefaultNamespace,
 			},
 			Identifier: name,
@@ -68,32 +68,32 @@ func MakeInstalledPackageSummary(name string, plugin *plugins.Plugin) *corev1.In
 		},
 		Name:    name,
 		IconUrl: DefaultIconURL,
-		PkgVersionReference: &corev1.VersionReference{
+		PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 			Version: DefaultPkgVersion,
 		},
-		CurrentVersion: &corev1.PackageAppVersion{
+		CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 			PkgVersion: DefaultPkgVersion,
 			AppVersion: DefaultAppVersion,
 		},
 		PkgDisplayName:   name,
 		ShortDescription: DefaultDescription,
 		Status:           defaultInstalledPackageStatus,
-		LatestVersion: &corev1.PackageAppVersion{
+		LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 			PkgVersion: DefaultPkgVersion,
 			AppVersion: DefaultAppVersion,
 		},
 	}
 }
 
-func MakeAvailablePackageDetail(name string, plugin *plugins.Plugin) *corev1.AvailablePackageDetail {
-	return &corev1.AvailablePackageDetail{
-		AvailablePackageRef: &corev1.AvailablePackageReference{
-			Context:    &corev1.Context{Cluster: GlobalPackagingCluster, Namespace: DefaultNamespace},
+func MakeAvailablePackageDetail(name string, plugin *pluginsGRPCv1alpha1.Plugin) *pkgsGRPCv1alpha1.AvailablePackageDetail {
+	return &pkgsGRPCv1alpha1.AvailablePackageDetail{
+		AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+			Context:    &pkgsGRPCv1alpha1.Context{Cluster: GlobalPackagingCluster, Namespace: DefaultNamespace},
 			Identifier: DefaultId,
 			Plugin:     plugin,
 		},
 		Name: name,
-		Version: &corev1.PackageAppVersion{
+		Version: &pkgsGRPCv1alpha1.PackageAppVersion{
 			PkgVersion: DefaultPkgVersion,
 			AppVersion: DefaultAppVersion,
 		},
@@ -107,36 +107,36 @@ func MakeAvailablePackageDetail(name string, plugin *plugins.Plugin) *corev1.Ava
 		DefaultValues:    DefaultValues,
 		ValuesSchema:     DefaultValuesSchema,
 		SourceUrls:       []string{DefaultHomeURL},
-		Maintainers:      []*corev1.Maintainer{{Name: DefaultMaintainerName, Email: DefaultMaintainerEmail}},
+		Maintainers:      []*pkgsGRPCv1alpha1.Maintainer{{Name: DefaultMaintainerName, Email: DefaultMaintainerEmail}},
 	}
 }
 
-func MakeInstalledPackageDetail(name string, plugin *plugins.Plugin) *corev1.InstalledPackageDetail {
-	return &corev1.InstalledPackageDetail{
-		InstalledPackageRef: &corev1.InstalledPackageReference{
-			Context: &corev1.Context{
+func MakeInstalledPackageDetail(name string, plugin *pluginsGRPCv1alpha1.Plugin) *pkgsGRPCv1alpha1.InstalledPackageDetail {
+	return &pkgsGRPCv1alpha1.InstalledPackageDetail{
+		InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+			Context: &pkgsGRPCv1alpha1.Context{
 				Namespace: DefaultReleaseNamespace,
 				Cluster:   GlobalPackagingCluster,
 			},
 			Identifier: DefaultReleaseName,
 		},
-		PkgVersionReference: &corev1.VersionReference{
+		PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 			Version: DefaultReleaseVersion,
 		},
 		Name: DefaultReleaseName,
-		CurrentVersion: &corev1.PackageAppVersion{
+		CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 			PkgVersion: DefaultReleaseVersion,
 			AppVersion: DefaultAppVersion,
 		},
-		LatestVersion: &corev1.PackageAppVersion{
+		LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 			PkgVersion: DefaultReleaseVersion,
 			AppVersion: DefaultAppVersion,
 		},
 		ValuesApplied:         DefaultReleaseValues,
 		PostInstallationNotes: DefaultReleaseNotes,
 		Status:                defaultInstalledPackageStatus,
-		AvailablePackageRef: &corev1.AvailablePackageReference{
-			Context: &corev1.Context{
+		AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+			Context: &pkgsGRPCv1alpha1.Context{
 				Namespace: DefaultReleaseNamespace,
 				Cluster:   GlobalPackagingCluster,
 			},
@@ -147,8 +147,8 @@ func MakeInstalledPackageDetail(name string, plugin *plugins.Plugin) *corev1.Ins
 	}
 }
 
-func MakePackageAppVersion(appVersion, pkgVersion string) *corev1.PackageAppVersion {
-	return &corev1.PackageAppVersion{
+func MakePackageAppVersion(appVersion, pkgVersion string) *pkgsGRPCv1alpha1.PackageAppVersion {
+	return &pkgsGRPCv1alpha1.PackageAppVersion{
 		AppVersion: appVersion,
 		PkgVersion: pkgVersion,
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/chart_cache.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/chart_cache.go
@@ -14,18 +14,18 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-redis/redis/v8"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
+	redis "github.com/go-redis/redis/v8"
+	pkgfluxv2common "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
+	pkgutils "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
-	k8scache "k8s.io/client-go/tools/cache"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	k8sruntimeutil "k8s.io/apimachinery/pkg/util/runtime"
+	k8ssets "k8s.io/apimachinery/pkg/util/sets"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+	k8stoolscache "k8s.io/client-go/tools/cache"
 	log "k8s.io/klog/v2"
 )
 
@@ -57,7 +57,7 @@ type ChartCache struct {
 	// is called by the producer and runWorker consumer picks up
 	// the corresponding item from the queue. Upon successful processing
 	// of the item, the corresponding store entry is deleted
-	processing k8scache.Store
+	processing k8stoolscache.Store
 
 	// I am using a Read/Write Mutex to gate access to cache's resync() operation, which is
 	// significant in that it flushes the whole redis cache and re-populates the state from k8s.
@@ -82,7 +82,7 @@ type chartCacheStoreEntry struct {
 	id            string
 	version       string
 	url           string
-	clientOptions *common.ClientOptions
+	clientOptions *pkgfluxv2common.ClientOptions
 	deleted       bool
 }
 
@@ -96,7 +96,7 @@ func NewChartCache(name string, redisCli *redis.Client, stopCh <-chan struct{}) 
 	c := ChartCache{
 		redisCli:   redisCli,
 		queue:      NewRateLimitingQueue(name, verboseChartCacheQueue),
-		processing: k8scache.NewStore(chartCacheKeyFunc),
+		processing: k8stoolscache.NewStore(chartCacheKeyFunc),
 		resyncCond: sync.NewCond(&sync.RWMutex{}),
 	}
 
@@ -109,7 +109,7 @@ func NewChartCache(name string, redisCli *redis.Client, stopCh <-chan struct{}) 
 		fn := func() {
 			c.runWorker(name)
 		}
-		go wait.Until(fn, time.Second, stopCh)
+		go k8swait.Until(fn, time.Second, stopCh)
 	}
 
 	return &c, nil
@@ -117,7 +117,7 @@ func NewChartCache(name string, redisCli *redis.Client, stopCh <-chan struct{}) 
 
 // this func will enqueue work items into chart work queue and return.
 // the charts will be synced by a worker thread running in the background
-func (c *ChartCache) SyncCharts(charts []models.Chart, clientOptions *common.ClientOptions) error {
+func (c *ChartCache) SyncCharts(charts []chartmodels.Chart, clientOptions *pkgfluxv2common.ClientOptions) error {
 	log.Infof("+SyncCharts()")
 	totalToSync := 0
 	defer func() {
@@ -200,7 +200,7 @@ func (c *ChartCache) processNextWorkItem(workerName string) bool {
 		// Forget() here else we'd go into a loop of attempting to
 		// process a work item that is invalid.
 		c.queue.Forget(obj)
-		runtime.HandleError(fmt.Errorf("expected string in work queue but got %#v", obj))
+		k8sruntimeutil.HandleError(fmt.Errorf("expected string in work queue but got %#v", obj))
 		return true
 	}
 	if !c.queue.IsProcessing(key) {
@@ -222,12 +222,12 @@ func (c *ChartCache) processNextWorkItem(workerName string) bool {
 		log.Errorf("Error processing %s (giving up): %v", key, err)
 		c.queue.Forget(key)
 		c.processing.Delete(key)
-		runtime.HandleError(fmt.Errorf("error syncing key [%s] due to: %v", key, err))
+		k8sruntimeutil.HandleError(fmt.Errorf("error syncing key [%s] due to: %v", key, err))
 	}
 	return true
 }
 
-func (c *ChartCache) DeleteChartsForRepo(repo *types.NamespacedName) error {
+func (c *ChartCache) DeleteChartsForRepo(repo *k8stypes.NamespacedName) error {
 	log.Infof("+DeleteChartsFor(%s)", repo)
 	defer log.Infof("-DeleteChartsFor(%s)", repo)
 
@@ -244,7 +244,7 @@ func (c *ChartCache) DeleteChartsForRepo(repo *types.NamespacedName) error {
 		KeySegmentsSeparator,
 		repo.Name,
 		KeySegmentsSeparator)
-	redisKeysToDelete := sets.String{}
+	redisKeysToDelete := k8ssets.String{}
 	// https://redis.io/commands/scan An iteration starts when the cursor is set to 0,
 	// and terminates when the cursor returned by the server is 0
 	cursor := uint64(0)
@@ -318,7 +318,7 @@ func (c *ChartCache) OnResync() error {
 
 	log.Infof("Resetting work queue [%s] and store...", c.queue.Name())
 	c.queue.Reset()
-	c.processing = k8scache.NewStore(chartCacheKeyFunc)
+	c.processing = k8stoolscache.NewStore(chartCacheKeyFunc)
 	return nil
 }
 
@@ -377,7 +377,7 @@ func (c *ChartCache) syncHandler(workerName, key string) error {
 			return fmt.Errorf("failed to set value for object with key [%s] in cache due to: %v", key, err)
 		} else {
 			duration := time.Since(startTime)
-			usedMemory, totalMemory := common.RedisMemoryStats(c.redisCli)
+			usedMemory, totalMemory := pkgfluxv2common.RedisMemoryStats(c.redisCli)
 			log.Infof("Redis [SET %s]: %s in [%d] ms. Redis [INFO memory]: [%s/%s]",
 				key, result, duration.Milliseconds(), usedMemory, totalMemory)
 		}
@@ -424,7 +424,7 @@ func (c *ChartCache) FetchForOne(key string) ([]byte, error) {
  • otherwise return the bytes stored in the
  chart cache for the given entry
 */
-func (c *ChartCache) GetForOne(key string, chart *models.Chart, clientOptions *common.ClientOptions) ([]byte, error) {
+func (c *ChartCache) GetForOne(key string, chart *chartmodels.Chart, clientOptions *pkgfluxv2common.ClientOptions) ([]byte, error) {
 	// TODO (gfichtenholt) it'd be nice to get rid of all arguments except for the key, similar to that of
 	// NamespacedResourceWatcherCache.GetForOne()
 	log.Infof("+GetForOne(%s)", key)
@@ -482,7 +482,7 @@ func (c *ChartCache) String() string {
 func (c *ChartCache) fromKey(key string) (namespace, chartID, chartVersion string, err error) {
 	parts := strings.Split(key, KeySegmentsSeparator)
 	if len(parts) != 4 || parts[0] != "helmcharts" || len(parts[1]) == 0 || len(parts[2]) == 0 || len(parts[3]) == 0 {
-		return "", "", "", status.Errorf(codes.Internal, "invalid key [%s]", key)
+		return "", "", "", grpcstatus.Errorf(grpccodes.Internal, "invalid key [%s]", key)
 	}
 	return parts[1], parts[2], parts[3], nil
 }
@@ -514,7 +514,7 @@ func (c *ChartCache) ExpectResync() (chan int, error) {
 	}()
 
 	if c.resyncCh != nil {
-		return nil, status.Errorf(codes.Internal, "ExpectSync() already called")
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "ExpectSync() already called")
 	} else {
 		c.resyncCh = make(chan int, 1)
 		return c.resyncCh, nil
@@ -569,8 +569,8 @@ func chartCacheKeyFor(namespace, chartID, chartVersion string) (string, error) {
 }
 
 // FYI: The work queue is able to retry transient HTTP errors
-func ChartCacheComputeValue(chartID, chartUrl, chartVersion string, clientOptions *common.ClientOptions) ([]byte, error) {
-	client, headers, err := common.NewHttpClientAndHeaders(clientOptions)
+func ChartCacheComputeValue(chartID, chartUrl, chartVersion string, clientOptions *pkgfluxv2common.ClientOptions) ([]byte, error) {
+	client, headers, err := pkgfluxv2common.NewHttpClientAndHeaders(clientOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/watcher_cache.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/watcher_cache.go
@@ -13,23 +13,23 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-redis/redis/v8"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/clientgetter"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	apiv1 "k8s.io/api/core/v1"
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	errorutil "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/watch"
-	watchutil "k8s.io/client-go/tools/watch"
+	redis "github.com/go-redis/redis/v8"
+	pkgfluxv2common "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
+	clientgetter "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/clientgetter"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	k8scorev1 "k8s.io/api/core/v1"
+	k8sapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8smetaunstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	k8serrorsutil "k8s.io/apimachinery/pkg/util/errors"
+	k8sruntimeutil "k8s.io/apimachinery/pkg/util/runtime"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
+	k8swatch "k8s.io/apimachinery/pkg/watch"
+	k8stoolswatch "k8s.io/client-go/tools/watch"
 	log "k8s.io/klog/v2"
 )
 
@@ -93,7 +93,7 @@ type KeyDeleterFunc func(key string) (deleteValue bool, err error)
 type ResyncFunc func() error
 
 type NamespacedResourceWatcherCacheConfig struct {
-	Gvr schema.GroupVersionResource
+	Gvr k8sschema.GroupVersionResource
 	// this ClientGetter is for running out-of-request interactions with the Kubernetes API server,
 	// such as watching for resource changes
 	ClientGetter clientgetter.ClientGetterWithApiExtFunc
@@ -167,7 +167,7 @@ func NewNamespacedResourceWatcherCache(name string, config NamespacedResourceWat
 	// then rekick the worker after one second
 	// We should be able to launch multiple workers, and the workqueue will make sure that
 	// only a single worker works on an item with a given key.
-	go wait.Until(c.runWorker, time.Second, stopCh)
+	go k8swait.Until(c.runWorker, time.Second, stopCh)
 
 	go c.watchLoop(watcher, stopCh)
 	return &c, nil
@@ -187,12 +187,12 @@ func (c *NamespacedResourceWatcherCache) isGvrValid() error {
 	}
 
 	name := fmt.Sprintf("%s.%s", c.config.Gvr.Resource, c.config.Gvr.Group)
-	if crd, err := apiExt.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{}); err != nil {
+	if crd, err := apiExt.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, k8smetav1.GetOptions{}); err != nil {
 		return err
 	} else {
 		for _, condition := range crd.Status.Conditions {
-			if condition.Type == apiextv1.Established &&
-				condition.Status == apiextv1.ConditionTrue {
+			if condition.Type == k8sapiextensionsv1.Established &&
+				condition.Status == k8sapiextensionsv1.ConditionTrue {
 				return nil
 			}
 		}
@@ -241,7 +241,7 @@ func (c *NamespacedResourceWatcherCache) processNextWorkItem() bool {
 		// Forget() here else we'd go into a loop of attempting to
 		// process a work item that is invalid.
 		c.queue.Forget(obj)
-		runtime.HandleError(fmt.Errorf("expected string in work queue but got %#v", obj))
+		k8sruntimeutil.HandleError(fmt.Errorf("expected string in work queue but got %#v", obj))
 		return true
 	}
 	if !c.queue.IsProcessing(key) {
@@ -261,12 +261,12 @@ func (c *NamespacedResourceWatcherCache) processNextWorkItem() bool {
 		// err != nil and too many retries
 		log.Errorf("Error processing %s (giving up): %v", key, err)
 		c.queue.Forget(key)
-		runtime.HandleError(fmt.Errorf("error syncing key [%s] due to: %v", key, err))
+		k8sruntimeutil.HandleError(fmt.Errorf("error syncing key [%s] due to: %v", key, err))
 	}
 	return true
 }
 
-func (c *NamespacedResourceWatcherCache) watchLoop(watcher *watchutil.RetryWatcher, stopCh <-chan struct{}) {
+func (c *NamespacedResourceWatcherCache) watchLoop(watcher *k8stoolswatch.RetryWatcher, stopCh <-chan struct{}) {
 	for {
 		shutdown := c.processEvents(watcher.ResultChan(), stopCh)
 
@@ -301,13 +301,13 @@ func (c *NamespacedResourceWatcherCache) watchLoop(watcher *watchutil.RetryWatch
 				c.queue.Name(), maxWatcherCacheRetries, err)
 			// yes, I really want this to panic. Something is seriously wrong
 			// possibly restarting plugin/kubeapps-apis server is needed...
-			defer runtime.Must(err)
+			defer k8sruntimeutil.Must(err)
 			break
 		}
 	}
 }
 
-func (c *NamespacedResourceWatcherCache) resyncAndNewRetryWatcher(bootstrap bool) (watcher *watchutil.RetryWatcher, eror error) {
+func (c *NamespacedResourceWatcherCache) resyncAndNewRetryWatcher(bootstrap bool) (watcher *k8stoolswatch.RetryWatcher, eror error) {
 	log.Infof("+resyncAndNewRetryWatcher()")
 	c.resyncCond.L.Lock()
 	defer func() {
@@ -326,9 +326,9 @@ func (c *NamespacedResourceWatcherCache) resyncAndNewRetryWatcher(bootstrap bool
 	// max backoff is 2^(NamespacedResourceWatcherCacheMaxResyncBackoff) seconds
 	for i := 0; i < maxWatcherCacheResyncBackoff; i++ {
 		if resourceVersion, err = c.resync(bootstrap); err != nil {
-			runtime.HandleError(fmt.Errorf("failed to resync due to: %v", err))
-		} else if watcher, err = watchutil.NewRetryWatcher(resourceVersion, c); err != nil {
-			runtime.HandleError(fmt.Errorf("failed to create a new RetryWatcher due to: %v", err))
+			k8sruntimeutil.HandleError(fmt.Errorf("failed to resync due to: %v", err))
+		} else if watcher, err = k8stoolswatch.NewRetryWatcher(resourceVersion, c); err != nil {
+			k8sruntimeutil.HandleError(fmt.Errorf("failed to create a new RetryWatcher due to: %v", err))
 		} else {
 			break
 		}
@@ -346,16 +346,16 @@ func (c *NamespacedResourceWatcherCache) resyncAndNewRetryWatcher(bootstrap bool
 
 // ResourceWatcherCache must implement cache.Watcher interface, which is this:
 // https://pkg.go.dev/k8s.io/client-go@v0.20.8/tools/cache#Watcher
-func (c *NamespacedResourceWatcherCache) Watch(options metav1.ListOptions) (watch.Interface, error) {
+func (c *NamespacedResourceWatcherCache) Watch(options k8smetav1.ListOptions) (k8swatch.Interface, error) {
 	ctx := context.Background()
 
 	_, dynamicClient, _, err := c.config.ClientGetter(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "unable to get client due to: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition, "unable to get client due to: %v", err)
 	}
 
 	// this will start a watcher on all namespaces
-	return dynamicClient.Resource(c.config.Gvr).Namespace(apiv1.NamespaceAll).Watch(ctx, options)
+	return dynamicClient.Resource(c.config.Gvr).Namespace(k8scorev1.NamespaceAll).Watch(ctx, options)
 }
 
 // it is expected that the caller will perform lock/unlock of c.resyncCond as there maybe
@@ -366,8 +366,8 @@ func (c *NamespacedResourceWatcherCache) resync(bootstrap bool) (string, error) 
 
 	// confidence test: I'd like to make sure this is called within the context
 	// of resync, i.e. resync.Cond.L is locked by this goroutine.
-	if !common.RWMutexWriteLocked(c.resyncCond.L.(*sync.RWMutex)) {
-		return "", status.Errorf(codes.Internal, "Invalid state of the cache in resync()")
+	if !pkgfluxv2common.RWMutexWriteLocked(c.resyncCond.L.(*sync.RWMutex)) {
+		return "", grpcstatus.Errorf(grpccodes.Internal, "Invalid state of the cache in resync()")
 	}
 
 	// no need to do any of this on bootstrap, queue should be empty
@@ -384,7 +384,7 @@ func (c *NamespacedResourceWatcherCache) resync(bootstrap bool) (string, error) 
 		c.queue.Reset()
 
 		if err := c.config.OnResyncFunc(); err != nil {
-			return "", status.Errorf(codes.Internal, "invocation of [OnResync] failed due to: %v", err)
+			return "", grpcstatus.Errorf(grpccodes.Internal, "invocation of [OnResync] failed due to: %v", err)
 		}
 	}
 
@@ -398,7 +398,7 @@ func (c *NamespacedResourceWatcherCache) resync(bootstrap bool) (string, error) 
 	ctx := context.Background()
 	_, dynamicClient, _, err := c.config.ClientGetter(ctx)
 	if err != nil {
-		return "", status.Errorf(codes.FailedPrecondition, "unable to get client due to: %v", err)
+		return "", grpcstatus.Errorf(grpccodes.FailedPrecondition, "unable to get client due to: %v", err)
 	}
 
 	// This code runs in the background, i.e. not in a context of any specific user request.
@@ -410,19 +410,19 @@ func (c *NamespacedResourceWatcherCache) resync(bootstrap bool) (string, error) 
 	// per https://kubernetes.io/docs/reference/using-api/api-concepts/
 	// For Get() and List(), the semantics of resource version unset are to get the most recent
 	// version
-	listItems, err := dynamicClient.Resource(c.config.Gvr).Namespace(apiv1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	listItems, err := dynamicClient.Resource(c.config.Gvr).Namespace(k8scorev1.NamespaceAll).List(ctx, k8smetav1.ListOptions{})
 	if err != nil {
 		return "", err
 	}
 
 	// for debug only, will remove later
 	log.Infof("List(%s) returned list with [%d] items, object:\n%s",
-		c.config.Gvr.Resource, len(listItems.Items), common.PrettyPrintMap(listItems.Object))
+		c.config.Gvr.Resource, len(listItems.Items), pkgfluxv2common.PrettyPrintMap(listItems.Object))
 
 	rv := listItems.GetResourceVersion()
 	if rv == "" {
 		// fail fast, without a valid resource version the whole workflow breaks down
-		return "", status.Errorf(codes.Internal, "List() call response does not contain resource version")
+		return "", grpcstatus.Errorf(grpccodes.Internal, "List() call response does not contain resource version")
 	}
 
 	// re-populate the cache with current state from k8s
@@ -430,13 +430,13 @@ func (c *NamespacedResourceWatcherCache) resync(bootstrap bool) (string, error) 
 		// we don't want to fail the whole re-sync process and trigger retries
 		// if, for example, just one of the repos fails to sync to cache, so
 		// for now log the error(s)
-		runtime.HandleError(fmt.Errorf("populateWith failed due to: %+v", err))
+		k8sruntimeutil.HandleError(fmt.Errorf("populateWith failed due to: %+v", err))
 	}
 	return rv, nil
 }
 
 // this is loop that waits for new events and processes them when they happen
-func (c *NamespacedResourceWatcherCache) processEvents(watchCh <-chan watch.Event, stopCh <-chan struct{}) (shuttingDown bool) {
+func (c *NamespacedResourceWatcherCache) processEvents(watchCh <-chan k8swatch.Event, stopCh <-chan struct{}) (shuttingDown bool) {
 	for {
 		select {
 		case event, ok := <-watchCh:
@@ -459,30 +459,30 @@ func (c *NamespacedResourceWatcherCache) processEvents(watchCh <-chan watch.Even
 	}
 }
 
-func (c *NamespacedResourceWatcherCache) processOneEvent(event watch.Event) {
+func (c *NamespacedResourceWatcherCache) processOneEvent(event k8swatch.Event) {
 	if event.Type == "" {
 		// not quite sure why this happens (the docs don't say), but it seems to happen quite often
 		return
 	}
-	log.Infof("Got event: type: [%v] object:\n[%s]", event.Type, common.PrettyPrintObject(event.Object))
+	log.Infof("Got event: type: [%v] object:\n[%s]", event.Type, pkgfluxv2common.PrettyPrintObject(event.Object))
 	switch event.Type {
-	case watch.Added, watch.Modified, watch.Deleted:
-		if unstructuredObj, ok := event.Object.(*unstructured.Unstructured); !ok {
-			runtime.HandleError(fmt.Errorf("could not cast %s to unstructured.Unstructured", reflect.TypeOf(event.Object)))
+	case k8swatch.Added, k8swatch.Modified, k8swatch.Deleted:
+		if unstructuredObj, ok := event.Object.(*k8smetaunstructuredv1.Unstructured); !ok {
+			k8sruntimeutil.HandleError(fmt.Errorf("could not cast %s to k8smetaunstructuredv1.Unstructured", reflect.TypeOf(event.Object)))
 		} else {
 			if key, err := c.keyFor(unstructuredObj.Object); err != nil {
-				runtime.HandleError(err)
+				k8sruntimeutil.HandleError(err)
 			} else {
 				c.queue.AddRateLimited(key)
 			}
 		}
-	case watch.Error:
+	case k8swatch.Error:
 		// will let RetryWatcher deal with it, which will close the channel
 		return
 
 	default:
 		// TODO (gfichtenholt) handle other kinds of events?
-		runtime.HandleError(fmt.Errorf("got unexpected event: %v", event))
+		k8sruntimeutil.HandleError(fmt.Errorf("got unexpected event: %v", event))
 	}
 }
 
@@ -501,7 +501,7 @@ func (c *NamespacedResourceWatcherCache) syncHandler(key string) error {
 	ctx := context.Background()
 	_, dynamicClient, _, err := c.config.ClientGetter(ctx)
 	if err != nil {
-		return status.Errorf(codes.FailedPrecondition, "unable to get client due to: %v", err)
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition, "unable to get client due to: %v", err)
 	}
 
 	// TODO: (gfichtenholt) confidence test: I'd like to make sure the caller has the read lock,
@@ -512,13 +512,13 @@ func (c *NamespacedResourceWatcherCache) syncHandler(key string) error {
 	// attempt processing again later. This could have been caused by a temporary network
 	// failure, or any other transient reason.
 	unstructuredObj, err := dynamicClient.Resource(c.config.Gvr).Namespace(name.Namespace).
-		Get(ctx, name.Name, metav1.GetOptions{})
+		Get(ctx, name.Name, k8smetav1.GetOptions{})
 	if err != nil {
 		// The resource may no longer exist, in which case we stop processing.
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return c.onDelete(key)
 		} else {
-			return status.Errorf(codes.Internal, "error fetching object with key [%s]: %v", key, err)
+			return grpcstatus.Errorf(grpccodes.Internal, "error fetching object with key [%s]: %v", key, err)
 		}
 	}
 	return c.onAddOrModify(true, unstructuredObj.Object)
@@ -555,7 +555,7 @@ func (c *NamespacedResourceWatcherCache) onAddOrModify(checkOldValue bool, unstr
 	}
 
 	if err != nil {
-		log.Errorf("Invocation of [%s] for object %s\nfailed due to: %v", funcName, common.PrettyPrintMap(unstructuredObj), err)
+		log.Errorf("Invocation of [%s] for object %s\nfailed due to: %v", funcName, pkgfluxv2common.PrettyPrintMap(unstructuredObj), err)
 		// clear that key so cache doesn't contain any stale info for this object
 		keysremoved, err2 := c.redisCli.Del(c.redisCli.Context(), key).Result()
 		if err2 != nil {
@@ -576,7 +576,7 @@ func (c *NamespacedResourceWatcherCache) onAddOrModify(checkOldValue bool, unstr
 		} else {
 			duration := time.Since(startTime)
 			// debugging an intermittent issue
-			usedMemory, totalMemory := common.RedisMemoryStats(c.redisCli)
+			usedMemory, totalMemory := pkgfluxv2common.RedisMemoryStats(c.redisCli)
 			log.Infof("Redis [SET %s]: %s in [%d] ms. Redis [INFO memory]: [%s/%s]",
 				key, result, duration.Milliseconds(), usedMemory, totalMemory)
 		}
@@ -706,7 +706,7 @@ func (c *NamespacedResourceWatcherCache) fetchForMultiple(keys []string) (map[st
 			errs = append(errs, resp.err)
 		}
 	}
-	return response, errorutil.NewAggregate(errs)
+	return response, k8serrorsutil.NewAggregate(errs)
 }
 
 // the difference between 'fetchForMultiple' and 'GetForMultiple' is that 'fetch' will only
@@ -809,24 +809,24 @@ func (c *NamespacedResourceWatcherCache) GetForMultiple(keys []string) (map[stri
 			errs = append(errs, resp.err)
 		}
 	}
-	return chartsUntyped, errorutil.NewAggregate(errs)
+	return chartsUntyped, k8serrorsutil.NewAggregate(errs)
 }
 
 // TODO (gfichtenholt) give the plug-ins the ability to override this (default) implementation
 // for generating a cache key given an object
 // some kind of 'KeyFunc(unstructuredObj) string'
 func (c *NamespacedResourceWatcherCache) keyFor(unstructuredObj map[string]interface{}) (string, error) {
-	name, err := common.NamespacedName(unstructuredObj)
+	name, err := pkgfluxv2common.NamespacedName(unstructuredObj)
 	if err != nil {
 		return "", err
 	}
 	return c.KeyForNamespacedName(*name), nil
 }
 
-func (c *NamespacedResourceWatcherCache) KeyForNamespacedName(name types.NamespacedName) string {
+func (c *NamespacedResourceWatcherCache) KeyForNamespacedName(name k8stypes.NamespacedName) string {
 	// redis convention on key format
 	// https://redis.io/topics/data-types-intro
-	// Try to stick with a schema. For instance "object-type:id" is a good idea, as in "user:1000".
+	// Try to stick with a k8sschema. For instance "object-type:id" is a good idea, as in "user:1000".
 	// We will use "helmrepositories:ns:repoName"
 	return fmt.Sprintf("%s%s%s%s%s",
 		c.config.Gvr.Resource,
@@ -838,12 +838,12 @@ func (c *NamespacedResourceWatcherCache) KeyForNamespacedName(name types.Namespa
 
 // the opposite of keyFor()
 // the goal is to keep the details of what exactly the key looks like localized to one piece of code
-func (c *NamespacedResourceWatcherCache) fromKey(key string) (*types.NamespacedName, error) {
+func (c *NamespacedResourceWatcherCache) fromKey(key string) (*k8stypes.NamespacedName, error) {
 	parts := strings.Split(key, KeySegmentsSeparator)
 	if len(parts) != 3 || parts[0] != c.config.Gvr.Resource || len(parts[1]) == 0 || len(parts[2]) == 0 {
-		return nil, status.Errorf(codes.Internal, "invalid key [%s]", key)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "invalid key [%s]", key)
 	}
-	return &types.NamespacedName{Namespace: parts[1], Name: parts[2]}, nil
+	return &k8stypes.NamespacedName{Namespace: parts[1], Name: parts[2]}, nil
 }
 
 // This func is only called in the context of a resync() operation,
@@ -852,11 +852,11 @@ func (c *NamespacedResourceWatcherCache) fromKey(key string) (*types.NamespacedN
 // Computing a value for a key maybe expensive, e.g. indexing a repo takes a while,
 // so we will do this in a concurrent fashion to minimize the time window and performance
 // impact of doing so
-func (c *NamespacedResourceWatcherCache) populateWith(items []unstructured.Unstructured) error {
+func (c *NamespacedResourceWatcherCache) populateWith(items []k8smetaunstructuredv1.Unstructured) error {
 	// confidence test: I'd like to make sure this is called within the context
 	// of resync, i.e. resync.Cond.L is locked by this goroutine.
-	if !common.RWMutexWriteLocked(c.resyncCond.L.(*sync.RWMutex)) {
-		return status.Errorf(codes.Internal, "Invalid state of the cache in populateWith()")
+	if !pkgfluxv2common.RWMutexWriteLocked(c.resyncCond.L.(*sync.RWMutex)) {
+		return grpcstatus.Errorf(grpccodes.Internal, "Invalid state of the cache in populateWith()")
 	}
 
 	// max number of concurrent workers computing cache values at the same time
@@ -912,7 +912,7 @@ func (c *NamespacedResourceWatcherCache) populateWith(items []unstructured.Unstr
 			errs = append(errs, resp.err)
 		}
 	}
-	return errorutil.NewAggregate(errs)
+	return k8serrorsutil.NewAggregate(errs)
 }
 
 // GetForOne() is like fetchForOne() but if there is a cache miss, it will also check the
@@ -970,7 +970,7 @@ func (c *NamespacedResourceWatcherCache) ExpectResync() (chan int, error) {
 	}()
 
 	if c.resyncCh != nil {
-		return nil, status.Errorf(codes.Internal, "ExpectSync() already called")
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "ExpectSync() already called")
 	} else {
 		c.resyncCh = make(chan int, 1)
 		// this channel will be closed and nil'ed out at the end of resync()

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart_test.go
@@ -14,20 +14,20 @@ import (
 	"testing"
 
 	redismock "github.com/go-redis/redismock/v8"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
+	cmp "github.com/google/go-cmp/cmp"
+	cmpopts "github.com/google/go-cmp/cmp/cmpopts"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	pkgfluxv2cache "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache"
+	pkgfluxv2common "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8smetaunstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
 type testSpecChartWithFile struct {
@@ -39,15 +39,15 @@ type testSpecChartWithFile struct {
 func TestGetAvailablePackageDetail(t *testing.T) {
 	testCases := []struct {
 		testName              string
-		request               *corev1.GetAvailablePackageDetailRequest
+		request               *pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest
 		chartCacheHit         bool
 		basicAuth             bool // also known as "private" or "secure"
 		tls                   bool // also known as "private" or "secure"
-		expectedPackageDetail *corev1.AvailablePackageDetail
+		expectedPackageDetail *pkgsGRPCv1alpha1.AvailablePackageDetail
 	}{
 		{
 			testName: "it returns details about the latest redis package in bitnami repo",
-			request: &corev1.GetAvailablePackageDetailRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef("bitnami-1/redis", "default"),
 			},
 			chartCacheHit:         true,
@@ -55,7 +55,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 		},
 		{
 			testName: "it returns details about the redis package with specific version in bitnami repo",
-			request: &corev1.GetAvailablePackageDetailRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef("bitnami-1/redis", "default"),
 				PkgVersion:          "14.3.4",
 			},
@@ -64,7 +64,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 		},
 		{
 			testName: "it returns details about the latest redis package from a repo with basic auth",
-			request: &corev1.GetAvailablePackageDetailRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef("bitnami-1/redis", "default"),
 			},
 			chartCacheHit:         true,
@@ -73,7 +73,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 		},
 		{
 			testName: "it returns details about the latest redis package from a repo with TLS",
-			request: &corev1.GetAvailablePackageDetailRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef("bitnami-1/redis", "default"),
 			},
 			chartCacheHit:         true,
@@ -83,7 +83,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 		},
 		{
 			testName: "it returns details about the latest redis package from a repo with TLS and basic auth",
-			request: &corev1.GetAvailablePackageDetailRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef("bitnami-1/redis", "default"),
 			},
 			chartCacheHit:         true,
@@ -114,7 +114,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 			requestChartUrl := ""
 
 			// these will be used later in a few places
-			opts := &common.ClientOptions{}
+			opts := &pkgfluxv2common.ClientOptions{}
 			if tc.basicAuth {
 				opts.Username = "foo"
 				opts.Password = "bar"
@@ -172,7 +172,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 			}
 
 			secretRef := ""
-			secretObjs := []runtime.Object{}
+			secretObjs := []k8sruntime.Object{}
 			if tc.basicAuth && tc.tls {
 				secretRef = "both-credentials"
 				if secret, err := newBasicAuthTlsSecret(secretRef, repoNamespace, "foo", "bar", pub, priv, ca); err != nil {
@@ -199,7 +199,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 			}
 			defer ts2.Close()
 
-			s, mock, _, _, err := newServerWithRepos(t, []runtime.Object{repo}, charts, secretObjs)
+			s, mock, _, _, err := newServerWithRepos(t, []k8sruntime.Object{repo}, charts, secretObjs)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -294,7 +294,7 @@ func TestTransientHttpFailuresAreRetriedForChartCache(t *testing.T) {
 		}
 		defer ts2.Close()
 
-		s, mock, _, _, err := newServerWithRepos(t, []runtime.Object{repo}, charts, nil)
+		s, mock, _, _, err := newServerWithRepos(t, []k8sruntime.Object{repo}, charts, nil)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -318,7 +318,7 @@ func TestTransientHttpFailuresAreRetriedForChartCache(t *testing.T) {
 
 		response, err := s.GetAvailablePackageDetail(
 			context.Background(),
-			&corev1.GetAvailablePackageDetailRequest{
+			&pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef(packageIdentifier, repoNamespace),
 			})
 		if err != nil {
@@ -337,23 +337,23 @@ func TestTransientHttpFailuresAreRetriedForChartCache(t *testing.T) {
 func TestNegativeGetAvailablePackageDetail(t *testing.T) {
 	negativeTestCases := []struct {
 		testName   string
-		request    *corev1.GetAvailablePackageDetailRequest
-		statusCode codes.Code
+		request    *pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest
+		statusCode grpccodes.Code
 	}{
 		{
 			testName: "it fails if request is missing namespace",
-			request: &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
 					Identifier: "redis",
 				}},
-			statusCode: codes.InvalidArgument,
+			statusCode: grpccodes.InvalidArgument,
 		},
 		{
 			testName: "it fails if request has invalid identifier",
-			request: &corev1.GetAvailablePackageDetailRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef("redis", "default"),
 			},
-			statusCode: codes.InvalidArgument,
+			statusCode: grpccodes.InvalidArgument,
 		},
 	}
 
@@ -369,7 +369,7 @@ func TestNegativeGetAvailablePackageDetail(t *testing.T) {
 			if err == nil {
 				t.Fatalf("got nil, want error")
 			}
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
@@ -385,51 +385,51 @@ func TestNegativeGetAvailablePackageDetail(t *testing.T) {
 }
 
 // TODO: (gfichtenholt) some, if not all, these scenarios probably ought to return
-// codes.NotFound instead of codes.Internal. The spec does not specify yet.
+// grpccodes.NotFound instead of grpccodes.Internal. The spec does not specify yet.
 func TestNonExistingRepoOrInvalidPkgVersionGetAvailablePackageDetail(t *testing.T) {
 	negativeTestCases := []struct {
 		testName      string
-		request       *corev1.GetAvailablePackageDetailRequest
+		request       *pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest
 		repoName      string
 		repoNamespace string
-		statusCode    codes.Code
+		statusCode    grpccodes.Code
 	}{
 		{
 			testName:      "it fails if request has invalid package version",
 			repoName:      "bitnami-1",
 			repoNamespace: "default",
-			request: &corev1.GetAvailablePackageDetailRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef("bitnami-1/redis", "default"),
 				PkgVersion:          "99.99.0",
 			},
-			statusCode: codes.Internal,
+			statusCode: grpccodes.Internal,
 		},
 		{
 			testName:      "it fails if repo does not exist",
 			repoName:      "bitnami-1",
 			repoNamespace: "default",
-			request: &corev1.GetAvailablePackageDetailRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef("bitnami-2/redis", "default"),
 			},
-			statusCode: codes.NotFound,
+			statusCode: grpccodes.NotFound,
 		},
 		{
 			testName:      "it fails if repo does not exist in specified namespace",
 			repoName:      "bitnami-1",
 			repoNamespace: "non-default",
-			request: &corev1.GetAvailablePackageDetailRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef("bitnami-1/redis", "default"),
 			},
-			statusCode: codes.NotFound,
+			statusCode: grpccodes.NotFound,
 		},
 		{
 			testName:      "it fails if request has invalid chart",
 			repoName:      "bitnami-1",
 			repoNamespace: "default",
-			request: &corev1.GetAvailablePackageDetailRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
 				AvailablePackageRef: availableRef("bitnami-1/redis-123", "default"),
 			},
-			statusCode: codes.NotFound,
+			statusCode: grpccodes.NotFound,
 		},
 	}
 
@@ -465,7 +465,7 @@ func TestNonExistingRepoOrInvalidPkgVersionGetAvailablePackageDetail(t *testing.
 			}
 			defer ts2.Close()
 
-			s, mock, _, _, err := newServerWithRepos(t, []runtime.Object{repo}, charts, nil)
+			s, mock, _, _, err := newServerWithRepos(t, []k8sruntime.Object{repo}, charts, nil)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -499,7 +499,7 @@ func TestNonExistingRepoOrInvalidPkgVersionGetAvailablePackageDetail(t *testing.
 			if err == nil {
 				t.Fatalf("got nil, want error")
 			}
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
@@ -517,35 +517,35 @@ func TestNonExistingRepoOrInvalidPkgVersionGetAvailablePackageDetail(t *testing.
 func TestNegativeGetAvailablePackageVersions(t *testing.T) {
 	testCases := []struct {
 		name               string
-		request            *corev1.GetAvailablePackageVersionsRequest
-		expectedStatusCode codes.Code
-		expectedResponse   *corev1.GetAvailablePackageVersionsResponse
+		request            *pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest
+		expectedStatusCode grpccodes.Code
+		expectedResponse   *pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse
 	}{
 		{
 			name:               "it returns invalid argument if called without a package reference",
 			request:            nil,
-			expectedStatusCode: codes.InvalidArgument,
+			expectedStatusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name: "it returns invalid argument if called without namespace",
-			request: &corev1.GetAvailablePackageVersionsRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{},
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{},
 					Identifier: "bitnami/apache",
 				},
 			},
-			expectedStatusCode: codes.InvalidArgument,
+			expectedStatusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name: "it returns invalid argument if called without an identifier",
-			request: &corev1.GetAvailablePackageVersionsRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Namespace: "kubeapps",
 					},
 				},
 			},
-			expectedStatusCode: codes.InvalidArgument,
+			expectedStatusCode: grpccodes.InvalidArgument,
 		},
 	}
 
@@ -558,16 +558,16 @@ func TestNegativeGetAvailablePackageVersions(t *testing.T) {
 
 			response, err := s.GetAvailablePackageVersions(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedStatusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedStatusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			// We don't need to check anything else for non-OK codes.
-			if tc.expectedStatusCode != codes.OK {
+			// We don't need to check anything else for non-OK grpccodes.
+			if tc.expectedStatusCode != grpccodes.OK {
 				return
 			}
 
-			opts := cmpopts.IgnoreUnexported(corev1.GetAvailablePackageVersionsResponse{}, corev1.PackageAppVersion{})
+			opts := cmpopts.IgnoreUnexported(pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{}, pkgsGRPCv1alpha1.PackageAppVersion{})
 			if got, want := response, tc.expectedResponse; !cmp.Equal(want, got, opts) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opts))
 			}
@@ -585,19 +585,19 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 		repoIndex          string
 		repoNamespace      string
 		repoName           string
-		request            *corev1.GetAvailablePackageVersionsRequest
-		expectedStatusCode codes.Code
-		expectedResponse   *corev1.GetAvailablePackageVersionsResponse
+		request            *pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest
+		expectedStatusCode grpccodes.Code
+		expectedResponse   *pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse
 	}{
 		{
 			name:          "it returns the package version summary for redis chart in bitnami repo",
 			repoIndex:     "testdata/redis-many-versions.yaml",
 			repoNamespace: "kubeapps",
 			repoName:      "bitnami",
-			request: &corev1.GetAvailablePackageVersionsRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest{
 				AvailablePackageRef: availableRef("bitnami/redis", "kubeapps"),
 			},
-			expectedStatusCode: codes.OK,
+			expectedStatusCode: grpccodes.OK,
 			expectedResponse:   expected_versions_redis,
 		},
 		{
@@ -605,10 +605,10 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 			repoIndex:     "testdata/redis-many-versions.yaml",
 			repoNamespace: "kubeapps",
 			repoName:      "bitnami",
-			request: &corev1.GetAvailablePackageVersionsRequest{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest{
 				AvailablePackageRef: availableRef("bitnami/redis-123", "kubeapps"),
 			},
-			expectedStatusCode: codes.Internal,
+			expectedStatusCode: grpccodes.Internal,
 		},
 	}
 
@@ -644,7 +644,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 			}
 			defer ts.Close()
 
-			s, mock, _, _, err := newServerWithRepos(t, []runtime.Object{repo}, charts, nil)
+			s, mock, _, _, err := newServerWithRepos(t, []k8sruntime.Object{repo}, charts, nil)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -663,7 +663,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 
 			response, err := s.GetAvailablePackageVersions(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedStatusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedStatusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
@@ -672,14 +672,14 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 				t.Errorf("there were unfulfilled expectations: %s", err)
 			}
 
-			// We don't need to check anything else for non-OK codes.
-			if tc.expectedStatusCode != codes.OK {
+			// We don't need to check anything else for non-OK grpccodes.
+			if tc.expectedStatusCode != grpccodes.OK {
 				return
 			}
 
 			opts := cmpopts.IgnoreUnexported(
-				corev1.GetAvailablePackageVersionsResponse{},
-				corev1.PackageAppVersion{})
+				pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{},
+				pkgsGRPCv1alpha1.PackageAppVersion{})
 			if got, want := response, tc.expectedResponse; !cmp.Equal(want, got, opts) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opts))
 			}
@@ -747,7 +747,7 @@ func TestChartCacheResyncNotIdle(t *testing.T) {
 		defer ts2.Close()
 
 		if _, err = dyncli.Resource(repositoriesGvr).Namespace(repoNamespace).
-			Create(context.Background(), r, metav1.CreateOptions{}); err != nil {
+			Create(context.Background(), r, k8smetav1.CreateOptions{}); err != nil {
 			t.Fatalf("%v", err)
 		}
 
@@ -758,7 +758,7 @@ func TestChartCacheResyncNotIdle(t *testing.T) {
 		mock.ExpectGet(repoKey).RedisNil()
 		redisMockSetValueForRepo(mock, repoKey, repoBytes)
 
-		opts := &common.ClientOptions{}
+		opts := &pkgfluxv2common.ClientOptions{}
 
 		chartCacheKeys := []string{}
 		var chartBytes []byte
@@ -770,7 +770,7 @@ func TestChartCacheResyncNotIdle(t *testing.T) {
 				t.Fatalf("%+v", err)
 			}
 			if i == 0 {
-				chartBytes, err = cache.ChartCacheComputeValue(chartID, ts.URL, chartVersion, opts)
+				chartBytes, err = pkgfluxv2cache.ChartCacheComputeValue(chartID, ts.URL, chartVersion, opts)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -805,7 +805,7 @@ func TestChartCacheResyncNotIdle(t *testing.T) {
 			}
 
 			// now we will simulate a HTTP 410 Gone error in the watcher
-			watcher.Error(&errors.NewGone("test HTTP 410 Gone").ErrStatus)
+			watcher.Error(&k8serrors.NewGone("test HTTP 410 Gone").ErrStatus)
 			// we need to wait until server can guarantee no more Redis SETs after
 			// this until resync() kicks in
 			len := <-repoResyncCh
@@ -856,7 +856,7 @@ func TestChartCacheResyncNotIdle(t *testing.T) {
 	})
 }
 
-func newChart(name, namespace string, spec, status map[string]interface{}) *unstructured.Unstructured {
+func newChart(name, namespace string, spec, status map[string]interface{}) *k8smetaunstructuredv1.Unstructured {
 	metadata := map[string]interface{}{
 		"name":            name,
 		"generation":      int64(1),
@@ -881,15 +881,15 @@ func newChart(name, namespace string, spec, status map[string]interface{}) *unst
 		obj["status"] = status
 	}
 
-	return &unstructured.Unstructured{
+	return &k8smetaunstructuredv1.Unstructured{
 		Object: obj,
 	}
 }
 
-func availableRef(id, namespace string) *corev1.AvailablePackageReference {
-	return &corev1.AvailablePackageReference{
+func availableRef(id, namespace string) *pkgsGRPCv1alpha1.AvailablePackageReference {
+	return &pkgsGRPCv1alpha1.AvailablePackageReference{
 		Identifier: id,
-		Context: &corev1.Context{
+		Context: &pkgsGRPCv1alpha1.Context{
 			Namespace: namespace,
 			Cluster:   KubeappsCluster,
 		},
@@ -897,7 +897,7 @@ func availableRef(id, namespace string) *corev1.AvailablePackageReference {
 	}
 }
 
-func (s *Server) redisMockSetValueForChart(mock redismock.ClientMock, key, url string, opts *common.ClientOptions) error {
+func (s *Server) redisMockSetValueForChart(mock redismock.ClientMock, key, url string, opts *pkgfluxv2common.ClientOptions) error {
 	cs := repoEventSink{
 		clientGetter: s.clientGetter,
 		chartCache:   s.chartCache,
@@ -905,12 +905,12 @@ func (s *Server) redisMockSetValueForChart(mock redismock.ClientMock, key, url s
 	return cs.redisMockSetValueForChart(mock, key, url, opts)
 }
 
-func (cs *repoEventSink) redisMockSetValueForChart(mock redismock.ClientMock, key, url string, opts *common.ClientOptions) error {
+func (cs *repoEventSink) redisMockSetValueForChart(mock redismock.ClientMock, key, url string, opts *pkgfluxv2common.ClientOptions) error {
 	_, chartID, version, err := fromRedisKeyForChart(key)
 	if err != nil {
 		return err
 	}
-	byteArray, err := cache.ChartCacheComputeValue(chartID, url, version, opts)
+	byteArray, err := pkgfluxv2cache.ChartCacheComputeValue(chartID, url, version, opts)
 	if err != nil {
 		return fmt.Errorf("chartCacheComputeValue failed due to: %+v", err)
 	}
@@ -925,13 +925,13 @@ func redisMockSetValueForChart(mock redismock.ClientMock, key string, byteArray 
 }
 
 // does a series of mock.ExpectGet(...)
-func redisMockExpectGetFromChartCache(mock redismock.ClientMock, key, url string, opts *common.ClientOptions) error {
+func redisMockExpectGetFromChartCache(mock redismock.ClientMock, key, url string, opts *pkgfluxv2common.ClientOptions) error {
 	if url != "" {
 		_, chartID, version, err := fromRedisKeyForChart(key)
 		if err != nil {
 			return err
 		}
-		bytes, err := cache.ChartCacheComputeValue(chartID, url, version, opts)
+		bytes, err := pkgfluxv2cache.ChartCacheComputeValue(chartID, url, version, opts)
 		if err != nil {
 			return err
 		}
@@ -942,7 +942,7 @@ func redisMockExpectGetFromChartCache(mock redismock.ClientMock, key, url string
 	return nil
 }
 
-func redisMockExpectDeleteRepoWithCharts(mock redismock.ClientMock, name types.NamespacedName, charts []string) error {
+func redisMockExpectDeleteRepoWithCharts(mock redismock.ClientMock, name k8stypes.NamespacedName, charts []string) error {
 	key, err := redisKeyForRepoNamespacedName(name)
 	if err != nil {
 		return err
@@ -967,16 +967,16 @@ func redisMockExpectDeleteRepoWithCharts(mock redismock.ClientMock, name types.N
 func fromRedisKeyForChart(key string) (namespace, chartID, chartVersion string, err error) {
 	parts := strings.Split(key, ":")
 	if len(parts) != 4 || parts[0] != "helmcharts" || len(parts[1]) == 0 || len(parts[2]) == 0 || len(parts[3]) == 0 {
-		return "", "", "", status.Errorf(codes.Internal, "invalid key [%s]", key)
+		return "", "", "", grpcstatus.Errorf(grpccodes.Internal, "invalid key [%s]", key)
 	}
 	return parts[1], parts[2], parts[3], nil
 }
 
-func compareActualVsExpectedAvailablePackageDetail(t *testing.T, actual *corev1.AvailablePackageDetail, expected *corev1.AvailablePackageDetail) {
-	opt1 := cmpopts.IgnoreUnexported(corev1.AvailablePackageDetail{}, corev1.AvailablePackageReference{}, corev1.Context{}, corev1.Maintainer{}, plugins.Plugin{}, corev1.PackageAppVersion{})
+func compareActualVsExpectedAvailablePackageDetail(t *testing.T, actual *pkgsGRPCv1alpha1.AvailablePackageDetail, expected *pkgsGRPCv1alpha1.AvailablePackageDetail) {
+	opt1 := cmpopts.IgnoreUnexported(pkgsGRPCv1alpha1.AvailablePackageDetail{}, pkgsGRPCv1alpha1.AvailablePackageReference{}, pkgsGRPCv1alpha1.Context{}, pkgsGRPCv1alpha1.Maintainer{}, pluginsGRPCv1alpha1.Plugin{}, pkgsGRPCv1alpha1.PackageAppVersion{})
 	// these few fields a bit special in that they are all very long strings,
 	// so we'll do a 'Contains' check for these instead of 'Equals'
-	opt2 := cmpopts.IgnoreFields(corev1.AvailablePackageDetail{}, "Readme", "DefaultValues", "ValuesSchema")
+	opt2 := cmpopts.IgnoreFields(pkgsGRPCv1alpha1.AvailablePackageDetail{}, "Readme", "DefaultValues", "ValuesSchema")
 	if got, want := actual, expected; !cmp.Equal(got, want, opt1, opt2) {
 		t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opt1, opt2))
 	}
@@ -1006,10 +1006,10 @@ var redis_charts_spec = []testSpecChartWithFile{
 	},
 }
 
-var expected_detail_redis_1 = &corev1.AvailablePackageDetail{
+var expected_detail_redis_1 = &pkgsGRPCv1alpha1.AvailablePackageDetail{
 	AvailablePackageRef: availableRef("bitnami-1/redis", "default"),
 	Name:                "redis",
-	Version: &corev1.PackageAppVersion{
+	Version: &pkgsGRPCv1alpha1.PackageAppVersion{
 		PkgVersion: "14.4.0",
 		AppVersion: "6.2.4",
 	},
@@ -1023,7 +1023,7 @@ var expected_detail_redis_1 = &corev1.AvailablePackageDetail{
 	DefaultValues:    "## @param global.imageRegistry Global Docker image registry",
 	ValuesSchema:     "\"$schema\": \"http://json-schema.org/schema#\"",
 	SourceUrls:       []string{"https://github.com/bitnami/bitnami-docker-redis", "http://redis.io/"},
-	Maintainers: []*corev1.Maintainer{
+	Maintainers: []*pkgsGRPCv1alpha1.Maintainer{
 		{
 			Name:  "Bitnami",
 			Email: "containers@bitnami.com",
@@ -1035,10 +1035,10 @@ var expected_detail_redis_1 = &corev1.AvailablePackageDetail{
 	},
 }
 
-var expected_detail_redis_2 = &corev1.AvailablePackageDetail{
+var expected_detail_redis_2 = &pkgsGRPCv1alpha1.AvailablePackageDetail{
 	AvailablePackageRef: availableRef("bitnami-1/redis", "default"),
 	Name:                "redis",
-	Version: &corev1.PackageAppVersion{
+	Version: &pkgsGRPCv1alpha1.PackageAppVersion{
 		PkgVersion: "14.3.4",
 		AppVersion: "6.2.4",
 	},
@@ -1052,7 +1052,7 @@ var expected_detail_redis_2 = &corev1.AvailablePackageDetail{
 	DefaultValues:    "## @param global.imageRegistry Global Docker image registry",
 	ValuesSchema:     "\"$schema\": \"http://json-schema.org/schema#\"",
 	SourceUrls:       []string{"https://github.com/bitnami/bitnami-docker-redis", "http://redis.io/"},
-	Maintainers: []*corev1.Maintainer{
+	Maintainers: []*pkgsGRPCv1alpha1.Maintainer{
 		{
 			Name:  "Bitnami",
 			Email: "containers@bitnami.com",
@@ -1064,8 +1064,8 @@ var expected_detail_redis_2 = &corev1.AvailablePackageDetail{
 	},
 }
 
-var expected_versions_redis = &corev1.GetAvailablePackageVersionsResponse{
-	PackageAppVersions: []*corev1.PackageAppVersion{
+var expected_versions_redis = &pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{
+	PackageAppVersions: []*pkgsGRPCv1alpha1.PackageAppVersion{
 		{PkgVersion: "14.4.0", AppVersion: "6.2.4"},
 		{PkgVersion: "14.3.4", AppVersion: "6.2.4"},
 		{PkgVersion: "14.3.3", AppVersion: "6.2.4"},

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
@@ -6,19 +6,19 @@ package main
 import (
 	"context"
 
-	"google.golang.org/grpc"
+	grpc "google.golang.org/grpc"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/pkg/kube"
+	grpcgwruntime "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	apiscore "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
+	pkgfluxv2v1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
+	kubeutils "github.com/kubeapps/kubeapps/pkg/kube"
 	log "k8s.io/klog/v2"
 )
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
-	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter apiscore.KubernetesConfigGetter,
+	clustersConfig kubeutils.ClustersConfig, pluginConfigPath string) (interface{}, error) {
 	log.Infof("+fluxv2 RegisterWithGRPCServer")
 
 	// TODO (gfichtenholt) stub channel for now. Ideally, the caller (kubeappsapis-server)
@@ -30,13 +30,13 @@ func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.Kubernete
 	if err != nil {
 		return nil, err
 	}
-	v1alpha1.RegisterFluxV2PackagesServiceServer(s, svr)
+	pkgfluxv2v1alpha1.RegisterFluxV2PackagesServiceServer(s, svr)
 	return svr, nil
 }
 
 // RegisterHTTPHandlerFromEndpoint enables a plugin to register an http
 // handler to translate to the gRPC request.
-func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *grpcgwruntime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 	log.Infof("+fluxv2 RegisterHTTPHandlerFromEndpoint")
-	return v1alpha1.RegisterFluxV2PackagesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
+	return pkgfluxv2v1alpha1.RegisterFluxV2PackagesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/repo.go
@@ -13,23 +13,23 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/clientgetter"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/kubeapps/kubeapps/pkg/helm"
+	pkgfluxv2v1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
+	pkgfluxv2cache "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache"
+	pkgfluxv2common "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
+	clientgetter "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/clientgetter"
+	statuserror "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	helmutils "github.com/kubeapps/kubeapps/pkg/helm"
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/dynamic"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	k8scorev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8smetaunstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	k8dynamicclient "k8s.io/client-go/dynamic"
 	log "k8s.io/klog/v2"
 )
 
@@ -43,13 +43,13 @@ const (
 	fluxHelmRepositoryList = "HelmRepositoryList"
 )
 
-func (s *Server) getRepoResourceInterface(ctx context.Context, namespace string) (dynamic.ResourceInterface, error) {
+func (s *Server) getRepoResourceInterface(ctx context.Context, namespace string) (k8dynamicclient.ResourceInterface, error) {
 	_, client, _, err := s.GetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	repositoriesResource := schema.GroupVersionResource{
+	repositoriesResource := k8sschema.GroupVersionResource{
 		Group:    fluxGroup,
 		Version:  fluxVersion,
 		Resource: fluxHelmRepositories,
@@ -59,38 +59,38 @@ func (s *Server) getRepoResourceInterface(ctx context.Context, namespace string)
 }
 
 // namespace maybe apiv1.NamespaceAll, in which case repositories from all namespaces are returned
-func (s *Server) listReposInNamespace(ctx context.Context, namespace string) (*unstructured.UnstructuredList, error) {
+func (s *Server) listReposInNamespace(ctx context.Context, namespace string) (*k8smetaunstructuredv1.UnstructuredList, error) {
 	resourceIfc, err := s.getRepoResourceInterface(ctx, namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	if repos, err := resourceIfc.List(ctx, metav1.ListOptions{}); err != nil {
+	if repos, err := resourceIfc.List(ctx, k8smetav1.ListOptions{}); err != nil {
 		return nil, statuserror.FromK8sError("list", "HelmRepository", namespace+"/*", err)
 	} else {
 		return repos, nil
 	}
 }
 
-func (s *Server) getRepoInCluster(ctx context.Context, name types.NamespacedName) (*unstructured.Unstructured, error) {
+func (s *Server) getRepoInCluster(ctx context.Context, name k8stypes.NamespacedName) (*k8smetaunstructuredv1.Unstructured, error) {
 	resourceIfc, err := s.getRepoResourceInterface(ctx, name.Namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := resourceIfc.Get(ctx, name.Name, metav1.GetOptions{})
+	result, err := resourceIfc.Get(ctx, name.Name, k8smetav1.GetOptions{})
 	if err != nil {
 		return nil, statuserror.FromK8sError("get", "HelmRepository", name.String(), err)
 	} else if result == nil {
-		return nil, status.Errorf(codes.NotFound, "unable to find HelmRepository [%s]", name)
+		return nil, grpcstatus.Errorf(grpccodes.NotFound, "unable to find HelmRepository [%s]", name)
 	}
 	return result, nil
 }
 
 // regexp expressions are used for matching actual names against expected patters
-func (s *Server) filterReadyReposByName(repoList *unstructured.UnstructuredList, match []string) ([]string, error) {
+func (s *Server) filterReadyReposByName(repoList *k8smetaunstructuredv1.UnstructuredList, match []string) ([]string, error) {
 	if s.repoCache == nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "server cache has not been properly initialized")
+		return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition, "server cache has not been properly initialized")
 	}
 
 	resultKeys := make([]string, 0)
@@ -100,7 +100,7 @@ func (s *Server) filterReadyReposByName(repoList *unstructured.UnstructuredList,
 			// just skip it
 			continue
 		}
-		name, err := common.NamespacedName(repo.Object)
+		name, err := pkgfluxv2common.NamespacedName(repo.Object)
 		if err != nil {
 			// just skip it
 			continue
@@ -123,11 +123,11 @@ func (s *Server) filterReadyReposByName(repoList *unstructured.UnstructuredList,
 	return resultKeys, nil
 }
 
-func (s *Server) getChartsForRepos(ctx context.Context, match []string) (map[string][]models.Chart, error) {
+func (s *Server) getChartsForRepos(ctx context.Context, match []string) (map[string][]chartmodels.Chart, error) {
 	// 1. with flux an available package may be from a repo in any namespace
 	// 2. can't rely on cache as a real source of truth for key names
 	//    because redis may evict cache entries due to memory pressure to make room for new ones
-	repoList, err := s.listReposInNamespace(ctx, apiv1.NamespaceAll)
+	repoList, err := s.listReposInNamespace(ctx, k8scorev1.NamespaceAll)
 	if err != nil {
 		return nil, err
 	}
@@ -142,15 +142,15 @@ func (s *Server) getChartsForRepos(ctx context.Context, match []string) (map[str
 		return nil, err
 	}
 
-	chartsTyped := make(map[string][]models.Chart)
+	chartsTyped := make(map[string][]chartmodels.Chart)
 	for key, value := range chartsUntyped {
 		if value == nil {
 			chartsTyped[key] = nil
 		} else {
 			typedValue, ok := value.(repoCacheEntryValue)
 			if !ok {
-				return nil, status.Errorf(
-					codes.Internal,
+				return nil, grpcstatus.Errorf(
+					grpccodes.Internal,
 					"unexpected value fetched from cache: type: [%s], value: [%v]",
 					reflect.TypeOf(value), value)
 			}
@@ -160,7 +160,7 @@ func (s *Server) getChartsForRepos(ctx context.Context, match []string) (map[str
 	return chartsTyped, nil
 }
 
-func (s *Server) clientOptionsForRepo(ctx context.Context, repo types.NamespacedName) (*common.ClientOptions, error) {
+func (s *Server) clientOptionsForRepo(ctx context.Context, repo k8stypes.NamespacedName) (*pkgfluxv2common.ClientOptions, error) {
 	unstructuredRepo, err := s.getRepoInCluster(ctx, repo)
 	if err != nil {
 		return nil, err
@@ -186,14 +186,14 @@ func (s *Server) clientOptionsForRepo(ctx context.Context, repo types.Namespaced
 //
 type repoEventSink struct {
 	clientGetter clientgetter.ClientGetterWithApiExtFunc
-	chartCache   *cache.ChartCache // chartCache maybe nil only in unit tests
+	chartCache   *pkgfluxv2cache.ChartCache // chartCache maybe nil only in unit tests
 }
 
 // this is what we store in the cache for each cached repo
 // all struct fields are capitalized so they're exported by gob encoding
 type repoCacheEntryValue struct {
 	Checksum string
-	Charts   []models.Chart
+	Charts   []chartmodels.Chart
 }
 
 // onAddRepo essentially tells the cache whether to and what to store for a given key
@@ -208,11 +208,11 @@ func (s *repoEventSink) onAddRepo(key string, unstructuredRepo map[string]interf
 	// first, check the repo is ready
 	if isRepoReady(unstructuredRepo) {
 		// ref https://fluxcd.io/docs/components/source/helmrepositories/#status
-		checksum, found, err := unstructured.NestedString(unstructuredRepo, "status", "artifact", "checksum")
+		checksum, found, err := k8smetaunstructuredv1.NestedString(unstructuredRepo, "status", "artifact", "checksum")
 		if err != nil || !found {
-			return nil, false, status.Errorf(codes.Internal,
-				"expected field status.artifact.checksum not found on HelmRepository\n[%s], error %v",
-				common.PrettyPrintMap(unstructuredRepo), err)
+			return nil, false, grpcstatus.Errorf(grpccodes.Internal,
+				"expected field grpcstatus.artifact.checksum not found on HelmRepository\n[%s], error %v",
+				pkgfluxv2common.PrettyPrintMap(unstructuredRepo), err)
 		}
 		return s.indexAndEncode(checksum, unstructuredRepo)
 	} else {
@@ -260,7 +260,7 @@ func (s *repoEventSink) indexAndEncode(checksum string, unstructuredRepo map[str
 
 // it is assumed the caller has already checked that this repo is ready
 // At present, there is only one caller of indexOneRepo() and this check is already done by it
-func (s *repoEventSink) indexOneRepo(unstructuredRepo map[string]interface{}) ([]models.Chart, error) {
+func (s *repoEventSink) indexOneRepo(unstructuredRepo map[string]interface{}) ([]chartmodels.Chart, error) {
 	startTime := time.Now()
 
 	repo, err := packageRepositoryFromUnstructured(unstructuredRepo)
@@ -269,10 +269,10 @@ func (s *repoEventSink) indexOneRepo(unstructuredRepo map[string]interface{}) ([
 	}
 
 	// ref https://fluxcd.io/docs/components/source/helmrepositories/#status
-	indexUrl, found, err := unstructured.NestedString(unstructuredRepo, "status", "url")
+	indexUrl, found, err := k8smetaunstructuredv1.NestedString(unstructuredRepo, "status", "url")
 	if err != nil || !found {
-		return nil, status.Errorf(codes.Internal,
-			"expected field status.url not found on HelmRepository\n[%s], error %v",
+		return nil, grpcstatus.Errorf(grpccodes.Internal,
+			"expected field grpcstatus.url not found on HelmRepository\n[%s], error %v",
 			repo.Name, err)
 	}
 
@@ -291,7 +291,7 @@ func (s *repoEventSink) indexOneRepo(unstructuredRepo map[string]interface{}) ([
 		return nil, err
 	}
 
-	modelRepo := &models.Repo{
+	modelRepo := &chartmodels.Repo{
 		Namespace: repo.Namespace,
 		Name:      repo.Name,
 		URL:       repo.Url,
@@ -302,7 +302,7 @@ func (s *repoEventSink) indexOneRepo(unstructuredRepo map[string]interface{}) ([
 	// shallow = true  => 8-9 sec
 	// shallow = false => 12-13 sec, so deep copy adds 50% to cost, but we need it to
 	// for GetAvailablePackageVersions()
-	charts, err := helm.ChartsFromIndex(byteArray, modelRepo, false)
+	charts, err := helmutils.ChartsFromIndex(byteArray, modelRepo, false)
 	if err != nil {
 		return nil, err
 	}
@@ -327,12 +327,12 @@ func (s *repoEventSink) onModifyRepo(key string, unstructuredRepo map[string]int
 		// vs the modified object to see if the contents has really changed before embarking on
 		// expensive operation indexOneRepo() below.
 		// ref https://fluxcd.io/docs/components/source/helmrepositories/#status
-		newChecksum, found, err := unstructured.NestedString(unstructuredRepo, "status", "artifact", "checksum")
+		newChecksum, found, err := k8smetaunstructuredv1.NestedString(unstructuredRepo, "status", "artifact", "checksum")
 		if err != nil || !found {
-			return nil, false, status.Errorf(
-				codes.Internal,
-				"expected field status.artifact.checksum not found on HelmRepository\n[%s], error %v",
-				common.PrettyPrintMap(unstructuredRepo), err)
+			return nil, false, grpcstatus.Errorf(
+				grpccodes.Internal,
+				"expected field grpcstatus.artifact.checksum not found on HelmRepository\n[%s], error %v",
+				pkgfluxv2common.PrettyPrintMap(unstructuredRepo), err)
 		}
 
 		cacheEntryUntyped, err := s.onGetRepo(key, oldValue)
@@ -342,8 +342,8 @@ func (s *repoEventSink) onModifyRepo(key string, unstructuredRepo map[string]int
 
 		cacheEntry, ok := cacheEntryUntyped.(repoCacheEntryValue)
 		if !ok {
-			return nil, false, status.Errorf(
-				codes.Internal,
+			return nil, false, grpcstatus.Errorf(
+				grpccodes.Internal,
 				"unexpected value found in cache for key [%s]: %v",
 				key, cacheEntryUntyped)
 		}
@@ -365,7 +365,7 @@ func (s *repoEventSink) onModifyRepo(key string, unstructuredRepo map[string]int
 func (s *repoEventSink) onGetRepo(key string, value interface{}) (interface{}, error) {
 	b, ok := value.([]byte)
 	if !ok {
-		return nil, status.Errorf(codes.Internal, "unexpected value found in cache for key [%s]: %v", key, value)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "unexpected value found in cache for key [%s]: %v", key, value)
 	}
 
 	dec := gob.NewDecoder(bytes.NewReader(b))
@@ -398,12 +398,12 @@ func (s *repoEventSink) onResync() error {
 // TODO (gfichtenholt) low priority: don't really like the fact that these 4 lines of code
 // basically repeat same logic as NamespacedResourceWatcherCache.fromKey() but can't
 // quite come up with with a more elegant alternative right now
-func (c *repoEventSink) fromKey(key string) (*types.NamespacedName, error) {
-	parts := strings.Split(key, cache.KeySegmentsSeparator)
+func (c *repoEventSink) fromKey(key string) (*k8stypes.NamespacedName, error) {
+	parts := strings.Split(key, pkgfluxv2cache.KeySegmentsSeparator)
 	if len(parts) != 3 || parts[0] != fluxHelmRepositories || len(parts[1]) == 0 || len(parts[2]) == 0 {
-		return nil, status.Errorf(codes.Internal, "invalid key [%s]", key)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "invalid key [%s]", key)
 	}
-	return &types.NamespacedName{Namespace: parts[1], Name: parts[2]}, nil
+	return &k8stypes.NamespacedName{Namespace: parts[1], Name: parts[2]}, nil
 }
 
 // unstructuredRepo is passed as map[string]interface{}
@@ -412,31 +412,31 @@ func (c *repoEventSink) fromKey(key string) (*types.NamespacedName, error) {
 // gets implemented. After that, the auth should be part of packageRepositoryFromUnstructured()
 // The reason I do this here is to set up auth that may be needed to fetch chart tarballs by
 // ChartCache
-func (s *repoEventSink) clientOptionsForRepo(ctx context.Context, unstructuredRepo map[string]interface{}) (*common.ClientOptions, error) {
-	secretName, found, err := unstructured.NestedString(unstructuredRepo, "spec", "secretRef", "name")
+func (s *repoEventSink) clientOptionsForRepo(ctx context.Context, unstructuredRepo map[string]interface{}) (*pkgfluxv2common.ClientOptions, error) {
+	secretName, found, err := k8smetaunstructuredv1.NestedString(unstructuredRepo, "spec", "secretRef", "name")
 	if !found || err != nil || secretName == "" {
 		return nil, nil
 	}
 	if s == nil || s.clientGetter == nil {
-		return nil, status.Errorf(codes.Internal, "unexpected state in clientGetterHolder instance")
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "unexpected state in clientGetterHolder instance")
 	}
 	typedClient, _, _, err := s.clientGetter(ctx)
 	if err != nil {
 		return nil, err
 	}
-	repoName, err := common.NamespacedName(unstructuredRepo)
+	repoName, err := pkgfluxv2common.NamespacedName(unstructuredRepo)
 	if err != nil {
 		return nil, err
 	}
-	secret, err := typedClient.CoreV1().Secrets(repoName.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+	secret, err := typedClient.CoreV1().Secrets(repoName.Namespace).Get(ctx, secretName, k8smetav1.GetOptions{})
 	if err != nil {
-		if errors.IsForbidden(err) || errors.IsUnauthorized(err) {
-			return nil, status.Errorf(codes.Unauthenticated, "unable to get secret due to %v", err)
+		if k8serrors.IsForbidden(err) || k8serrors.IsUnauthorized(err) {
+			return nil, grpcstatus.Errorf(grpccodes.Unauthenticated, "unable to get secret due to %v", err)
 		} else {
-			return nil, status.Errorf(codes.Internal, "unable to get secret due to %v", err)
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "unable to get secret due to %v", err)
 		}
 	}
-	return common.ClientOptionsFromSecret(*secret)
+	return pkgfluxv2common.ClientOptionsFromSecret(*secret)
 }
 
 //
@@ -446,7 +446,7 @@ func (s *repoEventSink) clientOptionsForRepo(ctx context.Context, unstructuredRe
 func isRepoReady(unstructuredRepo map[string]interface{}) bool {
 	// see docs at https://fluxcd.io/docs/components/source/helmrepositories/
 	// Confirm the state we are observing is for the current generation
-	if !common.CheckGeneration(unstructuredRepo) {
+	if !pkgfluxv2common.CheckGeneration(unstructuredRepo) {
 		return false
 	}
 
@@ -454,19 +454,19 @@ func isRepoReady(unstructuredRepo map[string]interface{}) bool {
 	return completed && success
 }
 
-func packageRepositoryFromUnstructured(unstructuredRepo map[string]interface{}) (*v1alpha1.PackageRepository, error) {
-	name, err := common.NamespacedName(unstructuredRepo)
+func packageRepositoryFromUnstructured(unstructuredRepo map[string]interface{}) (*pkgfluxv2v1alpha1.PackageRepository, error) {
+	name, err := pkgfluxv2common.NamespacedName(unstructuredRepo)
 	if err != nil {
 		return nil, err
 	}
 
-	url, found, err := unstructured.NestedString(unstructuredRepo, "spec", "url")
+	url, found, err := k8smetaunstructuredv1.NestedString(unstructuredRepo, "spec", "url")
 	if err != nil || !found {
-		return nil, status.Errorf(
-			codes.Internal,
-			"required field spec.url not found on HelmRepository:\n%s, error: %v", common.PrettyPrintMap(unstructuredRepo), err)
+		return nil, grpcstatus.Errorf(
+			grpccodes.Internal,
+			"required field spec.url not found on HelmRepository:\n%s, error: %v", pkgfluxv2common.PrettyPrintMap(unstructuredRepo), err)
 	}
-	return &v1alpha1.PackageRepository{
+	return &pkgfluxv2v1alpha1.PackageRepository{
 		Name:      name.Name,
 		Namespace: name.Namespace,
 		Url:       url,
@@ -480,11 +480,11 @@ func packageRepositoryFromUnstructured(unstructuredRepo map[string]interface{}) 
 // docs:
 // 1. https://fluxcd.io/docs/components/source/helmrepositories/#status-examples
 func isHelmRepositoryReady(unstructuredObj map[string]interface{}) (complete bool, success bool, reason string) {
-	if !common.CheckGeneration(unstructuredObj) {
+	if !pkgfluxv2common.CheckGeneration(unstructuredObj) {
 		return false, false, ""
 	}
 
-	conditions, found, err := unstructured.NestedSlice(unstructuredObj, "status", "conditions")
+	conditions, found, err := k8smetaunstructuredv1.NestedSlice(unstructuredObj, "status", "conditions")
 	if err != nil || !found {
 		return false, false, ""
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/getresourcerefs_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/getresourcerefs_test.go
@@ -7,14 +7,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefstest"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cmp "github.com/google/go-cmp/cmp"
+	cmpopts "github.com/google/go-cmp/cmp/cmpopts"
+	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	resourcerefstest "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefstest"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetInstalledPackageResourceRefs(t *testing.T) {
@@ -26,21 +26,21 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 
 	type testCase struct {
 		baseTestCase       resourcerefstest.TestCase
-		request            *corev1.GetInstalledPackageResourceRefsRequest
-		expectedResponse   *corev1.GetInstalledPackageResourceRefsResponse
-		expectedStatusCode codes.Code
+		request            *pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest
+		expectedResponse   *pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsResponse
+		expectedStatusCode grpccodes.Code
 	}
 
 	// newTestCase is a function to take an existing test-case
 	// (a so-called baseTestCase in pkg/resourcerefs module, which contains a LOT of useful data)
 	// and "enrich" it with some new fields to create a different kind of test case
 	// that tests server.GetInstalledPackageResourceRefs() func
-	newTestCase := func(tc int, identifier string, response bool, code codes.Code) testCase {
+	newTestCase := func(tc int, identifier string, response bool, code grpccodes.Code) testCase {
 		newCase := testCase{
 			baseTestCase: resourcerefstest.TestCases1[tc],
-			request: &corev1.GetInstalledPackageResourceRefsRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Cluster:   "default",
 						Namespace: "default",
 					},
@@ -49,8 +49,8 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 			},
 		}
 		if response {
-			newCase.expectedResponse = &corev1.GetInstalledPackageResourceRefsResponse{
-				Context: &corev1.Context{
+			newCase.expectedResponse = &pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsResponse{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
@@ -62,26 +62,26 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		newTestCase(0, "my-apache", true, codes.OK),
-		newTestCase(1, "my-apache", true, codes.OK),
-		newTestCase(2, "my-apache", true, codes.OK),
-		newTestCase(3, "my-apache", true, codes.OK),
-		newTestCase(4, "my-iis", false, codes.NotFound),
-		newTestCase(5, "my-apache", false, codes.Internal),
+		newTestCase(0, "my-apache", true, grpccodes.OK),
+		newTestCase(1, "my-apache", true, grpccodes.OK),
+		newTestCase(2, "my-apache", true, grpccodes.OK),
+		newTestCase(3, "my-apache", true, grpccodes.OK),
+		newTestCase(4, "my-iis", false, grpccodes.NotFound),
+		newTestCase(5, "my-apache", false, grpccodes.Internal),
 		// See https://github.com/kubeapps/kubeapps/issues/632
-		newTestCase(6, "my-apache", true, codes.OK),
-		newTestCase(7, "my-apache", true, codes.OK),
-		newTestCase(8, "my-apache", true, codes.OK),
+		newTestCase(6, "my-apache", true, grpccodes.OK),
+		newTestCase(7, "my-apache", true, grpccodes.OK),
+		newTestCase(8, "my-apache", true, grpccodes.OK),
 		// See https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/role-v1/#RoleList
-		newTestCase(9, "my-apache", true, codes.OK),
+		newTestCase(9, "my-apache", true, grpccodes.OK),
 		// See https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/#ClusterRoleList
-		newTestCase(10, "my-apache", true, codes.OK),
+		newTestCase(10, "my-apache", true, grpccodes.OK),
 	}
 
 	ignoredFields := cmpopts.IgnoreUnexported(
-		corev1.GetInstalledPackageResourceRefsResponse{},
-		corev1.ResourceRef{},
-		corev1.Context{},
+		pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsResponse{},
+		pkgsGRPCv1alpha1.ResourceRef{},
+		pkgsGRPCv1alpha1.Context{},
 	)
 
 	toHelmReleaseStubs := func(in []resourcerefstest.TestReleaseStub) []releaseStub {
@@ -101,8 +101,8 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 				toHelmReleaseStubs(tc.baseTestCase.ExistingReleases),
 				nil)
 
-			server, _, cleanup := makeServer(t, authorized, actionConfig, &v1alpha1.AppRepository{
-				ObjectMeta: metav1.ObjectMeta{
+			server, _, cleanup := makeServer(t, authorized, actionConfig, &apprepov1alpha1.AppRepository{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "bitnami",
 					Namespace: globalPackagingNamespace,
 				},
@@ -111,7 +111,7 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 
 			response, err := server.GetInstalledPackageResourceRefs(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedStatusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedStatusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/main.go
@@ -6,26 +6,25 @@ package main
 import (
 	"context"
 
-	"google.golang.org/grpc"
-
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/pkg/kube"
+	grpcgwruntime "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	apiscore "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	pkghelmv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
+	kubeutils "github.com/kubeapps/kubeapps/pkg/kube"
+	grpc "google.golang.org/grpc"
 )
 
 // Set the pluginDetail once during a module init function so the single struct
 // can be used throughout the plugin.
 var (
-	pluginDetail plugins.Plugin
+	pluginDetail pluginsGRPCv1alpha1.Plugin
 	// This version var is updated during the build (see the -ldflags option
 	// in the cmd/kubeapps-apis/Dockerfile)
 	version = "devel"
 )
 
 func init() {
-	pluginDetail = plugins.Plugin{
+	pluginDetail = pluginsGRPCv1alpha1.Plugin{
 		Name:    "helm.packages",
 		Version: "v1alpha1",
 	}
@@ -33,20 +32,20 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
-	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter apiscore.KubernetesConfigGetter,
+	clustersConfig kubeutils.ClustersConfig, pluginConfigPath string) (interface{}, error) {
 	svr := NewServer(configGetter, clustersConfig.KubeappsClusterName, clustersConfig.GlobalReposNamespace, pluginConfigPath)
-	v1alpha1.RegisterHelmPackagesServiceServer(s, svr)
+	pkghelmv1alpha1.RegisterHelmPackagesServiceServer(s, svr)
 	return svr, nil
 }
 
 // RegisterHTTPHandlerFromEndpoint enables a plugin to register an http
 // handler to translate to the gRPC request.
-func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
-	return v1alpha1.RegisterHelmPackagesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
+func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *grpcgwruntime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+	return pkghelmv1alpha1.RegisterHelmPackagesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }
 
-// GetPluginDetail returns a core.plugins.Plugin describing itself.
-func GetPluginDetail() *plugins.Plugin {
+// GetPluginDetail returns a apiscore.plugins.Plugin describing itself.
+func GetPluginDetail() *pluginsGRPCv1alpha1.Plugin {
 	return &pluginDetail
 }

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -14,59 +14,59 @@ import (
 	"path"
 	"strings"
 
-	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	helmv1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/clientgetter"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/paginate"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/resourcerefs"
-	"github.com/kubeapps/kubeapps/pkg/agent"
+	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	assetmanager "github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
+	apiscore "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pkghelmv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
+	clientgetter "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/clientgetter"
+	paginate "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/paginate"
+	pkgutils "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
+	resourcerefs "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/resourcerefs"
+	helmagent "github.com/kubeapps/kubeapps/pkg/agent"
 	chartutils "github.com/kubeapps/kubeapps/pkg/chart"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
-	"github.com/kubeapps/kubeapps/pkg/handlerutil"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/anypb"
-	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/release"
-	"helm.sh/helm/v3/pkg/storage/driver"
-	authorizationv1 "k8s.io/api/authorization/v1"
-	corek8sv1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
+	handlerutil "github.com/kubeapps/kubeapps/pkg/handlerutil"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	anypb "google.golang.org/protobuf/types/known/anypb"
+	helmaction "helm.sh/helm/v3/pkg/action"
+	helmchart "helm.sh/helm/v3/pkg/chart"
+	helmrelease "helm.sh/helm/v3/pkg/release"
+	helmstoragedriver "helm.sh/helm/v3/pkg/storage/driver"
+	k8sauthorizationv1 "k8s.io/api/authorization/v1"
+	k8scorev1 "k8s.io/api/core/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8dynamicclient "k8s.io/client-go/dynamic"
+	k8stypedclient "k8s.io/client-go/kubernetes"
 	log "k8s.io/klog/v2"
 )
 
-type helmActionConfigGetter func(ctx context.Context, pkgContext *corev1.Context) (*action.Configuration, error)
+type helmActionConfigGetter func(ctx context.Context, pkgContext *pkgsGRPCv1alpha1.Context) (*helmaction.Configuration, error)
 
 // Compile-time statement to ensure this service implementation satisfies the core packaging API
-var _ corev1.PackagesServiceServer = (*Server)(nil)
+var _ pkgsGRPCv1alpha1.PackagesServiceServer = (*Server)(nil)
 
 const (
 	UserAgentPrefix             = "kubeapps-apis/plugins"
 	DefaultTimeoutSeconds int32 = 300
 )
 
-type createRelease func(*action.Configuration, string, string, string, *chart.Chart, map[string]string, int32) (*release.Release, error)
+type createRelease func(*helmaction.Configuration, string, string, string, *helmchart.Chart, map[string]string, int32) (*helmrelease.Release, error)
 
 // Server implements the helm packages v1alpha1 interface.
 type Server struct {
-	helmv1.UnimplementedHelmPackagesServiceServer
+	pkghelmv1alpha1.UnimplementedHelmPackagesServiceServer
 	// clientGetter is a field so that it can be switched in tests for
 	// a fake client. NewServer() below sets this automatically with the
 	// non-test implementation.
 	clientGetter             clientgetter.ClientGetterFunc
 	globalPackagingNamespace string
 	globalPackagingCluster   string
-	manager                  utils.AssetManager
+	manager                  assetmanager.AssetManager
 	actionConfigGetter       helmActionConfigGetter
 	chartClientFactory       chartutils.ChartClientFactoryInterface
 	versionsInSummary        pkgutils.VersionsInSummary
@@ -81,7 +81,7 @@ func parsePluginConfig(pluginConfigPath string) (pkgutils.VersionsInSummary, int
 	// and if required this func can be enhaned to return helmConfig struct
 
 	// In the helm plugin, for example, we are interested in config for the
-	// core.packages.v1alpha1 only. So the plugin defines the following struct and parses the config.
+	// apiscore.packages.v1alpha1 only. So the plugin defines the following struct and parses the config.
 	type helmConfig struct {
 		Core struct {
 			Packages struct {
@@ -109,7 +109,7 @@ func parsePluginConfig(pluginConfigPath string) (pkgutils.VersionsInSummary, int
 
 // NewServer returns a Server automatically configured with a function to obtain
 // the k8s client config.
-func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster string, globalReposNamespace string, pluginConfigPath string) *Server {
+func NewServer(configGetter apiscore.KubernetesConfigGetter, globalPackagingCluster string, globalReposNamespace string, pluginConfigPath string) *Server {
 	var ASSET_SYNCER_DB_URL = os.Getenv("ASSET_SYNCER_DB_URL")
 	var ASSET_SYNCER_DB_NAME = os.Getenv("ASSET_SYNCER_DB_NAME")
 	var ASSET_SYNCER_DB_USERNAME = os.Getenv("ASSET_SYNCER_DB_USERNAME")
@@ -117,7 +117,7 @@ func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster 
 
 	var dbConfig = dbutils.Config{URL: ASSET_SYNCER_DB_URL, Database: ASSET_SYNCER_DB_NAME, Username: ASSET_SYNCER_DB_USERNAME, Password: ASSET_SYNCER_DB_USERPASSWORD}
 
-	manager, err := utils.NewPGManager(dbConfig, globalReposNamespace)
+	manager, err := assetmanager.NewPGManager(dbConfig, globalReposNamespace)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}
@@ -142,7 +142,7 @@ func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster 
 
 	return &Server{
 		clientGetter: clientgetter.NewClientGetter(configGetter),
-		actionConfigGetter: func(ctx context.Context, pkgContext *corev1.Context) (*action.Configuration, error) {
+		actionConfigGetter: func(ctx context.Context, pkgContext *pkgsGRPCv1alpha1.Context) (*helmaction.Configuration, error) {
 			cluster := pkgContext.GetCluster()
 			// Don't force clients to send a cluster unless we are sure all use-cases
 			// of kubeapps-api are multicluster.
@@ -158,33 +158,33 @@ func NewServer(configGetter core.KubernetesConfigGetter, globalPackagingCluster 
 		chartClientFactory:       &chartutils.ChartClientFactory{},
 		versionsInSummary:        versionsInSummary,
 		timeoutSeconds:           timeoutSeconds,
-		createReleaseFunc:        agent.CreateRelease,
+		createReleaseFunc:        helmagent.CreateRelease,
 	}
 }
 
 // GetClients ensures a client getter is available and uses it to return both a typed and dynamic k8s client.
-func (s *Server) GetClients(ctx context.Context, cluster string) (kubernetes.Interface, dynamic.Interface, error) {
+func (s *Server) GetClients(ctx context.Context, cluster string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
 	if s.clientGetter == nil {
-		return nil, nil, status.Errorf(codes.Internal, "server not configured with configGetter")
+		return nil, nil, grpcstatus.Errorf(grpccodes.Internal, "server not configured with configGetter")
 	}
 	typedClient, dynamicClient, err := s.clientGetter(ctx, cluster)
 	if err != nil {
-		return nil, nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("unable to get client : %v", err))
+		return nil, nil, grpcstatus.Errorf(grpccodes.FailedPrecondition, fmt.Sprintf("unable to get client : %v", err))
 	}
 	return typedClient, dynamicClient, nil
 }
 
 // GetManager ensures a manager is available and returns it.
-func (s *Server) GetManager() (utils.AssetManager, error) {
+func (s *Server) GetManager() (assetmanager.AssetManager, error) {
 	if s.manager == nil {
-		return nil, status.Errorf(codes.Internal, "server not configured with manager")
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "server not configured with manager")
 	}
 	manager := s.manager
 	return manager, nil
 }
 
 // GetAvailablePackageSummaries returns the available packages based on the request.
-func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *corev1.GetAvailablePackageSummariesRequest) (*corev1.GetAvailablePackageSummariesResponse, error) {
+func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest) (*pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetContext().GetCluster(), request.GetContext().GetNamespace())
 	log.Infof("+helm GetAvailablePackageSummaries %s", contextMsg)
 
@@ -195,7 +195,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	// otherwise, first check if the user can access the requested ns
 	if namespace == "" {
 		// TODO(agamez): not including a namespace means that it returns everything a user can read
-		return nil, status.Errorf(codes.Unimplemented, "Not supported yet: not including a namespace means that it returns everything a user can read")
+		return nil, grpcstatus.Errorf(grpccodes.Unimplemented, "Not supported yet: not including a namespace means that it returns everything a user can read")
 	}
 	// After requesting a specific namespace, we have to ensure the user can actually access to it
 	if err := s.hasAccessToNamespace(ctx, cluster, namespace); err != nil {
@@ -209,7 +209,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	}
 
 	// Create the initial chart query with the namespace
-	cq := utils.ChartQuery{
+	cq := assetmanager.ChartQuery{
 		Namespace: namespace,
 	}
 
@@ -230,9 +230,9 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 
 	// This plugin will include, as part of the GetAvailablePackageSummariesResponse,
 	// a "Categories" field containing only the distinct category names considering just the namespace
-	chartCategories, err := s.manager.GetAllChartCategories(utils.ChartQuery{Namespace: namespace})
+	chartCategories, err := s.manager.GetAllChartCategories(assetmanager.ChartQuery{Namespace: namespace})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to fetch chart categories: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to fetch chart categories: %v", err)
 	}
 
 	var categories []string
@@ -245,15 +245,15 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	pageNumber := pageOffset + 1
 	charts, _, err := s.manager.GetPaginatedChartListWithFilters(cq, pageNumber, int(pageSize))
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to retrieve charts: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to retrieve charts: %v", err)
 	}
 
 	// Convert the charts response into a GetAvailablePackageSummariesResponse
-	responsePackages := []*corev1.AvailablePackageSummary{}
+	responsePackages := []*pkgsGRPCv1alpha1.AvailablePackageSummary{}
 	for _, chart := range charts {
 		pkg, err := pkgutils.AvailablePackageSummaryFromChart(chart, GetPluginDetail())
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Unable to parse chart to an AvailablePackageSummary: %v", err)
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to parse chart to an AvailablePackageSummary: %v", err)
 		}
 		// We currently support app repositories on the kubeapps cluster only.
 		pkg.AvailablePackageRef.Context.Cluster = s.globalPackagingCluster
@@ -266,7 +266,7 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	if pageSize > 0 && len(responsePackages) == int(pageSize) {
 		nextPageToken = fmt.Sprintf("%d", pageOffset+1)
 	}
-	return &corev1.GetAvailablePackageSummariesResponse{
+	return &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
 		AvailablePackageSummaries: responsePackages,
 		NextPageToken:             nextPageToken,
 		Categories:                categories,
@@ -274,12 +274,12 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 }
 
 // GetAvailablePackageDetail returns the package metadata managed by the 'helm' plugin
-func (s *Server) GetAvailablePackageDetail(ctx context.Context, request *corev1.GetAvailablePackageDetailRequest) (*corev1.GetAvailablePackageDetailResponse, error) {
+func (s *Server) GetAvailablePackageDetail(ctx context.Context, request *pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest) (*pkgsGRPCv1alpha1.GetAvailablePackageDetailResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetAvailablePackageRef().GetContext().GetCluster(), request.GetAvailablePackageRef().GetContext().GetNamespace())
 	log.Infof("+helm GetAvailablePackageDetail %s", contextMsg)
 
 	if request.GetAvailablePackageRef().GetContext() == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "No request AvailablePackageRef.Context provided")
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "No request AvailablePackageRef.Context provided")
 	}
 
 	// Retrieve namespace, cluster, version from the request
@@ -289,7 +289,7 @@ func (s *Server) GetAvailablePackageDetail(ctx context.Context, request *corev1.
 
 	// Currently we support available packages on the kubeapps cluster only.
 	if cluster != "" && cluster != s.globalPackagingCluster {
-		return nil, status.Errorf(codes.InvalidArgument, "Requests for available packages on clusters other than %q not supported. Requested cluster was: %q", s.globalPackagingCluster, cluster)
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Requests for available packages on clusters other than %q not supported. Requested cluster was: %q", s.globalPackagingCluster, cluster)
 	}
 
 	// After requesting a specific namespace, we have to ensure the user can actually access to it
@@ -304,7 +304,7 @@ func (s *Server) GetAvailablePackageDetail(ctx context.Context, request *corev1.
 
 	// Since the version is optional, in case of an empty one, fall back to get all versions and get the first one
 	// Note that the chart version array should be ordered
-	var chart models.Chart
+	var chart chartmodels.Chart
 	if version == "" {
 		log.Infof("Requesting chart '%s' (latest version) in ns '%s'", unescapedChartID, namespace)
 		chart, err = s.manager.GetChart(namespace, unescapedChartID)
@@ -313,11 +313,11 @@ func (s *Server) GetAvailablePackageDetail(ctx context.Context, request *corev1.
 		chart, err = s.manager.GetChartVersion(namespace, unescapedChartID, version)
 	}
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to retrieve chart: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to retrieve chart: %v", err)
 	}
 
 	if len(chart.ChartVersions) == 0 {
-		return nil, status.Errorf(codes.Internal, "Chart returned without any versions: %+v", chart)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Chart returned without any versions: %+v", chart)
 	}
 	if version == "" {
 		version = chart.ChartVersions[0].Version
@@ -325,15 +325,15 @@ func (s *Server) GetAvailablePackageDetail(ctx context.Context, request *corev1.
 	fileID := fileIDForChart(unescapedChartID, chart.ChartVersions[0].Version)
 	chartFiles, err := s.manager.GetChartFiles(namespace, fileID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to retrieve chart files: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to retrieve chart files: %v", err)
 	}
 
 	availablePackageDetail, err := AvailablePackageDetailFromChart(&chart, &chartFiles)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to parse chart to an availablePackageDetail: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to parse chart to an availablePackageDetail: %v", err)
 	}
 
-	return &corev1.GetAvailablePackageDetailResponse{
+	return &pkgsGRPCv1alpha1.GetAvailablePackageDetailResponse{
 		AvailablePackageDetail: availablePackageDetail,
 	}, nil
 }
@@ -344,18 +344,18 @@ func fileIDForChart(id, version string) string {
 }
 
 // GetAvailablePackageVersions returns the package versions managed by the 'helm' plugin
-func (s *Server) GetAvailablePackageVersions(ctx context.Context, request *corev1.GetAvailablePackageVersionsRequest) (*corev1.GetAvailablePackageVersionsResponse, error) {
+func (s *Server) GetAvailablePackageVersions(ctx context.Context, request *pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest) (*pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetAvailablePackageRef().GetContext().GetCluster(), request.GetAvailablePackageRef().GetContext().GetNamespace())
 	log.Infof("+helm GetAvailablePackageVersions %s", contextMsg)
 
 	namespace := request.GetAvailablePackageRef().GetContext().GetNamespace()
 	if namespace == "" || request.GetAvailablePackageRef().GetIdentifier() == "" {
-		return nil, status.Errorf(codes.InvalidArgument, "Required context or identifier not provided")
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Required context or identifier not provided")
 	}
 	cluster := request.GetAvailablePackageRef().GetContext().GetCluster()
 	// Currently we support available packages on the kubeapps cluster only.
 	if cluster != "" && cluster != s.globalPackagingCluster {
-		return nil, status.Errorf(codes.InvalidArgument, "Requests for versions of available packages on clusters other than %q not supported. Requested cluster was %q.", s.globalPackagingCluster, cluster)
+		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "Requests for versions of available packages on clusters other than %q not supported. Requested cluster was %q.", s.globalPackagingCluster, cluster)
 	}
 
 	// After requesting a specific namespace, we have to ensure the user can actually access to it
@@ -371,21 +371,21 @@ func (s *Server) GetAvailablePackageVersions(ctx context.Context, request *corev
 	log.Infof("Requesting chart '%s' (latest version) in ns '%s'", unescapedChartID, namespace)
 	chart, err := s.manager.GetChart(namespace, unescapedChartID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to retrieve chart: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to retrieve chart: %v", err)
 	}
 
-	return &corev1.GetAvailablePackageVersionsResponse{
+	return &pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{
 		PackageAppVersions: pkgutils.PackageAppVersionsSummary(chart.ChartVersions, s.versionsInSummary),
 	}, nil
 }
 
 // AvailablePackageDetailFromChart builds an AvailablePackageDetail from a Chart
-func AvailablePackageDetailFromChart(chart *models.Chart, chartFiles *models.ChartFiles) (*corev1.AvailablePackageDetail, error) {
-	pkg := &corev1.AvailablePackageDetail{}
+func AvailablePackageDetailFromChart(chart *chartmodels.Chart, chartFiles *chartmodels.ChartFiles) (*pkgsGRPCv1alpha1.AvailablePackageDetail, error) {
+	pkg := &pkgsGRPCv1alpha1.AvailablePackageDetail{}
 
 	isValid, err := pkgutils.IsValidChart(chart)
 	if !isValid || err != nil {
-		return nil, status.Errorf(codes.Internal, "invalid chart: %s", err.Error())
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "invalid chart: %s", err.Error())
 	}
 
 	pkg.DisplayName = chart.Name
@@ -396,24 +396,24 @@ func AvailablePackageDetailFromChart(chart *models.Chart, chartFiles *models.Cha
 	pkg.Categories = []string{chart.Category}
 	pkg.SourceUrls = chart.Sources
 
-	pkg.Maintainers = []*corev1.Maintainer{}
+	pkg.Maintainers = []*pkgsGRPCv1alpha1.Maintainer{}
 	for _, maintainer := range chart.Maintainers {
-		m := &corev1.Maintainer{Name: maintainer.Name, Email: maintainer.Email}
+		m := &pkgsGRPCv1alpha1.Maintainer{Name: maintainer.Name, Email: maintainer.Email}
 		pkg.Maintainers = append(pkg.Maintainers, m)
 	}
 
-	pkg.AvailablePackageRef = &corev1.AvailablePackageReference{
+	pkg.AvailablePackageRef = &pkgsGRPCv1alpha1.AvailablePackageReference{
 		Identifier: chart.ID,
 		Plugin:     GetPluginDetail(),
 	}
 	if chart.Repo != nil {
 		pkg.RepoUrl = chart.Repo.URL
-		pkg.AvailablePackageRef.Context = &corev1.Context{Namespace: chart.Repo.Namespace}
+		pkg.AvailablePackageRef.Context = &pkgsGRPCv1alpha1.Context{Namespace: chart.Repo.Namespace}
 	}
 
-	// We assume that chart.ChartVersions[0] will always contain either: the latest version or the specified version
+	// We assume that helmchart.ChartVersions[0] will always contain either: the latest version or the specified version
 	if chart.ChartVersions != nil || len(chart.ChartVersions) != 0 {
-		pkg.Version = &corev1.PackageAppVersion{
+		pkg.Version = &pkgsGRPCv1alpha1.PackageAppVersion{
 			PkgVersion: chart.ChartVersions[0].Version,
 			AppVersion: chart.ChartVersions[0].AppVersion,
 		}
@@ -435,36 +435,36 @@ func (s *Server) hasAccessToNamespace(ctx context.Context, cluster, namespace st
 		return err
 	}
 
-	res, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(context.TODO(), &authorizationv1.SelfSubjectAccessReview{
-		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &authorizationv1.ResourceAttributes{
+	res, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(context.TODO(), &k8sauthorizationv1.SelfSubjectAccessReview{
+		Spec: k8sauthorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &k8sauthorizationv1.ResourceAttributes{
 				Group:     "",
 				Resource:  "secrets",
 				Verb:      "get",
 				Namespace: namespace,
 			},
 		},
-	}, metav1.CreateOptions{})
+	}, k8smetav1.CreateOptions{})
 	if err != nil {
-		return status.Errorf(codes.Internal, "Unable to check if the user has access to the namespace: %s", err)
+		return grpcstatus.Errorf(grpccodes.Internal, "Unable to check if the user has access to the namespace: %s", err)
 	}
 	if !res.Status.Allowed {
 		// If the user has not access, return a unauthenticated response, otherwise, continue
-		return status.Errorf(codes.Unauthenticated, "The current user has no access to the namespace %q", namespace)
+		return grpcstatus.Errorf(grpccodes.Unauthenticated, "The current user has no access to the namespace %q", namespace)
 	}
 	return nil
 }
 
 // GetInstalledPackageSummaries returns the installed packages managed by the 'helm' plugin
-func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *corev1.GetInstalledPackageSummariesRequest) (*corev1.GetInstalledPackageSummariesResponse, error) {
+func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest) (*pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetContext().GetCluster(), request.GetContext().GetNamespace())
 	log.Infof("+helm GetInstalledPackageSummaries %s", contextMsg)
 
 	actionConfig, err := s.actionConfigGetter(ctx, request.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create Helm action config: %v", err)
 	}
-	cmd := action.NewList(actionConfig)
+	cmd := helmaction.NewList(actionConfig)
 	if request.GetContext().GetNamespace() == "" {
 		cmd.AllNamespaces = true
 	}
@@ -479,10 +479,10 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 
 	releases, err := cmd.Run()
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to run Helm List action: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to run Helm List action: %v", err)
 	}
 
-	installedPkgSummaries := make([]*corev1.InstalledPackageSummary, len(releases))
+	installedPkgSummaries := make([]*pkgsGRPCv1alpha1.InstalledPackageSummary, len(releases))
 	cluster := request.GetContext().GetCluster()
 	if cluster == "" {
 		cluster = s.globalPackagingCluster
@@ -494,14 +494,14 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 
 	// Fill in the latest package version for each.
 	// TODO(mnelson): Update to do this with a single query rather than iterating and
-	// querying per release.
+	// querying per helmrelease.
 	for i, rel := range releases {
 		// Helm does not store a back-reference to the chart used to create a
 		// release (https://github.com/helm/helm/issues/6464), so for each
 		// release, we look up a chart with than name and version available in
 		// the release namespace, and if one is found, pull out the latest chart
 		// version.
-		cq := utils.ChartQuery{
+		cq := assetmanager.ChartQuery{
 			Namespace:  rel.Namespace,
 			ChartName:  rel.Chart.Metadata.Name,
 			Version:    rel.Chart.Metadata.Version,
@@ -509,28 +509,28 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 		}
 		charts, _, err := s.manager.GetPaginatedChartListWithFilters(cq, 1, 0)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Error while fetching related charts: %v", err)
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "Error while fetching related charts: %v", err)
 		}
 		// TODO(agamez): deal with multiple matches, perhaps returning []AvailablePackageRef ?
 		// Example: global + namespaced repo including an overlapping subset of packages.
 		if len(charts) > 0 && len(charts[0].ChartVersions) > 0 {
-			installedPkgSummaries[i].LatestVersion = &corev1.PackageAppVersion{
+			installedPkgSummaries[i].LatestVersion = &pkgsGRPCv1alpha1.PackageAppVersion{
 				PkgVersion: charts[0].ChartVersions[0].Version,
 				AppVersion: charts[0].ChartVersions[0].AppVersion,
 			}
 		}
-		installedPkgSummaries[i].Status = &corev1.InstalledPackageStatus{
-			Ready:      rel.Info.Status == release.StatusDeployed,
+		installedPkgSummaries[i].Status = &pkgsGRPCv1alpha1.InstalledPackageStatus{
+			Ready:      rel.Info.Status == helmrelease.StatusDeployed,
 			Reason:     statusReasonForHelmStatus(rel.Info.Status),
 			UserReason: rel.Info.Status.String(),
 		}
-		installedPkgSummaries[i].CurrentVersion = &corev1.PackageAppVersion{
+		installedPkgSummaries[i].CurrentVersion = &pkgsGRPCv1alpha1.PackageAppVersion{
 			PkgVersion: rel.Chart.Metadata.Version,
 			AppVersion: rel.Chart.Metadata.AppVersion,
 		}
 	}
 
-	response := &corev1.GetInstalledPackageSummariesResponse{
+	response := &pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{
 		InstalledPackageSummaries: installedPkgSummaries,
 	}
 	if len(releases) == cmd.Limit {
@@ -539,32 +539,32 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *core
 	return response, nil
 }
 
-func statusReasonForHelmStatus(s release.Status) corev1.InstalledPackageStatus_StatusReason {
+func statusReasonForHelmStatus(s helmrelease.Status) pkgsGRPCv1alpha1.InstalledPackageStatus_StatusReason {
 	switch s {
-	case release.StatusDeployed:
-		return corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED
-	case release.StatusFailed:
-		return corev1.InstalledPackageStatus_STATUS_REASON_FAILED
-	case release.StatusPendingInstall, release.StatusPendingRollback, release.StatusPendingUpgrade, release.StatusUninstalling:
-		return corev1.InstalledPackageStatus_STATUS_REASON_PENDING
+	case helmrelease.StatusDeployed:
+		return pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED
+	case helmrelease.StatusFailed:
+		return pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_FAILED
+	case helmrelease.StatusPendingInstall, helmrelease.StatusPendingRollback, helmrelease.StatusPendingUpgrade, helmrelease.StatusUninstalling:
+		return pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_PENDING
 	}
 	// Both StatusUninstalled and StatusSuperseded will be unknown/unspecified.
-	return corev1.InstalledPackageStatus_STATUS_REASON_UNSPECIFIED
+	return pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_UNSPECIFIED
 }
 
-func installedPkgSummaryFromRelease(r *release.Release) *corev1.InstalledPackageSummary {
-	return &corev1.InstalledPackageSummary{
-		InstalledPackageRef: &corev1.InstalledPackageReference{
-			Context: &corev1.Context{
+func installedPkgSummaryFromRelease(r *helmrelease.Release) *pkgsGRPCv1alpha1.InstalledPackageSummary {
+	return &pkgsGRPCv1alpha1.InstalledPackageSummary{
+		InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+			Context: &pkgsGRPCv1alpha1.Context{
 				Namespace: r.Namespace,
 			},
 			Identifier: r.Name,
 		},
 		Name: r.Name,
-		PkgVersionReference: &corev1.VersionReference{
+		PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 			Version: r.Chart.Metadata.Version,
 		},
-		CurrentVersion: &corev1.PackageAppVersion{
+		CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 			PkgVersion: r.Chart.Metadata.Version,
 			AppVersion: r.Chart.Metadata.AppVersion,
 		},
@@ -575,7 +575,7 @@ func installedPkgSummaryFromRelease(r *release.Release) *corev1.InstalledPackage
 }
 
 // GetInstalledPackageDetail returns the package metadata managed by the 'helm' plugin
-func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.GetInstalledPackageDetailRequest) (*corev1.GetInstalledPackageDetailResponse, error) {
+func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *pkgsGRPCv1alpha1.GetInstalledPackageDetailRequest) (*pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetInstalledPackageRef().GetContext().GetCluster(), request.GetInstalledPackageRef().GetContext().GetNamespace())
 	log.Infof("+helm GetInstalledPackageDetail %s", contextMsg)
 
@@ -584,37 +584,37 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.
 
 	actionConfig, err := s.actionConfigGetter(ctx, request.GetInstalledPackageRef().GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create Helm action config: %v", err)
 	}
 
-	// First grab the release.
-	getcmd := action.NewGet(actionConfig)
+	// First grab the helmrelease.
+	getcmd := helmaction.NewGet(actionConfig)
 	release, err := getcmd.Run(identifier)
 	if err != nil {
-		if err == driver.ErrReleaseNotFound {
-			return nil, status.Errorf(codes.NotFound, "Unable to find Helm release %q in namespace %q: %+v", identifier, namespace, err)
+		if err == helmstoragedriver.ErrReleaseNotFound {
+			return nil, grpcstatus.Errorf(grpccodes.NotFound, "Unable to find Helm release %q in namespace %q: %+v", identifier, namespace, err)
 		}
-		return nil, status.Errorf(codes.Internal, "Unable to run Helm get action: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to run Helm get action: %v", err)
 	}
 	installedPkgDetail, err := installedPkgDetailFromRelease(release, request.GetInstalledPackageRef())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create installed package detail from release: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create installed package detail from release: %v", err)
 	}
 
 	// Grab the released values.
-	valuescmd := action.NewGetValues(actionConfig)
+	valuescmd := helmaction.NewGetValues(actionConfig)
 	values, err := valuescmd.Run(identifier)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to get Helm release values: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to get Helm release values: %v", err)
 	}
 	valuesMarshalled, err := json.Marshal(values)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to marshal Helm release values: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to marshal Helm release values: %v", err)
 	}
 	installedPkgDetail.ValuesApplied = string(valuesMarshalled)
 
 	// Check for a chart matching the installed package.
-	cq := utils.ChartQuery{
+	cq := assetmanager.ChartQuery{
 		Namespace:  release.Namespace,
 		ChartName:  release.Chart.Metadata.Name,
 		Version:    release.Chart.Metadata.Version,
@@ -622,55 +622,55 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.
 	}
 	charts, _, err := s.manager.GetPaginatedChartListWithFilters(cq, 1, 0)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Error while fetching related chart: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Error while fetching related chart: %v", err)
 	}
 	// TODO(agamez): deal with multiple matches, perhaps returning []AvailablePackageRef ?
 	// Example: global + namespaced repo including an overlapping subset of packages.
 	if len(charts) > 0 {
-		installedPkgDetail.AvailablePackageRef = &corev1.AvailablePackageReference{
+		installedPkgDetail.AvailablePackageRef = &pkgsGRPCv1alpha1.AvailablePackageReference{
 			Identifier: charts[0].ID,
 			Plugin:     GetPluginDetail(),
 		}
 		if charts[0].Repo != nil {
-			installedPkgDetail.AvailablePackageRef.Context = &corev1.Context{
+			installedPkgDetail.AvailablePackageRef.Context = &pkgsGRPCv1alpha1.Context{
 				Namespace: charts[0].Repo.Namespace,
 				Cluster:   s.globalPackagingCluster,
 			}
 		}
 		if len(charts[0].ChartVersions) > 0 {
 			cv := charts[0].ChartVersions[0]
-			installedPkgDetail.LatestVersion = &corev1.PackageAppVersion{
+			installedPkgDetail.LatestVersion = &pkgsGRPCv1alpha1.PackageAppVersion{
 				PkgVersion: cv.Version,
 				AppVersion: cv.AppVersion,
 			}
 		}
 	}
 
-	return &corev1.GetInstalledPackageDetailResponse{
+	return &pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse{
 		InstalledPackageDetail: installedPkgDetail,
 	}, nil
 }
 
-func installedPkgDetailFromRelease(r *release.Release, ref *corev1.InstalledPackageReference) (*corev1.InstalledPackageDetail, error) {
-	customDetailHelm, err := anypb.New(&helmv1.InstalledPackageDetailCustomDataHelm{
+func installedPkgDetailFromRelease(r *helmrelease.Release, ref *pkgsGRPCv1alpha1.InstalledPackageReference) (*pkgsGRPCv1alpha1.InstalledPackageDetail, error) {
+	customDetailHelm, err := anypb.New(&pkghelmv1alpha1.InstalledPackageDetailCustomDataHelm{
 		ReleaseRevision: int32(r.Version),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return &corev1.InstalledPackageDetail{
+	return &pkgsGRPCv1alpha1.InstalledPackageDetail{
 		InstalledPackageRef: ref,
 		Name:                r.Name,
-		PkgVersionReference: &corev1.VersionReference{
+		PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 			Version: r.Chart.Metadata.Version,
 		},
-		CurrentVersion: &corev1.PackageAppVersion{
+		CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 			PkgVersion: r.Chart.Metadata.Version,
 			AppVersion: r.Chart.Metadata.AppVersion,
 		},
 		PostInstallationNotes: r.Info.Notes,
-		Status: &corev1.InstalledPackageStatus{
-			Ready:      r.Info.Status == release.StatusDeployed,
+		Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
+			Ready:      r.Info.Status == helmrelease.StatusDeployed,
 			Reason:     statusReasonForHelmStatus(r.Info.Status),
 			UserReason: r.Info.Status.String(),
 		},
@@ -679,13 +679,13 @@ func installedPkgDetailFromRelease(r *release.Release, ref *corev1.InstalledPack
 }
 
 // CreateInstalledPackage creates an installed package.
-func (s *Server) CreateInstalledPackage(ctx context.Context, request *corev1.CreateInstalledPackageRequest) (*corev1.CreateInstalledPackageResponse, error) {
+func (s *Server) CreateInstalledPackage(ctx context.Context, request *pkgsGRPCv1alpha1.CreateInstalledPackageRequest) (*pkgsGRPCv1alpha1.CreateInstalledPackageResponse, error) {
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", request.GetTargetContext().GetCluster(), request.GetTargetContext().GetNamespace())
 	log.Infof("+helm CreateInstalledPackage %s", contextMsg)
 
 	typedClient, _, err := s.GetClients(ctx, s.globalPackagingCluster)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create kubernetes clientset: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create kubernetes clientset: %v", err)
 	}
 	chartID := request.GetAvailablePackageRef().GetIdentifier()
 	repoNamespace := request.GetAvailablePackageRef().GetContext().GetNamespace()
@@ -701,27 +701,27 @@ func (s *Server) CreateInstalledPackage(ctx context.Context, request *corev1.Cre
 	}
 	ch, registrySecrets, err := s.fetchChartWithRegistrySecrets(ctx, chartDetails, typedClient)
 	if err != nil {
-		return nil, status.Errorf(codes.Unauthenticated, "Missing permissions %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Unauthenticated, "Missing permissions %v", err)
 	}
 
 	// Create an action config for the target namespace.
 	actionConfig, err := s.actionConfigGetter(ctx, request.GetTargetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create Helm action config: %v", err)
 	}
 
 	release, err := s.createReleaseFunc(actionConfig, request.GetName(), request.GetTargetContext().GetNamespace(), request.GetValues(), ch, registrySecrets, s.timeoutSeconds)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create helm release %q in the namespace %q: %v", request.GetName(), request.GetTargetContext().GetNamespace(), err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create helm release %q in the namespace %q: %v", request.GetName(), request.GetTargetContext().GetNamespace(), err)
 	}
 
 	cluster := request.GetTargetContext().GetCluster()
 	if cluster == "" {
 		cluster = s.globalPackagingCluster
 	}
-	return &corev1.CreateInstalledPackageResponse{
-		InstalledPackageRef: &corev1.InstalledPackageReference{
-			Context: &corev1.Context{
+	return &pkgsGRPCv1alpha1.CreateInstalledPackageResponse{
+		InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+			Context: &pkgsGRPCv1alpha1.Context{
 				Cluster:   cluster,
 				Namespace: release.Namespace,
 			},
@@ -732,7 +732,7 @@ func (s *Server) CreateInstalledPackage(ctx context.Context, request *corev1.Cre
 }
 
 // UpdateInstalledPackage updates an installed package.
-func (s *Server) UpdateInstalledPackage(ctx context.Context, request *corev1.UpdateInstalledPackageRequest) (*corev1.UpdateInstalledPackageResponse, error) {
+func (s *Server) UpdateInstalledPackage(ctx context.Context, request *pkgsGRPCv1alpha1.UpdateInstalledPackageRequest) (*pkgsGRPCv1alpha1.UpdateInstalledPackageResponse, error) {
 	installedRef := request.GetInstalledPackageRef()
 	releaseName := installedRef.GetIdentifier()
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", installedRef.GetContext().GetCluster(), installedRef.GetContext().GetNamespace())
@@ -744,7 +744,7 @@ func (s *Server) UpdateInstalledPackage(ctx context.Context, request *corev1.Upd
 	// user to select which chart to use, so until then, we're fetching the
 	// available package ref via the detail (bit of a short-cut, could query
 	// for the ref directly).
-	detailResponse, err := s.GetInstalledPackageDetail(ctx, &corev1.GetInstalledPackageDetailRequest{
+	detailResponse, err := s.GetInstalledPackageDetail(ctx, &pkgsGRPCv1alpha1.GetInstalledPackageDetailRequest{
 		InstalledPackageRef: installedRef,
 	})
 	if err != nil {
@@ -753,12 +753,12 @@ func (s *Server) UpdateInstalledPackage(ctx context.Context, request *corev1.Upd
 
 	availablePkgRef := detailResponse.GetInstalledPackageDetail().GetAvailablePackageRef()
 	if availablePkgRef == nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "Unable to find the available package used to deploy %q in the namespace %q.", releaseName, installedRef.GetContext().GetNamespace())
+		return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition, "Unable to find the available package used to deploy %q in the namespace %q.", releaseName, installedRef.GetContext().GetNamespace())
 	}
 
 	typedClient, _, err := s.GetClients(ctx, s.globalPackagingCluster)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create kubernetes clientset: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create kubernetes clientset: %v", err)
 	}
 	chartID := availablePkgRef.GetIdentifier()
 	repoName, chartName, err := pkgutils.SplitChartIdentifier(chartID)
@@ -773,18 +773,18 @@ func (s *Server) UpdateInstalledPackage(ctx context.Context, request *corev1.Upd
 	}
 	ch, registrySecrets, err := s.fetchChartWithRegistrySecrets(ctx, chartDetails, typedClient)
 	if err != nil {
-		return nil, status.Errorf(codes.Unauthenticated, "Missing permissions %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Unauthenticated, "Missing permissions %v", err)
 	}
 
 	// Create an action config for the installed pkg context.
 	actionConfig, err := s.actionConfigGetter(ctx, installedRef.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create Helm action config: %v", err)
 	}
 
-	release, err := agent.UpgradeRelease(actionConfig, releaseName, request.GetValues(), ch, registrySecrets, s.timeoutSeconds)
+	release, err := helmagent.UpgradeRelease(actionConfig, releaseName, request.GetValues(), ch, registrySecrets, s.timeoutSeconds)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to upgrade helm release %q in the namespace %q: %v", releaseName, installedRef.GetContext().GetNamespace(), err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to upgrade helm release %q in the namespace %q: %v", releaseName, installedRef.GetContext().GetNamespace(), err)
 	}
 
 	cluster := installedRef.GetContext().GetCluster()
@@ -792,9 +792,9 @@ func (s *Server) UpdateInstalledPackage(ctx context.Context, request *corev1.Upd
 		cluster = s.globalPackagingCluster
 	}
 
-	return &corev1.UpdateInstalledPackageResponse{
-		InstalledPackageRef: &corev1.InstalledPackageReference{
-			Context: &corev1.Context{
+	return &pkgsGRPCv1alpha1.UpdateInstalledPackageResponse{
+		InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+			Context: &pkgsGRPCv1alpha1.Context{
 				Cluster:   cluster,
 				Namespace: release.Namespace,
 			},
@@ -806,7 +806,7 @@ func (s *Server) UpdateInstalledPackage(ctx context.Context, request *corev1.Upd
 
 // GetAppRepoAndRelatedSecrets retrieves the given repo from its namespace
 // Depending on the repo namespace and the
-func (s *Server) getAppRepoAndRelatedSecrets(ctx context.Context, appRepoName, appRepoNamespace string) (*appRepov1.AppRepository, *corek8sv1.Secret, *corek8sv1.Secret, error) {
+func (s *Server) getAppRepoAndRelatedSecrets(ctx context.Context, appRepoName, appRepoNamespace string) (*apprepov1alpha1.AppRepository, *k8scorev1.Secret, *k8scorev1.Secret, error) {
 
 	// We currently get app repositories on the kubeapps cluster only.
 	typedClient, dynClient, err := s.GetClients(ctx, s.globalPackagingCluster)
@@ -817,36 +817,36 @@ func (s *Server) getAppRepoAndRelatedSecrets(ctx context.Context, appRepoName, a
 	// Using the dynamic client to get the AppRepository rather than updating the interface
 	// returned by the client getter, then converting the result back to a typed AppRepository
 	// since our existing code that we're re-using expects one.
-	gvr := schema.GroupVersionResource{
+	gvr := k8sschema.GroupVersionResource{
 		Group:    "kubeapps.com",
 		Version:  "v1alpha1",
 		Resource: "apprepositories",
 	}
-	appRepoUnstructured, err := dynClient.Resource(gvr).Namespace(appRepoNamespace).Get(ctx, appRepoName, metav1.GetOptions{})
+	appRepoUnstructured, err := dynClient.Resource(gvr).Namespace(appRepoNamespace).Get(ctx, appRepoName, k8smetav1.GetOptions{})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to get app repository %s/%s: %v", appRepoNamespace, appRepoName, err)
 	}
 
-	var appRepo appRepov1.AppRepository
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(appRepoUnstructured.UnstructuredContent(), &appRepo)
+	var appRepo apprepov1alpha1.AppRepository
+	err = k8sruntime.DefaultUnstructuredConverter.FromUnstructured(appRepoUnstructured.UnstructuredContent(), &appRepo)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to convert unstructured AppRepository for %s/%s to a structured AppRepository: %v", appRepoNamespace, appRepoName, err)
 	}
 
 	auth := appRepo.Spec.Auth
-	var caCertSecret *corek8sv1.Secret
+	var caCertSecret *k8scorev1.Secret
 	if auth.CustomCA != nil {
 		secretName := auth.CustomCA.SecretKeyRef.Name
-		caCertSecret, err = typedClient.CoreV1().Secrets(appRepoNamespace).Get(ctx, secretName, metav1.GetOptions{})
+		caCertSecret, err = typedClient.CoreV1().Secrets(appRepoNamespace).Get(ctx, secretName, k8smetav1.GetOptions{})
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("unable to read secret %q: %v", auth.CustomCA.SecretKeyRef.Name, err)
 		}
 	}
 
-	var authSecret *corek8sv1.Secret
+	var authSecret *k8scorev1.Secret
 	if auth.Header != nil {
 		secretName := auth.Header.SecretKeyRef.Name
-		authSecret, err = typedClient.CoreV1().Secrets(appRepoNamespace).Get(ctx, secretName, metav1.GetOptions{})
+		authSecret, err = typedClient.CoreV1().Secrets(appRepoNamespace).Get(ctx, secretName, k8smetav1.GetOptions{})
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("unable to read secret %q: %v", secretName, err)
 		}
@@ -858,11 +858,11 @@ func (s *Server) getAppRepoAndRelatedSecrets(ctx context.Context, appRepoName, a
 // fetchChartWithRegistrySecrets returns the chart and related registry secrets.
 //
 // Mainly to DRY up similar code in the create and update methods.
-func (s *Server) fetchChartWithRegistrySecrets(ctx context.Context, chartDetails *chartutils.Details, client kubernetes.Interface) (*chart.Chart, map[string]string, error) {
+func (s *Server) fetchChartWithRegistrySecrets(ctx context.Context, chartDetails *chartutils.Details, client k8stypedclient.Interface) (*helmchart.Chart, map[string]string, error) {
 	// Most of the existing code that we want to reuse is based on having a typed AppRepository.
 	appRepo, caCertSecret, authSecret, err := s.getAppRepoAndRelatedSecrets(ctx, chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace)
 	if err != nil {
-		return nil, nil, status.Errorf(codes.Internal, "Unable to fetch app repo %q from namespace %q: %v", chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, err)
+		return nil, nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to fetch app repo %q from namespace %q: %v", chartDetails.AppRepositoryResourceName, chartDetails.AppRepositoryResourceNamespace, err)
 	}
 
 	userAgentString := fmt.Sprintf("%s/%s/%s/%s", UserAgentPrefix, pluginDetail.Name, pluginDetail.Version, version)
@@ -873,7 +873,7 @@ func (s *Server) fetchChartWithRegistrySecrets(ctx context.Context, chartDetails
 	// Look up the cachedChart cached in our DB to populate the tarball URL
 	cachedChart, err := s.manager.GetChartVersion(chartDetails.AppRepositoryResourceNamespace, chartID, chartDetails.Version)
 	if err != nil {
-		return nil, nil, status.Errorf(codes.Internal, "Unable to fetch the chart %s (version %s) from the namespace %q: %v", chartID, chartDetails.Version, chartDetails.AppRepositoryResourceNamespace, err)
+		return nil, nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to fetch the chart %s (version %s) from the namespace %q: %v", chartID, chartDetails.Version, chartDetails.AppRepositoryResourceNamespace, err)
 	}
 	var tarballURL string
 	if cachedChart.ChartVersions != nil && len(cachedChart.ChartVersions) == 1 && cachedChart.ChartVersions[0].URLs != nil {
@@ -898,18 +898,18 @@ func (s *Server) fetchChartWithRegistrySecrets(ctx context.Context, chartDetails
 		s.chartClientFactory.New(appRepo.Spec.Type, userAgentString),
 	)
 	if err != nil {
-		return nil, nil, status.Errorf(codes.Internal, "Unable to fetch the chart %s from the namespace %q: %v", chartDetails.ChartName, appRepo.Namespace, err)
+		return nil, nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to fetch the chart %s from the namespace %q: %v", chartDetails.ChartName, appRepo.Namespace, err)
 	}
 
 	registrySecrets, err := chartutils.RegistrySecretsPerDomain(ctx, appRepo.Spec.DockerRegistrySecrets, appRepo.Namespace, client)
 	if err != nil {
-		return nil, nil, status.Errorf(codes.Internal, "Unable to fetch registry secrets from the namespace %q: %v", appRepo.Namespace, err)
+		return nil, nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to fetch registry secrets from the namespace %q: %v", appRepo.Namespace, err)
 	}
 
 	return ch, registrySecrets, nil
 }
 
-func chartTarballURL(r *models.Repo, cv models.ChartVersion) string {
+func chartTarballURL(r *chartmodels.Repo, cv chartmodels.ChartVersion) string {
 	source := strings.TrimSpace(cv.URLs[0])
 	parsedUrl, err := url.ParseRequestURI(source)
 	if err != nil || parsedUrl.Scheme == "" {
@@ -924,7 +924,7 @@ func chartTarballURL(r *models.Repo, cv models.ChartVersion) string {
 }
 
 // DeleteInstalledPackage deletes an installed package.
-func (s *Server) DeleteInstalledPackage(ctx context.Context, request *corev1.DeleteInstalledPackageRequest) (*corev1.DeleteInstalledPackageResponse, error) {
+func (s *Server) DeleteInstalledPackage(ctx context.Context, request *pkgsGRPCv1alpha1.DeleteInstalledPackageRequest) (*pkgsGRPCv1alpha1.DeleteInstalledPackageResponse, error) {
 	installedRef := request.GetInstalledPackageRef()
 	releaseName := installedRef.GetIdentifier()
 	namespace := installedRef.GetContext().GetNamespace()
@@ -934,24 +934,24 @@ func (s *Server) DeleteInstalledPackage(ctx context.Context, request *corev1.Del
 	// Create an action config for the installed pkg context.
 	actionConfig, err := s.actionConfigGetter(ctx, installedRef.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create Helm action config: %v", err)
 	}
 
 	keepHistory := false
-	err = agent.DeleteRelease(actionConfig, releaseName, keepHistory, s.timeoutSeconds)
+	err = helmagent.DeleteRelease(actionConfig, releaseName, keepHistory, s.timeoutSeconds)
 	if err != nil {
 		log.Errorf("error: %+v", err)
-		if errors.Is(err, driver.ErrReleaseNotFound) {
-			return nil, status.Errorf(codes.NotFound, "Unable to find Helm release %q in namespace %q: %+v", releaseName, namespace, err)
+		if errors.Is(err, helmstoragedriver.ErrReleaseNotFound) {
+			return nil, grpcstatus.Errorf(grpccodes.NotFound, "Unable to find Helm release %q in namespace %q: %+v", releaseName, namespace, err)
 		}
-		return nil, status.Errorf(codes.Internal, "Unable to delete helm release %q in the namespace %q: %v", releaseName, namespace, err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to delete helm release %q in the namespace %q: %v", releaseName, namespace, err)
 	}
 
-	return &corev1.DeleteInstalledPackageResponse{}, nil
+	return &pkgsGRPCv1alpha1.DeleteInstalledPackageResponse{}, nil
 }
 
 // RollbackInstalledPackage updates an installed package.
-func (s *Server) RollbackInstalledPackage(ctx context.Context, request *helmv1.RollbackInstalledPackageRequest) (*helmv1.RollbackInstalledPackageResponse, error) {
+func (s *Server) RollbackInstalledPackage(ctx context.Context, request *pkghelmv1alpha1.RollbackInstalledPackageRequest) (*pkghelmv1alpha1.RollbackInstalledPackageResponse, error) {
 	installedRef := request.GetInstalledPackageRef()
 	releaseName := installedRef.GetIdentifier()
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", installedRef.GetContext().GetCluster(), installedRef.GetContext().GetNamespace())
@@ -960,15 +960,15 @@ func (s *Server) RollbackInstalledPackage(ctx context.Context, request *helmv1.R
 	// Create an action config for the installed pkg context.
 	actionConfig, err := s.actionConfigGetter(ctx, installedRef.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create Helm action config: %v", err)
 	}
 
-	release, err := agent.RollbackRelease(actionConfig, releaseName, int(request.GetReleaseRevision()), s.timeoutSeconds)
+	release, err := helmagent.RollbackRelease(actionConfig, releaseName, int(request.GetReleaseRevision()), s.timeoutSeconds)
 	if err != nil {
-		if errors.Is(err, driver.ErrReleaseNotFound) {
-			return nil, status.Errorf(codes.NotFound, "Unable to find Helm release %q in namespace %q: %+v", releaseName, installedRef.GetContext().GetNamespace(), err)
+		if errors.Is(err, helmstoragedriver.ErrReleaseNotFound) {
+			return nil, grpcstatus.Errorf(grpccodes.NotFound, "Unable to find Helm release %q in namespace %q: %+v", releaseName, installedRef.GetContext().GetNamespace(), err)
 		}
-		return nil, status.Errorf(codes.Internal, "Unable to rollback helm release %q in the namespace %q: %v", releaseName, installedRef.GetContext().GetNamespace(), err)
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to rollback helm release %q in the namespace %q: %v", releaseName, installedRef.GetContext().GetNamespace(), err)
 	}
 
 	cluster := installedRef.GetContext().GetCluster()
@@ -976,9 +976,9 @@ func (s *Server) RollbackInstalledPackage(ctx context.Context, request *helmv1.R
 		cluster = s.globalPackagingCluster
 	}
 
-	return &helmv1.RollbackInstalledPackageResponse{
-		InstalledPackageRef: &corev1.InstalledPackageReference{
-			Context: &corev1.Context{
+	return &pkghelmv1alpha1.RollbackInstalledPackageResponse{
+		InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+			Context: &pkgsGRPCv1alpha1.Context{
 				Cluster:   cluster,
 				Namespace: release.Namespace,
 			},
@@ -990,16 +990,16 @@ func (s *Server) RollbackInstalledPackage(ctx context.Context, request *helmv1.R
 
 // GetInstalledPackageResourceRefs returns the references for the Kubernetes
 // resources created by an installed package.
-func (s *Server) GetInstalledPackageResourceRefs(ctx context.Context, request *corev1.GetInstalledPackageResourceRefsRequest) (*corev1.GetInstalledPackageResourceRefsResponse, error) {
+func (s *Server) GetInstalledPackageResourceRefs(ctx context.Context, request *pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsRequest) (*pkgsGRPCv1alpha1.GetInstalledPackageResourceRefsResponse, error) {
 	pkgRef := request.GetInstalledPackageRef()
 	contextMsg := fmt.Sprintf("(cluster=%q, namespace=%q)", pkgRef.GetContext().GetCluster(), pkgRef.GetContext().GetNamespace())
 	identifier := pkgRef.GetIdentifier()
 	log.Infof("+helm GetInstalledPackageResourceRefs %s %s", contextMsg, identifier)
 
-	fn := func(ctx context.Context, namespace string) (*action.Configuration, error) {
+	fn := func(ctx context.Context, namespace string) (*helmaction.Configuration, error) {
 		actionGetter, err := s.actionConfigGetter(ctx, pkgRef.GetContext())
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Unable to create Helm action config: %v", err)
+			return nil, grpcstatus.Errorf(grpccodes.Internal, "Unable to create Helm action config: %v", err)
 		}
 		return actionGetter, nil
 	}

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -15,43 +15,42 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	helmv1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/clientgetter"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/paginate"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
-	"sigs.k8s.io/yaml"
-
-	"github.com/kubeapps/kubeapps/pkg/agent"
-	"github.com/kubeapps/kubeapps/pkg/chart/fake"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/anypb"
-	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chartutil"
-	kube "helm.sh/helm/v3/pkg/kube"
-	kubefake "helm.sh/helm/v3/pkg/kube/fake"
-	"helm.sh/helm/v3/pkg/release"
-	"helm.sh/helm/v3/pkg/storage"
-	"helm.sh/helm/v3/pkg/storage/driver"
-	authorizationv1 "k8s.io/api/authorization/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	dynfake "k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/kubernetes"
-	typfake "k8s.io/client-go/kubernetes/fake"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	cmp "github.com/google/go-cmp/cmp"
+	cmpopts "github.com/google/go-cmp/cmp/cmpopts"
+	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	assetmanager "github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	pkghelmv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
+	clientgetter "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/clientgetter"
+	paginate "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/paginate"
+	pkgutils "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
+	helmagent "github.com/kubeapps/kubeapps/pkg/agent"
+	chartutilsfake "github.com/kubeapps/kubeapps/pkg/chart/fake"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	anypb "google.golang.org/protobuf/types/known/anypb"
+	helmaction "helm.sh/helm/v3/pkg/action"
+	helmchart "helm.sh/helm/v3/pkg/chart"
+	helmchartutil "helm.sh/helm/v3/pkg/chartutil"
+	helmkube "helm.sh/helm/v3/pkg/kube"
+	helmkubefake "helm.sh/helm/v3/pkg/kube/fake"
+	helmrelease "helm.sh/helm/v3/pkg/release"
+	helmstorage "helm.sh/helm/v3/pkg/storage"
+	helmstoragedriver "helm.sh/helm/v3/pkg/storage/driver"
+	k8sauthorizationv1 "k8s.io/api/authorization/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8dynamicclient "k8s.io/client-go/dynamic"
+	k8dynamicclientfake "k8s.io/client-go/dynamic/fake"
+	k8stypedclient "k8s.io/client-go/kubernetes"
+	k8stypedclientfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	log "k8s.io/klog/v2"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 const (
@@ -60,31 +59,31 @@ const (
 	DefaultAppVersion        = "1.2.6"
 	DefaultReleaseRevision   = 1
 	DefaultChartDescription  = "default chart description"
-	DefaultChartIconURL      = "https://example.com/chart.svg"
+	DefaultChartIconURL      = "https://example.com/helmchart.svg"
 	DefaultChartHomeURL      = "https://helm.sh/helm"
 	DefaultChartCategory     = "cat1"
 )
 
-func setMockManager(t *testing.T) (sqlmock.Sqlmock, func(), utils.AssetManager) {
-	var manager utils.AssetManager
+func setMockManager(t *testing.T) (sqlmock.Sqlmock, func(), assetmanager.AssetManager) {
+	var manager assetmanager.AssetManager
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
-	manager = &utils.PostgresAssetManager{&dbutils.PostgresAssetManager{DB: db, GlobalReposNamespace: globalPackagingNamespace}}
+	manager = &assetmanager.PostgresAssetManager{&dbutils.PostgresAssetManager{DB: db, GlobalReposNamespace: globalPackagingNamespace}}
 	return mock, func() { db.Close() }, manager
 }
 
 func TestGetClient(t *testing.T) {
 	dbConfig := dbutils.Config{URL: "localhost:5432", Database: "assetsvc", Username: "postgres", Password: "password"}
-	manager, err := utils.NewPGManager(dbConfig, globalPackagingNamespace)
+	manager, err := assetmanager.NewPGManager(dbConfig, globalPackagingNamespace)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}
-	testClientGetter := func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
-		return typfake.NewSimpleClientset(), dynfake.NewSimpleDynamicClientWithCustomListKinds(
-			runtime.NewScheme(),
-			map[schema.GroupVersionResource]string{
+	testClientGetter := func(context.Context, string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
+		return k8stypedclientfake.NewSimpleClientset(), k8dynamicclientfake.NewSimpleDynamicClientWithCustomListKinds(
+			k8sruntime.NewScheme(),
+			map[k8sschema.GroupVersionResource]string{
 				{Group: "foo", Version: "bar", Resource: "baz"}: "PackageList",
 			},
 		), nil
@@ -92,40 +91,40 @@ func TestGetClient(t *testing.T) {
 
 	testCases := []struct {
 		name              string
-		manager           utils.AssetManager
+		manager           assetmanager.AssetManager
 		clientGetter      clientgetter.ClientGetterFunc
-		statusCodeClient  codes.Code
-		statusCodeManager codes.Code
+		statusCodeClient  grpccodes.Code
+		statusCodeManager grpccodes.Code
 	}{
 		{
 			name:              "it returns internal error status when no clientGetter configured",
 			manager:           manager,
 			clientGetter:      nil,
-			statusCodeClient:  codes.Internal,
-			statusCodeManager: codes.OK,
+			statusCodeClient:  grpccodes.Internal,
+			statusCodeManager: grpccodes.OK,
 		},
 		{
 			name:              "it returns internal error status when no manager configured",
 			manager:           nil,
 			clientGetter:      testClientGetter,
-			statusCodeClient:  codes.OK,
-			statusCodeManager: codes.Internal,
+			statusCodeClient:  grpccodes.OK,
+			statusCodeManager: grpccodes.Internal,
 		},
 		{
 			name:              "it returns internal error status when no clientGetter/manager configured",
 			manager:           nil,
 			clientGetter:      nil,
-			statusCodeClient:  codes.Internal,
-			statusCodeManager: codes.Internal,
+			statusCodeClient:  grpccodes.Internal,
+			statusCodeManager: grpccodes.Internal,
 		},
 		{
 			name:    "it returns failed-precondition when configGetter itself errors",
 			manager: manager,
-			clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+			clientGetter: func(context.Context, string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
 				return nil, nil, fmt.Errorf("Bang!")
 			},
-			statusCodeClient:  codes.FailedPrecondition,
-			statusCodeManager: codes.OK,
+			statusCodeClient:  grpccodes.FailedPrecondition,
+			statusCodeManager: grpccodes.OK,
 		},
 		{
 			name:         "it returns client without error when configured correctly",
@@ -140,23 +139,23 @@ func TestGetClient(t *testing.T) {
 
 			typedClient, dynamicClient, errClient := s.GetClients(context.Background(), "")
 
-			if got, want := status.Code(errClient), tc.statusCodeClient; got != want {
+			if got, want := grpcstatus.Code(errClient), tc.statusCodeClient; got != want {
 				t.Errorf("got: %+v, want: %+v", got, want)
 			}
 
 			_, errManager := s.GetManager()
 
-			if got, want := status.Code(errManager), tc.statusCodeManager; got != want {
+			if got, want := grpcstatus.Code(errManager), tc.statusCodeManager; got != want {
 				t.Errorf("got: %+v, want: %+v", got, want)
 			}
 
-			// If there is no error, the client should be a dynamic.Interface implementation.
-			if tc.statusCodeClient == codes.OK {
+			// If there is no error, the client should be a k8dynamicclient.Interface implementation.
+			if tc.statusCodeClient == grpccodes.OK {
 				if dynamicClient == nil {
-					t.Errorf("got: nil, want: dynamic.Interface")
+					t.Errorf("got: nil, want: k8dynamicclient.Interface")
 				}
 				if typedClient == nil {
-					t.Errorf("got: nil, want: kubernetes.Interface")
+					t.Errorf("got: nil, want: k8stypedclient.Interface")
 				}
 			}
 		})
@@ -164,25 +163,25 @@ func TestGetClient(t *testing.T) {
 }
 
 // makeChart makes a chart with specific input used in the test and default constants for other relevant data.
-func makeChart(chart_name, repo_name, repo_url, namespace string, chart_versions []string, category string) *models.Chart {
-	ch := &models.Chart{
+func makeChart(chart_name, repo_name, repo_url, namespace string, chart_versions []string, category string) *chartmodels.Chart {
+	ch := &chartmodels.Chart{
 		Name:        chart_name,
 		ID:          fmt.Sprintf("%s/%s", repo_name, chart_name),
 		Category:    category,
 		Description: DefaultChartDescription,
 		Home:        DefaultChartHomeURL,
 		Icon:        DefaultChartIconURL,
-		Maintainers: []chart.Maintainer{{Name: "me", Email: "me@me.me"}},
+		Maintainers: []helmchart.Maintainer{{Name: "me", Email: "me@me.me"}},
 		Sources:     []string{"http://source-1"},
-		Repo: &models.Repo{
+		Repo: &chartmodels.Repo{
 			Name:      repo_name,
 			Namespace: namespace,
 			URL:       repo_url,
 		},
 	}
-	versions := []models.ChartVersion{}
+	versions := []chartmodels.ChartVersion{}
 	for _, v := range chart_versions {
-		versions = append(versions, models.ChartVersion{
+		versions = append(versions, chartmodels.ChartVersion{
 			Version:    v,
 			AppVersion: DefaultAppVersion,
 			Readme:     "not-used",
@@ -195,7 +194,7 @@ func makeChart(chart_name, repo_name, repo_url, namespace string, chart_versions
 }
 
 // makeChartRowsJSON returns a slice of paginated JSON chart info data.
-func makeChartRowsJSON(t *testing.T, charts []*models.Chart, pageToken string, pageSize int) []string {
+func makeChartRowsJSON(t *testing.T, charts []*chartmodels.Chart, pageToken string, pageSize int) []string {
 	// Simulate the pagination by reducing the rows of JSON based on the offset and limit.
 	rowsJSON := []string{}
 	for _, chart := range charts {
@@ -226,29 +225,29 @@ func makeChartRowsJSON(t *testing.T, charts []*models.Chart, pageToken string, p
 }
 
 // makeServer returns a server backed with an sql mock and a cleanup function
-func makeServer(t *testing.T, authorized bool, actionConfig *action.Configuration, objects ...runtime.Object) (*Server, sqlmock.Sqlmock, func()) {
+func makeServer(t *testing.T, authorized bool, actionConfig *helmaction.Configuration, objects ...k8sruntime.Object) (*Server, sqlmock.Sqlmock, func()) {
 	// Creating the dynamic client
-	scheme := runtime.NewScheme()
-	err := v1alpha1.AddToScheme(scheme)
+	scheme := k8sruntime.NewScheme()
+	err := apprepov1alpha1.AddToScheme(scheme)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
-	dynamicClient := dynfake.NewSimpleDynamicClientWithCustomListKinds(
+	dynamicClient := k8dynamicclientfake.NewSimpleDynamicClientWithCustomListKinds(
 		scheme,
-		map[schema.GroupVersionResource]string{
+		map[k8sschema.GroupVersionResource]string{
 			{Group: "foo", Version: "bar", Resource: "baz"}: "PackageList",
 		},
 		objects...,
 	)
 
 	// Creating an authorized clientGetter
-	clientSet := typfake.NewSimpleClientset()
-	clientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &authorizationv1.SelfSubjectAccessReview{
-			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: authorized},
+	clientSet := k8stypedclientfake.NewSimpleClientset()
+	clientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (handled bool, ret k8sruntime.Object, err error) {
+		return true, &k8sauthorizationv1.SelfSubjectAccessReview{
+			Status: k8sauthorizationv1.SubjectAccessReviewStatus{Allowed: authorized},
 		}, nil
 	})
-	clientGetter := func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+	clientGetter := func(context.Context, string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
 		return clientSet, dynamicClient, nil
 	}
 
@@ -260,271 +259,271 @@ func makeServer(t *testing.T, authorized bool, actionConfig *action.Configuratio
 		manager:                  manager,
 		globalPackagingNamespace: globalPackagingNamespace,
 		globalPackagingCluster:   globalPackagingCluster,
-		actionConfigGetter: func(context.Context, *corev1.Context) (*action.Configuration, error) {
+		actionConfigGetter: func(context.Context, *pkgsGRPCv1alpha1.Context) (*helmaction.Configuration, error) {
 			return actionConfig, nil
 		},
-		chartClientFactory: &fake.ChartClientFactory{},
+		chartClientFactory: &chartutilsfake.ChartClientFactory{},
 		versionsInSummary:  pkgutils.GetDefaultVersionsInSummary(),
-		createReleaseFunc:  agent.CreateRelease,
+		createReleaseFunc:  helmagent.CreateRelease,
 	}, mock, cleanup
 }
 
 func TestGetAvailablePackageSummaries(t *testing.T) {
 	testCases := []struct {
 		name                   string
-		charts                 []*models.Chart
+		charts                 []*chartmodels.Chart
 		expectDBQueryNamespace string
-		statusCode             codes.Code
-		request                *corev1.GetAvailablePackageSummariesRequest
-		expectedResponse       *corev1.GetAvailablePackageSummariesResponse
+		statusCode             grpccodes.Code
+		request                *pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest
+		expectedResponse       *pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse
 		authorized             bool
-		expectedCategories     []*models.ChartCategory
+		expectedCategories     []*chartmodels.ChartCategory
 	}{
 		{
 			name:       "it returns a set of availablePackageSummary from the database (global ns)",
 			authorized: true,
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
 			},
 			expectDBQueryNamespace: globalPackagingNamespace,
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
 				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
 				makeChart("chart-3-global", "repo-1", "http://chart-3", globalPackagingNamespace, []string{"2.0.0"}, DefaultChartCategory),
 			},
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
 					{
 						Name:        "chart-1",
 						DisplayName: "chart-1",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "3.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-1",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 					{
 						Name:        "chart-2",
 						DisplayName: "chart-2",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "2.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-2",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 					{
 						Name:        "chart-3-global",
 						DisplayName: "chart-3-global",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "2.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: globalPackagingNamespace},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: globalPackagingNamespace},
 							Identifier: "repo-1/chart-3-global",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 				},
 				Categories: []string{"cat1"},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name:       "it returns a set of availablePackageSummary from the database (specific ns)",
 			authorized: true,
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Namespace: "my-ns",
 				},
 			},
 			expectDBQueryNamespace: "my-ns",
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
 				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
 			},
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
 					{
 						Name:        "chart-1",
 						DisplayName: "chart-1",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "3.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-1",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 					{
 						Name:        "chart-2",
 						DisplayName: "chart-2",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "2.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-2",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 				},
 				Categories: []string{"cat1"},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name:       "it returns a set of the global availablePackageSummary from the database (not the specific ns on other cluster)",
 			authorized: true,
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "other",
 					Namespace: "my-ns",
 				},
 			},
 			expectDBQueryNamespace: globalPackagingNamespace,
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
 				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
 			},
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
 					{
 						Name:        "chart-1",
 						DisplayName: "chart-1",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "3.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-1",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 					{
 						Name:        "chart-2",
 						DisplayName: "chart-2",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "2.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-2",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 				},
 				Categories: []string{"cat1"},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name:       "it returns a unimplemented status if no namespaces is provided",
 			authorized: true,
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Namespace: "",
 				},
 			},
-			charts:     []*models.Chart{},
-			statusCode: codes.Unimplemented,
+			charts:     []*chartmodels.Chart{},
+			statusCode: grpccodes.Unimplemented,
 		},
 		{
 			name:       "it returns an internal error status if response does not contain version",
 			authorized: true,
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
 			},
 			expectDBQueryNamespace: globalPackagingNamespace,
-			charts:                 []*models.Chart{makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{}, DefaultChartCategory)},
-			statusCode:             codes.Internal,
+			charts:                 []*chartmodels.Chart{makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{}, DefaultChartCategory)},
+			statusCode:             grpccodes.Internal,
 		},
 		{
 			name:       "it returns an unauthenticated status if the user doesn't have permissions",
 			authorized: false,
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Namespace: "my-ns",
 				},
 			},
-			charts:     []*models.Chart{{Name: "foo"}},
-			statusCode: codes.Unauthenticated,
+			charts:     []*chartmodels.Chart{{Name: "foo"}},
+			statusCode: grpccodes.Unauthenticated,
 		},
 		{
 			name:       "it returns only the requested page of results and includes the next page token",
 			authorized: true,
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{
+				PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{
 					PageToken: "2",
 					PageSize:  1,
 				},
 			},
 			expectDBQueryNamespace: globalPackagingNamespace,
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
 				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
 				makeChart("chart-3", "repo-1", "http://chart-3", "my-ns", []string{"1.0.0"}, DefaultChartCategory),
 			},
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
 					{
 						Name:        "chart-2",
 						DisplayName: "chart-2",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "2.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						ShortDescription: DefaultChartDescription,
 						Categories:       []string{DefaultChartCategory},
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-2",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 				},
@@ -535,40 +534,40 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		{
 			name:       "it returns the last page without a next page token",
 			authorized: true,
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
 				// Start on page two with two results per page, which in this input
-				// corresponds only to the third chart.
-				PaginationOptions: &corev1.PaginationOptions{
+				// corresponds only to the third helmchart.
+				PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{
 					PageToken: "2",
 					PageSize:  2,
 				},
 			},
 			expectDBQueryNamespace: globalPackagingNamespace,
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
 				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, DefaultChartCategory),
 				makeChart("chart-3", "repo-1", "http://chart-3", "my-ns", []string{"1.0.0"}, DefaultChartCategory),
 			},
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
 					{
 						Name:        "chart-3",
 						DisplayName: "chart-3",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "1.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{DefaultChartCategory},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-3",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 				},
@@ -579,87 +578,87 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		{
 			name:       "it returns an invalid argument error if the page token is invalid",
 			authorized: true,
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: globalPackagingNamespace,
 				},
-				PaginationOptions: &corev1.PaginationOptions{
+				PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{
 					PageToken: "this is not a page token",
 					PageSize:  2,
 				},
 			},
-			statusCode: codes.InvalidArgument,
+			statusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name:       "it returns the proper chart categories",
 			authorized: true,
-			request: &corev1.GetAvailablePackageSummariesRequest{
-				Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "",
 					Namespace: "my-ns",
 				},
 			},
 			expectDBQueryNamespace: "my-ns",
-			charts: []*models.Chart{
+			charts: []*chartmodels.Chart{
 				makeChart("chart-1", "repo-1", "http://chart-1", "my-ns", []string{"3.0.0"}, "foo"),
 				makeChart("chart-2", "repo-1", "http://chart-2", "my-ns", []string{"2.0.0"}, "bar"),
 				makeChart("chart-3", "repo-1", "http://chart-3", "my-ns", []string{"1.0.0"}, "bar"),
 			},
-			expectedResponse: &corev1.GetAvailablePackageSummariesResponse{
-				AvailablePackageSummaries: []*corev1.AvailablePackageSummary{
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{
+				AvailablePackageSummaries: []*pkgsGRPCv1alpha1.AvailablePackageSummary{
 					{
 						Name:        "chart-1",
 						DisplayName: "chart-1",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "3.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{"foo"},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-1",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 					{
 						Name:        "chart-2",
 						DisplayName: "chart-2",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "2.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{"bar"},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-2",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 					{
 						Name:        "chart-3",
 						DisplayName: "chart-3",
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "1.0.0",
 							AppVersion: DefaultAppVersion,
 						},
 						IconUrl:          DefaultChartIconURL,
 						Categories:       []string{"bar"},
 						ShortDescription: DefaultChartDescription,
-						AvailablePackageRef: &corev1.AvailablePackageReference{
-							Context:    &corev1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
+						AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+							Context:    &pkgsGRPCv1alpha1.Context{Cluster: globalPackagingCluster, Namespace: "my-ns"},
 							Identifier: "repo-1/chart-3",
-							Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+							Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 						},
 					},
 				},
 				Categories: []string{"bar", "foo"},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 	}
 
@@ -715,12 +714,12 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 
 			availablePackageSummaries, err := server.GetAvailablePackageSummaries(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
-				opt1 := cmpopts.IgnoreUnexported(corev1.GetAvailablePackageSummariesResponse{}, corev1.AvailablePackageSummary{}, corev1.AvailablePackageReference{}, corev1.Context{}, plugins.Plugin{}, corev1.PackageAppVersion{})
+			if tc.statusCode == grpccodes.OK {
+				opt1 := cmpopts.IgnoreUnexported(pkgsGRPCv1alpha1.GetAvailablePackageSummariesResponse{}, pkgsGRPCv1alpha1.AvailablePackageSummary{}, pkgsGRPCv1alpha1.AvailablePackageReference{}, pkgsGRPCv1alpha1.Context{}, pluginsGRPCv1alpha1.Plugin{}, pkgsGRPCv1alpha1.PackageAppVersion{})
 				if got, want := availablePackageSummaries, tc.expectedResponse; !cmp.Equal(got, want, opt1) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opt1))
 				}
@@ -736,20 +735,20 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 func TestAvailablePackageDetailFromChart(t *testing.T) {
 	testCases := []struct {
 		name       string
-		chart      *models.Chart
-		chartFiles *models.ChartFiles
-		expected   *corev1.AvailablePackageDetail
-		statusCode codes.Code
+		chart      *chartmodels.Chart
+		chartFiles *chartmodels.ChartFiles
+		expected   *pkgsGRPCv1alpha1.AvailablePackageDetail
+		statusCode grpccodes.Code
 	}{
 		{
 			name:  "it returns AvailablePackageDetail if the chart is correct",
 			chart: makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"3.0.0"}, DefaultChartCategory),
-			chartFiles: &models.ChartFiles{
+			chartFiles: &chartmodels.ChartFiles{
 				Readme: "chart readme",
 				Values: "chart values",
 				Schema: "chart schema",
 			},
-			expected: &corev1.AvailablePackageDetail{
+			expected: &pkgsGRPCv1alpha1.AvailablePackageDetail{
 				Name:             "foo",
 				DisplayName:      "foo",
 				RepoUrl:          "http://foo",
@@ -758,7 +757,7 @@ func TestAvailablePackageDetailFromChart(t *testing.T) {
 				Categories:       []string{DefaultChartCategory},
 				ShortDescription: DefaultChartDescription,
 				LongDescription:  "",
-				Version: &corev1.PackageAppVersion{
+				Version: &pkgsGRPCv1alpha1.PackageAppVersion{
 					PkgVersion: "3.0.0",
 					AppVersion: DefaultAppVersion,
 				},
@@ -766,24 +765,24 @@ func TestAvailablePackageDetailFromChart(t *testing.T) {
 				DefaultValues: "chart values",
 				ValuesSchema:  "chart schema",
 				SourceUrls:    []string{"http://source-1"},
-				Maintainers:   []*corev1.Maintainer{{Name: "me", Email: "me@me.me"}},
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
+				Maintainers:   []*pkgsGRPCv1alpha1.Maintainer{{Name: "me", Email: "me@me.me"}},
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Namespace: "my-ns"},
 					Identifier: "repo-1/foo",
-					Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 				},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name:       "it returns internal error if empty chart",
-			chart:      &models.Chart{},
-			statusCode: codes.Internal,
+			chart:      &chartmodels.Chart{},
+			statusCode: grpccodes.Internal,
 		},
 		{
 			name:       "it returns internal error if chart is invalid",
-			chart:      &models.Chart{Name: "foo"},
-			statusCode: codes.Internal,
+			chart:      &chartmodels.Chart{Name: "foo"},
+			statusCode: grpccodes.Internal,
 		},
 	}
 
@@ -791,12 +790,12 @@ func TestAvailablePackageDetailFromChart(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			availablePackageDetail, err := AvailablePackageDetailFromChart(tc.chart, tc.chartFiles)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
-				opt1 := cmpopts.IgnoreUnexported(corev1.AvailablePackageDetail{}, corev1.AvailablePackageSummary{}, corev1.AvailablePackageReference{}, corev1.Context{}, plugins.Plugin{}, corev1.Maintainer{}, corev1.PackageAppVersion{})
+			if tc.statusCode == grpccodes.OK {
+				opt1 := cmpopts.IgnoreUnexported(pkgsGRPCv1alpha1.AvailablePackageDetail{}, pkgsGRPCv1alpha1.AvailablePackageSummary{}, pkgsGRPCv1alpha1.AvailablePackageReference{}, pkgsGRPCv1alpha1.Context{}, pluginsGRPCv1alpha1.Plugin{}, pkgsGRPCv1alpha1.Maintainer{}, pkgsGRPCv1alpha1.PackageAppVersion{})
 				if got, want := availablePackageDetail, tc.expected; !cmp.Equal(got, want, opt1) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opt1))
 				}
@@ -808,23 +807,23 @@ func TestAvailablePackageDetailFromChart(t *testing.T) {
 func TestGetAvailablePackageDetail(t *testing.T) {
 	testCases := []struct {
 		name            string
-		charts          []*models.Chart
-		expectedPackage *corev1.AvailablePackageDetail
-		statusCode      codes.Code
-		request         *corev1.GetAvailablePackageDetailRequest
+		charts          []*chartmodels.Chart
+		expectedPackage *pkgsGRPCv1alpha1.AvailablePackageDetail
+		statusCode      grpccodes.Code
+		request         *pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest
 		authorized      bool
 	}{
 		{
 			name:       "it returns an availablePackageDetail from the database (latest version)",
 			authorized: true,
-			request: &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Namespace: "my-ns"},
 					Identifier: "repo-1%2Ffoo",
 				},
 			},
-			charts: []*models.Chart{makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"3.0.0"}, DefaultChartCategory)},
-			expectedPackage: &corev1.AvailablePackageDetail{
+			charts: []*chartmodels.Chart{makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"3.0.0"}, DefaultChartCategory)},
+			expectedPackage: &pkgsGRPCv1alpha1.AvailablePackageDetail{
 				Name:             "foo",
 				DisplayName:      "foo",
 				HomeUrl:          DefaultChartHomeURL,
@@ -832,7 +831,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				IconUrl:          DefaultChartIconURL,
 				Categories:       []string{DefaultChartCategory},
 				ShortDescription: DefaultChartDescription,
-				Version: &corev1.PackageAppVersion{
+				Version: &pkgsGRPCv1alpha1.PackageAppVersion{
 					PkgVersion: "3.0.0",
 					AppVersion: DefaultAppVersion,
 				},
@@ -840,27 +839,27 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				DefaultValues: "chart values",
 				ValuesSchema:  "chart schema",
 				SourceUrls:    []string{"http://source-1"},
-				Maintainers:   []*corev1.Maintainer{{Name: "me", Email: "me@me.me"}},
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
+				Maintainers:   []*pkgsGRPCv1alpha1.Maintainer{{Name: "me", Email: "me@me.me"}},
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Namespace: "my-ns"},
 					Identifier: "repo-1/foo",
-					Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 				},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name:       "it returns an availablePackageDetail from the database (specific version)",
 			authorized: true,
-			request: &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Namespace: "my-ns"},
 					Identifier: "foo/bar",
 				},
 				PkgVersion: "1.0.0",
 			},
-			charts: []*models.Chart{makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"3.0.0", "2.0.0", "1.0.0"}, DefaultChartCategory)},
-			expectedPackage: &corev1.AvailablePackageDetail{
+			charts: []*chartmodels.Chart{makeChart("foo", "repo-1", "http://foo", "my-ns", []string{"3.0.0", "2.0.0", "1.0.0"}, DefaultChartCategory)},
+			expectedPackage: &pkgsGRPCv1alpha1.AvailablePackageDetail{
 				Name:             "foo",
 				DisplayName:      "foo",
 				HomeUrl:          DefaultChartHomeURL,
@@ -869,7 +868,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				Categories:       []string{DefaultChartCategory},
 				ShortDescription: DefaultChartDescription,
 				LongDescription:  "",
-				Version: &corev1.PackageAppVersion{
+				Version: &pkgsGRPCv1alpha1.PackageAppVersion{
 					PkgVersion: "1.0.0",
 					AppVersion: DefaultAppVersion,
 				},
@@ -877,77 +876,77 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				DefaultValues: "chart values",
 				ValuesSchema:  "chart schema",
 				SourceUrls:    []string{"http://source-1"},
-				Maintainers:   []*corev1.Maintainer{{Name: "me", Email: "me@me.me"}},
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
+				Maintainers:   []*pkgsGRPCv1alpha1.Maintainer{{Name: "me", Email: "me@me.me"}},
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Namespace: "my-ns"},
 					Identifier: "repo-1/foo",
-					Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 				},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name:       "it returns an invalid arg error status if no context is provided",
 			authorized: true,
-			request: &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
 					Identifier: "foo/bar",
 				},
 			},
-			charts:     []*models.Chart{{Name: "foo"}},
-			statusCode: codes.InvalidArgument,
+			charts:     []*chartmodels.Chart{{Name: "foo"}},
+			statusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name:       "it returns an invalid arg error status if cluster is not the global/kubeapps one",
 			authorized: true,
-			request: &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Cluster: "other-cluster", Namespace: "my-ns"},
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Cluster: "other-cluster", Namespace: "my-ns"},
 					Identifier: "foo/bar",
 				},
 			},
-			charts:     []*models.Chart{{Name: "foo"}},
-			statusCode: codes.InvalidArgument,
+			charts:     []*chartmodels.Chart{{Name: "foo"}},
+			statusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name:       "it returns an internal error status if the chart is invalid",
 			authorized: true,
-			request: &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Namespace: "my-ns"},
 					Identifier: "foo/bar",
 				},
 			},
-			charts:          []*models.Chart{{Name: "foo"}},
-			expectedPackage: &corev1.AvailablePackageDetail{},
-			statusCode:      codes.Internal,
+			charts:          []*chartmodels.Chart{{Name: "foo"}},
+			expectedPackage: &pkgsGRPCv1alpha1.AvailablePackageDetail{},
+			statusCode:      grpccodes.Internal,
 		},
 		{
 			name:       "it returns an internal error status if the requested chart version doesn't exist",
 			authorized: true,
-			request: &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Namespace: "my-ns"},
 					Identifier: "foo/bar",
 				},
 				PkgVersion: "9.9.9",
 			},
-			charts:          []*models.Chart{{Name: "foo"}},
-			expectedPackage: &corev1.AvailablePackageDetail{},
-			statusCode:      codes.Internal,
+			charts:          []*chartmodels.Chart{{Name: "foo"}},
+			expectedPackage: &pkgsGRPCv1alpha1.AvailablePackageDetail{},
+			statusCode:      grpccodes.Internal,
 		},
 		{
 			name:       "it returns an unauthenticated status if the user doesn't have permissions",
 			authorized: false,
-			request: &corev1.GetAvailablePackageDetailRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageDetailRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Namespace: "my-ns"},
 					Identifier: "foo/bar",
 				},
 			},
-			charts:          []*models.Chart{{Name: "foo"}},
-			expectedPackage: &corev1.AvailablePackageDetail{},
-			statusCode:      codes.Unauthenticated,
+			charts:          []*chartmodels.Chart{{Name: "foo"}},
+			expectedPackage: &pkgsGRPCv1alpha1.AvailablePackageDetail{},
+			statusCode:      grpccodes.Unauthenticated,
 		},
 	}
 
@@ -965,7 +964,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 				}
 				rows.AddRow(string(chartJSON))
 			}
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				// Checking if the WHERE condition is properly applied
 				chartIDUnescaped, err := url.QueryUnescape(tc.request.AvailablePackageRef.Identifier)
 				if err != nil {
@@ -975,7 +974,7 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 					WithArgs(tc.request.AvailablePackageRef.Context.Namespace, chartIDUnescaped).
 					WillReturnRows(rows)
 				fileID := fileIDForChart(chartIDUnescaped, tc.expectedPackage.Version.PkgVersion)
-				fileJSON, err := json.Marshal(models.ChartFiles{
+				fileJSON, err := json.Marshal(chartmodels.ChartFiles{
 					Readme: tc.expectedPackage.Readme,
 					Values: tc.expectedPackage.DefaultValues,
 					Schema: tc.expectedPackage.ValuesSchema,
@@ -992,12 +991,12 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 
 			availablePackageDetails, err := server.GetAvailablePackageDetail(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
-				opt1 := cmpopts.IgnoreUnexported(corev1.AvailablePackageDetail{}, corev1.AvailablePackageSummary{}, corev1.AvailablePackageReference{}, corev1.Context{}, plugins.Plugin{}, corev1.Maintainer{}, corev1.PackageAppVersion{})
+			if tc.statusCode == grpccodes.OK {
+				opt1 := cmpopts.IgnoreUnexported(pkgsGRPCv1alpha1.AvailablePackageDetail{}, pkgsGRPCv1alpha1.AvailablePackageSummary{}, pkgsGRPCv1alpha1.AvailablePackageReference{}, pkgsGRPCv1alpha1.Context{}, pluginsGRPCv1alpha1.Plugin{}, pkgsGRPCv1alpha1.Maintainer{}, pkgsGRPCv1alpha1.PackageAppVersion{})
 				if got, want := availablePackageDetails.AvailablePackageDetail, tc.expectedPackage; !cmp.Equal(got, want, opt1) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opt1))
 				}
@@ -1014,61 +1013,61 @@ func TestGetAvailablePackageDetail(t *testing.T) {
 func TestGetAvailablePackageVersions(t *testing.T) {
 	testCases := []struct {
 		name               string
-		charts             []*models.Chart
-		request            *corev1.GetAvailablePackageVersionsRequest
-		expectedStatusCode codes.Code
-		expectedResponse   *corev1.GetAvailablePackageVersionsResponse
+		charts             []*chartmodels.Chart
+		request            *pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest
+		expectedStatusCode grpccodes.Code
+		expectedResponse   *pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse
 	}{
 		{
 			name:               "it returns invalid argument if called without a package reference",
 			request:            nil,
-			expectedStatusCode: codes.InvalidArgument,
+			expectedStatusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name: "it returns invalid argument if called without namespace",
-			request: &corev1.GetAvailablePackageVersionsRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{},
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{},
 					Identifier: "bitnami/apache",
 				},
 			},
-			expectedStatusCode: codes.InvalidArgument,
+			expectedStatusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name: "it returns invalid argument if called without an identifier",
-			request: &corev1.GetAvailablePackageVersionsRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Namespace: "kubeapps",
 					},
 				},
 			},
-			expectedStatusCode: codes.InvalidArgument,
+			expectedStatusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name: "it returns invalid argument if called with a cluster other than the global/kubeapps one",
-			request: &corev1.GetAvailablePackageVersionsRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Cluster: "other-cluster", Namespace: "kubeapps"},
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Cluster: "other-cluster", Namespace: "kubeapps"},
 					Identifier: "bitnami/apache",
 				},
 			},
-			expectedStatusCode: codes.InvalidArgument,
+			expectedStatusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name:   "it returns the package version summary",
-			charts: []*models.Chart{makeChart("apache", "bitnami", "http://apache", "kubeapps", []string{"3.0.0", "2.0.0", "1.0.0"}, DefaultChartCategory)},
-			request: &corev1.GetAvailablePackageVersionsRequest{
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context: &corev1.Context{
+			charts: []*chartmodels.Chart{makeChart("apache", "bitnami", "http://apache", "kubeapps", []string{"3.0.0", "2.0.0", "1.0.0"}, DefaultChartCategory)},
+			request: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsRequest{
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Namespace: "kubeapps",
 					},
 					Identifier: "bitnami/apache",
 				},
 			},
-			expectedStatusCode: codes.OK,
-			expectedResponse: &corev1.GetAvailablePackageVersionsResponse{
-				PackageAppVersions: []*corev1.PackageAppVersion{
+			expectedStatusCode: grpccodes.OK,
+			expectedResponse: &pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{
+				PackageAppVersions: []*pkgsGRPCv1alpha1.PackageAppVersion{
 					{
 						PkgVersion: "3.0.0",
 						AppVersion: DefaultAppVersion,
@@ -1101,7 +1100,7 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 				}
 				rows.AddRow(string(chartJSON))
 			}
-			if tc.expectedStatusCode == codes.OK {
+			if tc.expectedStatusCode == grpccodes.OK {
 				mock.ExpectQuery("SELECT info FROM").
 					WithArgs(tc.request.AvailablePackageRef.Context.Namespace, tc.request.AvailablePackageRef.Identifier).
 					WillReturnRows(rows)
@@ -1109,16 +1108,16 @@ func TestGetAvailablePackageVersions(t *testing.T) {
 
 			response, err := server.GetAvailablePackageVersions(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedStatusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedStatusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			// We don't need to check anything else for non-OK codes.
-			if tc.expectedStatusCode != codes.OK {
+			// We don't need to check anything else for non-OK grpccodes.
+			if tc.expectedStatusCode != grpccodes.OK {
 				return
 			}
 
-			opts := cmpopts.IgnoreUnexported(corev1.GetAvailablePackageVersionsResponse{}, corev1.PackageAppVersion{})
+			opts := cmpopts.IgnoreUnexported(pkgsGRPCv1alpha1.GetAvailablePackageVersionsResponse{}, pkgsGRPCv1alpha1.PackageAppVersion{})
 			if got, want := response, tc.expectedResponse; !cmp.Equal(want, got, opts) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opts))
 			}
@@ -1189,7 +1188,7 @@ core:
 		t.Run(tc.name, func(t *testing.T) {
 			filename := ""
 			if tc.pluginYAMLConf != nil {
-				pluginJSONConf, err := yaml.YAMLToJSON(tc.pluginYAMLConf)
+				pluginJSONConf, err := k8syaml.YAMLToJSON(tc.pluginYAMLConf)
 				if err != nil {
 					log.Fatalf("%s", err)
 				}
@@ -1246,7 +1245,7 @@ core:
 		t.Run(tc.name, func(t *testing.T) {
 			filename := ""
 			if tc.pluginYAMLConf != nil {
-				pluginJSONConf, err := yaml.YAMLToJSON(tc.pluginYAMLConf)
+				pluginJSONConf, err := k8syaml.YAMLToJSON(tc.pluginYAMLConf)
 				if err != nil {
 					log.Fatalf("%s", err)
 				}
@@ -1276,44 +1275,44 @@ core:
 func TestGetInstalledPackageSummaries(t *testing.T) {
 	testCases := []struct {
 		name               string
-		request            *corev1.GetInstalledPackageSummariesRequest
+		request            *pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest
 		existingReleases   []releaseStub
-		expectedStatusCode codes.Code
-		expectedResponse   *corev1.GetInstalledPackageSummariesResponse
+		expectedStatusCode grpccodes.Code
+		expectedResponse   *pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse
 	}{
 		{
 			name: "returns installed packages in a specific namespace",
-			request: &corev1.GetInstalledPackageSummariesRequest{
-				Context: &corev1.Context{Namespace: "namespace-1"},
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{Namespace: "namespace-1"},
 			},
 			existingReleases: []releaseStub{
 				{
 					name:         "my-release-1",
 					namespace:    "namespace-1",
 					chartVersion: "1.2.3",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					version:      2,
 				},
 				{
 					name:      "my-release-2",
 					namespace: "other-namespace",
-					status:    release.StatusDeployed,
+					status:    helmrelease.StatusDeployed,
 					version:   4,
 				},
 				{
 					name:         "my-release-3",
 					namespace:    "namespace-1",
 					chartVersion: "4.5.6",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					version:      6,
 				},
 			},
-			expectedStatusCode: codes.OK,
-			expectedResponse: &corev1.GetInstalledPackageSummariesResponse{
-				InstalledPackageSummaries: []*corev1.InstalledPackageSummary{
+			expectedStatusCode: grpccodes.OK,
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{
+				InstalledPackageSummaries: []*pkgsGRPCv1alpha1.InstalledPackageSummary{
 					{
-						InstalledPackageRef: &corev1.InstalledPackageReference{
-							Context: &corev1.Context{
+						InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+							Context: &pkgsGRPCv1alpha1.Context{
 								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-1",
 							},
@@ -1321,26 +1320,26 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Name:    "my-release-1",
 						IconUrl: "https://example.com/icon.png",
-						PkgVersionReference: &corev1.VersionReference{
+						PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 							Version: "1.2.3",
 						},
-						CurrentVersion: &corev1.PackageAppVersion{
+						CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 
 							PkgVersion: "1.2.3",
 							AppVersion: DefaultAppVersion,
 						},
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "1.2.3",
 						},
-						Status: &corev1.InstalledPackageStatus{
+						Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
 							Ready:      true,
-							Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+							Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 							UserReason: "deployed",
 						},
 					},
 					{
-						InstalledPackageRef: &corev1.InstalledPackageReference{
-							Context: &corev1.Context{
+						InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+							Context: &pkgsGRPCv1alpha1.Context{
 								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-1",
 							},
@@ -1348,20 +1347,20 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Name:    "my-release-3",
 						IconUrl: "https://example.com/icon.png",
-						PkgVersionReference: &corev1.VersionReference{
+						PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 							Version: "4.5.6",
 						},
-						CurrentVersion: &corev1.PackageAppVersion{
+						CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 
 							PkgVersion: "4.5.6",
 							AppVersion: DefaultAppVersion,
 						},
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "4.5.6",
 						},
-						Status: &corev1.InstalledPackageStatus{
+						Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
 							Ready:      true,
-							Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+							Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 							UserReason: "deployed",
 						},
 					},
@@ -1370,21 +1369,21 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		},
 		{
 			name: "returns installed packages across all namespaces",
-			request: &corev1.GetInstalledPackageSummariesRequest{
-				Context: &corev1.Context{Namespace: ""},
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{Namespace: ""},
 			},
 			existingReleases: []releaseStub{
 				{
 					name:         "my-release-1",
 					namespace:    "namespace-1",
 					chartVersion: "1.2.3",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					version:      1,
 				},
 				{
 					name:         "my-release-2",
 					namespace:    "namespace-2",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					chartVersion: "3.4.5",
 					version:      1,
 				},
@@ -1392,16 +1391,16 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					name:         "my-release-3",
 					namespace:    "namespace-3",
 					chartVersion: "4.5.6",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					version:      1,
 				},
 			},
-			expectedStatusCode: codes.OK,
-			expectedResponse: &corev1.GetInstalledPackageSummariesResponse{
-				InstalledPackageSummaries: []*corev1.InstalledPackageSummary{
+			expectedStatusCode: grpccodes.OK,
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{
+				InstalledPackageSummaries: []*pkgsGRPCv1alpha1.InstalledPackageSummary{
 					{
-						InstalledPackageRef: &corev1.InstalledPackageReference{
-							Context: &corev1.Context{
+						InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+							Context: &pkgsGRPCv1alpha1.Context{
 								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-1",
 							},
@@ -1409,26 +1408,26 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Name:    "my-release-1",
 						IconUrl: "https://example.com/icon.png",
-						PkgVersionReference: &corev1.VersionReference{
+						PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 							Version: "1.2.3",
 						},
-						CurrentVersion: &corev1.PackageAppVersion{
+						CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 
 							PkgVersion: "1.2.3",
 							AppVersion: DefaultAppVersion,
 						},
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "1.2.3",
 						},
-						Status: &corev1.InstalledPackageStatus{
+						Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
 							Ready:      true,
-							Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+							Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 							UserReason: "deployed",
 						},
 					},
 					{
-						InstalledPackageRef: &corev1.InstalledPackageReference{
-							Context: &corev1.Context{
+						InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+							Context: &pkgsGRPCv1alpha1.Context{
 								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-2",
 							},
@@ -1436,26 +1435,26 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Name:    "my-release-2",
 						IconUrl: "https://example.com/icon.png",
-						PkgVersionReference: &corev1.VersionReference{
+						PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 							Version: "3.4.5",
 						},
-						CurrentVersion: &corev1.PackageAppVersion{
+						CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 
 							PkgVersion: "3.4.5",
 							AppVersion: DefaultAppVersion,
 						},
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "3.4.5",
 						},
-						Status: &corev1.InstalledPackageStatus{
+						Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
 							Ready:      true,
-							Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+							Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 							UserReason: "deployed",
 						},
 					},
 					{
-						InstalledPackageRef: &corev1.InstalledPackageReference{
-							Context: &corev1.Context{
+						InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+							Context: &pkgsGRPCv1alpha1.Context{
 								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-3",
 							},
@@ -1463,20 +1462,20 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Name:    "my-release-3",
 						IconUrl: "https://example.com/icon.png",
-						PkgVersionReference: &corev1.VersionReference{
+						PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 							Version: "4.5.6",
 						},
-						CurrentVersion: &corev1.PackageAppVersion{
+						CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 
 							PkgVersion: "4.5.6",
 							AppVersion: DefaultAppVersion,
 						},
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "4.5.6",
 						},
-						Status: &corev1.InstalledPackageStatus{
+						Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
 							Ready:      true,
-							Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+							Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 							UserReason: "deployed",
 						},
 					},
@@ -1485,9 +1484,9 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		},
 		{
 			name: "returns limited results",
-			request: &corev1.GetInstalledPackageSummariesRequest{
-				Context: &corev1.Context{Namespace: ""},
-				PaginationOptions: &corev1.PaginationOptions{
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{Namespace: ""},
+				PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{
 					PageSize: 2,
 				},
 			},
@@ -1496,13 +1495,13 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					name:         "my-release-1",
 					namespace:    "namespace-1",
 					chartVersion: "1.2.3",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					version:      1,
 				},
 				{
 					name:         "my-release-2",
 					namespace:    "namespace-2",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					chartVersion: "3.4.5",
 					version:      1,
 				},
@@ -1510,16 +1509,16 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					name:         "my-release-3",
 					namespace:    "namespace-3",
 					chartVersion: "4.5.6",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					version:      1,
 				},
 			},
-			expectedStatusCode: codes.OK,
-			expectedResponse: &corev1.GetInstalledPackageSummariesResponse{
-				InstalledPackageSummaries: []*corev1.InstalledPackageSummary{
+			expectedStatusCode: grpccodes.OK,
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{
+				InstalledPackageSummaries: []*pkgsGRPCv1alpha1.InstalledPackageSummary{
 					{
-						InstalledPackageRef: &corev1.InstalledPackageReference{
-							Context: &corev1.Context{
+						InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+							Context: &pkgsGRPCv1alpha1.Context{
 								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-1",
 							},
@@ -1527,26 +1526,26 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Name:    "my-release-1",
 						IconUrl: "https://example.com/icon.png",
-						PkgVersionReference: &corev1.VersionReference{
+						PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 							Version: "1.2.3",
 						},
-						CurrentVersion: &corev1.PackageAppVersion{
+						CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 
 							PkgVersion: "1.2.3",
 							AppVersion: DefaultAppVersion,
 						},
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "1.2.3",
 						},
-						Status: &corev1.InstalledPackageStatus{
+						Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
 							Ready:      true,
-							Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+							Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 							UserReason: "deployed",
 						},
 					},
 					{
-						InstalledPackageRef: &corev1.InstalledPackageReference{
-							Context: &corev1.Context{
+						InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+							Context: &pkgsGRPCv1alpha1.Context{
 								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-2",
 							},
@@ -1554,20 +1553,20 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Name:    "my-release-2",
 						IconUrl: "https://example.com/icon.png",
-						PkgVersionReference: &corev1.VersionReference{
+						PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 							Version: "3.4.5",
 						},
-						CurrentVersion: &corev1.PackageAppVersion{
+						CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 
 							PkgVersion: "3.4.5",
 							AppVersion: DefaultAppVersion,
 						},
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "3.4.5",
 						},
-						Status: &corev1.InstalledPackageStatus{
+						Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
 							Ready:      true,
-							Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+							Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 							UserReason: "deployed",
 						},
 					},
@@ -1577,9 +1576,9 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		},
 		{
 			name: "fetches results from an offset",
-			request: &corev1.GetInstalledPackageSummariesRequest{
-				Context: &corev1.Context{Namespace: ""},
-				PaginationOptions: &corev1.PaginationOptions{
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{Namespace: ""},
+				PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{
 					PageSize:  2,
 					PageToken: "2",
 				},
@@ -1589,13 +1588,13 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					name:         "my-release-1",
 					namespace:    "namespace-1",
 					chartVersion: "1.2.3",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					version:      1,
 				},
 				{
 					name:         "my-release-2",
 					namespace:    "namespace-2",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					chartVersion: "3.4.5",
 					version:      1,
 				},
@@ -1603,16 +1602,16 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 					name:         "my-release-3",
 					namespace:    "namespace-3",
 					chartVersion: "4.5.6",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					version:      1,
 				},
 			},
-			expectedStatusCode: codes.OK,
-			expectedResponse: &corev1.GetInstalledPackageSummariesResponse{
-				InstalledPackageSummaries: []*corev1.InstalledPackageSummary{
+			expectedStatusCode: grpccodes.OK,
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{
+				InstalledPackageSummaries: []*pkgsGRPCv1alpha1.InstalledPackageSummary{
 					{
-						InstalledPackageRef: &corev1.InstalledPackageReference{
-							Context: &corev1.Context{
+						InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+							Context: &pkgsGRPCv1alpha1.Context{
 								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-3",
 							},
@@ -1620,20 +1619,20 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Name:    "my-release-3",
 						IconUrl: "https://example.com/icon.png",
-						PkgVersionReference: &corev1.VersionReference{
+						PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 							Version: "4.5.6",
 						},
-						CurrentVersion: &corev1.PackageAppVersion{
+						CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 
 							PkgVersion: "4.5.6",
 							AppVersion: DefaultAppVersion,
 						},
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "4.5.6",
 						},
-						Status: &corev1.InstalledPackageStatus{
+						Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
 							Ready:      true,
-							Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+							Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 							UserReason: "deployed",
 						},
 					},
@@ -1643,24 +1642,24 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 		},
 		{
 			name: "includes a latest package version when available",
-			request: &corev1.GetInstalledPackageSummariesRequest{
-				Context: &corev1.Context{Namespace: "namespace-1"},
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest{
+				Context: &pkgsGRPCv1alpha1.Context{Namespace: "namespace-1"},
 			},
 			existingReleases: []releaseStub{
 				{
 					name:         "my-release-1",
 					namespace:    "namespace-1",
 					chartVersion: "1.2.3",
-					status:       release.StatusDeployed,
+					status:       helmrelease.StatusDeployed,
 					version:      1,
 				},
 			},
-			expectedStatusCode: codes.OK,
-			expectedResponse: &corev1.GetInstalledPackageSummariesResponse{
-				InstalledPackageSummaries: []*corev1.InstalledPackageSummary{
+			expectedStatusCode: grpccodes.OK,
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{
+				InstalledPackageSummaries: []*pkgsGRPCv1alpha1.InstalledPackageSummary{
 					{
-						InstalledPackageRef: &corev1.InstalledPackageReference{
-							Context: &corev1.Context{
+						InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+							Context: &pkgsGRPCv1alpha1.Context{
 								Cluster:   globalPackagingCluster,
 								Namespace: "namespace-1",
 							},
@@ -1668,20 +1667,20 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 						},
 						Name:    "my-release-1",
 						IconUrl: "https://example.com/icon.png",
-						PkgVersionReference: &corev1.VersionReference{
+						PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 							Version: "1.2.3",
 						},
-						CurrentVersion: &corev1.PackageAppVersion{
+						CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 
 							PkgVersion: "1.2.3",
 							AppVersion: DefaultAppVersion,
 						},
-						LatestVersion: &corev1.PackageAppVersion{
+						LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 							PkgVersion: "1.2.5",
 						},
-						Status: &corev1.InstalledPackageStatus{
+						Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
 							Ready:      true,
-							Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+							Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 							UserReason: "deployed",
 						},
 					},
@@ -1697,22 +1696,22 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 			server, mock, cleanup := makeServer(t, authorized, actionConfig)
 			defer cleanup()
 
-			if tc.expectedStatusCode == codes.OK {
+			if tc.expectedStatusCode == grpccodes.OK {
 				populateAssetDBWithSummaries(t, mock, tc.expectedResponse.InstalledPackageSummaries)
 			}
 
 			response, err := server.GetInstalledPackageSummaries(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedStatusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedStatusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			// We don't need to check anything else for non-OK codes.
-			if tc.expectedStatusCode != codes.OK {
+			// We don't need to check anything else for non-OK grpccodes.
+			if tc.expectedStatusCode != grpccodes.OK {
 				return
 			}
 
-			opts := cmpopts.IgnoreUnexported(corev1.GetInstalledPackageSummariesResponse{}, corev1.InstalledPackageSummary{}, corev1.InstalledPackageReference{}, corev1.Context{}, corev1.VersionReference{}, corev1.InstalledPackageStatus{}, corev1.PackageAppVersion{})
+			opts := cmpopts.IgnoreUnexported(pkgsGRPCv1alpha1.GetInstalledPackageSummariesResponse{}, pkgsGRPCv1alpha1.InstalledPackageSummary{}, pkgsGRPCv1alpha1.InstalledPackageReference{}, pkgsGRPCv1alpha1.Context{}, pkgsGRPCv1alpha1.VersionReference{}, pkgsGRPCv1alpha1.InstalledPackageStatus{}, pkgsGRPCv1alpha1.PackageAppVersion{})
 			if got, want := response, tc.expectedResponse; !cmp.Equal(want, got, opts) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opts))
 			}
@@ -1726,7 +1725,7 @@ func TestGetInstalledPackageSummaries(t *testing.T) {
 }
 
 func TestGetInstalledPackageDetail(t *testing.T) {
-	customDetailRevision2, err := anypb.New(&helmv1.InstalledPackageDetailCustomDataHelm{
+	customDetailRevision2, err := anypb.New(&pkghelmv1alpha1.InstalledPackageDetailCustomDataHelm{
 		ReleaseRevision: 2,
 	})
 	if err != nil {
@@ -1742,9 +1741,9 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 	testCases := []struct {
 		name               string
 		existingReleases   []releaseStub
-		request            *corev1.GetInstalledPackageDetailRequest
-		expectedResponse   *corev1.GetInstalledPackageDetailResponse
-		expectedStatusCode codes.Code
+		request            *pkgsGRPCv1alpha1.GetInstalledPackageDetailRequest
+		expectedResponse   *pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse
+		expectedStatusCode grpccodes.Code
 	}{
 		{
 			name: "returns an installed package detail",
@@ -1756,7 +1755,7 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 					chartNamespace: releaseNamespace,
 					values:         releaseValues,
 					notes:          releaseNotes,
-					status:         release.StatusSuperseded,
+					status:         helmrelease.StatusSuperseded,
 					version:        1,
 				},
 				{
@@ -1766,49 +1765,49 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 					chartNamespace: releaseNamespace,
 					values:         releaseValues,
 					notes:          releaseNotes,
-					status:         release.StatusDeployed,
+					status:         helmrelease.StatusDeployed,
 					version:        2,
 				},
 			},
-			request: &corev1.GetInstalledPackageDetailRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageDetailRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Namespace: releaseNamespace,
 						Cluster:   globalPackagingCluster,
 					},
 					Identifier: releaseName,
 				},
 			},
-			expectedResponse: &corev1.GetInstalledPackageDetailResponse{
-				InstalledPackageDetail: &corev1.InstalledPackageDetail{
-					InstalledPackageRef: &corev1.InstalledPackageReference{
-						Context: &corev1.Context{
+			expectedResponse: &pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse{
+				InstalledPackageDetail: &pkgsGRPCv1alpha1.InstalledPackageDetail{
+					InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+						Context: &pkgsGRPCv1alpha1.Context{
 							Namespace: releaseNamespace,
 							Cluster:   globalPackagingCluster,
 						},
 						Identifier: releaseName,
 					},
-					PkgVersionReference: &corev1.VersionReference{
+					PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 						Version: releaseVersion,
 					},
 					Name: releaseName,
-					CurrentVersion: &corev1.PackageAppVersion{
+					CurrentVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 						PkgVersion: releaseVersion,
 						AppVersion: DefaultAppVersion,
 					},
-					LatestVersion: &corev1.PackageAppVersion{
+					LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 						PkgVersion: releaseVersion,
 						AppVersion: DefaultAppVersion,
 					},
 					ValuesApplied:         releaseValues,
 					PostInstallationNotes: releaseNotes,
-					Status: &corev1.InstalledPackageStatus{
+					Status: &pkgsGRPCv1alpha1.InstalledPackageStatus{
 						Ready:      true,
-						Reason:     corev1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
+						Reason:     pkgsGRPCv1alpha1.InstalledPackageStatus_STATUS_REASON_INSTALLED,
 						UserReason: "deployed",
 					},
-					AvailablePackageRef: &corev1.AvailablePackageReference{
-						Context: &corev1.Context{
+					AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+						Context: &pkgsGRPCv1alpha1.Context{
 							Namespace: releaseNamespace,
 							Cluster:   globalPackagingCluster,
 						},
@@ -1818,19 +1817,19 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 					CustomDetail: customDetailRevision2,
 				},
 			},
-			expectedStatusCode: codes.OK,
+			expectedStatusCode: grpccodes.OK,
 		},
 		{
 			name: "returns a 404 if the installed package is not found",
-			request: &corev1.GetInstalledPackageDetailRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.GetInstalledPackageDetailRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Namespace: releaseNamespace,
 					},
 					Identifier: releaseName,
 				},
 			},
-			expectedStatusCode: codes.NotFound,
+			expectedStatusCode: grpccodes.NotFound,
 		},
 	}
 
@@ -1841,22 +1840,22 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 			server, mock, cleanup := makeServer(t, authorized, actionConfig)
 			defer cleanup()
 
-			if tc.expectedStatusCode == codes.OK {
+			if tc.expectedStatusCode == grpccodes.OK {
 				populateAssetDBWithDetail(t, mock, tc.expectedResponse.InstalledPackageDetail)
 			}
 
 			response, err := server.GetInstalledPackageDetail(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedStatusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedStatusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			// We don't need to check anything else for non-OK codes.
-			if tc.expectedStatusCode != codes.OK {
+			// We don't need to check anything else for non-OK grpccodes.
+			if tc.expectedStatusCode != grpccodes.OK {
 				return
 			}
 
-			opts := cmpopts.IgnoreUnexported(corev1.GetInstalledPackageDetailResponse{}, corev1.InstalledPackageDetail{}, corev1.InstalledPackageReference{}, corev1.Context{}, corev1.VersionReference{}, corev1.InstalledPackageStatus{}, corev1.AvailablePackageReference{}, plugins.Plugin{}, corev1.PackageAppVersion{}, anypb.Any{})
+			opts := cmpopts.IgnoreUnexported(pkgsGRPCv1alpha1.GetInstalledPackageDetailResponse{}, pkgsGRPCv1alpha1.InstalledPackageDetail{}, pkgsGRPCv1alpha1.InstalledPackageReference{}, pkgsGRPCv1alpha1.Context{}, pkgsGRPCv1alpha1.VersionReference{}, pkgsGRPCv1alpha1.InstalledPackageStatus{}, pkgsGRPCv1alpha1.AvailablePackageReference{}, pluginsGRPCv1alpha1.Plugin{}, pkgsGRPCv1alpha1.PackageAppVersion{}, anypb.Any{})
 			if got, want := response, tc.expectedResponse; !cmp.Equal(want, got, opts) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opts))
 			}
@@ -1872,26 +1871,26 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 func TestChartTarballURLBuild(t *testing.T) {
 	testCases := []struct {
 		name         string
-		repo         *models.Repo
-		chartVersion *models.ChartVersion
+		repo         *chartmodels.Repo
+		chartVersion *chartmodels.ChartVersion
 		expectedUrl  string
 	}{
 		{
 			name:         "tarball url with relative URL without leading slash in chart",
-			repo:         &models.Repo{URL: "https://demo.repo/repo1"},
-			chartVersion: &models.ChartVersion{URLs: []string{"chart/test"}},
+			repo:         &chartmodels.Repo{URL: "https://demo.repo/repo1"},
+			chartVersion: &chartmodels.ChartVersion{URLs: []string{"chart/test"}},
 			expectedUrl:  "https://demo.repo/repo1/chart/test",
 		},
 		{
 			name:         "tarball url with relative URL with leading slash in chart",
-			repo:         &models.Repo{URL: "https://demo.repo/repo1"},
-			chartVersion: &models.ChartVersion{URLs: []string{"/chart/test"}},
+			repo:         &chartmodels.Repo{URL: "https://demo.repo/repo1"},
+			chartVersion: &chartmodels.ChartVersion{URLs: []string{"/chart/test"}},
 			expectedUrl:  "https://demo.repo/repo1/chart/test",
 		},
 		{
 			name:         "tarball url with absolute URL",
-			repo:         &models.Repo{URL: "https://demo.repo/repo1"},
-			chartVersion: &models.ChartVersion{URLs: []string{"https://demo.repo/repo1/chart/test"}},
+			repo:         &chartmodels.Repo{URL: "https://demo.repo/repo1"},
+			chartVersion: &chartmodels.ChartVersion{URLs: []string{"https://demo.repo/repo1/chart/test"}},
 			expectedUrl:  "https://demo.repo/repo1/chart/test",
 		},
 	}
@@ -1907,28 +1906,28 @@ func TestChartTarballURLBuild(t *testing.T) {
 	}
 }
 
-// newActionConfigFixture returns an action.Configuration with fake clients
-// and memory storage.
-func newActionConfigFixture(t *testing.T, namespace string, rels []releaseStub, kubeClient kube.Interface) *action.Configuration {
+// newActionConfigFixture returns an helmaction.Configuration with fake clients
+// and memory helmstorage.
+func newActionConfigFixture(t *testing.T, namespace string, rels []releaseStub, kubeClient helmkube.Interface) *helmaction.Configuration {
 	t.Helper()
 
-	memDriver := driver.NewMemory()
+	memDriver := helmstoragedriver.NewMemory()
 
 	if kubeClient == nil {
-		kubeClient = &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: ioutil.Discard}}
+		kubeClient = &helmkubefake.FailingKubeClient{PrintingKubeClient: helmkubefake.PrintingKubeClient{Out: ioutil.Discard}}
 	}
 
-	actionConfig := &action.Configuration{
+	actionConfig := &helmaction.Configuration{
 		// Create the Releases storage explicitly so we can set the
 		// internal log function used to see data in test output.
-		Releases: &storage.Storage{
+		Releases: &helmstorage.Storage{
 			Driver: memDriver,
 			Log: func(format string, v ...interface{}) {
 				t.Logf(format, v...)
 			},
 		},
 		KubeClient:   kubeClient,
-		Capabilities: chartutil.DefaultCapabilities,
+		Capabilities: helmchartutil.DefaultCapabilities,
 		Log: func(format string, v ...interface{}) {
 			t.Helper()
 			t.Logf(format, v...)
@@ -1949,7 +1948,7 @@ func newActionConfigFixture(t *testing.T, namespace string, rels []releaseStub, 
 	return actionConfig
 }
 
-func releaseForStub(t *testing.T, r releaseStub) *release.Release {
+func releaseForStub(t *testing.T, r releaseStub) *helmrelease.Release {
 	config := map[string]interface{}{}
 	if r.values != "" {
 		err := json.Unmarshal([]byte(r.values), &config)
@@ -1957,17 +1956,17 @@ func releaseForStub(t *testing.T, r releaseStub) *release.Release {
 			t.Fatalf("%+v", err)
 		}
 	}
-	return &release.Release{
+	return &helmrelease.Release{
 		Name:      r.name,
 		Namespace: r.namespace,
 		Manifest:  r.manifest,
 		Version:   r.version,
-		Info: &release.Info{
+		Info: &helmrelease.Info{
 			Status: r.status,
 			Notes:  r.notes,
 		},
-		Chart: &chart.Chart{
-			Metadata: &chart.Metadata{
+		Chart: &helmchart.Chart{
+			Metadata: &helmchart.Metadata{
 				Version:    r.chartVersion,
 				Icon:       "https://example.com/icon.png",
 				AppVersion: DefaultAppVersion,
@@ -1977,47 +1976,47 @@ func releaseForStub(t *testing.T, r releaseStub) *release.Release {
 	}
 }
 
-func chartAssetForPackage(pkg *corev1.InstalledPackageSummary) *models.Chart {
-	chartVersions := []models.ChartVersion{}
+func chartAssetForPackage(pkg *pkgsGRPCv1alpha1.InstalledPackageSummary) *chartmodels.Chart {
+	chartVersions := []chartmodels.ChartVersion{}
 	if pkg.LatestVersion.PkgVersion != "" {
-		chartVersions = append(chartVersions, models.ChartVersion{
+		chartVersions = append(chartVersions, chartmodels.ChartVersion{
 			Version: pkg.LatestVersion.PkgVersion,
 		})
 	}
-	chartVersions = append(chartVersions, models.ChartVersion{
+	chartVersions = append(chartVersions, chartmodels.ChartVersion{
 		Version: pkg.CurrentVersion.PkgVersion,
 	})
 
-	return &models.Chart{
+	return &chartmodels.Chart{
 		Name:          pkg.Name,
 		ChartVersions: chartVersions,
 	}
 }
 
-func chartAssetForReleaseStub(rel *releaseStub) *models.Chart {
-	chartVersions := []models.ChartVersion{}
+func chartAssetForReleaseStub(rel *releaseStub) *chartmodels.Chart {
+	chartVersions := []chartmodels.ChartVersion{}
 	if rel.latestVersion != "" {
-		chartVersions = append(chartVersions, models.ChartVersion{
+		chartVersions = append(chartVersions, chartmodels.ChartVersion{
 			Version: rel.latestVersion,
 			URLs:    []string{fmt.Sprintf("https://example.com/%s-%s.tgz", rel.chartID, rel.latestVersion)},
 		})
 	}
-	chartVersions = append(chartVersions, models.ChartVersion{
+	chartVersions = append(chartVersions, chartmodels.ChartVersion{
 		Version:    rel.chartVersion,
 		AppVersion: DefaultAppVersion,
 	})
 
-	return &models.Chart{
+	return &chartmodels.Chart{
 		Name: rel.name,
 		ID:   rel.chartID,
-		Repo: &models.Repo{
+		Repo: &chartmodels.Repo{
 			Namespace: rel.chartNamespace,
 		},
 		ChartVersions: chartVersions,
 	}
 }
 
-func populateAssetDBWithSummaries(t *testing.T, mock sqlmock.Sqlmock, pkgs []*corev1.InstalledPackageSummary) {
+func populateAssetDBWithSummaries(t *testing.T, mock sqlmock.Sqlmock, pkgs []*pkgsGRPCv1alpha1.InstalledPackageSummary) {
 	// The code currently executes one query per release in the paginated
 	// results and should receive a single row response.
 	rels := []releaseStub{}
@@ -2033,7 +2032,7 @@ func populateAssetDBWithSummaries(t *testing.T, mock sqlmock.Sqlmock, pkgs []*co
 	populateAssetDB(t, mock, rels)
 }
 
-func populateAssetDBWithDetail(t *testing.T, mock sqlmock.Sqlmock, pkg *corev1.InstalledPackageDetail) {
+func populateAssetDBWithDetail(t *testing.T, mock sqlmock.Sqlmock, pkg *pkgsGRPCv1alpha1.InstalledPackageDetail) {
 	// The code currently executes one query per release in the paginated
 	// results and should receive a single row response.
 	rel := releaseStub{
@@ -2048,13 +2047,13 @@ func populateAssetDBWithDetail(t *testing.T, mock sqlmock.Sqlmock, pkg *corev1.I
 }
 
 func populateAssetForTarball(t *testing.T, mock sqlmock.Sqlmock, chartId, namespace, version string) {
-	chart := &models.Chart{
+	chart := &chartmodels.Chart{
 		Name: chartId,
 		ID:   chartId,
-		Repo: &models.Repo{
+		Repo: &chartmodels.Repo{
 			Namespace: globalPackagingNamespace,
 		},
-		ChartVersions: []models.ChartVersion{{
+		ChartVersions: []chartmodels.ChartVersion{{
 			Version: version,
 			URLs:    []string{fmt.Sprintf("https://example.com/%s-%s.tgz", chartId, version)}}},
 	}
@@ -2094,6 +2093,6 @@ type releaseStub struct {
 	latestVersion  string
 	values         string
 	notes          string
-	status         release.Status
+	status         helmrelease.Status
 	manifest       string
 }

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/update_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/update_test.go
@@ -8,26 +8,26 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/release"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cmp "github.com/google/go-cmp/cmp"
+	cmpopts "github.com/google/go-cmp/cmp/cmpopts"
+	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	helmchart "helm.sh/helm/v3/pkg/chart"
+	helmrelease "helm.sh/helm/v3/pkg/release"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestUpdateInstalledPackage(t *testing.T) {
 	testCases := []struct {
 		name               string
 		existingReleases   []releaseStub
-		request            *corev1.UpdateInstalledPackageRequest
-		expectedResponse   *corev1.UpdateInstalledPackageResponse
-		expectedStatusCode codes.Code
-		expectedRelease    *release.Release
+		request            *pkgsGRPCv1alpha1.UpdateInstalledPackageRequest
+		expectedResponse   *pkgsGRPCv1alpha1.UpdateInstalledPackageResponse
+		expectedStatusCode grpccodes.Code
+		expectedRelease    *helmrelease.Release
 	}{
 		{
 			name: "updates the installed package from repo without credentials",
@@ -38,25 +38,25 @@ func TestUpdateInstalledPackage(t *testing.T) {
 					chartID:        "bitnami/apache",
 					chartVersion:   "1.18.3",
 					chartNamespace: globalPackagingNamespace,
-					status:         release.StatusDeployed,
+					status:         helmrelease.StatusDeployed,
 				},
 			},
-			request: &corev1.UpdateInstalledPackageRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.UpdateInstalledPackageRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Cluster:   "default",
 						Namespace: "default",
 					},
 					Identifier: "my-apache",
 				},
-				PkgVersionReference: &corev1.VersionReference{
+				PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 					Version: "1.18.4",
 				},
 				Values: "{\"foo\": \"baz\"}",
 			},
-			expectedResponse: &corev1.UpdateInstalledPackageResponse{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context: &corev1.Context{
+			expectedResponse: &pkgsGRPCv1alpha1.UpdateInstalledPackageResponse{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Cluster:   "default",
 						Namespace: "default",
 					},
@@ -64,15 +64,15 @@ func TestUpdateInstalledPackage(t *testing.T) {
 					Plugin:     GetPluginDetail(),
 				},
 			},
-			expectedStatusCode: codes.OK,
-			expectedRelease: &release.Release{
+			expectedStatusCode: grpccodes.OK,
+			expectedRelease: &helmrelease.Release{
 				Name: "my-apache",
-				Info: &release.Info{
+				Info: &helmrelease.Info{
 					Description: "Upgrade complete",
-					Status:      release.StatusDeployed,
+					Status:      helmrelease.StatusDeployed,
 				},
-				Chart: &chart.Chart{
-					Metadata: &chart.Metadata{
+				Chart: &helmchart.Chart{
+					Metadata: &helmchart.Metadata{
 						Name:    "apache",
 						Version: "1.18.4",
 					},
@@ -92,24 +92,24 @@ func TestUpdateInstalledPackage(t *testing.T) {
 					chartID:        "bitnami/apache",
 					chartVersion:   "1.18.3",
 					chartNamespace: globalPackagingNamespace,
-					status:         release.StatusDeployed,
+					status:         helmrelease.StatusDeployed,
 				},
 			},
-			request: &corev1.UpdateInstalledPackageRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.UpdateInstalledPackageRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Namespace: "default",
 					},
 					Identifier: "my-apache",
 				},
-				PkgVersionReference: &corev1.VersionReference{
+				PkgVersionReference: &pkgsGRPCv1alpha1.VersionReference{
 					Version: "1.18.4",
 				},
 				Values: "{\"foo\": \"baz\"}",
 			},
-			expectedResponse: &corev1.UpdateInstalledPackageResponse{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context: &corev1.Context{
+			expectedResponse: &pkgsGRPCv1alpha1.UpdateInstalledPackageResponse{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Cluster:   "default",
 						Namespace: "default",
 					},
@@ -117,15 +117,15 @@ func TestUpdateInstalledPackage(t *testing.T) {
 					Plugin:     GetPluginDetail(),
 				},
 			},
-			expectedStatusCode: codes.OK,
-			expectedRelease: &release.Release{
+			expectedStatusCode: grpccodes.OK,
+			expectedRelease: &helmrelease.Release{
 				Name: "my-apache",
-				Info: &release.Info{
+				Info: &helmrelease.Info{
 					Description: "Upgrade complete",
-					Status:      release.StatusDeployed,
+					Status:      helmrelease.StatusDeployed,
 				},
-				Chart: &chart.Chart{
-					Metadata: &chart.Metadata{
+				Chart: &helmchart.Chart{
+					Metadata: &helmchart.Metadata{
 						Name:    "apache",
 						Version: "1.18.4",
 					},
@@ -138,32 +138,32 @@ func TestUpdateInstalledPackage(t *testing.T) {
 		},
 		{
 			name: "returns invalid if installed package doesn't exist",
-			request: &corev1.UpdateInstalledPackageRequest{
-				InstalledPackageRef: &corev1.InstalledPackageReference{
-					Context: &corev1.Context{
+			request: &pkgsGRPCv1alpha1.UpdateInstalledPackageRequest{
+				InstalledPackageRef: &pkgsGRPCv1alpha1.InstalledPackageReference{
+					Context: &pkgsGRPCv1alpha1.Context{
 						Namespace: "default",
 					},
 					Identifier: "not-a-valid-identifier",
 				},
 			},
-			expectedStatusCode: codes.NotFound,
+			expectedStatusCode: grpccodes.NotFound,
 		},
 	}
 
 	ignoredUnexported := cmpopts.IgnoreUnexported(
-		corev1.UpdateInstalledPackageResponse{},
-		corev1.InstalledPackageReference{},
-		corev1.Context{},
-		plugins.Plugin{},
-		chart.Chart{},
+		pkgsGRPCv1alpha1.UpdateInstalledPackageResponse{},
+		pkgsGRPCv1alpha1.InstalledPackageReference{},
+		pkgsGRPCv1alpha1.Context{},
+		pluginsGRPCv1alpha1.Plugin{},
+		helmchart.Chart{},
 	)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			authorized := true
 			actionConfig := newActionConfigFixture(t, tc.request.GetInstalledPackageRef().GetContext().GetNamespace(), tc.existingReleases, nil)
-			server, mockDB, cleanup := makeServer(t, authorized, actionConfig, &v1alpha1.AppRepository{
-				ObjectMeta: metav1.ObjectMeta{
+			server, mockDB, cleanup := makeServer(t, authorized, actionConfig, &apprepov1alpha1.AppRepository{
+				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "bitnami",
 					Namespace: globalPackagingNamespace,
 				},
@@ -175,7 +175,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 			}
 			response, err := server.UpdateInstalledPackage(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedStatusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedStatusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
@@ -186,8 +186,8 @@ func TestUpdateInstalledPackage(t *testing.T) {
 
 			if tc.expectedRelease != nil {
 				// Verify the expected request was made to Helm (our contract to the helm lib).
-				deployedFilter := func(r *release.Release) bool {
-					return r.Info.Status == release.StatusDeployed
+				deployedFilter := func(r *helmrelease.Release) bool {
+					return r.Info.Status == helmrelease.StatusDeployed
 				}
 				releases, err := actionConfig.Releases.Driver.List(deployedFilter)
 				if err != nil {
@@ -197,7 +197,7 @@ func TestUpdateInstalledPackage(t *testing.T) {
 					t.Fatalf("got: %d, want: %d", got, want)
 				}
 
-				ignoredFields := cmpopts.IgnoreFields(release.Info{}, "FirstDeployed", "LastDeployed")
+				ignoredFields := cmpopts.IgnoreFields(helmrelease.Info{}, "FirstDeployed", "LastDeployed")
 				if got, want := releases[0], tc.expectedRelease; !cmp.Equal(got, want, ignoredUnexported, ignoredFields) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported, ignoredFields))
 				}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
@@ -6,21 +6,21 @@ package main
 import (
 	"context"
 
-	"google.golang.org/grpc"
+	grpc "google.golang.org/grpc"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/pkg/kube"
+	grpcgwruntime "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	apiscore "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	pkgkappv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
+	kubeutils "github.com/kubeapps/kubeapps/pkg/kube"
 )
 
 // Set the pluginDetail once during a module init function so the single struct
 // can be used throughout the plugin.
-var pluginDetail plugins.Plugin
+var pluginDetail pluginsGRPCv1alpha1.Plugin
 
 func init() {
-	pluginDetail = plugins.Plugin{
+	pluginDetail = pluginsGRPCv1alpha1.Plugin{
 		Name:    "kapp_controller.packages",
 		Version: "v1alpha1",
 	}
@@ -28,20 +28,20 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
-	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter apiscore.KubernetesConfigGetter,
+	clustersConfig kubeutils.ClustersConfig, pluginConfigPath string) (interface{}, error) {
 	svr := NewServer(configGetter, clustersConfig.KubeappsClusterName, pluginConfigPath)
-	v1alpha1.RegisterKappControllerPackagesServiceServer(s, svr)
+	pkgkappv1alpha1.RegisterKappControllerPackagesServiceServer(s, svr)
 	return svr, nil
 }
 
 // RegisterHTTPHandlerFromEndpoint enables a plugin to register an http
 // handler to translate to the gRPC request.
-func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
-	return v1alpha1.RegisterKappControllerPackagesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
+func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *grpcgwruntime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+	return pkgkappv1alpha1.RegisterKappControllerPackagesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }
 
-// GetPluginDetail returns a core.plugins.Plugin describing itself.
-func GetPluginDetail() *plugins.Plugin {
+// GetPluginDetail returns a apiscore.plugins.Plugin describing itself.
+func GetPluginDetail() *pluginsGRPCv1alpha1.Plugin {
 	return &pluginDetail
 }

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_repositories.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_repositories.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
+	pkgkappv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
+	statuserror "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
 	log "k8s.io/klog/v2"
 )
 
 // GetPackageRepositories returns the package repositories based on the request managed by the 'kapp_controller' plugin
-func (s *Server) GetPackageRepositories(ctx context.Context, request *v1alpha1.GetPackageRepositoriesRequest) (*v1alpha1.GetPackageRepositoriesResponse, error) {
+func (s *Server) GetPackageRepositories(ctx context.Context, request *pkgkappv1alpha1.GetPackageRepositoriesRequest) (*pkgkappv1alpha1.GetPackageRepositoriesResponse, error) {
 	log.Infof("+kapp-controller GetPackageRepositories")
 
 	namespace := request.GetContext().GetNamespace()
@@ -29,7 +29,7 @@ func (s *Server) GetPackageRepositories(ctx context.Context, request *v1alpha1.G
 	}
 
 	// convert the Carvel PackageRepository to our API PackageRepository struct
-	responseRepos := []*v1alpha1.PackageRepository{}
+	responseRepos := []*pkgkappv1alpha1.PackageRepository{}
 	for _, repo := range pkgRepositories {
 		repo, err := getPackageRepository(repo)
 		if err != nil {
@@ -38,7 +38,7 @@ func (s *Server) GetPackageRepositories(ctx context.Context, request *v1alpha1.G
 		responseRepos = append(responseRepos, repo)
 	}
 
-	return &v1alpha1.GetPackageRepositoriesResponse{
+	return &pkgkappv1alpha1.GetPackageRepositoriesResponse{
 		Repositories: responseRepos,
 	}, nil
 }

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_resources.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_data_resources.go
@@ -7,16 +7,16 @@ import (
 	"context"
 	"fmt"
 
-	ctlres "github.com/k14s/kapp/pkg/kapp/resources"
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	kappresources "github.com/k14s/kapp/pkg/kapp/resources"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	kappctrlv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
-	packagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
-	datapackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
+	kappctrlpackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
+	kappctrldatapackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8smetaunstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8dynamicclient "k8s.io/client-go/dynamic"
 )
 
 const (
@@ -36,68 +36,68 @@ const (
 // Dynamic ResourceInterface getters to encapsulate the logic of getting the proper group version API resources
 
 // See https://carvel.dev/kapp-controller/docs/latest/packaging/#package-cr
-func (s *Server) getPkgResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
+func (s *Server) getPkgResource(ctx context.Context, cluster, namespace string) (k8dynamicclient.ResourceInterface, error) {
 	_, dynClient, err := s.GetClients(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
-	gvr := schema.GroupVersionResource{
-		Group:    datapackagingv1alpha1.SchemeGroupVersion.Group,
-		Version:  datapackagingv1alpha1.SchemeGroupVersion.Version,
+	gvr := k8sschema.GroupVersionResource{
+		Group:    kappctrldatapackagingv1alpha1.SchemeGroupVersion.Group,
+		Version:  kappctrldatapackagingv1alpha1.SchemeGroupVersion.Version,
 		Resource: pkgsResource}
 	ri := dynClient.Resource(gvr).Namespace(namespace)
 	return ri, nil
 }
 
 // See https://carvel.dev/kapp-controller/docs/latest/packaging/#package-metadata
-func (s *Server) getPkgMetadataResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
+func (s *Server) getPkgMetadataResource(ctx context.Context, cluster, namespace string) (k8dynamicclient.ResourceInterface, error) {
 	_, dynClient, err := s.GetClients(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
-	gvr := schema.GroupVersionResource{
-		Group:    datapackagingv1alpha1.SchemeGroupVersion.Group,
-		Version:  datapackagingv1alpha1.SchemeGroupVersion.Version,
+	gvr := k8sschema.GroupVersionResource{
+		Group:    kappctrldatapackagingv1alpha1.SchemeGroupVersion.Group,
+		Version:  kappctrldatapackagingv1alpha1.SchemeGroupVersion.Version,
 		Resource: pkgMetadatasResource}
 	ri := dynClient.Resource(gvr).Namespace(namespace)
 	return ri, nil
 }
 
 // See https://carvel.dev/kapp-controller/docs/latest/packaging/#package-install
-func (s *Server) getPkgInstallResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
+func (s *Server) getPkgInstallResource(ctx context.Context, cluster, namespace string) (k8dynamicclient.ResourceInterface, error) {
 	_, dynClient, err := s.GetClients(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
-	gvr := schema.GroupVersionResource{
-		Group:    packagingv1alpha1.SchemeGroupVersion.Group,
-		Version:  packagingv1alpha1.SchemeGroupVersion.Version,
+	gvr := k8sschema.GroupVersionResource{
+		Group:    kappctrlpackagingv1alpha1.SchemeGroupVersion.Group,
+		Version:  kappctrlpackagingv1alpha1.SchemeGroupVersion.Version,
 		Resource: pkgInstallsResource}
 	ri := dynClient.Resource(gvr).Namespace(namespace)
 	return ri, nil
 }
 
 // See https://carvel.dev/kapp-controller/docs/latest/packaging/#packagerepository-cr
-func (s *Server) getPkgRepositoryResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
+func (s *Server) getPkgRepositoryResource(ctx context.Context, cluster, namespace string) (k8dynamicclient.ResourceInterface, error) {
 	_, dynClient, err := s.GetClients(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
-	gvr := schema.GroupVersionResource{
-		Group:    packagingv1alpha1.SchemeGroupVersion.Group,
-		Version:  packagingv1alpha1.SchemeGroupVersion.Version,
+	gvr := k8sschema.GroupVersionResource{
+		Group:    kappctrlpackagingv1alpha1.SchemeGroupVersion.Group,
+		Version:  kappctrlpackagingv1alpha1.SchemeGroupVersion.Version,
 		Resource: pkgRepositoriesResource}
 	ri := dynClient.Resource(gvr).Namespace(namespace)
 	return ri, nil
 }
 
 // See https://carvel.dev/kapp-controller/docs/latest/app-spec/
-func (s *Server) getAppResource(ctx context.Context, cluster, namespace string) (dynamic.ResourceInterface, error) {
+func (s *Server) getAppResource(ctx context.Context, cluster, namespace string) (k8dynamicclient.ResourceInterface, error) {
 	_, dynClient, err := s.GetClients(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
-	gvr := schema.GroupVersionResource{
+	gvr := k8sschema.GroupVersionResource{
 		Group:    kappctrlv1alpha1.SchemeGroupVersion.Group,
 		Version:  kappctrlv1alpha1.SchemeGroupVersion.Version,
 		Resource: appsResource}
@@ -108,17 +108,17 @@ func (s *Server) getAppResource(ctx context.Context, cluster, namespace string) 
 //  Single resource getters
 
 // getPkg returns the package for the given cluster, namespace and identifier
-func (s *Server) getPkg(ctx context.Context, cluster, namespace, identifier string) (*datapackagingv1alpha1.Package, error) {
-	var pkg datapackagingv1alpha1.Package
+func (s *Server) getPkg(ctx context.Context, cluster, namespace, identifier string) (*kappctrldatapackagingv1alpha1.Package, error) {
+	var pkg kappctrldatapackagingv1alpha1.Package
 	resource, err := s.getPkgResource(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
-	unstructured, err := resource.Get(ctx, identifier, metav1.GetOptions{})
+	unstructured, err := resource.Get(ctx, identifier, k8smetav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &pkg)
+	err = k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &pkg)
 	if err != nil {
 		return nil, err
 	}
@@ -126,17 +126,17 @@ func (s *Server) getPkg(ctx context.Context, cluster, namespace, identifier stri
 }
 
 // getPkgMetadata returns the package metadata for the given cluster, namespace and identifier
-func (s *Server) getPkgMetadata(ctx context.Context, cluster, namespace, identifier string) (*datapackagingv1alpha1.PackageMetadata, error) {
-	var pkgMetadata datapackagingv1alpha1.PackageMetadata
+func (s *Server) getPkgMetadata(ctx context.Context, cluster, namespace, identifier string) (*kappctrldatapackagingv1alpha1.PackageMetadata, error) {
+	var pkgMetadata kappctrldatapackagingv1alpha1.PackageMetadata
 	resource, err := s.getPkgMetadataResource(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
-	unstructured, err := resource.Get(ctx, identifier, metav1.GetOptions{})
+	unstructured, err := resource.Get(ctx, identifier, k8smetav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &pkgMetadata)
+	err = k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &pkgMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -144,17 +144,17 @@ func (s *Server) getPkgMetadata(ctx context.Context, cluster, namespace, identif
 }
 
 // getPkgInstall returns the package install for the given cluster, namespace and identifier
-func (s *Server) getPkgInstall(ctx context.Context, cluster, namespace, identifier string) (*packagingv1alpha1.PackageInstall, error) {
-	var pkgInstall packagingv1alpha1.PackageInstall
+func (s *Server) getPkgInstall(ctx context.Context, cluster, namespace, identifier string) (*kappctrlpackagingv1alpha1.PackageInstall, error) {
+	var pkgInstall kappctrlpackagingv1alpha1.PackageInstall
 	resource, err := s.getPkgInstallResource(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
-	unstructured, err := resource.Get(ctx, identifier, metav1.GetOptions{})
+	unstructured, err := resource.Get(ctx, identifier, k8smetav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &pkgInstall)
+	err = k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &pkgInstall)
 	if err != nil {
 		return nil, err
 	}
@@ -162,17 +162,17 @@ func (s *Server) getPkgInstall(ctx context.Context, cluster, namespace, identifi
 }
 
 // getPkgRepository returns the package repository for the given cluster, namespace and identifier
-func (s *Server) getPkgRepository(ctx context.Context, cluster, namespace, identifier string) (*packagingv1alpha1.PackageRepository, error) {
-	var pkgRepository packagingv1alpha1.PackageRepository
+func (s *Server) getPkgRepository(ctx context.Context, cluster, namespace, identifier string) (*kappctrlpackagingv1alpha1.PackageRepository, error) {
+	var pkgRepository kappctrlpackagingv1alpha1.PackageRepository
 	resource, err := s.getPkgRepositoryResource(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
-	unstructured, err := resource.Get(ctx, identifier, metav1.GetOptions{})
+	unstructured, err := resource.Get(ctx, identifier, k8smetav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &pkgRepository)
+	err = k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &pkgRepository)
 	if err != nil {
 		return nil, err
 	}
@@ -186,11 +186,11 @@ func (s *Server) getApp(ctx context.Context, cluster, namespace, identifier stri
 	if err != nil {
 		return nil, err
 	}
-	unstructured, err := resource.Get(ctx, identifier, metav1.GetOptions{})
+	unstructured, err := resource.Get(ctx, identifier, k8smetav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &app)
+	err = k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, &app)
 	if err != nil {
 		return nil, err
 	}
@@ -200,17 +200,17 @@ func (s *Server) getApp(ctx context.Context, cluster, namespace, identifier stri
 //  List of resources getters
 
 // getPkgs returns the list of packages for the given cluster and namespace
-func (s *Server) getPkgs(ctx context.Context, cluster, namespace string) ([]*datapackagingv1alpha1.Package, error) {
+func (s *Server) getPkgs(ctx context.Context, cluster, namespace string) ([]*kappctrldatapackagingv1alpha1.Package, error) {
 	return s.getPkgsWithFieldSelector(ctx, cluster, namespace, "")
 }
 
 // getPkgs returns the list of packages for the given cluster and namespace
-func (s *Server) getPkgsWithFieldSelector(ctx context.Context, cluster, namespace, fieldSelector string) ([]*datapackagingv1alpha1.Package, error) {
+func (s *Server) getPkgsWithFieldSelector(ctx context.Context, cluster, namespace, fieldSelector string) ([]*kappctrldatapackagingv1alpha1.Package, error) {
 	resource, err := s.getPkgResource(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
-	listOptions := metav1.ListOptions{}
+	listOptions := k8smetav1.ListOptions{}
 	if fieldSelector != "" {
 		listOptions.FieldSelector = fieldSelector
 	}
@@ -221,10 +221,10 @@ func (s *Server) getPkgsWithFieldSelector(ctx context.Context, cluster, namespac
 		return nil, err
 	}
 
-	var pkgs []*datapackagingv1alpha1.Package
+	var pkgs []*kappctrldatapackagingv1alpha1.Package
 	for _, unstructured := range unstructured.Items {
-		pkg := &datapackagingv1alpha1.Package{}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, pkg)
+		pkg := &kappctrldatapackagingv1alpha1.Package{}
+		err := k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, pkg)
 		if err != nil {
 			return nil, err
 		}
@@ -234,19 +234,19 @@ func (s *Server) getPkgsWithFieldSelector(ctx context.Context, cluster, namespac
 }
 
 // getPkgMetadatas returns the list of package metadatas for the given cluster and namespace
-func (s *Server) getPkgMetadatas(ctx context.Context, cluster, namespace string) ([]*datapackagingv1alpha1.PackageMetadata, error) {
+func (s *Server) getPkgMetadatas(ctx context.Context, cluster, namespace string) ([]*kappctrldatapackagingv1alpha1.PackageMetadata, error) {
 	resource, err := s.getPkgMetadataResource(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
-	unstructured, err := resource.List(ctx, metav1.ListOptions{})
+	unstructured, err := resource.List(ctx, k8smetav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	var pkgMetadatas []*datapackagingv1alpha1.PackageMetadata
+	var pkgMetadatas []*kappctrldatapackagingv1alpha1.PackageMetadata
 	for _, unstructured := range unstructured.Items {
-		pkgMetadata := &datapackagingv1alpha1.PackageMetadata{}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, pkgMetadata)
+		pkgMetadata := &kappctrldatapackagingv1alpha1.PackageMetadata{}
+		err := k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, pkgMetadata)
 		if err != nil {
 			return nil, err
 		}
@@ -256,19 +256,19 @@ func (s *Server) getPkgMetadatas(ctx context.Context, cluster, namespace string)
 }
 
 // getPkgInstalls returns the list of package installs for the given cluster and namespace
-func (s *Server) getPkgInstalls(ctx context.Context, cluster, namespace string) ([]*packagingv1alpha1.PackageInstall, error) {
+func (s *Server) getPkgInstalls(ctx context.Context, cluster, namespace string) ([]*kappctrlpackagingv1alpha1.PackageInstall, error) {
 	resource, err := s.getPkgInstallResource(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
-	unstructured, err := resource.List(ctx, metav1.ListOptions{})
+	unstructured, err := resource.List(ctx, k8smetav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	var pkgInstalls []*packagingv1alpha1.PackageInstall
+	var pkgInstalls []*kappctrlpackagingv1alpha1.PackageInstall
 	for _, unstructured := range unstructured.Items {
-		pkgInstall := &packagingv1alpha1.PackageInstall{}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, pkgInstall)
+		pkgInstall := &kappctrlpackagingv1alpha1.PackageInstall{}
+		err := k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, pkgInstall)
 		if err != nil {
 			return nil, err
 		}
@@ -278,19 +278,19 @@ func (s *Server) getPkgInstalls(ctx context.Context, cluster, namespace string) 
 }
 
 // getPkgRepositories returns the list of package repositories for the given cluster and namespace
-func (s *Server) getPkgRepositories(ctx context.Context, cluster, namespace string) ([]*packagingv1alpha1.PackageRepository, error) {
+func (s *Server) getPkgRepositories(ctx context.Context, cluster, namespace string) ([]*kappctrlpackagingv1alpha1.PackageRepository, error) {
 	resource, err := s.getPkgRepositoryResource(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
-	unstructured, err := resource.List(ctx, metav1.ListOptions{})
+	unstructured, err := resource.List(ctx, k8smetav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	var pkgRepositories []*packagingv1alpha1.PackageRepository
+	var pkgRepositories []*kappctrlpackagingv1alpha1.PackageRepository
 	for _, unstructured := range unstructured.Items {
-		pkgRepository := &packagingv1alpha1.PackageRepository{}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, pkgRepository)
+		pkgRepository := &kappctrlpackagingv1alpha1.PackageRepository{}
+		err := k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, pkgRepository)
 		if err != nil {
 			return nil, err
 		}
@@ -305,14 +305,14 @@ func (s *Server) getApps(ctx context.Context, cluster, namespace, identifier str
 	if err != nil {
 		return nil, err
 	}
-	unstructured, err := resource.List(ctx, metav1.ListOptions{})
+	unstructured, err := resource.List(ctx, k8smetav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	var apps []*kappctrlv1alpha1.App
 	for _, unstructured := range unstructured.Items {
 		app := &kappctrlv1alpha1.App{}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, app)
+		err := k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, app)
 		if err != nil {
 			return nil, err
 		}
@@ -324,26 +324,26 @@ func (s *Server) getApps(ctx context.Context, cluster, namespace, identifier str
 // Creation functions
 
 // createPkgInstall creates a package install for the given cluster, namespace and identifier
-func (s *Server) createPkgInstall(ctx context.Context, cluster, namespace string, newPkgInstall *packagingv1alpha1.PackageInstall) (*packagingv1alpha1.PackageInstall, error) {
-	var pkgInstall packagingv1alpha1.PackageInstall
+func (s *Server) createPkgInstall(ctx context.Context, cluster, namespace string, newPkgInstall *kappctrlpackagingv1alpha1.PackageInstall) (*kappctrlpackagingv1alpha1.PackageInstall, error) {
+	var pkgInstall kappctrlpackagingv1alpha1.PackageInstall
 	resource, err := s.getPkgInstallResource(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	unstructuredPkgInstallContent, err := runtime.DefaultUnstructuredConverter.ToUnstructured(newPkgInstall)
+	unstructuredPkgInstallContent, err := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(newPkgInstall)
 	if err != nil {
 		return nil, err
 	}
-	unstructuredPkgInstall := unstructured.Unstructured{}
+	unstructuredPkgInstall := k8smetaunstructuredv1.Unstructured{}
 	unstructuredPkgInstall.SetUnstructuredContent(unstructuredPkgInstallContent)
 
-	unstructuredNewPkgInstall, err := resource.Create(ctx, &unstructuredPkgInstall, metav1.CreateOptions{})
+	unstructuredNewPkgInstall, err := resource.Create(ctx, &unstructuredPkgInstall, k8smetav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredNewPkgInstall.Object, &pkgInstall)
+	err = k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructuredNewPkgInstall.Object, &pkgInstall)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func (s *Server) deletePkgInstall(ctx context.Context, cluster, namespace, ident
 	if err != nil {
 		return err
 	}
-	err = resource.Delete(ctx, identifier, metav1.DeleteOptions{})
+	err = resource.Delete(ctx, identifier, k8smetav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -368,26 +368,26 @@ func (s *Server) deletePkgInstall(ctx context.Context, cluster, namespace, ident
 // Update functions
 
 // createPkgInstall creates a package install for the given cluster, namespace and identifier
-func (s *Server) updatePkgInstall(ctx context.Context, cluster, namespace string, newPkgInstall *packagingv1alpha1.PackageInstall) (*packagingv1alpha1.PackageInstall, error) {
-	var pkgInstall packagingv1alpha1.PackageInstall
+func (s *Server) updatePkgInstall(ctx context.Context, cluster, namespace string, newPkgInstall *kappctrlpackagingv1alpha1.PackageInstall) (*kappctrlpackagingv1alpha1.PackageInstall, error) {
+	var pkgInstall kappctrlpackagingv1alpha1.PackageInstall
 	resource, err := s.getPkgInstallResource(ctx, cluster, namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	unstructuredPkgInstallContent, err := runtime.DefaultUnstructuredConverter.ToUnstructured(newPkgInstall)
+	unstructuredPkgInstallContent, err := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(newPkgInstall)
 	if err != nil {
 		return nil, err
 	}
-	unstructuredPkgInstall := unstructured.Unstructured{}
+	unstructuredPkgInstall := k8smetaunstructuredv1.Unstructured{}
 	unstructuredPkgInstall.SetUnstructuredContent(unstructuredPkgInstallContent)
 
-	unstructuredNewPkgInstall, err := resource.Update(ctx, &unstructuredPkgInstall, metav1.UpdateOptions{})
+	unstructuredNewPkgInstall, err := resource.Update(ctx, &unstructuredPkgInstall, k8smetav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredNewPkgInstall.Object, &pkgInstall)
+	err = k8sruntime.DefaultUnstructuredConverter.FromUnstructured(unstructuredNewPkgInstall.Object, &pkgInstall)
 	if err != nil {
 		return nil, err
 	}
@@ -395,11 +395,11 @@ func (s *Server) updatePkgInstall(ctx context.Context, cluster, namespace string
 }
 
 // inspectKappK8sResources returns the list of k8s resources matching the given listOptions
-func (s *Server) inspectKappK8sResources(ctx context.Context, cluster, namespace, packageId string) ([]*corev1.ResourceRef, error) {
+func (s *Server) inspectKappK8sResources(ctx context.Context, cluster, namespace, packageId string) ([]*pkgsGRPCv1alpha1.ResourceRef, error) {
 	// As per https://github.com/vmware-tanzu/carvel-kapp-controller/blob/v0.31.0/pkg/deploy/kapp.go#L151
 	appName := fmt.Sprintf("%s-ctrl", packageId)
 
-	refs := []*corev1.ResourceRef{}
+	refs := []*pkgsGRPCv1alpha1.ResourceRef{}
 
 	// Get the Kapp different clients
 	appsClient, resourcesClient, failingAPIServicesPolicy, _, err := s.GetKappClients(ctx, cluster, namespace)
@@ -429,14 +429,14 @@ func (s *Server) inspectKappK8sResources(ctx context.Context, cluster, namespace
 	}
 
 	// List the k8s resources that match the label selector
-	resources, err := resourcesClient.List(labelSelector, nil, ctlres.IdentifiedResourcesListOpts{})
+	resources, err := resourcesClient.List(labelSelector, nil, kappresources.IdentifiedResourcesListOpts{})
 	if err != nil {
 		return nil, err
 	}
 
 	// For each resource, generate and append the ResourceRef
 	for _, resource := range resources {
-		refs = append(refs, &corev1.ResourceRef{
+		refs = append(refs, &pkgsGRPCv1alpha1.ResourceRef{
 			ApiVersion: resource.GroupVersion().String(),
 			Kind:       resource.Kind(),
 			Name:       resource.Name(),

--- a/cmd/kubeapps-apis/plugins/pkg/clientgetter/clientgetter_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/clientgetter/clientgetter_test.go
@@ -8,42 +8,42 @@ import (
 	"fmt"
 	"testing"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	dynfake "k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/kubernetes"
-	typfake "k8s.io/client-go/kubernetes/fake"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8dynamicclient "k8s.io/client-go/dynamic"
+	k8dynamicclientfake "k8s.io/client-go/dynamic/fake"
+	k8stypedclient "k8s.io/client-go/kubernetes"
+	k8stypedclientfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestGetClient(t *testing.T) {
-	testClientGetter := func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
-		return typfake.NewSimpleClientset(), dynfake.NewSimpleDynamicClientWithCustomListKinds(
-			runtime.NewScheme(),
-			map[schema.GroupVersionResource]string{
+	testClientGetter := func(context.Context, string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
+		return k8stypedclientfake.NewSimpleClientset(), k8dynamicclientfake.NewSimpleDynamicClientWithCustomListKinds(
+			k8sruntime.NewScheme(),
+			map[k8sschema.GroupVersionResource]string{
 				{Group: "foo", Version: "bar", Resource: "baz"}: "PackageList",
 			},
 		), nil
 	}
-	badClientGetter := func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+	badClientGetter := func(context.Context, string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
 		return nil, nil, fmt.Errorf("Bang!")
 	}
 
 	testCases := []struct {
 		name         string
 		clientGetter ClientGetterFunc
-		statusCode   codes.Code
+		statusCode   grpccodes.Code
 	}{
 		{
 			name:         "it returns failed-precondition when configGetter itself errors",
-			statusCode:   codes.Unknown,
+			statusCode:   grpccodes.Unknown,
 			clientGetter: badClientGetter,
 		},
 		{
 			name:         "it returns client without error when configured correctly",
-			statusCode:   codes.OK,
+			statusCode:   grpccodes.OK,
 			clientGetter: testClientGetter,
 		},
 	}
@@ -51,17 +51,17 @@ func TestGetClient(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			typedClient, dynamicClient, err := tc.clientGetter(context.Background(), "")
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Errorf("got: %+v, want: %+v", got, want)
 			}
 
-			// If there is no error, the client should be a dynamic.Interface implementation.
-			if tc.statusCode == codes.OK {
+			// If there is no error, the client should be a k8dynamicclient.Interface implementation.
+			if tc.statusCode == grpccodes.OK {
 				if dynamicClient == nil {
-					t.Errorf("got: nil, want: dynamic.Interface")
+					t.Errorf("got: nil, want: k8dynamicclient.Interface")
 				}
 				if typedClient == nil {
-					t.Errorf("got: nil, want: kubernetes.Interface")
+					t.Errorf("got: nil, want: k8stypedclient.Interface")
 				}
 			}
 		})

--- a/cmd/kubeapps-apis/plugins/pkg/paginate/paginate.go
+++ b/cmd/kubeapps-apis/plugins/pkg/paginate/paginate.go
@@ -6,9 +6,9 @@ package paginate
 import (
 	"strconv"
 
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 // PageOffsetFromPageToken converts a page token to an integer offset
@@ -28,20 +28,20 @@ func PageOffsetFromPageToken(pageToken string) (int, error) {
 	return int(offset), nil
 }
 
-func PageOffsetFromInstalledRequest(request *corev1.GetInstalledPackageSummariesRequest) (int, error) {
+func PageOffsetFromInstalledRequest(request *pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest) (int, error) {
 	offset, err := PageOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
 	if err != nil {
-		return 0, status.Errorf(codes.InvalidArgument, "unable to intepret page token %q: %v",
+		return 0, grpcstatus.Errorf(grpccodes.InvalidArgument, "unable to intepret page token %q: %v",
 			request.GetPaginationOptions().GetPageToken(), err)
 	} else {
 		return offset, nil
 	}
 }
 
-func PageOffsetFromAvailableRequest(request *corev1.GetAvailablePackageSummariesRequest) (int, error) {
+func PageOffsetFromAvailableRequest(request *pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest) (int, error) {
 	offset, err := PageOffsetFromPageToken(request.GetPaginationOptions().GetPageToken())
 	if err != nil {
-		return 0, status.Errorf(codes.InvalidArgument, "unable to intepret page token %q: %v",
+		return 0, grpcstatus.Errorf(grpccodes.InvalidArgument, "unable to intepret page token %q: %v",
 			request.GetPaginationOptions().GetPageToken(), err)
 	} else {
 		return offset, nil

--- a/cmd/kubeapps-apis/plugins/pkg/paginate/paginate_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/paginate/paginate_test.go
@@ -6,9 +6,9 @@ package paginate
 import (
 	"testing"
 
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 func TestPageOffsetFromPageToken(t *testing.T) {
@@ -21,12 +21,12 @@ func TestPageOffsetFromPageToken(t *testing.T) {
 	}
 
 	_, err = PageOffsetFromPageToken("not a number")
-	if got, want := status.Code(err), codes.Unknown; got != want {
+	if got, want := grpcstatus.Code(err), grpccodes.Unknown; got != want {
 		t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 	}
 
-	req1 := &corev1.GetInstalledPackageSummariesRequest{
-		Context: &corev1.Context{Namespace: "namespace-1"},
+	req1 := &pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest{
+		Context: &pkgsGRPCv1alpha1.Context{Namespace: "namespace-1"},
 	}
 	offset, err = PageOffsetFromInstalledRequest(req1)
 	if err != nil {
@@ -36,9 +36,9 @@ func TestPageOffsetFromPageToken(t *testing.T) {
 		t.Fatalf("expected 1, got: %d", offset)
 	}
 
-	req2 := &corev1.GetInstalledPackageSummariesRequest{
-		Context: &corev1.Context{Namespace: "namespace-1"},
-		PaginationOptions: &corev1.PaginationOptions{
+	req2 := &pkgsGRPCv1alpha1.GetInstalledPackageSummariesRequest{
+		Context: &pkgsGRPCv1alpha1.Context{Namespace: "namespace-1"},
+		PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{
 			PageToken: "1",
 		},
 	}
@@ -50,8 +50,8 @@ func TestPageOffsetFromPageToken(t *testing.T) {
 		t.Fatalf("expected 1, got: %d", offset)
 	}
 
-	req3 := &corev1.GetAvailablePackageSummariesRequest{
-		Context: &corev1.Context{Namespace: "namespace-1"},
+	req3 := &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+		Context: &pkgsGRPCv1alpha1.Context{Namespace: "namespace-1"},
 	}
 	offset, err = PageOffsetFromAvailableRequest(req3)
 	if err != nil {
@@ -61,9 +61,9 @@ func TestPageOffsetFromPageToken(t *testing.T) {
 		t.Fatalf("expected 1, got: %d", offset)
 	}
 
-	req4 := &corev1.GetAvailablePackageSummariesRequest{
-		Context: &corev1.Context{Namespace: "namespace-1"},
-		PaginationOptions: &corev1.PaginationOptions{
+	req4 := &pkgsGRPCv1alpha1.GetAvailablePackageSummariesRequest{
+		Context: &pkgsGRPCv1alpha1.Context{Namespace: "namespace-1"},
+		PaginationOptions: &pkgsGRPCv1alpha1.PaginationOptions{
 			PageToken: "1",
 		},
 	}

--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils_test.go
@@ -6,20 +6,20 @@ package pkgutils
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"helm.sh/helm/v3/pkg/chart"
+	cmp "github.com/google/go-cmp/cmp"
+	cmpopts "github.com/google/go-cmp/cmp/cmpopts"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	helmchart "helm.sh/helm/v3/pkg/chart"
 )
 
 const (
 	DefaultAppVersion       = "1.2.6"
 	DefaultChartDescription = "default chart description"
-	DefaultChartIconURL     = "https://example.com/chart.svg"
+	DefaultChartIconURL     = "https://example.com/helmchart.svg"
 	DefaultChartHomeURL     = "https://helm.sh/helm"
 	DefaultChartCategory    = "cat1"
 )
@@ -27,19 +27,19 @@ const (
 func TestPackageAppVersionsSummary(t *testing.T) {
 	testCases := []struct {
 		name                      string
-		chart_versions            []models.ChartVersion
-		version_summary           []*corev1.PackageAppVersion
+		chart_versions            []chartmodels.ChartVersion
+		version_summary           []*pkgsGRPCv1alpha1.PackageAppVersion
 		input_versions_in_summary VersionsInSummary
 	}{
 		{
 			name: "it includes the latest three major versions only",
-			chart_versions: []models.ChartVersion{
+			chart_versions: []chartmodels.ChartVersion{
 				{Version: "8.5.6", AppVersion: DefaultAppVersion},
 				{Version: "7.5.6", AppVersion: DefaultAppVersion},
 				{Version: "6.5.6", AppVersion: DefaultAppVersion},
 				{Version: "5.5.6", AppVersion: DefaultAppVersion},
 			},
-			version_summary: []*corev1.PackageAppVersion{
+			version_summary: []*pkgsGRPCv1alpha1.PackageAppVersion{
 				{PkgVersion: "8.5.6", AppVersion: DefaultAppVersion},
 				{PkgVersion: "7.5.6", AppVersion: DefaultAppVersion},
 				{PkgVersion: "6.5.6", AppVersion: DefaultAppVersion},
@@ -48,13 +48,13 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 		},
 		{
 			name: "it includes the latest three minor versions for each major version only",
-			chart_versions: []models.ChartVersion{
+			chart_versions: []chartmodels.ChartVersion{
 				{Version: "8.5.6", AppVersion: DefaultAppVersion},
 				{Version: "8.4.6", AppVersion: DefaultAppVersion},
 				{Version: "8.3.6", AppVersion: DefaultAppVersion},
 				{Version: "8.2.6", AppVersion: DefaultAppVersion},
 			},
-			version_summary: []*corev1.PackageAppVersion{
+			version_summary: []*pkgsGRPCv1alpha1.PackageAppVersion{
 				{PkgVersion: "8.5.6", AppVersion: DefaultAppVersion},
 				{PkgVersion: "8.4.6", AppVersion: DefaultAppVersion},
 				{PkgVersion: "8.3.6", AppVersion: DefaultAppVersion},
@@ -63,13 +63,13 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 		},
 		{
 			name: "it includes the latest three patch versions for each minor version only",
-			chart_versions: []models.ChartVersion{
+			chart_versions: []chartmodels.ChartVersion{
 				{Version: "8.5.6", AppVersion: DefaultAppVersion},
 				{Version: "8.5.5", AppVersion: DefaultAppVersion},
 				{Version: "8.5.4", AppVersion: DefaultAppVersion},
 				{Version: "8.5.3", AppVersion: DefaultAppVersion},
 			},
-			version_summary: []*corev1.PackageAppVersion{
+			version_summary: []*pkgsGRPCv1alpha1.PackageAppVersion{
 				{PkgVersion: "8.5.6", AppVersion: DefaultAppVersion},
 				{PkgVersion: "8.5.5", AppVersion: DefaultAppVersion},
 				{PkgVersion: "8.5.4", AppVersion: DefaultAppVersion},
@@ -78,7 +78,7 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 		},
 		{
 			name: "it includes the latest three patch versions of the latest three minor versions of the latest three major versions only",
-			chart_versions: []models.ChartVersion{
+			chart_versions: []chartmodels.ChartVersion{
 				{Version: "8.5.6", AppVersion: DefaultAppVersion},
 				{Version: "8.5.5", AppVersion: DefaultAppVersion},
 				{Version: "8.5.4", AppVersion: DefaultAppVersion},
@@ -144,7 +144,7 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 				{Version: "2.2.4", AppVersion: DefaultAppVersion},
 				{Version: "2.2.3", AppVersion: DefaultAppVersion},
 			},
-			version_summary: []*corev1.PackageAppVersion{
+			version_summary: []*pkgsGRPCv1alpha1.PackageAppVersion{
 				{PkgVersion: "8.5.6", AppVersion: DefaultAppVersion},
 				{PkgVersion: "8.5.5", AppVersion: DefaultAppVersion},
 				{PkgVersion: "8.5.4", AppVersion: DefaultAppVersion},
@@ -177,7 +177,7 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 		},
 		{
 			name: "it includes the latest four patch versions of the latest one minor versions of the latest two major versions only",
-			chart_versions: []models.ChartVersion{
+			chart_versions: []chartmodels.ChartVersion{
 				{Version: "8.5.6", AppVersion: DefaultAppVersion},
 				{Version: "8.5.5", AppVersion: DefaultAppVersion},
 				{Version: "8.5.4", AppVersion: DefaultAppVersion},
@@ -245,7 +245,7 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 				{Version: "2.2.4", AppVersion: DefaultAppVersion},
 				{Version: "2.2.3", AppVersion: DefaultAppVersion},
 			},
-			version_summary: []*corev1.PackageAppVersion{
+			version_summary: []*pkgsGRPCv1alpha1.PackageAppVersion{
 				{PkgVersion: "8.5.6", AppVersion: DefaultAppVersion},
 				{PkgVersion: "8.5.5", AppVersion: DefaultAppVersion},
 				{PkgVersion: "8.5.4", AppVersion: DefaultAppVersion},
@@ -262,7 +262,7 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 		},
 		{
 			name: "it includes the latest zero patch versions of the latest zero minor versions of the latest six major versions only",
-			chart_versions: []models.ChartVersion{
+			chart_versions: []chartmodels.ChartVersion{
 				{Version: "8.5.6", AppVersion: DefaultAppVersion},
 				{Version: "8.5.5", AppVersion: DefaultAppVersion},
 				{Version: "8.5.4", AppVersion: DefaultAppVersion},
@@ -326,7 +326,7 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 				{Version: "1.2.4", AppVersion: DefaultAppVersion},
 				{Version: "1.2.3", AppVersion: DefaultAppVersion},
 			},
-			version_summary: []*corev1.PackageAppVersion{
+			version_summary: []*pkgsGRPCv1alpha1.PackageAppVersion{
 				{PkgVersion: "8.5.6", AppVersion: DefaultAppVersion},
 				{PkgVersion: "6.5.6", AppVersion: DefaultAppVersion},
 				{PkgVersion: "4.5.6", AppVersion: DefaultAppVersion},
@@ -340,7 +340,7 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 		},
 	}
 
-	opts := cmpopts.IgnoreUnexported(corev1.PackageAppVersion{})
+	opts := cmpopts.IgnoreUnexported(pkgsGRPCv1alpha1.PackageAppVersion{})
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -354,19 +354,19 @@ func TestPackageAppVersionsSummary(t *testing.T) {
 func TestIsValidChart(t *testing.T) {
 	testCases := []struct {
 		name     string
-		in       *models.Chart
+		in       *chartmodels.Chart
 		expected bool
 	}{
 		{
 			name: "it returns true if the chart name, ID, repo and versions are specified",
-			in: &models.Chart{
+			in: &chartmodels.Chart{
 				Name: "foo",
 				ID:   "foo/bar",
-				Repo: &models.Repo{
+				Repo: &chartmodels.Repo{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
-				ChartVersions: []models.ChartVersion{
+				ChartVersions: []chartmodels.ChartVersion{
 					{
 						Version: "3.0.0",
 					},
@@ -376,13 +376,13 @@ func TestIsValidChart(t *testing.T) {
 		},
 		{
 			name: "it returns false if the chart name is missing",
-			in: &models.Chart{
+			in: &chartmodels.Chart{
 				ID: "foo/bar",
-				Repo: &models.Repo{
+				Repo: &chartmodels.Repo{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
-				ChartVersions: []models.ChartVersion{
+				ChartVersions: []chartmodels.ChartVersion{
 					{
 						Version: "3.0.0",
 					},
@@ -392,13 +392,13 @@ func TestIsValidChart(t *testing.T) {
 		},
 		{
 			name: "it returns false if the chart ID is missing",
-			in: &models.Chart{
+			in: &chartmodels.Chart{
 				Name: "foo",
-				Repo: &models.Repo{
+				Repo: &chartmodels.Repo{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
-				ChartVersions: []models.ChartVersion{
+				ChartVersions: []chartmodels.ChartVersion{
 					{
 						Version: "3.0.0",
 					},
@@ -408,10 +408,10 @@ func TestIsValidChart(t *testing.T) {
 		},
 		{
 			name: "it returns false if the chart repo is missing",
-			in: &models.Chart{
+			in: &chartmodels.Chart{
 				Name: "foo",
 				ID:   "foo/bar",
-				ChartVersions: []models.ChartVersion{
+				ChartVersions: []chartmodels.ChartVersion{
 					{
 						Version: "3.0.0",
 					},
@@ -421,7 +421,7 @@ func TestIsValidChart(t *testing.T) {
 		},
 		{
 			name: "it returns false if the ChartVersions are missing",
-			in: &models.Chart{
+			in: &chartmodels.Chart{
 				Name: "foo",
 				ID:   "foo/bar",
 			},
@@ -429,10 +429,10 @@ func TestIsValidChart(t *testing.T) {
 		},
 		{
 			name: "it returns false if a ChartVersions.Version is missing",
-			in: &models.Chart{
+			in: &chartmodels.Chart{
 				Name: "foo",
 				ID:   "foo/bar",
-				ChartVersions: []models.ChartVersion{
+				ChartVersions: []chartmodels.ChartVersion{
 					{Version: "3.0.0"},
 					{AppVersion: DefaultAppVersion},
 				},
@@ -441,33 +441,33 @@ func TestIsValidChart(t *testing.T) {
 		},
 		{
 			name: "it returns true if the minimum (+maintainer) chart is correct",
-			in: &models.Chart{
+			in: &chartmodels.Chart{
 				Name: "foo",
 				ID:   "foo/bar",
-				Repo: &models.Repo{
+				Repo: &chartmodels.Repo{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
-				ChartVersions: []models.ChartVersion{
+				ChartVersions: []chartmodels.ChartVersion{
 					{
 						Version: "3.0.0",
 					},
 				},
-				Maintainers: []chart.Maintainer{{Name: "me"}},
+				Maintainers: []helmchart.Maintainer{{Name: "me"}},
 			},
 			expected: true,
 		},
 		{
 			name: "it returns false if a Maintainer.Name is missing",
-			in: &models.Chart{
+			in: &chartmodels.Chart{
 				Name: "foo",
 				ID:   "foo/bar",
-				ChartVersions: []models.ChartVersion{
+				ChartVersions: []chartmodels.ChartVersion{
 					{
 						Version: "3.0.0",
 					},
 				},
-				Maintainers: []chart.Maintainer{{Name: "me"}, {Email: "you"}},
+				Maintainers: []helmchart.Maintainer{{Name: "me"}, {Email: "you"}},
 			},
 			expected: false,
 		},
@@ -484,96 +484,96 @@ func TestIsValidChart(t *testing.T) {
 }
 
 func TestAvailablePackageSummaryFromChart(t *testing.T) {
-	invalidChart := &models.Chart{Name: "foo"}
+	invalidChart := &chartmodels.Chart{Name: "foo"}
 
 	testCases := []struct {
 		name       string
-		in         *models.Chart
-		expected   *corev1.AvailablePackageSummary
-		statusCode codes.Code
+		in         *chartmodels.Chart
+		expected   *pkgsGRPCv1alpha1.AvailablePackageSummary
+		statusCode grpccodes.Code
 	}{
 		{
 			name: "it returns a complete AvailablePackageSummary for a complete chart",
-			in: &models.Chart{
+			in: &chartmodels.Chart{
 				Name:        "foo",
 				ID:          "foo/bar",
 				Category:    DefaultChartCategory,
 				Description: "best chart",
 				Icon:        "foo.bar/icon.svg",
-				Repo: &models.Repo{
+				Repo: &chartmodels.Repo{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
-				Maintainers: []chart.Maintainer{{Name: "me", Email: "me@me.me"}},
-				ChartVersions: []models.ChartVersion{
+				Maintainers: []helmchart.Maintainer{{Name: "me", Email: "me@me.me"}},
+				ChartVersions: []chartmodels.ChartVersion{
 					{Version: "3.0.0", AppVersion: DefaultAppVersion, Readme: "chart readme", Values: "chart values", Schema: "chart schema"},
 					{Version: "2.0.0", AppVersion: DefaultAppVersion, Readme: "chart readme", Values: "chart values", Schema: "chart schema"},
 					{Version: "1.0.0", AppVersion: DefaultAppVersion, Readme: "chart readme", Values: "chart values", Schema: "chart schema"},
 				},
 			},
-			expected: &corev1.AvailablePackageSummary{
+			expected: &pkgsGRPCv1alpha1.AvailablePackageSummary{
 				Name:        "foo",
 				DisplayName: "foo",
-				LatestVersion: &corev1.PackageAppVersion{
+				LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 					PkgVersion: "3.0.0",
 					AppVersion: DefaultAppVersion,
 				},
 				IconUrl:          "foo.bar/icon.svg",
 				ShortDescription: "best chart",
 				Categories:       []string{DefaultChartCategory},
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Namespace: "my-ns"},
 					Identifier: "foo/bar",
-					Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 				},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name: "it returns a valid AvailablePackageSummary if the minimal chart is correct",
-			in: &models.Chart{
+			in: &chartmodels.Chart{
 				Name: "foo",
 				ID:   "foo/bar",
-				Repo: &models.Repo{
+				Repo: &chartmodels.Repo{
 					Name:      "bar",
 					Namespace: "my-ns",
 				},
-				ChartVersions: []models.ChartVersion{
+				ChartVersions: []chartmodels.ChartVersion{
 					{
 						Version:    "3.0.0",
 						AppVersion: DefaultAppVersion,
 					},
 				},
 			},
-			expected: &corev1.AvailablePackageSummary{
+			expected: &pkgsGRPCv1alpha1.AvailablePackageSummary{
 				Name:        "foo",
 				DisplayName: "foo",
-				LatestVersion: &corev1.PackageAppVersion{
+				LatestVersion: &pkgsGRPCv1alpha1.PackageAppVersion{
 					PkgVersion: "3.0.0",
 					AppVersion: DefaultAppVersion,
 				},
 				Categories: []string{""},
-				AvailablePackageRef: &corev1.AvailablePackageReference{
-					Context:    &corev1.Context{Namespace: "my-ns"},
+				AvailablePackageRef: &pkgsGRPCv1alpha1.AvailablePackageReference{
+					Context:    &pkgsGRPCv1alpha1.Context{Namespace: "my-ns"},
 					Identifier: "foo/bar",
-					Plugin:     &plugins.Plugin{Name: "helm.packages", Version: "v1alpha1"},
+					Plugin:     &pluginsGRPCv1alpha1.Plugin{Name: "helm.packages", Version: "v1alpha1"},
 				},
 			},
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name:       "it returns internal error if empty chart",
-			in:         &models.Chart{},
-			statusCode: codes.Internal,
+			in:         &chartmodels.Chart{},
+			statusCode: grpccodes.Internal,
 		},
 		{
 			name:       "it returns internal error if chart is invalid",
 			in:         invalidChart,
-			statusCode: codes.Internal,
+			statusCode: grpccodes.Internal,
 		},
 	}
 
-	pluginDetail := plugins.Plugin{
+	pluginDetail := pluginsGRPCv1alpha1.Plugin{
 		Name:    "helm.packages",
 		Version: "v1alpha1",
 	}
@@ -582,12 +582,12 @@ func TestAvailablePackageSummaryFromChart(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			availablePackageSummary, err := AvailablePackageSummaryFromChart(tc.in, &pluginDetail)
 
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
-				opt1 := cmpopts.IgnoreUnexported(corev1.AvailablePackageDetail{}, corev1.AvailablePackageSummary{}, corev1.AvailablePackageReference{}, corev1.Context{}, plugins.Plugin{}, corev1.Maintainer{}, corev1.PackageAppVersion{})
+			if tc.statusCode == grpccodes.OK {
+				opt1 := cmpopts.IgnoreUnexported(pkgsGRPCv1alpha1.AvailablePackageDetail{}, pkgsGRPCv1alpha1.AvailablePackageSummary{}, pkgsGRPCv1alpha1.AvailablePackageReference{}, pkgsGRPCv1alpha1.Context{}, pluginsGRPCv1alpha1.Plugin{}, pkgsGRPCv1alpha1.Maintainer{}, pkgsGRPCv1alpha1.PackageAppVersion{})
 				if got, want := availablePackageSummary, tc.expected; !cmp.Equal(got, want, opt1) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, opt1))
 				}
@@ -601,40 +601,40 @@ func TestGetUnescapedChartID(t *testing.T) {
 		name       string
 		in         string
 		out        string
-		statusCode codes.Code
+		statusCode grpccodes.Code
 	}{
 		{
 			name:       "it returns a chartID for a valid input",
 			in:         "foo/bar",
 			out:        "foo/bar",
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name:       "it returns a chartID for a valid input (2)",
 			in:         "foo%2Fbar",
 			out:        "foo/bar",
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name:       "it fails for an invalid chartID",
 			in:         "foo%ZZbar",
-			statusCode: codes.InvalidArgument,
+			statusCode: grpccodes.InvalidArgument,
 		},
 		{
 			name:       "it fails for an invalid chartID (2)",
 			in:         "foo/bar/zot",
-			statusCode: codes.InvalidArgument,
+			statusCode: grpccodes.InvalidArgument,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualOut, err := GetUnescapedChartID(tc.in)
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				if got, want := actualOut, tc.out; !cmp.Equal(got, want) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 				}
@@ -649,30 +649,30 @@ func TestSplitChartIdentifier(t *testing.T) {
 		in         string
 		repoName   string
 		chartName  string
-		statusCode codes.Code
+		statusCode grpccodes.Code
 	}{
 		{
 			name:       "it returns a repoName and chartName for a valid input",
 			in:         "foo/bar",
 			repoName:   "foo",
 			chartName:  "bar",
-			statusCode: codes.OK,
+			statusCode: grpccodes.OK,
 		},
 		{
 			name:       "it fails for invalid input",
 			in:         "foo/bar/zot",
-			statusCode: codes.InvalidArgument,
+			statusCode: grpccodes.InvalidArgument,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			repoName, chartName, err := SplitChartIdentifier(tc.in)
-			if got, want := status.Code(err), tc.statusCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.statusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 
-			if tc.statusCode == codes.OK {
+			if tc.statusCode == grpccodes.OK {
 				if got, want := repoName, tc.repoName; !cmp.Equal(got, want) {
 					t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 				}

--- a/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefs_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefs_test.go
@@ -6,17 +6,17 @@ package resourcerefs
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefstest"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	cmp "github.com/google/go-cmp/cmp"
+	cmpopts "github.com/google/go-cmp/cmp/cmpopts"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	resourcerefstest "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefstest"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 func TestGetInstalledPackageResourceRefs(t *testing.T) {
 	ignoredFields := cmpopts.IgnoreUnexported(
-		corev1.ResourceRef{},
+		pkgsGRPCv1alpha1.ResourceRef{},
 	)
 
 	testCases := []resourcerefstest.TestCase{}
@@ -33,9 +33,9 @@ func TestGetInstalledPackageResourceRefs(t *testing.T) {
 				tc.ExistingReleases[0].Namespace)
 			expectedStatusCode := tc.ExpectedErrStatusCode
 			if expectedStatusCode == 0 {
-				expectedStatusCode = codes.OK
+				expectedStatusCode = grpccodes.OK
 			}
-			if got, want := status.Code(err), expectedStatusCode; got != want {
+			if got, want := grpcstatus.Code(err), expectedStatusCode; got != want {
 				t.Fatalf("got: %+v, want: %+v, err: %+v", got, want, err)
 			}
 

--- a/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefstest/testsetup.go
+++ b/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefstest/testsetup.go
@@ -4,8 +4,8 @@
 package resourcerefstest
 
 import (
-	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	"google.golang.org/grpc/codes"
+	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
+	grpccodes "google.golang.org/grpc/codes"
 )
 
 // this is done so that test scenarios can be re-used in another package (helm and flux plug-ins)
@@ -19,8 +19,8 @@ type TestReleaseStub struct {
 type TestCase struct {
 	Name                  string
 	ExistingReleases      []TestReleaseStub
-	ExpectedResourceRefs  []*corev1.ResourceRef
-	ExpectedErrStatusCode codes.Code
+	ExpectedResourceRefs  []*pkgsGRPCv1alpha1.ResourceRef
+	ExpectedErrStatusCode grpccodes.Code
 }
 
 var (
@@ -54,7 +54,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "v1",
 					Name:       "apache-test",
@@ -85,7 +85,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "v1",
 					Name:       "apache-test",
@@ -116,7 +116,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "v1",
 					Name:       "test-cluster-role",
@@ -154,7 +154,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "apps/v1",
 					Name:       "apache-test",
@@ -171,7 +171,7 @@ metadata:
 					Namespace: "default",
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{},
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{},
 		},
 		{
 			Name: "returns internal error if the yaml manifest cannot be parsed",
@@ -186,7 +186,7 @@ should not be :! parsed as yaml$
 `,
 				},
 			},
-			ExpectedErrStatusCode: codes.Internal,
+			ExpectedErrStatusCode: grpccodes.Internal,
 		},
 		{
 			Name: "handles duplicate labels as helm does",
@@ -209,7 +209,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "apps/v1",
 					Name:       "apache-test",
@@ -235,7 +235,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "apps/v1",
 					Name:       "apache-test",
@@ -268,7 +268,7 @@ items:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "apps/v1",
 					Name:       "apache-test",
@@ -308,7 +308,7 @@ items:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "rbac.authorization.k8s.io/v1",
 					Name:       "role-1",
@@ -346,7 +346,7 @@ items:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "rbac.authorization.k8s.io/v1",
 					Name:       "clusterrole-1",
@@ -392,7 +392,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "v1",
 					Name:       "redis-test",
@@ -423,7 +423,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "v1",
 					Name:       "redis-test",
@@ -453,7 +453,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "v1",
 					Name:       "test-cluster-role",
@@ -488,7 +488,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "apps/v1",
 					Name:       "redis-test",
@@ -499,7 +499,7 @@ metadata:
 		},
 		{
 			Name:                  "returns a not found error if the helm release is not found (2)",
-			ExpectedErrStatusCode: codes.NotFound,
+			ExpectedErrStatusCode: grpccodes.NotFound,
 		},
 		{
 			Name: "returns internal error if the yaml manifest cannot be parsed (2)",
@@ -514,7 +514,7 @@ should not be :! parsed as yaml$
 `,
 				},
 			},
-			ExpectedErrStatusCode: codes.Internal,
+			ExpectedErrStatusCode: grpccodes.Internal,
 		},
 		{
 			Name: "handles duplicate labels in the manifest as helm does (2)",
@@ -536,7 +536,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "apps/v1",
 					Name:       "redis-test",
@@ -561,7 +561,7 @@ metadata:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "apps/v1",
 					Name:       "redis-test",
@@ -594,7 +594,7 @@ items:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "apps/v1",
 					Name:       "redis-test",
@@ -634,7 +634,7 @@ items:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "rbac.authorization.k8s.io/v1",
 					Name:       "role-1",
@@ -672,7 +672,7 @@ items:
 `,
 				},
 			},
-			ExpectedResourceRefs: []*corev1.ResourceRef{
+			ExpectedResourceRefs: []*pkgsGRPCv1alpha1.ResourceRef{
 				{
 					ApiVersion: "rbac.authorization.k8s.io/v1",
 					Name:       "clusterrole-1",

--- a/cmd/kubeapps-apis/plugins/pkg/statuserror/statuserror.go
+++ b/cmd/kubeapps-apis/plugins/pkg/statuserror/statuserror.go
@@ -4,9 +4,9 @@
 package statuserror
 
 import (
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/api/errors"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // FromK8sResourceError generates a grpc status error from a Kubernetes error
@@ -15,14 +15,14 @@ func FromK8sError(verb, resource, identifier string, err error) error {
 	if identifier == "" {
 		identifier = "all"
 	}
-	if errors.IsNotFound(err) {
-		return status.Errorf(codes.NotFound, "unable to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
-	} else if errors.IsForbidden(err) {
-		return status.Errorf(codes.PermissionDenied, "Forbidden to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
-	} else if errors.IsUnauthorized(err) {
-		return status.Errorf(codes.Unauthenticated, "Authorization required to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
-	} else if errors.IsAlreadyExists(err) {
-		return status.Errorf(codes.AlreadyExists, "Cannot %s the %s '%s' due to '%v' as it already exists", verb, resource, identifier, err)
+	if k8serrors.IsNotFound(err) {
+		return grpcstatus.Errorf(grpccodes.NotFound, "unable to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+	} else if k8serrors.IsForbidden(err) {
+		return grpcstatus.Errorf(grpccodes.PermissionDenied, "Forbidden to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+	} else if k8serrors.IsUnauthorized(err) {
+		return grpcstatus.Errorf(grpccodes.Unauthenticated, "Authorization required to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+	} else if k8serrors.IsAlreadyExists(err) {
+		return grpcstatus.Errorf(grpccodes.AlreadyExists, "Cannot %s the %s '%s' due to '%v' as it already exists", verb, resource, identifier, err)
 	}
-	return status.Errorf(codes.Internal, "unable to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
+	return grpcstatus.Errorf(grpccodes.Internal, "unable to %s the %s '%s' due to '%v'", verb, resource, identifier, err)
 }

--- a/cmd/kubeapps-apis/plugins/pkg/statuserror/statuserror_test.go
+++ b/cmd/kubeapps-apis/plugins/pkg/statuserror/statuserror_test.go
@@ -6,9 +6,9 @@ package statuserror
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	cmp "github.com/google/go-cmp/cmp"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 func TestErrorByStatus(t *testing.T) {
@@ -25,16 +25,16 @@ func TestErrorByStatus(t *testing.T) {
 			"get",
 			"my-resource",
 			"",
-			status.Errorf(codes.InvalidArgument, "boom!"),
-			status.Errorf(codes.Internal, "unable to get the my-resource 'all' due to 'rpc error: code = InvalidArgument desc = boom!'"),
+			grpcstatus.Errorf(grpccodes.InvalidArgument, "boom!"),
+			grpcstatus.Errorf(grpccodes.Internal, "unable to get the my-resource 'all' due to 'rpc error: code = InvalidArgument desc = boom!'"),
 		},
 		{
 			"error msg for a single resources ",
 			"get",
 			"my-resource",
 			"my-id",
-			status.Errorf(codes.InvalidArgument, "boom!"),
-			status.Errorf(codes.Internal, "unable to get the my-resource 'my-id' due to 'rpc error: code = InvalidArgument desc = boom!'"),
+			grpcstatus.Errorf(grpccodes.InvalidArgument, "boom!"),
+			grpcstatus.Errorf(grpccodes.Internal, "unable to get the my-resource 'my-id' due to 'rpc error: code = InvalidArgument desc = boom!'"),
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
@@ -6,26 +6,25 @@ package main
 import (
 	"context"
 
-	"google.golang.org/grpc"
-
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
-	"github.com/kubeapps/kubeapps/pkg/kube"
+	grpcgwruntime "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	apiscore "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
+	pluginsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	resourcesGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
+	kubeutils "github.com/kubeapps/kubeapps/pkg/kube"
+	grpc "google.golang.org/grpc"
 )
 
 // Set the pluginDetail once during a module init function so the single struct
 // can be used throughout the plugin.
 var (
-	pluginDetail plugins.Plugin
+	pluginDetail pluginsGRPCv1alpha1.Plugin
 	// This version var is updated during the build (see the -ldflags option
 	// in the cmd/kubeapps-apis/Dockerfile)
 	version = "devel"
 )
 
 func init() {
-	pluginDetail = plugins.Plugin{
+	pluginDetail = pluginsGRPCv1alpha1.Plugin{
 		Name:    "resources",
 		Version: "v1alpha1",
 	}
@@ -33,22 +32,22 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter, clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
+func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter apiscore.KubernetesConfigGetter, clustersConfig kubeutils.ClustersConfig, pluginConfigPath string) (interface{}, error) {
 	svr, err := NewServer(configGetter)
 	if err != nil {
 		return nil, err
 	}
-	v1alpha1.RegisterResourcesServiceServer(s, svr)
+	resourcesGRPCv1alpha1.RegisterResourcesServiceServer(s, svr)
 	return svr, nil
 }
 
 // RegisterHTTPHandlerFromEndpoint enables a plugin to register an http
 // handler to translate to the gRPC request.
-func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
-	return v1alpha1.RegisterResourcesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
+func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *grpcgwruntime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+	return resourcesGRPCv1alpha1.RegisterResourcesServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
 }
 
-// GetPluginDetail returns a core.plugins.Plugin describing itself.
-func GetPluginDetail() *plugins.Plugin {
+// GetPluginDetail returns a apiscore.plugins.Plugin describing itself.
+func GetPluginDetail() *pluginsGRPCv1alpha1.Plugin {
 	return &pluginDetail
 }

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/namespaces_test.go
@@ -8,119 +8,118 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
+	cmp "github.com/google/go-cmp/cmp"
+	cmpopts "github.com/google/go-cmp/cmp/cmpopts"
 	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	core "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
+	resourcesGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	k8scorev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
-	typfake "k8s.io/client-go/kubernetes/fake"
-	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
-	clientGoTesting "k8s.io/client-go/testing"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8dynamicclient "k8s.io/client-go/dynamic"
+	k8stypedclient "k8s.io/client-go/kubernetes"
+	k8stypedclientfake "k8s.io/client-go/kubernetes/fake"
+	k8stypedfakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestCheckNamespaceExists(t *testing.T) {
 
 	ignoredUnexported := cmpopts.IgnoreUnexported(
-		v1alpha1.CheckNamespaceExistsResponse{},
+		resourcesGRPCv1alpha1.CheckNamespaceExistsResponse{},
 	)
 
 	testCases := []struct {
 		name              string
-		request           *v1alpha1.CheckNamespaceExistsRequest
+		request           *resourcesGRPCv1alpha1.CheckNamespaceExistsRequest
 		k8sError          error
-		expectedResponse  *v1alpha1.CheckNamespaceExistsResponse
-		expectedErrorCode codes.Code
-		existingObjects   []runtime.Object
+		expectedResponse  *resourcesGRPCv1alpha1.CheckNamespaceExistsResponse
+		expectedErrorCode grpccodes.Code
+		existingObjects   []k8sruntime.Object
 	}{
 		{
 			name: "returns true if namespace exists",
-			request: &v1alpha1.CheckNamespaceExistsRequest{
+			request: &resourcesGRPCv1alpha1.CheckNamespaceExistsRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
-			existingObjects: []runtime.Object{
-				&core.Namespace{
-					TypeMeta: metav1.TypeMeta{
+			existingObjects: []k8sruntime.Object{
+				&k8scorev1.Namespace{
+					TypeMeta: k8smetav1.TypeMeta{
 						Kind:       "Namespace",
 						APIVersion: "v1",
 					},
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: k8smetav1.ObjectMeta{
 						Name: "default",
 					},
 				},
 			},
-			expectedResponse: &v1alpha1.CheckNamespaceExistsResponse{
+			expectedResponse: &resourcesGRPCv1alpha1.CheckNamespaceExistsResponse{
 				Exists: true,
 			},
 		},
 		{
 			name: "returns false if namespace does not exist",
-			request: &v1alpha1.CheckNamespaceExistsRequest{
+			request: &resourcesGRPCv1alpha1.CheckNamespaceExistsRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
-			expectedResponse: &v1alpha1.CheckNamespaceExistsResponse{
+			expectedResponse: &resourcesGRPCv1alpha1.CheckNamespaceExistsResponse{
 				Exists: false,
 			},
 		},
 		{
 			name: "returns permission denied if k8s returns a forbidden error",
-			request: &v1alpha1.CheckNamespaceExistsRequest{
+			request: &resourcesGRPCv1alpha1.CheckNamespaceExistsRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
-			k8sError: k8serrors.NewForbidden(schema.GroupResource{
+			k8sError: k8serrors.NewForbidden(k8sschema.GroupResource{
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default", errors.New("Bang")),
-			expectedErrorCode: codes.PermissionDenied,
+			expectedErrorCode: grpccodes.PermissionDenied,
 		},
 		{
 			name: "returns an internal error if k8s returns an unexpected error",
-			request: &v1alpha1.CheckNamespaceExistsRequest{
+			request: &resourcesGRPCv1alpha1.CheckNamespaceExistsRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
 			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
-			expectedErrorCode: codes.Internal,
+			expectedErrorCode: grpccodes.Internal,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			fakeClient := typfake.NewSimpleClientset(tc.existingObjects...)
+			fakeClient := k8stypedclientfake.NewSimpleClientset(tc.existingObjects...)
 			if tc.k8sError != nil {
-				fakeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor("get", "namespaces", func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &v1.Namespace{}, tc.k8sError
+				fakeClient.CoreV1().(*k8stypedfakecorev1.FakeCoreV1).PrependReactor("get", "namespaces", func(action k8stesting.Action) (handled bool, ret k8sruntime.Object, err error) {
+					return true, &k8scorev1.Namespace{}, tc.k8sError
 				})
 			}
 			s := Server{
-				clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+				clientGetter: func(context.Context, string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
 					return fakeClient, nil, nil
 				},
 			}
 
 			response, err := s.CheckNamespaceExists(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedErrorCode; got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
 			}
 
@@ -134,21 +133,21 @@ func TestCheckNamespaceExists(t *testing.T) {
 func TestCreateNamespace(t *testing.T) {
 
 	ignoredUnexported := cmpopts.IgnoreUnexported(
-		v1alpha1.CreateNamespaceResponse{},
+		resourcesGRPCv1alpha1.CreateNamespaceResponse{},
 	)
 
-	emptyResponse := &v1alpha1.CreateNamespaceResponse{}
+	emptyResponse := &resourcesGRPCv1alpha1.CreateNamespaceResponse{}
 	testCases := []struct {
 		name              string
-		request           *v1alpha1.CreateNamespaceRequest
+		request           *resourcesGRPCv1alpha1.CreateNamespaceRequest
 		k8sError          error
-		expectedResponse  *v1alpha1.CreateNamespaceResponse
-		expectedErrorCode codes.Code
-		existingObjects   []runtime.Object
+		expectedResponse  *resourcesGRPCv1alpha1.CreateNamespaceResponse
+		expectedErrorCode grpccodes.Code
+		existingObjects   []k8sruntime.Object
 	}{
 		{
 			name: "creates a new namespace",
-			request: &v1alpha1.CreateNamespaceRequest{
+			request: &resourcesGRPCv1alpha1.CreateNamespaceRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
@@ -158,63 +157,63 @@ func TestCreateNamespace(t *testing.T) {
 		},
 		{
 			name: "returns permission denied if k8s returns a forbidden error",
-			request: &v1alpha1.CreateNamespaceRequest{
+			request: &resourcesGRPCv1alpha1.CreateNamespaceRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
-			k8sError: k8serrors.NewForbidden(schema.GroupResource{
+			k8sError: k8serrors.NewForbidden(k8sschema.GroupResource{
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default", errors.New("Bang")),
-			expectedErrorCode: codes.PermissionDenied,
+			expectedErrorCode: grpccodes.PermissionDenied,
 		},
 		{
 			name: "returns already exists if k8s returns an already exists error",
-			request: &v1alpha1.CreateNamespaceRequest{
+			request: &resourcesGRPCv1alpha1.CreateNamespaceRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
-			k8sError: k8serrors.NewAlreadyExists(schema.GroupResource{
+			k8sError: k8serrors.NewAlreadyExists(k8sschema.GroupResource{
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default"),
-			expectedErrorCode: codes.AlreadyExists,
+			expectedErrorCode: grpccodes.AlreadyExists,
 		},
 		{
 			name: "returns an internal error if k8s returns an unexpected error",
-			request: &v1alpha1.CreateNamespaceRequest{
+			request: &resourcesGRPCv1alpha1.CreateNamespaceRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
 			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
-			expectedErrorCode: codes.Internal,
+			expectedErrorCode: grpccodes.Internal,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			fakeClient := typfake.NewSimpleClientset(tc.existingObjects...)
+			fakeClient := k8stypedclientfake.NewSimpleClientset(tc.existingObjects...)
 			if tc.k8sError != nil {
-				fakeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor("create", "namespaces", func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &v1.Namespace{}, tc.k8sError
+				fakeClient.CoreV1().(*k8stypedfakecorev1.FakeCoreV1).PrependReactor("create", "namespaces", func(action k8stesting.Action) (handled bool, ret k8sruntime.Object, err error) {
+					return true, &k8scorev1.Namespace{}, tc.k8sError
 				})
 			}
 			s := Server{
-				clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+				clientGetter: func(context.Context, string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
 					return fakeClient, nil, nil
 				},
 			}
 
 			response, err := s.CreateNamespace(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedErrorCode; got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
 			}
 
@@ -228,43 +227,43 @@ func TestCreateNamespace(t *testing.T) {
 func TestGetNamespaceNames(t *testing.T) {
 
 	ignoredUnexported := cmpopts.IgnoreUnexported(
-		v1alpha1.GetNamespaceNamesResponse{},
+		resourcesGRPCv1alpha1.GetNamespaceNamesResponse{},
 	)
 
 	testCases := []struct {
 		name              string
-		request           *v1alpha1.GetNamespaceNamesRequest
+		request           *resourcesGRPCv1alpha1.GetNamespaceNamesRequest
 		k8sError          error
-		expectedResponse  *v1alpha1.GetNamespaceNamesResponse
-		expectedErrorCode codes.Code
-		existingObjects   []runtime.Object
+		expectedResponse  *resourcesGRPCv1alpha1.GetNamespaceNamesResponse
+		expectedErrorCode grpccodes.Code
+		existingObjects   []k8sruntime.Object
 	}{
 		{
 			name: "returns existing namespaces if user has RBAC",
-			request: &v1alpha1.GetNamespaceNamesRequest{
+			request: &resourcesGRPCv1alpha1.GetNamespaceNamesRequest{
 				Cluster: "default",
 			},
-			existingObjects: []runtime.Object{
-				&core.Namespace{
-					TypeMeta: metav1.TypeMeta{
+			existingObjects: []k8sruntime.Object{
+				&k8scorev1.Namespace{
+					TypeMeta: k8smetav1.TypeMeta{
 						Kind:       "Namespace",
 						APIVersion: "v1",
 					},
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: k8smetav1.ObjectMeta{
 						Name: "default",
 					},
 				},
-				&core.Namespace{
-					TypeMeta: metav1.TypeMeta{
+				&k8scorev1.Namespace{
+					TypeMeta: k8smetav1.TypeMeta{
 						Kind:       "Namespace",
 						APIVersion: "v1",
 					},
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: k8smetav1.ObjectMeta{
 						Name: "kubeapps",
 					},
 				},
 			},
-			expectedResponse: &v1alpha1.GetNamespaceNamesResponse{
+			expectedResponse: &resourcesGRPCv1alpha1.GetNamespaceNamesResponse{
 				NamespaceNames: []string{
 					"default",
 					"kubeapps",
@@ -273,43 +272,43 @@ func TestGetNamespaceNames(t *testing.T) {
 		},
 		{
 			name: "returns permission denied if k8s returns a forbidden error",
-			request: &v1alpha1.GetNamespaceNamesRequest{
+			request: &resourcesGRPCv1alpha1.GetNamespaceNamesRequest{
 				Cluster: "default",
 			},
-			k8sError: k8serrors.NewForbidden(schema.GroupResource{
+			k8sError: k8serrors.NewForbidden(k8sschema.GroupResource{
 				Group:    "v1",
 				Resource: "namespaces",
 			}, "default", errors.New("Bang")),
-			expectedErrorCode: codes.PermissionDenied,
+			expectedErrorCode: grpccodes.PermissionDenied,
 		},
 		{
 			name: "returns an internal error if k8s returns an unexpected error",
-			request: &v1alpha1.GetNamespaceNamesRequest{
+			request: &resourcesGRPCv1alpha1.GetNamespaceNamesRequest{
 				Cluster: "default",
 			},
 			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
-			expectedErrorCode: codes.Internal,
+			expectedErrorCode: grpccodes.Internal,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			fakeClient := typfake.NewSimpleClientset(tc.existingObjects...)
+			fakeClient := k8stypedclientfake.NewSimpleClientset(tc.existingObjects...)
 			if tc.k8sError != nil {
-				fakeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor("list", "namespaces", func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &v1.NamespaceList{}, tc.k8sError
+				fakeClient.CoreV1().(*k8stypedfakecorev1.FakeCoreV1).PrependReactor("list", "namespaces", func(action k8stesting.Action) (handled bool, ret k8sruntime.Object, err error) {
+					return true, &k8scorev1.NamespaceList{}, tc.k8sError
 				})
 			}
 			s := Server{
-				clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+				clientGetter: func(context.Context, string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
 					return fakeClient, nil, nil
 				},
 			}
 
 			response, err := s.GetNamespaceNames(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedErrorCode; got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
 			}
 

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets_test.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/secrets_test.go
@@ -8,43 +8,42 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
+	cmp "github.com/google/go-cmp/cmp"
+	cmpopts "github.com/google/go-cmp/cmp/cmpopts"
 	pkgsGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	core "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
+	resourcesGRPCv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	k8scorev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
-	typfake "k8s.io/client-go/kubernetes/fake"
-	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
-	clientGoTesting "k8s.io/client-go/testing"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8dynamicclient "k8s.io/client-go/dynamic"
+	k8stypedclient "k8s.io/client-go/kubernetes"
+	k8stypedclientfake "k8s.io/client-go/kubernetes/fake"
+	k8stypedfakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestCreateSecret(t *testing.T) {
 
 	ignoredUnexported := cmpopts.IgnoreUnexported(
-		v1alpha1.CreateSecretResponse{},
+		resourcesGRPCv1alpha1.CreateSecretResponse{},
 	)
 
-	emptyResponse := &v1alpha1.CreateSecretResponse{}
+	emptyResponse := &resourcesGRPCv1alpha1.CreateSecretResponse{}
 	testCases := []struct {
 		name              string
-		request           *v1alpha1.CreateSecretRequest
+		request           *resourcesGRPCv1alpha1.CreateSecretRequest
 		k8sError          error
-		expectedResponse  *v1alpha1.CreateSecretResponse
-		expectedErrorCode codes.Code
-		existingObjects   []runtime.Object
+		expectedResponse  *resourcesGRPCv1alpha1.CreateSecretResponse
+		expectedErrorCode grpccodes.Code
+		existingObjects   []k8sruntime.Object
 	}{
 		{
 			name: "creates an opaque secret by default",
-			request: &v1alpha1.CreateSecretRequest{
+			request: &resourcesGRPCv1alpha1.CreateSecretRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
@@ -57,63 +56,63 @@ func TestCreateSecret(t *testing.T) {
 		},
 		{
 			name: "returns permission denied if k8s returns a forbidden error",
-			request: &v1alpha1.CreateSecretRequest{
+			request: &resourcesGRPCv1alpha1.CreateSecretRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
-			k8sError: k8serrors.NewForbidden(schema.GroupResource{
+			k8sError: k8serrors.NewForbidden(k8sschema.GroupResource{
 				Group:    "v1",
 				Resource: "secrets",
 			}, "default", errors.New("Bang")),
-			expectedErrorCode: codes.PermissionDenied,
+			expectedErrorCode: grpccodes.PermissionDenied,
 		},
 		{
 			name: "returns already exists if k8s returns an already exists error",
-			request: &v1alpha1.CreateSecretRequest{
+			request: &resourcesGRPCv1alpha1.CreateSecretRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
-			k8sError: k8serrors.NewAlreadyExists(schema.GroupResource{
+			k8sError: k8serrors.NewAlreadyExists(k8sschema.GroupResource{
 				Group:    "v1",
 				Resource: "secrets",
 			}, "default"),
-			expectedErrorCode: codes.AlreadyExists,
+			expectedErrorCode: grpccodes.AlreadyExists,
 		},
 		{
 			name: "returns an internal error if k8s returns an unexpected error",
-			request: &v1alpha1.CreateSecretRequest{
+			request: &resourcesGRPCv1alpha1.CreateSecretRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
 			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
-			expectedErrorCode: codes.Internal,
+			expectedErrorCode: grpccodes.Internal,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			fakeClient := typfake.NewSimpleClientset(tc.existingObjects...)
+			fakeClient := k8stypedclientfake.NewSimpleClientset(tc.existingObjects...)
 			if tc.k8sError != nil {
-				fakeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor("create", "secrets", func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &v1.Secret{}, tc.k8sError
+				fakeClient.CoreV1().(*k8stypedfakecorev1.FakeCoreV1).PrependReactor("create", "secrets", func(action k8stesting.Action) (handled bool, ret k8sruntime.Object, err error) {
+					return true, &k8scorev1.Secret{}, tc.k8sError
 				})
 			}
 			s := Server{
-				clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+				clientGetter: func(context.Context, string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
 					return fakeClient, nil, nil
 				},
 			}
 
 			response, err := s.CreateSecret(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedErrorCode; got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
 			}
 
@@ -121,10 +120,10 @@ func TestCreateSecret(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got, ignoredUnexported))
 			}
 
-			if tc.expectedErrorCode != codes.OK {
+			if tc.expectedErrorCode != grpccodes.OK {
 				return
 			}
-			secret, err := fakeClient.CoreV1().Secrets(tc.request.GetContext().GetNamespace()).Get(context.Background(), tc.request.GetName(), metav1.GetOptions{})
+			secret, err := fakeClient.CoreV1().Secrets(tc.request.GetContext().GetNamespace()).Get(context.Background(), tc.request.GetName(), k8smetav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -138,115 +137,115 @@ func TestCreateSecret(t *testing.T) {
 func TestGetSecretNames(t *testing.T) {
 
 	ignoredUnexported := cmpopts.IgnoreUnexported(
-		v1alpha1.GetSecretNamesResponse{},
+		resourcesGRPCv1alpha1.GetSecretNamesResponse{},
 	)
 
 	testCases := []struct {
 		name              string
-		request           *v1alpha1.GetSecretNamesRequest
+		request           *resourcesGRPCv1alpha1.GetSecretNamesRequest
 		k8sError          error
-		expectedResponse  *v1alpha1.GetSecretNamesResponse
-		expectedErrorCode codes.Code
-		existingObjects   []runtime.Object
+		expectedResponse  *resourcesGRPCv1alpha1.GetSecretNamesResponse
+		expectedErrorCode grpccodes.Code
+		existingObjects   []k8sruntime.Object
 	}{
 		{
 			name: "returns existing namespaces from the context namespace only if user has RBAC",
-			request: &v1alpha1.GetSecretNamesRequest{
+			request: &resourcesGRPCv1alpha1.GetSecretNamesRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
-			existingObjects: []runtime.Object{
-				&core.Secret{
-					TypeMeta: metav1.TypeMeta{
+			existingObjects: []k8sruntime.Object{
+				&k8scorev1.Secret{
+					TypeMeta: k8smetav1.TypeMeta{
 						Kind:       "Namespace",
 						APIVersion: "v1",
 					},
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: k8smetav1.ObjectMeta{
 						Name:      "secret-1",
 						Namespace: "default",
 					},
-					Type: core.SecretTypeOpaque,
+					Type: k8scorev1.SecretTypeOpaque,
 					StringData: map[string]string{
 						"ignored": "we don't use it",
 					},
 				},
-				&core.Secret{
-					TypeMeta: metav1.TypeMeta{
+				&k8scorev1.Secret{
+					TypeMeta: k8smetav1.TypeMeta{
 						Kind:       "Namespace",
 						APIVersion: "v1",
 					},
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: k8smetav1.ObjectMeta{
 						Name:      "secret-2",
 						Namespace: "default",
 					},
-					Type: core.SecretTypeDockerConfigJson,
+					Type: k8scorev1.SecretTypeDockerConfigJson,
 				},
-				&core.Secret{
-					TypeMeta: metav1.TypeMeta{
+				&k8scorev1.Secret{
+					TypeMeta: k8smetav1.TypeMeta{
 						Kind:       "Namespace",
 						APIVersion: "v1",
 					},
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: k8smetav1.ObjectMeta{
 						Name:      "secret-other-namespace",
 						Namespace: "other-namespace",
 					},
-					Type: core.SecretTypeDockerConfigJson,
+					Type: k8scorev1.SecretTypeDockerConfigJson,
 				},
 			},
-			expectedResponse: &v1alpha1.GetSecretNamesResponse{
-				SecretNames: map[string]v1alpha1.SecretType{
-					"secret-1": v1alpha1.SecretType_SECRET_TYPE_OPAQUE_UNSPECIFIED,
-					"secret-2": v1alpha1.SecretType_SECRET_TYPE_DOCKER_CONFIG_JSON,
+			expectedResponse: &resourcesGRPCv1alpha1.GetSecretNamesResponse{
+				SecretNames: map[string]resourcesGRPCv1alpha1.SecretType{
+					"secret-1": resourcesGRPCv1alpha1.SecretType_SECRET_TYPE_OPAQUE_UNSPECIFIED,
+					"secret-2": resourcesGRPCv1alpha1.SecretType_SECRET_TYPE_DOCKER_CONFIG_JSON,
 				},
 			},
 		},
 		{
 			name: "returns permission denied if k8s returns a forbidden error",
-			request: &v1alpha1.GetSecretNamesRequest{
+			request: &resourcesGRPCv1alpha1.GetSecretNamesRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
-			k8sError: k8serrors.NewForbidden(schema.GroupResource{
+			k8sError: k8serrors.NewForbidden(k8sschema.GroupResource{
 				Group:    "v1",
 				Resource: "secrets",
 			}, "default", errors.New("Bang")),
-			expectedErrorCode: codes.PermissionDenied,
+			expectedErrorCode: grpccodes.PermissionDenied,
 		},
 		{
 			name: "returns an internal error if k8s returns an unexpected error",
-			request: &v1alpha1.GetSecretNamesRequest{
+			request: &resourcesGRPCv1alpha1.GetSecretNamesRequest{
 				Context: &pkgsGRPCv1alpha1.Context{
 					Cluster:   "default",
 					Namespace: "default",
 				},
 			},
 			k8sError:          k8serrors.NewInternalError(errors.New("Bang")),
-			expectedErrorCode: codes.Internal,
+			expectedErrorCode: grpccodes.Internal,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			fakeClient := typfake.NewSimpleClientset(tc.existingObjects...)
+			fakeClient := k8stypedclientfake.NewSimpleClientset(tc.existingObjects...)
 			if tc.k8sError != nil {
-				fakeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor("list", "secrets", func(action clientGoTesting.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &v1.SecretList{}, tc.k8sError
+				fakeClient.CoreV1().(*k8stypedfakecorev1.FakeCoreV1).PrependReactor("list", "secrets", func(action k8stesting.Action) (handled bool, ret k8sruntime.Object, err error) {
+					return true, &k8scorev1.SecretList{}, tc.k8sError
 				})
 			}
 			s := Server{
-				clientGetter: func(context.Context, string) (kubernetes.Interface, dynamic.Interface, error) {
+				clientGetter: func(context.Context, string) (k8stypedclient.Interface, k8dynamicclient.Interface, error) {
 					return fakeClient, nil, nil
 				},
 			}
 
 			response, err := s.GetSecretNames(context.Background(), tc.request)
 
-			if got, want := status.Code(err), tc.expectedErrorCode; got != want {
+			if got, want := grpcstatus.Code(err), tc.expectedErrorCode; got != want {
 				t.Fatalf("got: %d, want: %d, err: %+v", got, want, err)
 			}
 

--- a/cmd/kubeops/cmd/root.go
+++ b/cmd/kubeops/cmd/root.go
@@ -7,15 +7,15 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubeapps/kubeapps/cmd/kubeops/server"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	kubeopsserver "github.com/kubeapps/kubeapps/cmd/kubeops/server"
+	cobra "github.com/spf13/cobra"
+	viper "github.com/spf13/viper"
 	log "k8s.io/klog/v2"
 )
 
 var (
 	cfgFile   string
-	serveOpts server.ServeOptions
+	serveOpts kubeopsserver.ServeOptions
 	// This Version var is updated during the build
 	// see the -ldflags option in the cmd/kubeops/Dockerfile
 	version = "devel"
@@ -32,7 +32,7 @@ func newRootCmd() *cobra.Command {
 			log.Infof("kubeops has been configured with: %#v", serveOpts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return server.Serve(serveOpts)
+			return kubeopsserver.Serve(serveOpts)
 		},
 		Version: "devel",
 	}

--- a/cmd/kubeops/cmd/root_test.go
+++ b/cmd/kubeops/cmd/root_test.go
@@ -7,15 +7,15 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/cmd/kubeops/server"
+	cmp "github.com/google/go-cmp/cmp"
+	kubeopsserver "github.com/kubeapps/kubeapps/cmd/kubeops/server"
 )
 
 func TestParseFlagsCorrect(t *testing.T) {
 	var tests = []struct {
 		name string
 		args []string
-		conf server.ServeOptions
+		conf kubeopsserver.ServeOptions
 	}{
 		{
 			"all arguments are captured",
@@ -34,7 +34,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 				"--namespace-header-pattern", "foo07",
 				"--global-repos-namespace", "kubeapps-global",
 			},
-			server.ServeOptions{
+			kubeopsserver.ServeOptions{
 				AssetsvcURL:            "foo01",
 				HelmDriverArg:          "foo02",
 				ListLimit:              901,

--- a/cmd/kubeops/main.go
+++ b/cmd/kubeops/main.go
@@ -3,11 +3,13 @@
 
 package main
 
-import "github.com/kubeapps/kubeapps/cmd/kubeops/cmd"
+import (
+	kubeopscmd "github.com/kubeapps/kubeapps/cmd/kubeops/cmd"
+)
 
 // This cobra command was initially generated together with the cmd/root with the command
 // cobra init --pkg-name github.com/kubeapps/kubeapps/cmd/kubeops
 
 func main() {
-	cmd.Execute()
+	kubeopscmd.Execute()
 }

--- a/pkg/agent/docker_secrets_postrenderer.go
+++ b/pkg/agent/docker_secrets_postrenderer.go
@@ -9,9 +9,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/distribution/distribution/reference"
+	distributionreference "github.com/distribution/distribution/reference"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -181,12 +181,12 @@ func (r *DockerSecretsPostRenderer) updatePodSpecWithPullSecrets(podSpec map[int
 			continue
 		}
 
-		ref, err := reference.ParseNormalizedNamed(image)
+		ref, err := distributionreference.ParseNormalizedNamed(image)
 		if err != nil {
 			log.Errorf("unable to parse image reference: %q", image)
 			continue
 		}
-		imageDomain := reference.Domain(ref)
+		imageDomain := distributionreference.Domain(ref)
 
 		secretName, ok := r.secrets[imageDomain]
 		if !ok {

--- a/pkg/agent/docker_secrets_postrenderer_test.go
+++ b/pkg/agent/docker_secrets_postrenderer_test.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v2"
+	cmp "github.com/google/go-cmp/cmp"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestNewDockerSecretsPostRenderer(t *testing.T) {

--- a/pkg/auth/fake/auth.go
+++ b/pkg/auth/fake/auth.go
@@ -4,11 +4,11 @@
 package fake
 
 import (
-	authUtils "github.com/kubeapps/kubeapps/pkg/auth"
+	authutils "github.com/kubeapps/kubeapps/pkg/auth"
 )
 
 type FakeAuth struct {
-	ForbiddenActions []authUtils.Action
+	ForbiddenActions []authutils.Action
 }
 
 func (f *FakeAuth) Validate() error {
@@ -19,6 +19,6 @@ func (f *FakeAuth) ValidateForNamespace(namespace string) (bool, error) {
 	return true, nil
 }
 
-func (f *FakeAuth) GetForbiddenActions(namespace, action, manifest string) ([]authUtils.Action, error) {
+func (f *FakeAuth) GetForbiddenActions(namespace, action, manifest string) ([]authutils.Action, error) {
 	return f.ForbiddenActions, nil
 }

--- a/pkg/chart/fake/chart.go
+++ b/pkg/chart/fake/chart.go
@@ -4,24 +4,24 @@
 package fake
 
 import (
-	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
-	chart3 "helm.sh/helm/v3/pkg/chart"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/yaml"
+	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	chartutils "github.com/kubeapps/kubeapps/pkg/chart"
+	helmchart "helm.sh/helm/v3/pkg/chart"
+	k8scorev1 "k8s.io/api/core/v1"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 // ChartClient implements Resolver inteface
 type ChartClient struct{}
 
 // GetChart fake
-func (f *ChartClient) GetChart(details *chartUtils.Details, repoURL string) (*chart3.Chart, error) {
+func (f *ChartClient) GetChart(details *chartutils.Details, repoURL string) (*helmchart.Chart, error) {
 	vals, err := getValues([]byte(details.Values))
 	if err != nil {
 		return nil, err
 	}
-	return &chart3.Chart{
-		Metadata: &chart3.Metadata{
+	return &helmchart.Chart{
+		Metadata: &helmchart.Metadata{
 			Name:    details.ChartName,
 			Version: details.Version,
 		},
@@ -31,7 +31,7 @@ func (f *ChartClient) GetChart(details *chartUtils.Details, repoURL string) (*ch
 
 func getValues(raw []byte) (map[string]interface{}, error) {
 	values := make(map[string]interface{})
-	err := yaml.Unmarshal(raw, &values)
+	err := k8syaml.Unmarshal(raw, &values)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func getValues(raw []byte) (map[string]interface{}, error) {
 }
 
 // Init fake
-func (f *ChartClient) Init(appRepo *appRepov1.AppRepository, caCertSecret *corev1.Secret, authSecret *corev1.Secret) error {
+func (f *ChartClient) Init(appRepo *apprepov1alpha1.AppRepository, caCertSecret *k8scorev1.Secret, authSecret *k8scorev1.Secret) error {
 	return nil
 }
 
@@ -47,6 +47,6 @@ func (f *ChartClient) Init(appRepo *appRepov1.AppRepository, caCertSecret *corev
 type ChartClientFactory struct{}
 
 // New returns a fake ChartClient
-func (c *ChartClientFactory) New(repoType, userAgent string) chartUtils.ChartClient {
+func (c *ChartClientFactory) New(repoType, userAgent string) chartutils.ChartClient {
 	return &ChartClient{}
 }

--- a/pkg/chart/models/chart.go
+++ b/pkg/chart/models/chart.go
@@ -4,12 +4,11 @@
 package models
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"time"
 
-	"database/sql/driver"
-
-	"helm.sh/helm/v3/pkg/chart"
+	helmchart "helm.sh/helm/v3/pkg/chart"
 )
 
 // Repo holds the App repository basic details
@@ -31,19 +30,19 @@ type RepoInternal struct {
 
 // Chart is a higher-level representation of a chart package
 type Chart struct {
-	ID              string             `json:"ID" bson:"chart_id"`
-	Name            string             `json:"name"`
-	Repo            *Repo              `json:"repo"`
-	Description     string             `json:"description"`
-	Home            string             `json:"home"`
-	Keywords        []string           `json:"keywords"`
-	Maintainers     []chart.Maintainer `json:"maintainers"`
-	Sources         []string           `json:"sources"`
-	Icon            string             `json:"icon"`
-	RawIcon         []byte             `json:"raw_icon" bson:"raw_icon"`
-	IconContentType string             `json:"icon_content_type" bson:"icon_content_type,omitempty"`
-	Category        string             `json:"category"`
-	ChartVersions   []ChartVersion     `json:"chartVersions"`
+	ID              string                 `json:"ID" bson:"chart_id"`
+	Name            string                 `json:"name"`
+	Repo            *Repo                  `json:"repo"`
+	Description     string                 `json:"description"`
+	Home            string                 `json:"home"`
+	Keywords        []string               `json:"keywords"`
+	Maintainers     []helmchart.Maintainer `json:"maintainers"`
+	Sources         []string               `json:"sources"`
+	Icon            string                 `json:"icon"`
+	RawIcon         []byte                 `json:"raw_icon" bson:"raw_icon"`
+	IconContentType string                 `json:"icon_content_type" bson:"icon_content_type,omitempty"`
+	Category        string                 `json:"category"`
+	ChartVersions   []ChartVersion         `json:"chartVersions"`
 }
 
 // ChartCategory is the representation of the chart category query

--- a/pkg/dbutils/dbutils.go
+++ b/pkg/dbutils/dbutils.go
@@ -3,7 +3,9 @@
 
 package dbutils
 
-import "time"
+import (
+	"time"
+)
 
 // AssetManager basic manager for the different db types
 type AssetManager interface {

--- a/pkg/dbutils/dbutilstest/pgtest/pgtest.go
+++ b/pkg/dbutils/dbutilstest/pgtest/pgtest.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/kubeapps/kubeapps/pkg/dbutils"
-	"github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
+	dbutilstest "github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest"
 )
 
 const (
@@ -63,7 +63,7 @@ func CountRows(t *testing.T, db dbutils.PostgresDB, table string) int {
 	return count
 }
 
-func EnsureChartsExist(t *testing.T, pam dbutils.PostgresAssetManagerIface, charts []models.Chart, repo models.Repo) {
+func EnsureChartsExist(t *testing.T, pam dbutils.PostgresAssetManagerIface, charts []chartmodels.Chart, repo chartmodels.Repo) {
 	_, err := pam.EnsureRepoExists(repo.Namespace, repo.Name)
 	if err != nil {
 		t.Fatalf("%+v", err)

--- a/pkg/dbutils/postgresql_utils.go
+++ b/pkg/dbutils/postgresql_utils.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
 )
 
 const (
@@ -37,8 +37,8 @@ type PostgresAssetManagerIface interface {
 	AssetManager
 	QueryCount(query string, args ...interface{}) (int, error)
 	QueryOne(target interface{}, query string, args ...interface{}) error
-	QueryAllCharts(query string, args ...interface{}) ([]*models.Chart, error)
-	QueryAllChartCategories(query string, args ...interface{}) ([]*models.ChartCategory, error)
+	QueryAllCharts(query string, args ...interface{}) ([]*chartmodels.Chart, error)
+	QueryAllChartCategories(query string, args ...interface{}) ([]*chartmodels.ChartCategory, error)
 	InitTables() error
 	InvalidateCache() error
 	EnsureRepoExists(repoNamespace, repoName string) (int, error)
@@ -93,7 +93,7 @@ func (m *PostgresAssetManager) QueryOne(target interface{}, query string, args .
 }
 
 // QueryAllCharts perform the given query and return the list of charts
-func (m *PostgresAssetManager) QueryAllCharts(query string, args ...interface{}) ([]*models.Chart, error) {
+func (m *PostgresAssetManager) QueryAllCharts(query string, args ...interface{}) ([]*chartmodels.Chart, error) {
 	rows, err := m.DB.Query(query, args...)
 	if rows != nil {
 		defer rows.Close()
@@ -101,14 +101,14 @@ func (m *PostgresAssetManager) QueryAllCharts(query string, args ...interface{})
 	if err != nil {
 		return nil, err
 	}
-	result := []*models.Chart{}
+	result := []*chartmodels.Chart{}
 	for rows.Next() {
 		var info string
 		err := rows.Scan(&info)
 		if err != nil {
 			return nil, err
 		}
-		var chart models.Chart
+		var chart chartmodels.Chart
 		err = json.Unmarshal([]byte(info), &chart)
 		if err != nil {
 			return nil, err
@@ -119,7 +119,7 @@ func (m *PostgresAssetManager) QueryAllCharts(query string, args ...interface{})
 }
 
 // QueryAllChartCategories performs the query and return the array of all the chart categories
-func (m *PostgresAssetManager) QueryAllChartCategories(query string, args ...interface{}) ([]*models.ChartCategory, error) {
+func (m *PostgresAssetManager) QueryAllChartCategories(query string, args ...interface{}) ([]*chartmodels.ChartCategory, error) {
 	rows, err := m.DB.Query(query, args...)
 	if rows != nil {
 		defer rows.Close()
@@ -127,7 +127,7 @@ func (m *PostgresAssetManager) QueryAllChartCategories(query string, args ...int
 	if err != nil {
 		return nil, err
 	}
-	result := []*models.ChartCategory{}
+	result := []*chartmodels.ChartCategory{}
 	for rows.Next() {
 		var name string
 		var count int
@@ -135,7 +135,7 @@ func (m *PostgresAssetManager) QueryAllChartCategories(query string, args ...int
 		if err != nil {
 			return nil, err
 		}
-		chartCategory := models.ChartCategory{Name: name, Count: count}
+		chartCategory := chartmodels.ChartCategory{Name: name, Count: count}
 		result = append(result, &chartCategory)
 	}
 	return result, nil

--- a/pkg/dbutils/postgresql_utils_test.go
+++ b/pkg/dbutils/postgresql_utils_test.go
@@ -6,9 +6,9 @@ package dbutils
 import (
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/google/go-cmp/cmp"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	cmp "github.com/google/go-cmp/cmp"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
 )
 
 func Test_NewPGManager(t *testing.T) {
@@ -54,7 +54,7 @@ func Test_QueryOne(t *testing.T) {
 	query := "SELECT * from charts"
 	rows := sqlmock.NewRows([]string{"info"}).AddRow(`{"ID": "foo"}`)
 	mock.ExpectQuery("^SELECT (.+)$").WillReturnRows(rows)
-	target := models.Chart{}
+	target := chartmodels.Chart{}
 	err = manager.QueryOne(&target, query)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -62,7 +62,7 @@ func Test_QueryOne(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
-	expectedChart := models.Chart{ID: "foo"}
+	expectedChart := chartmodels.Chart{ID: "foo"}
 	if !cmp.Equal(target, expectedChart) {
 		t.Errorf("Unexpected result %v", cmp.Diff(target, expectedChart))
 	}
@@ -89,7 +89,7 @@ func Test_QueryAll(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
-	expectedCharts := []*models.Chart{{ID: "foo"}, {ID: "bar"}}
+	expectedCharts := []*chartmodels.Chart{{ID: "foo"}, {ID: "bar"}}
 	if !cmp.Equal(charts, expectedCharts) {
 		t.Errorf("Unexpected result %v", cmp.Diff(charts, expectedCharts))
 	}
@@ -118,7 +118,7 @@ func Test_QueryAllChartCategories(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
-	expectedChartCategories := []*models.ChartCategory{
+	expectedChartCategories := []*chartmodels.ChartCategory{
 		{Name: "cat1", Count: 1},
 		{Name: "cat2", Count: 2},
 		{Name: "cat3", Count: 3},

--- a/pkg/handlerutil/handlerutil.go
+++ b/pkg/handlerutil/handlerutil.go
@@ -9,11 +9,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/gorilla/mux"
-	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	chartUtils "github.com/kubeapps/kubeapps/pkg/chart"
-	"helm.sh/helm/v3/pkg/chart"
-	corev1 "k8s.io/api/core/v1"
+	mux "github.com/gorilla/mux"
+	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	chartutils "github.com/kubeapps/kubeapps/pkg/chart"
+	helmchart "helm.sh/helm/v3/pkg/chart"
+	k8scorev1 "k8s.io/api/core/v1"
 )
 
 // Params a key-value map of path params
@@ -73,13 +73,13 @@ func ErrorCodeWithDefault(err error, defaultCode int) int {
 }
 
 // ParseRequest extract chart info from the request
-func ParseRequest(req *http.Request) (*chartUtils.Details, error) {
+func ParseRequest(req *http.Request) (*chartutils.Details, error) {
 	defer req.Body.Close()
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}
-	chartDetails, err := chartUtils.ParseDetails(body)
+	chartDetails, err := chartutils.ParseDetails(body)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func ParseRequest(req *http.Request) (*chartUtils.Details, error) {
 }
 
 // GetChart retrieves a chart
-func GetChart(chartDetails *chartUtils.Details, appRepo *appRepov1.AppRepository, caCertSecret *corev1.Secret, authSecret *corev1.Secret, chartClient chartUtils.ChartClient) (*chart.Chart, error) {
+func GetChart(chartDetails *chartutils.Details, appRepo *apprepov1alpha1.AppRepository, caCertSecret *k8scorev1.Secret, authSecret *k8scorev1.Secret, chartClient chartutils.ChartClient) (*helmchart.Chart, error) {
 	err := chartClient.Init(appRepo, caCertSecret, authSecret)
 	if err != nil {
 		return nil, err

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -11,14 +11,14 @@ import (
 	"os"
 	"strings"
 
-	"github.com/containerd/containerd/remotes"
+	containerdremotes "github.com/containerd/containerd/remotes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
+	errors "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"oras.land/oras-go/pkg/content"
+	logrus "github.com/sirupsen/logrus"
+	orascontent "oras.land/oras-go/pkg/content"
 	orascontext "oras.land/oras-go/pkg/context"
-	"oras.land/oras-go/pkg/oras"
+	oras "oras.land/oras-go/pkg/oras"
 )
 
 // Code from Helm Registry Client. Copied here since it belongs to a internal package.
@@ -75,7 +75,7 @@ type ChartPuller interface {
 
 // OCIPuller implements ChartPuller
 type OCIPuller struct {
-	Resolver remotes.Resolver
+	Resolver containerdremotes.Resolver
 }
 
 // Code from Helm Registry Client. Copied here since it belongs to a internal package.
@@ -86,7 +86,7 @@ type OCIPuller struct {
 // https://github.com/helm/helm/blob/v3.7.1/internal/experimental/registry/client.go#L209
 func (p *OCIPuller) PullOCIChart(ociFullName string) (*bytes.Buffer, string, error) {
 	ociFullName = strings.TrimPrefix(ociFullName, fmt.Sprintf("%s://", OCIScheme))
-	store := content.NewMemoryStore()
+	store := orascontent.NewMemoryStore()
 	allowedMediaTypes := []string{
 		ConfigMediaType,
 	}

--- a/pkg/helm/index.go
+++ b/pkg/helm/index.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"sort"
 
-	"github.com/ghodss/yaml"
-	"github.com/jinzhu/copier"
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
+	yaml "github.com/ghodss/yaml"
+	copier "github.com/jinzhu/copier"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
 	helmrepo "helm.sh/helm/v3/pkg/repo"
 	log "k8s.io/klog/v2"
 )
@@ -27,8 +27,8 @@ func parseRepoIndex(contents []byte) (*helmrepo.IndexFile, error) {
 
 // Takes an entry from the index and constructs a model representation of the
 // object.
-func newChart(entry helmrepo.ChartVersions, r *models.Repo, shallow bool) models.Chart {
-	var c models.Chart
+func newChart(entry helmrepo.ChartVersions, r *chartmodels.Repo, shallow bool) chartmodels.Chart {
+	var c chartmodels.Chart
 	copier.Copy(&c, entry[0])
 	if shallow {
 		copier.Copy(&c.ChartVersions, []helmrepo.ChartVersion{*entry[0]})
@@ -47,11 +47,11 @@ func newChart(entry helmrepo.ChartVersions, r *models.Repo, shallow bool) models
 // all Chart models from that index. The shallow flag controls whether only the latest version of the charts is returned
 // or all versions
 //
-func ChartsFromIndex(contents []byte, r *models.Repo, shallow bool) ([]models.Chart, error) {
-	var charts []models.Chart
+func ChartsFromIndex(contents []byte, r *chartmodels.Repo, shallow bool) ([]chartmodels.Chart, error) {
+	var charts []chartmodels.Chart
 	index, err := parseRepoIndex(contents)
 	if err != nil {
-		return []models.Chart{}, err
+		return []chartmodels.Chart{}, err
 	}
 	for key, entry := range index.Entries {
 		// note that 'entry' itself is an array of chart versions

--- a/pkg/helm/index_test.go
+++ b/pkg/helm/index_test.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/kubeapps/kubeapps/pkg/chart/models"
-	"github.com/stretchr/testify/assert"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
+	assert "github.com/stretchr/testify/assert"
 )
 
 var validRepoIndexYAMLBytes, _ = ioutil.ReadFile("testdata/valid-index.yaml")
@@ -37,7 +37,7 @@ func Test_parseRepoIndex(t *testing.T) {
 }
 
 func Test_chartsFromIndex(t *testing.T) {
-	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
+	r := &chartmodels.Repo{Name: "test", URL: "http://testrepo.com"}
 	charts, err := ChartsFromIndex([]byte(validRepoIndexYAML), r, false)
 	assert.NoError(t, err)
 	assert.Equal(t, len(charts), 2, "number of charts")
@@ -53,7 +53,7 @@ func Test_chartsFromIndex(t *testing.T) {
 }
 
 func Test_shallowChartsFromIndex(t *testing.T) {
-	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
+	r := &chartmodels.Repo{Name: "test", URL: "http://testrepo.com"}
 	charts, err := ChartsFromIndex([]byte(validRepoIndexYAML), r, true)
 	assert.NoError(t, err)
 	assert.Equal(t, len(charts), 2, "number of charts")
@@ -61,7 +61,7 @@ func Test_shallowChartsFromIndex(t *testing.T) {
 }
 
 func Test_newChart(t *testing.T) {
-	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
+	r := &chartmodels.Repo{Name: "test", URL: "http://testrepo.com"}
 	index, _ := parseRepoIndex([]byte(validRepoIndexYAML))
 	c := newChart(index.Entries["wordpress"], r, false)
 	assert.Equal(t, c.Name, "wordpress", "correctly built")
@@ -72,7 +72,7 @@ func Test_newChart(t *testing.T) {
 }
 
 func Test_loadRepoWithEmptyCharts(t *testing.T) {
-	r := &models.Repo{Name: "test", URL: "http://testrepo.com"}
+	r := &chartmodels.Repo{Name: "test", URL: "http://testrepo.com"}
 	indexWithEmptyChart := validRepoIndexYAML + `emptyChart: []`
 	charts, err := ChartsFromIndex([]byte(indexWithEmptyChart), r, true)
 	assert.NoError(t, err)

--- a/pkg/helm/test/utils.go
+++ b/pkg/helm/test/utils.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kubeapps/kubeapps/pkg/helm"
+	helmutils "github.com/kubeapps/kubeapps/pkg/helm"
 )
 
 // CheckHeader verifies that the given puller contains the given header
-func CheckHeader(t *testing.T, puller helm.ChartPuller, key, value string) {
+func CheckHeader(t *testing.T, puller helmutils.ChartPuller, key, value string) {
 	// The header property is private so we need to use reflect to get its value
-	resolver := puller.(*helm.OCIPuller).Resolver
+	resolver := puller.(*helmutils.OCIPuller).Resolver
 	resolverValue := reflect.ValueOf(resolver)
 	headerValue := reflect.Indirect(resolverValue).FieldByName("header")
 	got := fmt.Sprintf("%v", headerValue)

--- a/pkg/http-client/httpclient_test.go
+++ b/pkg/http-client/httpclient_test.go
@@ -5,10 +5,9 @@ package httpclient
 
 import (
 	"crypto/x509"
-	errors "errors"
+	"errors"
 	"net/http"
 	"net/url"
-
 	"testing"
 )
 

--- a/pkg/kube/fake.go
+++ b/pkg/kube/fake.go
@@ -6,20 +6,20 @@ package kube
 import (
 	"io"
 
-	v1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
-	authorizationapi "k8s.io/api/authorization/v1"
-	corev1 "k8s.io/api/core/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
+	k8sauthorizationv1 "k8s.io/api/authorization/v1"
+	k8scorev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // FakeHandler represents a fake Handler for testing purposes
 type FakeHandler struct {
-	AppRepos    []*v1alpha1.AppRepository
-	CreatedRepo *v1alpha1.AppRepository
-	UpdatedRepo *v1alpha1.AppRepository
-	Namespaces  []corev1.Namespace
-	Secrets     []*corev1.Secret
+	AppRepos    []*apprepov1alpha1.AppRepository
+	CreatedRepo *apprepov1alpha1.AppRepository
+	UpdatedRepo *apprepov1alpha1.AppRepository
+	Namespaces  []k8scorev1.Namespace
+	Secrets     []*k8scorev1.Secret
 	ValRes      *ValidationResponse
 	Options     KubeOptions
 	Err         error
@@ -42,8 +42,8 @@ func (c *FakeHandler) GetOptions() KubeOptions {
 }
 
 // ListAppRepositories fake
-func (c *FakeHandler) ListAppRepositories(requestNamespace string) (*v1alpha1.AppRepositoryList, error) {
-	appRepos := &v1alpha1.AppRepositoryList{}
+func (c *FakeHandler) ListAppRepositories(requestNamespace string) (*apprepov1alpha1.AppRepositoryList, error) {
+	appRepos := &apprepov1alpha1.AppRepositoryList{}
 	for _, repo := range c.AppRepos {
 		appRepos.Items = append(appRepos.Items, *repo)
 	}
@@ -51,18 +51,18 @@ func (c *FakeHandler) ListAppRepositories(requestNamespace string) (*v1alpha1.Ap
 }
 
 // CreateAppRepository fake
-func (c *FakeHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error) {
+func (c *FakeHandler) CreateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*apprepov1alpha1.AppRepository, error) {
 	c.AppRepos = append(c.AppRepos, c.CreatedRepo)
 	return c.CreatedRepo, c.Err
 }
 
 // RefreshAppRepository fake
-func (c *FakeHandler) RefreshAppRepository(repoName string, requestNamespace string) (*v1alpha1.AppRepository, error) {
+func (c *FakeHandler) RefreshAppRepository(repoName string, requestNamespace string) (*apprepov1alpha1.AppRepository, error) {
 	return c.UpdatedRepo, c.Err
 }
 
 // UpdateAppRepository fake
-func (c *FakeHandler) UpdateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*v1alpha1.AppRepository, error) {
+func (c *FakeHandler) UpdateAppRepository(appRepoBody io.ReadCloser, requestNamespace string) (*apprepov1alpha1.AppRepository, error) {
 	return c.UpdatedRepo, c.Err
 }
 
@@ -72,7 +72,7 @@ func (c *FakeHandler) DeleteAppRepository(name, namespace string) error {
 }
 
 // GetAppRepository fake
-func (c *FakeHandler) GetAppRepository(name, namespace string) (*v1alpha1.AppRepository, error) {
+func (c *FakeHandler) GetAppRepository(name, namespace string) (*apprepov1alpha1.AppRepository, error) {
 	if c.Err != nil {
 		return nil, c.Err
 	}
@@ -81,11 +81,11 @@ func (c *FakeHandler) GetAppRepository(name, namespace string) (*v1alpha1.AppRep
 			return r, nil
 		}
 	}
-	return nil, k8sErrors.NewNotFound(schema.GroupResource{}, "foo")
+	return nil, k8serrors.NewNotFound(k8sschema.GroupResource{}, "foo")
 }
 
 // GetNamespaces fake
-func (c *FakeHandler) GetNamespaces(precheckedNamespaces []corev1.Namespace) ([]corev1.Namespace, error) {
+func (c *FakeHandler) GetNamespaces(precheckedNamespaces []k8scorev1.Namespace) ([]k8scorev1.Namespace, error) {
 	if len(precheckedNamespaces) > 0 {
 		return precheckedNamespaces, c.Err
 	}
@@ -93,13 +93,13 @@ func (c *FakeHandler) GetNamespaces(precheckedNamespaces []corev1.Namespace) ([]
 }
 
 // GetSecret fake
-func (c *FakeHandler) GetSecret(name, namespace string) (*corev1.Secret, error) {
+func (c *FakeHandler) GetSecret(name, namespace string) (*k8scorev1.Secret, error) {
 	for _, r := range c.Secrets {
 		if r.Name == name && r.Namespace == namespace {
 			return r, nil
 		}
 	}
-	return nil, k8sErrors.NewNotFound(schema.GroupResource{}, "foo")
+	return nil, k8serrors.NewNotFound(k8sschema.GroupResource{}, "foo")
 }
 
 // ValidateAppRepository fake
@@ -113,6 +113,6 @@ func (c *FakeHandler) GetOperatorLogo(namespace, name string) ([]byte, error) {
 }
 
 // CanI fake
-func (c *FakeHandler) CanI(resourceAttributes *authorizationapi.ResourceAttributes) (bool, error) {
+func (c *FakeHandler) CanI(resourceAttributes *k8sauthorizationv1.ResourceAttributes) (bool, error) {
 	return c.Can, c.Err
 }

--- a/pkg/kube/pinniped_proxy_roundtripper.go
+++ b/pkg/kube/pinniped_proxy_roundtripper.go
@@ -3,7 +3,9 @@
 
 package kube
 
-import "net/http"
+import (
+	"net/http"
+)
 
 // pinnipedProxyRoundTripper is a round tripper that additionally sets
 // any required headers for the exchange of credentials and request proxying.

--- a/pkg/kube/pinniped_proxy_roundtripper_test.go
+++ b/pkg/kube/pinniped_proxy_roundtripper_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	cmp "github.com/google/go-cmp/cmp"
 )
 
 type fakeRoundTripper struct{}

--- a/pkg/response/response_test.go
+++ b/pkg/response/response_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	assert "github.com/stretchr/testify/assert"
 )
 
 type resource struct {

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -12,7 +12,7 @@ import (
 	"path"
 	"strings"
 
-	chart "github.com/kubeapps/kubeapps/pkg/chart/models"
+	chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
 )
 
@@ -75,10 +75,10 @@ func FetchChartDetailFromTarball(reader io.Reader, name string) (map[string]stri
 	schemaFileName := fixedName + "/values.schema.json"
 	chartYamlFileName := fixedName + "/Chart.yaml"
 	filenames := map[string]string{
-		chart.ValuesKey:    valuesFileName,
-		chart.ReadmeKey:    readmeFileName,
-		chart.SchemaKey:    schemaFileName,
-		chart.ChartYamlKey: chartYamlFileName,
+		chartmodels.ValuesKey:    valuesFileName,
+		chartmodels.ReadmeKey:    readmeFileName,
+		chartmodels.SchemaKey:    schemaFileName,
+		chartmodels.ChartYamlKey: chartYamlFileName,
 	}
 
 	files, err := ExtractFilesFromTarball(filenames, tarf)
@@ -87,10 +87,10 @@ func FetchChartDetailFromTarball(reader io.Reader, name string) (map[string]stri
 	}
 
 	return map[string]string{
-		chart.ValuesKey:    files[chart.ValuesKey],
-		chart.ReadmeKey:    files[chart.ReadmeKey],
-		chart.SchemaKey:    files[chart.SchemaKey],
-		chart.ChartYamlKey: files[chart.ChartYamlKey],
+		chartmodels.ValuesKey:    files[chartmodels.ValuesKey],
+		chartmodels.ReadmeKey:    files[chartmodels.ReadmeKey],
+		chartmodels.SchemaKey:    files[chartmodels.SchemaKey],
+		chartmodels.ChartYamlKey: files[chartmodels.ChartYamlKey],
 	}, nil
 }
 

--- a/pkg/tarutil/tarutil_test.go
+++ b/pkg/tarutil/tarutil_test.go
@@ -10,27 +10,27 @@ import (
 	"io"
 	"testing"
 
-	"github.com/kubeapps/kubeapps/pkg/tarutil/test"
-	"github.com/stretchr/testify/assert"
+	tartest "github.com/kubeapps/kubeapps/pkg/tarutil/test"
+	assert "github.com/stretchr/testify/assert"
 )
 
 func Test_extractFilesFromTarball(t *testing.T) {
 	tests := []struct {
 		name     string
-		files    []test.TarballFile
+		files    []tartest.TarballFile
 		filename string
 		want     string
 	}{
-		{"file", []test.TarballFile{{Name: "file.txt", Body: "best file ever"}}, "file.txt", "best file ever"},
-		{"multiple file tarball", []test.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "file2.txt", Body: "worst file ever"}}, "file2.txt", "worst file ever"},
-		{"file in dir", []test.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "test/file2.txt", Body: "worst file ever"}}, "test/file2.txt", "worst file ever"},
-		{"filename ignore case", []test.TarballFile{{Name: "Readme.md", Body: "# readme for chart"}, {Name: "values.yaml", Body: "key: value"}}, "README.md", "# readme for chart"},
+		{"file", []tartest.TarballFile{{Name: "file.txt", Body: "best file ever"}}, "file.txt", "best file ever"},
+		{"multiple file tarball", []tartest.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "file2.txt", Body: "worst file ever"}}, "file2.txt", "worst file ever"},
+		{"file in dir", []tartest.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "test/file2.txt", Body: "worst file ever"}}, "test/file2.txt", "worst file ever"},
+		{"filename ignore case", []tartest.TarballFile{{Name: "Readme.md", Body: "# readme for chart"}, {Name: "values.yaml", Body: "key: value"}}, "README.md", "# readme for chart"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var b bytes.Buffer
-			test.CreateTestTarball(&b, tt.files)
+			tartest.CreateTestTarball(&b, tt.files)
 			r := bytes.NewReader(b.Bytes())
 			tarf := tar.NewReader(r)
 			files, err := ExtractFilesFromTarball(map[string]string{tt.filename: tt.filename}, tarf)
@@ -41,8 +41,8 @@ func Test_extractFilesFromTarball(t *testing.T) {
 
 	t.Run("extract multiple files", func(t *testing.T) {
 		var b bytes.Buffer
-		tFiles := []test.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "file2.txt", Body: "worst file ever"}}
-		test.CreateTestTarball(&b, tFiles)
+		tFiles := []tartest.TarballFile{{Name: "file.txt", Body: "best file ever"}, {Name: "file2.txt", Body: "worst file ever"}}
+		tartest.CreateTestTarball(&b, tFiles)
 		r := bytes.NewReader(b.Bytes())
 		tarf := tar.NewReader(r)
 		files, err := ExtractFilesFromTarball(map[string]string{tFiles[0].Name: tFiles[0].Name, tFiles[1].Name: tFiles[1].Name}, tarf)
@@ -55,7 +55,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 
 	t.Run("file not found", func(t *testing.T) {
 		var b bytes.Buffer
-		test.CreateTestTarball(&b, []test.TarballFile{{Name: "file.txt", Body: "best file ever"}})
+		tartest.CreateTestTarball(&b, []tartest.TarballFile{{Name: "file.txt", Body: "best file ever"}})
 		r := bytes.NewReader(b.Bytes())
 		tarf := tar.NewReader(r)
 		name := "file2.txt"

--- a/pkg/yamlutil/yamlutil.go
+++ b/pkg/yamlutil/yamlutil.go
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-package yaml
+package yamlutil
 
 import (
 	"bufio"
@@ -9,22 +9,22 @@ import (
 	"io"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/yaml"
+	k8smetaunstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8syamlutil "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // This function was taken from Kubecfg:
 // https://github.com/ksonnet/kubecfg/blob/9be86f33f20342024dafbd2dd0a4463f3ec96a27/utils/acquire.go#L211
-func flattenToV1(objs []runtime.Object) []*unstructured.Unstructured {
-	ret := make([]*unstructured.Unstructured, 0, len(objs))
+func flattenToV1(objs []k8sruntime.Object) []*k8smetaunstructuredv1.Unstructured {
+	ret := make([]*k8smetaunstructuredv1.Unstructured, 0, len(objs))
 	for _, obj := range objs {
 		switch o := obj.(type) {
-		case *unstructured.UnstructuredList:
+		case *k8smetaunstructuredv1.UnstructuredList:
 			for i := range o.Items {
 				ret = append(ret, &o.Items[i])
 			}
-		case *unstructured.Unstructured:
+		case *k8smetaunstructuredv1.Unstructured:
 			ret = append(ret, o)
 		default:
 			panic("Unexpected unstructured object type")
@@ -34,10 +34,10 @@ func flattenToV1(objs []runtime.Object) []*unstructured.Unstructured {
 }
 
 // ParseObjects returns an Unstructured object list based on the content of a YAML manifest
-func ParseObjects(manifest string) ([]*unstructured.Unstructured, error) {
+func ParseObjects(manifest string) ([]*k8smetaunstructuredv1.Unstructured, error) {
 	r := strings.NewReader(manifest)
-	decoder := yaml.NewYAMLReader(bufio.NewReader(r))
-	ret := []runtime.Object{}
+	decoder := k8syamlutil.NewYAMLReader(bufio.NewReader(r))
+	ret := []k8sruntime.Object{}
 	nullResult := []byte("null")
 
 	for {
@@ -49,7 +49,7 @@ func ParseObjects(manifest string) ([]*unstructured.Unstructured, error) {
 			return nil, err
 		}
 
-		jsondata, err := yaml.ToJSON(objManifest)
+		jsondata, err := k8syamlutil.ToJSON(objManifest)
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func ParseObjects(manifest string) ([]*unstructured.Unstructured, error) {
 			continue
 		}
 
-		obj, _, err := unstructured.UnstructuredJSONScheme.Decode(jsondata, nil, nil)
+		obj, _, err := k8smetaunstructuredv1.UnstructuredJSONScheme.Decode(jsondata, nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/yamlutil/yamlutil_test.go
+++ b/pkg/yamlutil/yamlutil_test.go
@@ -1,7 +1,7 @@
 // Copyright 2018-2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-package yaml
+package yamlutil
 
 import (
 	"testing"


### PR DESCRIPTION
### Description of the change

First of all, apologies in advance for this series of endless PRs I'm sending this iteration :smile:  Except for some clean-up PRs once we finally deprecate asstesvc, kubeops, etc, I'd bet this is one of the last huge-PR.

While working on https://github.com/kubeapps/kubeapps/issues/3848, I noticed there were several dependencies being imported with no rationale underlying, leading to situations like: 1) a dep being imported multiple times but with different names; 2) inconsistent names for the same dependency across the codebase.

I tried to look for widespread good practices, but, to the best of my knowledge, there isn't any. Later on,  I came across the [code autogenerated by k8s for CRD controllers](https://github.com/kubernetes/sample-controller/blob/master/pkg/generated/clientset/versioned/clientset.go) and noticed they were adding an alias regardless of the actual dependency name (ie, no matter if it's the same).

So I've decided to go this way, and that's what this PR is for: adding an alias to every dependency in our codebase.

### Benefits

Even if the IDEs are smart enough to follow imports, find references, etc, sometimes (IMHO), nothing is more effective but performing a text search when developing. 
If each dep is imported each time with a different name, it is simply impossible. 
A couple of examples:

- Unequivocally way to discern if a `v1alpha1.xxx` is the package core API or the fluxv2 plugin one.
- Easy bulk renames with F2 in the IDE
- Easy way to identify dependencies that don't use the last fragment of their path as the pkg name.

### Possible drawbacks

I know go defaults to the package name of the imported dep, so doing the opposite could be seen like going against the "go-way", but apart from that, don't see any cons.

### Applicable issues

- rel #3848

### Additional information

The upcoming PRs use this one as a prequel.

#### Appendix

Find below the list of unique deps and the chosen alias. Happy to rename if you come up with a better name!

```Dockerfile
anypb "google.golang.org/protobuf/types/known/anypb"
apiscmd "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/cmd"
apiscore "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
apisserver "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
apprepo "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository"
apprepoclient "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
apprepoctrlcmd "github.com/kubeapps/kubeapps/cmd/apprepository-controller/cmd"
apprepoctrlserver "github.com/kubeapps/kubeapps/cmd/apprepository-controller/server"
apprepofakeclientset "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/fake"
apprepoinformers "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/informers/externalversions"
apprepolisters "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/listers/apprepository/v1alpha1"
appreposcheme "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/scheme"
appreposignals "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/signals"
apprepotypedv1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/typed/apprepository/v1alpha1"
apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
assert "github.com/stretchr/testify/assert"
assetmanager "github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
assetsvccmd "github.com/kubeapps/kubeapps/cmd/assetsvc/cmd"
assetsvcserver "github.com/kubeapps/kubeapps/cmd/assetsvc/server"
assetsyncercmd "github.com/kubeapps/kubeapps/cmd/asset-syncer/cmd"
assetsyncerserver "github.com/kubeapps/kubeapps/cmd/asset-syncer/server"
authutils "github.com/kubeapps/kubeapps/pkg/auth"
chartmodels "github.com/kubeapps/kubeapps/pkg/chart/models"
chartutils "github.com/kubeapps/kubeapps/pkg/chart"
chartutilsfake "github.com/kubeapps/kubeapps/pkg/chart/fake"
clientgetter "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/clientgetter"
cmp "github.com/google/go-cmp/cmp"
cmpopts "github.com/google/go-cmp/cmp/cmpopts"
cmux "github.com/soheilhy/cmux"
cobra "github.com/spf13/cobra"
containerddocker "github.com/containerd/containerd/remotes/docker"
containerdremotes "github.com/containerd/containerd/remotes"
copier "github.com/jinzhu/copier"
dbutils "github.com/kubeapps/kubeapps/pkg/dbutils"
dbutilstest "github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest"
distributionreference "github.com/distribution/distribution/reference"
gojq "github.com/itchyny/gojq"
grpc "google.golang.org/grpc"
grpccodes "google.golang.org/grpc/codes"
grpcgwruntime "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
grpcmetadata "google.golang.org/grpc/metadata"
grpcreflection "google.golang.org/grpc/reflection"
grpcstatus "google.golang.org/grpc/status"
grpcweb "github.com/improbable-eng/grpc-web/go/grpcweb"
handlerutil "github.com/kubeapps/kubeapps/pkg/handlerutil"
healthcheck "github.com/heptiolabs/healthcheck"
helmaction "helm.sh/helm/v3/pkg/action"
helmagent "github.com/kubeapps/kubeapps/pkg/agent"
helmchart "helm.sh/helm/v3/pkg/chart"
helmchartloader "helm.sh/helm/v3/pkg/chart/loader"
helmchartutil "helm.sh/helm/v3/pkg/chartutil"
helmfake "github.com/kubeapps/kubeapps/pkg/helm/fake"
helmkube "helm.sh/helm/v3/pkg/kube"
helmkubefake "helm.sh/helm/v3/pkg/kube/fake"
helmrelease "helm.sh/helm/v3/pkg/release"
helmrepo "helm.sh/helm/v3/pkg/repo"
helmstorage "helm.sh/helm/v3/pkg/storage"
helmstoragedriver "helm.sh/helm/v3/pkg/storage/driver"
helmtest "github.com/kubeapps/kubeapps/pkg/helm/test"
helmtime "helm.sh/helm/v3/pkg/time"
helmutils "github.com/kubeapps/kubeapps/pkg/helm"
homedir "github.com/mitchellh/go-homedir"
httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
httphandler "github.com/kubeapps/kubeapps/pkg/http-handler"
httpproxy "golang.org/x/net/http/httpproxy"
imaging "github.com/disintegration/imaging"
k8discoveryclient "k8s.io/client-go/discovery"
k8discoveryclientfake "k8s.io/client-go/discovery/fake"
k8dynamicclient "k8s.io/client-go/dynamic"
k8dynamicclientfake "k8s.io/client-go/dynamic/fake"
k8sapiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
k8sapiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
k8sapiextensionsclientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
k8sapiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
k8sappsv1 "k8s.io/api/apps/v1"
k8sauthorizationv1 "k8s.io/api/authorization/v1"
k8sbatchlistersv1 "k8s.io/client-go/listers/batch/v1"
k8sbatchv1 "k8s.io/api/batch/v1"
k8scorev1 "k8s.io/api/core/v1"
k8scredentialprovider "k8s.io/kubernetes/pkg/credentialprovider"
k8sdiskcached "k8s.io/client-go/discovery/cached/disk"
k8serrors "k8s.io/apimachinery/pkg/api/errors"
k8serrorsutil "k8s.io/apimachinery/pkg/util/errors"
k8sgenericclioptions "k8s.io/cli-runtime/pkg/genericclioptions"
k8sinformers "k8s.io/client-go/informers"
k8sjsonutil "k8s.io/apimachinery/pkg/util/json"
k8smeta "k8s.io/apimachinery/pkg/api/meta"
k8smetaunstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
k8srbacv1 "k8s.io/api/rbac/v1"
k8srest "k8s.io/client-go/rest"
k8srestfake "k8s.io/client-go/rest/fake"
k8srestmapper "k8s.io/client-go/restmapper"
k8sruntime "k8s.io/apimachinery/pkg/runtime"
k8sruntimeutil "k8s.io/apimachinery/pkg/util/runtime"
k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
k8sscheme "k8s.io/client-go/kubernetes/scheme"
k8sserializer "k8s.io/apimachinery/pkg/runtime/serializer"
k8ssets "k8s.io/apimachinery/pkg/util/sets"
k8sspdy "k8s.io/client-go/transport/spdy"
k8sstructuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
k8stesting "k8s.io/client-go/testing"
k8stoolscache "k8s.io/client-go/tools/cache"
k8stoolsclientcmd "k8s.io/client-go/tools/clientcmd"
k8stoolsclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
k8stoolsportforward "k8s.io/client-go/tools/portforward"
k8stoolsrecord "k8s.io/client-go/tools/record"
k8stoolswatch "k8s.io/client-go/tools/watch"
k8stypedauthorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
k8stypedclient "k8s.io/client-go/kubernetes"
k8stypedclientfake "k8s.io/client-go/kubernetes/fake"
k8stypedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
k8stypedfakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
k8stypes "k8s.io/apimachinery/pkg/types"
k8swait "k8s.io/apimachinery/pkg/util/wait"
k8swatch "k8s.io/apimachinery/pkg/watch"
k8sworkqueue "k8s.io/client-go/util/workqueue"
k8syamlutil "k8s.io/apimachinery/pkg/util/yaml"
k8typedsauthorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
k8workqueue "k8s.io/client-go/util/workqueue"
kappapp "github.com/k14s/kapp/pkg/kapp/app" 
kappcmdapp "github.com/k14s/kapp/pkg/kapp/cmd/app"
kappcmdcore "github.com/k14s/kapp/pkg/kapp/cmd/core"
kappcmdtools "github.com/k14s/kapp/pkg/kapp/cmd/tools"
kappctrldatapackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
kappctrlpackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
kappctrlv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
kapplogger "github.com/k14s/kapp/pkg/kapp/logger"
kappresources "github.com/k14s/kapp/pkg/kapp/resources"
kubeopscmd "github.com/kubeapps/kubeapps/cmd/kubeops/cmd"
kubeopshandler "github.com/kubeapps/kubeapps/cmd/kubeops/internal/handler"
kubeopsserver "github.com/kubeapps/kubeapps/cmd/kubeops/server"
kubeutils "github.com/kubeapps/kubeapps/pkg/kube"
linq "github.com/ahmetb/go-linq/v3"
log "github.com/sirupsen/logrus"
log "k8s.io/klog/v2"
mux "github.com/gorilla/mux"
negroni "github.com/urfave/negroni/v2"
ocispec "github.com/opencontainers/image-spec/specs-go/v1"
oksvg "github.com/srwiley/oksvg"
paginate "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/paginate"
pflag "github.com/spf13/pflag"
pgtest "github.com/kubeapps/kubeapps/pkg/dbutils/dbutilstest/pgtest"
pkgfluxv2cache "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache"
pkgfluxv2common "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
pkgfluxv2v1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
pkghelmv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/helm/packages/v1alpha1"
pkgkappv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
pkgsgrpcv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
pkgsv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core/packages/v1alpha1"
pkgutils "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
pluginsgrpcv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
pluginsgrpcv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
pluginsv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core/plugins/v1alpha1"
pluginsv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
plugintest "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugin_test"
protojson "google.golang.org/protobuf/encoding/protojson"
rasterx "github.com/srwiley/rasterx"
redis "github.com/go-redis/redis/v8"
redismock "github.com/go-redis/redismock/v8"
resourcerefs "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/resourcerefs"
resourcerefstest "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/resourcerefs/resourcerefstest"
resourcesgrpcv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
responseutils "github.com/kubeapps/kubeapps/pkg/response"
runtime "k8s.io/apimachinery/pkg/runtime"
semver "github.com/masterminds/semver/v3"
sqlmock "github.com/data-dog/go-sqlmock"
statuserror "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/statuserror"
tartest "github.com/kubeapps/kubeapps/pkg/tarutil/test"
tarutil "github.com/kubeapps/kubeapps/pkg/tarutil"
ui "github.com/cppforlife/go-cli-ui/ui"
vendirversionsv1alpha1 "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1"
viper "github.com/spf13/viper"
yamlutil "github.com/kubeapps/kubeapps/pkg/yamlutil"
``` 