### PR TITLE
Use the same cmd args in every cmd-based application

### DIFF
--- a/cmd/apprepository-controller/cmd/root.go
+++ b/cmd/apprepository-controller/cmd/root.go
@@ -4,14 +4,14 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
+	"flag"
 	"strings"
 
 	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/server"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
 	corev1 "k8s.io/api/core/v1"
 	log "k8s.io/klog/v2"
 )
@@ -49,10 +49,17 @@ func Execute() {
 }
 
 func init() {
+	log.InitFlags(nil)
 	cobra.OnInitialize(initConfig)
 	rootCmd = newRootCmd()
 	rootCmd.SetVersionTemplate(version)
 	setFlags(rootCmd)
+	//set initial value of verbosity
+	err := flag.Set("v", "3")
+	if err != nil {
+		log.Errorf("Error parsing verbosity: %v", viper.ConfigFileUsed())
+	}
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	serveOpts.ImagePullSecretsRefs = getImagePullSecretsRefs(serveOpts.RepoSyncImagePullSecrets)
 	serveOpts.ParsedCustomAnnotations = parseLabelsAnnotations(serveOpts.CustomAnnotations)
 	serveOpts.ParsedCustomLabels = parseLabelsAnnotations(serveOpts.CustomLabels)
@@ -89,7 +96,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		// Find home directory.
-		home, err := os.UserHomeDir()
+		home, err := homedir.Dir()
 		cobra.CheckErr(err)
 
 		// Search config in home directory with name ".kubeops" (without extension).
@@ -102,7 +109,7 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Errorf("Using config file: %v", viper.ConfigFileUsed())
 	}
 }
 

--- a/cmd/asset-syncer/cmd/root.go
+++ b/cmd/asset-syncer/cmd/root.go
@@ -4,13 +4,14 @@
 package cmd
 
 import (
-	"fmt"
+	"flag"
 	"os"
 
 	"github.com/kubeapps/kubeapps/cmd/asset-syncer/server"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
 	log "k8s.io/klog/v2"
 )
 
@@ -82,7 +83,14 @@ func Execute() {
 }
 
 func init() {
+	log.InitFlags(nil)
 	cobra.OnInitialize(initConfig)
+	//set initial value of verbosity
+	err := flag.Set("v", "3")
+	if err != nil {
+		log.Errorf("Error parsing verbosity: %v", viper.ConfigFileUsed())
+	}
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	// Create new commands
 	rootCmd = newRootCmd()
@@ -135,7 +143,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		// Find home directory.
-		home, err := os.UserHomeDir()
+		home, err := homedir.Dir()
 		cobra.CheckErr(err)
 
 		// Search config in home directory with name ".kubeops" (without extension).
@@ -148,6 +156,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Errorf("Using config file: %v", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/assetsvc/cmd/root.go
+++ b/cmd/assetsvc/cmd/root.go
@@ -4,11 +4,13 @@
 package cmd
 
 import (
-	"fmt"
+	"flag"
 	"os"
 
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/server"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	log "k8s.io/klog/v2"
 )
@@ -45,7 +47,14 @@ func Execute() {
 }
 
 func init() {
+	log.InitFlags(nil)
 	cobra.OnInitialize(initConfig)
+	//set initial value of verbosity
+	err := flag.Set("v", "3")
+	if err != nil {
+		log.Errorf("Error parsing verbosity: %v", viper.ConfigFileUsed())
+	}
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	rootCmd = newRootCmd()
 	rootCmd.SetVersionTemplate(version)
 	setFlags(rootCmd)
@@ -68,7 +77,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		// Find home directory.
-		home, err := os.UserHomeDir()
+		home, err := homedir.Dir()
 		cobra.CheckErr(err)
 
 		// Search config in home directory with name ".kubeops" (without extension).
@@ -81,6 +90,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Errorf("Using config file: %v", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/kubeapps-apis/Makefile
+++ b/cmd/kubeapps-apis/Makefile
@@ -26,7 +26,7 @@ generate:
 	buf generate
 
 run: build-plugins
-	go run main.go --plugin-dir devel/ --unsafe-use-demo-sa=true --unsafe-local-dev-kubeconfig=true
+	go run main.go --plugin-dir devel/ --unsafe-local-dev-kubeconfig=true
 
 test:
 	go test ./...

--- a/cmd/kubeapps-apis/cmd/root.go
+++ b/cmd/kubeapps-apis/cmd/root.go
@@ -4,15 +4,12 @@
 package cmd
 
 import (
-	goflag "flag"
-	"fmt"
-	"os"
+	"flag"
 
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	log "k8s.io/klog/v2"
 )
@@ -59,8 +56,10 @@ func init() {
 	rootCmd.SetVersionTemplate(version)
 	setFlags(rootCmd)
 	//set initial value of verbosity
-	goflag.Set("v", "3")
-	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	err := flag.Set("v", "3")
+	if err != nil {
+		log.Errorf("Error parsing verbosity: %v", viper.ConfigFileUsed())
+	}
 }
 
 func setFlags(c *cobra.Command) {
@@ -95,6 +94,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Errorf("Using config file: %v", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/kubeops/cmd/root.go
+++ b/cmd/kubeops/cmd/root.go
@@ -5,9 +5,9 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/kubeapps/kubeapps/cmd/kubeops/server"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	log "k8s.io/klog/v2"
@@ -75,7 +75,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		// Find home directory.
-		home, err := os.UserHomeDir()
+		home, err := homedir.Dir()
 		cobra.CheckErr(err)
 
 		// Search config in home directory with name ".kubeops" (without extension).
@@ -88,7 +88,7 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Errorf("Using config file: %v", viper.ConfigFileUsed())
 	}
 }
 

--- a/pkg/agent/httpConfigForCluster.go
+++ b/pkg/agent/httpConfigForCluster.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/go-homedir"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
@@ -16,7 +17,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 )
 
 // configForCluster implements the genericclioptions.RESTClientGetter interface
@@ -55,7 +55,11 @@ func (f *configForCluster) ToDiscoveryClient() (discovery.CachedDiscoveryInterfa
 	// double it just so we don't end up here again for a while.  This config is only used for discovery.
 	config.Burst = f.discoveryBurst
 
-	cacheDir := filepath.Join(homedir.HomeDir(), ".kube", "cache")
+	home, err := homedir.Dir()
+	if err != nil {
+		return nil, err
+	}
+	cacheDir := filepath.Join(home, ".kube", "cache")
 
 	// retrieve a user-provided value for the "cache-dir"
 	// override httpCacheDir and discoveryCacheDir if user-value is given.


### PR DESCRIPTION
### Description of the change

This PR extends https://github.com/kubeapps/kubeapps/pull/4176 in 1) performing some dep renames in the kubeapps-apis cmd with the latest changes introduced some weeks before (default verbosity and homedir); 2) extending those changes to the rest of cobra applications (asset-syncer, kubeops, etc...)

### Benefits

Uniform command-line applications in Kubeapps.

### Possible drawbacks

N/A

### Applicable issues

- rel #3848

### Additional information

N/A
