### PR TITLE
Migrate from go yaml.v2 to yaml.v3

### DIFF
--- a/pkg/agent/docker_secrets_postrenderer.go
+++ b/pkg/agent/docker_secrets_postrenderer.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/distribution/distribution/reference"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+
+	// The usual "sigs.k8s.io/yaml" is not used because we're dealing with unstructured yaml directly
+	yaml "gopkg.in/yaml.v3"
 )
 
 const (
@@ -57,7 +59,7 @@ func NewDockerSecretsPostRenderer(secrets map[string]string) (*DockerSecretsPost
 
 func (r *DockerSecretsPostRenderer) processResourceList(resourceList []interface{}) {
 	for _, resourceItem := range resourceList {
-		resource, ok := resourceItem.(map[interface{}]interface{})
+		resource, ok := resourceItem.(map[string]interface{})
 		if !ok {
 			continue
 		}
@@ -137,7 +139,7 @@ func (r *DockerSecretsPostRenderer) Run(renderedManifests *bytes.Buffer) (modifi
 // - The pod spec includes a 'containers' key with a slice value
 // - Each container value is a map with an 'image' key and string value.
 // An invalid resource doc is logged but left for the k8s API to respond to.
-func (r *DockerSecretsPostRenderer) updatePodSpecWithPullSecrets(podSpec map[interface{}]interface{}) {
+func (r *DockerSecretsPostRenderer) updatePodSpecWithPullSecrets(podSpec map[string]interface{}) {
 	containersObject, ok := podSpec["containers"]
 	if !ok {
 		log.Errorf("podSpec contained no containers key: %+v", podSpec)
@@ -156,7 +158,7 @@ func (r *DockerSecretsPostRenderer) updatePodSpecWithPullSecrets(podSpec map[int
 	existingNames := map[string]bool{}
 	if existingPullSecrets, ok := podSpec["imagePullSecrets"]; ok {
 		for _, s := range existingPullSecrets.([]interface{}) {
-			pullSecret := s.(map[interface{}]interface{})
+			pullSecret := s.(map[string]interface{})
 			if name, ok := pullSecret["name"]; ok {
 				if n, ok := name.(string); ok {
 					existingNames[n] = true
@@ -167,14 +169,14 @@ func (r *DockerSecretsPostRenderer) updatePodSpecWithPullSecrets(podSpec map[int
 	}
 
 	for _, c := range containers {
-		container, ok := c.(map[interface{}]interface{})
+		container, ok := c.(map[string]interface{})
 		if !ok {
 			log.Errorf("pod spec container is not a map: %+v", c)
 			continue
 		}
 		image, ok := container["image"].(string)
 		if !ok {
-			// NOTE: in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core
+			// NOTE: in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
 			// the image is optional to allow higher level config management to default or override (such as
 			// deployments or statefulsets), but both only define pod templates which in turn define containers?
 			log.Errorf("pod spec container does not define an string image: %+v", container)
@@ -212,30 +214,30 @@ func (r *DockerSecretsPostRenderer) updatePodSpecWithPullSecrets(podSpec map[int
 // invalid docs ignored and left for the API server to respond accordingly:
 // - A resource doc is a map with a "kind" key with a string value
 // - A pod resource doc has a "spec" key containing a map
-func getResourcePodSpec(kind string, resource map[interface{}]interface{}) map[interface{}]interface{} {
+func getResourcePodSpec(kind string, resource map[string]interface{}) map[string]interface{} {
 	switch kind {
 	case "Pod":
 		return getMapForKeys([]string{"spec"}, resource)
 	case "DaemonSet", "Deployment", "Job", "ReplicaSet", "ReplicationController", "StatefulSet":
 		// These resources all include a spec.template.spec PodSpec.
-		// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core
+		// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podtemplatespec-v1-core
 		return getMapForKeys([]string{"spec", "template", "spec"}, resource)
 	case "PodTemplate":
 		return getMapForKeys([]string{"template", "spec"}, resource)
 	case "CronJob":
 		// A CronJob spec contains a jobTemplate:
-		// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#cronjobspec-v1beta1-batch
+		// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#cronjobspec-v1beta1-batch
 		return getMapForKeys([]string{"spec", "jobTemplate", "spec", "template", "spec"}, resource)
 	}
 
 	return nil
 }
 
-func getMapForKeys(keys []string, m map[interface{}]interface{}) map[interface{}]interface{} {
+func getMapForKeys(keys []string, m map[string]interface{}) map[string]interface{} {
 	current := m
 	var ok bool
 	for _, k := range keys {
-		current, ok = current[k].(map[interface{}]interface{})
+		current, ok = current[k].(map[string]interface{})
 		if !ok {
 			log.Errorf("invalid resource: non-map %q, in %+v", k, m)
 			return nil

--- a/pkg/agent/docker_secrets_postrenderer_test.go
+++ b/pkg/agent/docker_secrets_postrenderer_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewDockerSecretsPostRenderer(t *testing.T) {
@@ -104,21 +104,21 @@ other: doc
 			output: bytes.NewBuffer([]byte(`apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    annotation-1: some-annotation
-  name: image-secret-test
+    annotations:
+        annotation-1: some-annotation
+    name: image-secret-test
 spec:
-  containers:
-  - command:
-    - sh
-    - -c
-    - echo 'foo'
-    env:
-    - name: SOME_ENV
-      value: env_value
-    image: example.com/bitnami/nginx:1.16.1-debian-10-r42
-    name: container-name
-  restartPolicy: Never
+    containers:
+        - command:
+            - sh
+            - -c
+            - echo 'foo'
+          env:
+            - name: SOME_ENV
+              value: env_value
+          image: example.com/bitnami/nginx:1.16.1-debian-10-r42
+          name: container-name
+    restartPolicy: Never
 ---
 kind: Unknown
 other: doc
@@ -152,23 +152,23 @@ other: doc
 			output: bytes.NewBuffer([]byte(`apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    annotation-1: some-annotation
-  name: image-secret-test
+    annotations:
+        annotation-1: some-annotation
+    name: image-secret-test
 spec:
-  containers:
-  - command:
-    - sh
-    - -c
-    - echo 'foo'
-    env:
-    - name: SOME_ENV
-      value: env_value
-    image: example.com/bitnami/nginx:1.16.1-debian-10-r42
-    name: container-name
-  imagePullSecrets:
-  - name: secret-1
-  restartPolicy: Never
+    containers:
+        - command:
+            - sh
+            - -c
+            - echo 'foo'
+          env:
+            - name: SOME_ENV
+              value: env_value
+          image: example.com/bitnami/nginx:1.16.1-debian-10-r42
+          name: container-name
+    imagePullSecrets:
+        - name: secret-1
+    restartPolicy: Never
 ---
 kind: Unknown
 other: doc
@@ -218,43 +218,43 @@ other: doc
 `)),
 			output: bytes.NewBuffer([]byte(`apiVersion: v1
 items:
-- kind: PodTemplate
-  template:
-    spec:
-      containers:
-      - command:
-        - sh
-        - -c
-        - echo 'foo'
-        env:
-        - name: SOME_ENV
-          value: env_value
-        image: example.com/bitnami/nginx:1.16.1-debian-10-r42
-        name: container-name
-      imagePullSecrets:
-      - name: secret-1
-      restartPolicy: Never
-- kind: PodTemplate
-  template:
-    spec:
-      containers:
-      - command:
-        - sh
-        - -c
-        - echo 'bar'
-        env:
-        - name: SOME_ENV
-          value: env_value
-        image: example.com/bitnami/nginx:1.16.1-debian-10-r42
-        name: container-name
-      imagePullSecrets:
-      - name: secret-1
-      restartPolicy: Never
+    - kind: PodTemplate
+      template:
+        spec:
+            containers:
+                - command:
+                    - sh
+                    - -c
+                    - echo 'foo'
+                  env:
+                    - name: SOME_ENV
+                      value: env_value
+                  image: example.com/bitnami/nginx:1.16.1-debian-10-r42
+                  name: container-name
+            imagePullSecrets:
+                - name: secret-1
+            restartPolicy: Never
+    - kind: PodTemplate
+      template:
+        spec:
+            containers:
+                - command:
+                    - sh
+                    - -c
+                    - echo 'bar'
+                  env:
+                    - name: SOME_ENV
+                      value: env_value
+                  image: example.com/bitnami/nginx:1.16.1-debian-10-r42
+                  name: container-name
+            imagePullSecrets:
+                - name: secret-1
+            restartPolicy: Never
 kind: PodTemplateList
 metadata:
-  annotations:
-    annotation-1: some-annotation
-  name: image-secret-test
+    annotations:
+        annotation-1: some-annotation
+    name: image-secret-test
 ---
 kind: Unknown
 other: doc
@@ -423,7 +423,9 @@ imagePullSecrets:
 				t.Fatalf("%+v", err)
 			}
 
-			var podSpec map[interface{}]interface{}
+			podSpec := make(map[string]interface{})
+
+			// var podSpec interface{}
 			err = yaml.Unmarshal([]byte(tc.podSpec), &podSpec)
 			if err != nil {
 				t.Fatalf("%+v", err)
@@ -441,13 +443,13 @@ func TestGetResourcePodSpec(t *testing.T) {
 	testCases := []struct {
 		name     string
 		kind     string
-		resource map[interface{}]interface{}
-		result   map[interface{}]interface{}
+		resource map[string]interface{}
+		result   map[string]interface{}
 	}{
 		{
 			name: "it ignores an invalid doc with a non-map spec",
 			kind: "Pod",
-			resource: map[interface{}]interface{}{
+			resource: map[string]interface{}{
 				"spec": "not a map",
 			},
 			result: nil,
@@ -455,53 +457,53 @@ func TestGetResourcePodSpec(t *testing.T) {
 		{
 			name: "it returns the pod spec from a pod",
 			kind: "Pod",
-			resource: map[interface{}]interface{}{
-				"spec": map[interface{}]interface{}{"some": "spec"},
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{"some": "spec"},
 			},
-			result: map[interface{}]interface{}{
+			result: map[string]interface{}{
 				"some": "spec",
 			},
 		},
 		{
 			name: "it returns the pod spec from a daemon set",
 			kind: "DaemonSet",
-			resource: map[interface{}]interface{}{
+			resource: map[string]interface{}{
 				"kind": "DaemonSet",
-				"spec": map[interface{}]interface{}{
-					"template": map[interface{}]interface{}{
-						"spec": map[interface{}]interface{}{"some": "spec"},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{"some": "spec"},
 					},
 				},
 			},
-			result: map[interface{}]interface{}{
+			result: map[string]interface{}{
 				"some": "spec",
 			},
 		},
 		{
 			name: "it returns the pod spec from a deployment",
 			kind: "Deployment",
-			resource: map[interface{}]interface{}{
+			resource: map[string]interface{}{
 				"kind": "Deployment",
-				"spec": map[interface{}]interface{}{
-					"template": map[interface{}]interface{}{
-						"spec": map[interface{}]interface{}{"some": "spec"},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{"some": "spec"},
 					},
 				},
 			},
-			result: map[interface{}]interface{}{
+			result: map[string]interface{}{
 				"some": "spec",
 			},
 		},
 		{
 			name: "it returns the pod spec from a CronJob",
 			kind: "CronJob",
-			resource: map[interface{}]interface{}{
+			resource: map[string]interface{}{
 				"kind": "CronJob",
-				"spec": map[interface{}]interface{}{
-					"jobTemplate": map[interface{}]interface{}{
-						"spec": map[interface{}]interface{}{
-							"template": map[interface{}]interface{}{
-								"spec": map[interface{}]interface{}{
+				"spec": map[string]interface{}{
+					"jobTemplate": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"template": map[string]interface{}{
+								"spec": map[string]interface{}{
 									"some": "spec",
 								},
 							},
@@ -509,7 +511,7 @@ func TestGetResourcePodSpec(t *testing.T) {
 					},
 				},
 			},
-			result: map[interface{}]interface{}{
+			result: map[string]interface{}{
 				"some": "spec",
 			},
 		},


### PR DESCRIPTION
### Description of the change

This PR simply updates a piece of code using the yaml version 2 instead of v3. Since it has some breaking changes, it is a separate PR.

### Benefits

Avoid multiple dependency versions in our codebase.

### Possible drawbacks

Some additional and unnoticed breaking changes? Let's see what the CI thinks.

### Applicable issues

- rel #3848

### Additional information

This is one of the few places we are using the go yaml library instead of the k8s one. In this piece of code, we don't have any typed model to marshal from/to, so I guess that's the reason.
However, I wonder about this decision, I mean, why not rely on a PodSpec since it is a well-established k8s API (corev1)?
Happy to discuss it offline in our standup, though.