### PR TITLE
Migrate from ghodss/yaml to sigs.k8s.io/yaml

### DIFF
--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -24,7 +24,6 @@ import (
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/disintegration/imaging"
-	"github.com/ghodss/yaml"
 	"github.com/itchyny/gojq"
 	apprepov1alpha1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
@@ -37,6 +36,7 @@ import (
 	"github.com/srwiley/rasterx"
 	"helm.sh/helm/v3/pkg/chart"
 	helmregistry "helm.sh/helm/v3/pkg/registry"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/chart.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
-	"github.com/ghodss/yaml"
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/common"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/plugins/pkg/pkgutils"
@@ -26,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	log "k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 // chart-related utilities

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils.go
@@ -17,8 +17,8 @@ import (
 	corev1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/packages/v1alpha1"
 	kappctrlv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	datapackagingv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	"gopkg.in/yaml.v3" // The usual "sigs.k8s.io/yaml" doesn't work: https://github.com/kubeapps/kubeapps/pull/4050
 	vendirversions "github.com/vmware-tanzu/carvel-vendir/pkg/vendir/versions/v1alpha1"
-	"gopkg.in/yaml.v3"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/ghodss/yaml"
 	appRepov1 "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	"github.com/kubeapps/kubeapps/pkg/helm"
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
@@ -29,6 +28,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/credentialprovider"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/pkg/helm/index.go
+++ b/pkg/helm/index.go
@@ -8,11 +8,11 @@ import (
 	"net/url"
 	"sort"
 
-	"github.com/ghodss/yaml"
 	"github.com/jinzhu/copier"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"helm.sh/helm/v3/pkg/repo"
 	log "k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 func parseRepoIndex(contents []byte) (*repo.IndexFile, error) {


### PR DESCRIPTION
### Description of the change

This PR just replaces `ghodss/yaml` with Kubernetes fork of the same library, `sigs.k8s.io/yaml`, as it was the most used along our codebase.

### Benefits

Reduce same-purpose deps.

### Possible drawbacks

I don't know we are ever relying on a very specific feature of the original dep whose behavior differs from the k8s-fork one. I can't think of it, but let's our CI decide.

### Applicable issues

- rel #3848

### Additional information

N/A