### PR TITLE
Replace `logrus` by `klog`

### DIFF
--- a/cmd/apprepository-controller/cmd/root.go
+++ b/cmd/apprepository-controller/cmd/root.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -102,7 +101,7 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Errorf("Using config file: %v", viper.ConfigFileUsed())
 	}
 }
 
@@ -125,7 +124,7 @@ func parseLabelsAnnotations(textArr []string) map[string]string {
 		if text != "" {
 			parts := strings.Split(text, "=")
 			if len(parts) != 2 {
-				log.Fatalf("Cannot parse '%s'", text)
+				log.Errorf("Cannot parse '%s'", text)
 			}
 			textMap[parts[0]] = parts[1]
 		}

--- a/cmd/apprepository-controller/server/controller.go
+++ b/cmd/apprepository-controller/server/controller.go
@@ -17,7 +17,6 @@ import (
 	informers "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/informers/externalversions"
 	listers "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/listers/apprepository/v1alpha1"
 	"github.com/kubeapps/kubeapps/pkg/kube"
-	log "github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	log "k8s.io/klog/v2"
 )
 
 const controllerAgentName = "apprepository-controller"

--- a/cmd/asset-syncer/cmd/root.go
+++ b/cmd/asset-syncer/cmd/root.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/kubeapps/kubeapps/cmd/asset-syncer/server"
@@ -148,6 +147,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Errorf("Using config file: %v", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -32,11 +32,11 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/helm"
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
 	"github.com/kubeapps/kubeapps/pkg/tarutil"
-	log "github.com/sirupsen/logrus"
 	"github.com/srwiley/oksvg"
 	"github.com/srwiley/rasterx"
 	"helm.sh/helm/v3/pkg/chart"
 	helmregistry "helm.sh/helm/v3/pkg/registry"
+	log "k8s.io/klog/v2"
 )
 
 const (
@@ -344,7 +344,7 @@ func (o *ociAPICli) TagList(appName string, userAgent string) (*TagList, error) 
 func (o *ociAPICli) IsHelmChart(appName, tag, userAgent string) (bool, error) {
 	repoURL := *o.url
 	repoURL.Path = path.Join("v2", repoURL.Path, appName, "manifests", tag)
-	log.Debugf("getting tag %s", repoURL.String())
+	log.V(4).Infof("getting tag %s", repoURL.String())
 	manifestData, err := doReq(
 		repoURL.String(),
 		o.netClient,
@@ -519,7 +519,7 @@ func pullAndExtract(repoURL *url.URL, appName, tag string, puller helm.ChartPull
 
 func chartImportWorker(repoURL *url.URL, r *OCIRegistry, chartJobs <-chan pullChartJob, resultChan chan pullChartResult) {
 	for j := range chartJobs {
-		log.WithFields(log.Fields{"name": j.AppName, "tag": j.Tag}).Debug("pulling chart")
+		log.V(4).Infof("pulling chart, name=%s, tag=%s", j.AppName, j.Tag)
 		chart, err := pullAndExtract(repoURL, j.AppName, j.Tag, r.puller, r)
 		resultChan <- pullChartResult{chart, err}
 	}
@@ -616,7 +616,7 @@ func (r *OCIRegistry) Charts(fetchLatestOnly bool) ([]models.Chart, error) {
 		close(chartResults)
 	}()
 
-	log.Debugf("starting %d workers", numWorkers)
+	log.V(4).Infof("starting %d workers", numWorkers)
 	go func() {
 		for _, appName := range r.repositories {
 			if fetchLatestOnly {
@@ -634,7 +634,7 @@ func (r *OCIRegistry) Charts(fetchLatestOnly bool) ([]models.Chart, error) {
 	for res := range chartResults {
 		if res.Error == nil {
 			ch := res.Chart
-			log.Debugf("received chart %s from channel", ch.ID)
+			log.V(4).Infof("received chart %s from channel", ch.ID)
 			if r, ok := result[ch.ID]; ok {
 				// Chart already exists, append version
 				r.ChartVersions = append(result[ch.ID].ChartVersions, ch.ChartVersions...)
@@ -676,7 +676,7 @@ func parseFilters(filters string) (*apprepov1alpha1.FilterRuleSpec, error) {
 func getHelmRepo(namespace, name, repoURL, authorizationHeader string, filter *apprepov1alpha1.FilterRuleSpec, netClient httpclient.Client, userAgent string) (Repo, error) {
 	url, err := parseRepoURL(repoURL)
 	if err != nil {
-		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
+		log.Errorf("failed to parse URL, url=%s: %v", repoURL, err)
 		return nil, err
 	}
 
@@ -701,7 +701,7 @@ func getHelmRepo(namespace, name, repoURL, authorizationHeader string, filter *a
 func getOCIRepo(namespace, name, repoURL, authorizationHeader string, filter *apprepov1alpha1.FilterRuleSpec, ociRepos []string, netClient *http.Client) (Repo, error) {
 	url, err := parseRepoURL(repoURL)
 	if err != nil {
-		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("failed to parse URL")
+		log.Errorf("failed to parse URL, url=%s: %v", repoURL, err)
 		return nil, err
 	}
 	headers := http.Header{}
@@ -722,7 +722,7 @@ func getOCIRepo(namespace, name, repoURL, authorizationHeader string, filter *ap
 func fetchRepoIndex(url, authHeader string, cli httpclient.Client, userAgent string) ([]byte, error) {
 	indexURL, err := parseRepoURL(url)
 	if err != nil {
-		log.WithFields(log.Fields{"url": url}).WithError(err).Error("failed to parse URL")
+		log.Errorf("failed to parse URL, url=%s: %v", url, err)
 		return nil, err
 	}
 	indexURL.Path = path.Join(indexURL.Path, "index.yaml")
@@ -752,7 +752,7 @@ func (f *fileImporter) fetchFiles(charts []models.Chart, repo Repo, userAgent st
 	chartFilesJobs := make(chan importChartFilesJob, numWorkers)
 	var wg sync.WaitGroup
 
-	log.Debugf("starting %d workers", numWorkers)
+	log.V(4).Infof("starting %d workers", numWorkers)
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)
 		go f.importWorker(&wg, iconJobs, chartFilesJobs, repo, userAgent, passCredentials)
@@ -792,22 +792,22 @@ func (f *fileImporter) fetchFiles(charts []models.Chart, repo Repo, userAgent st
 func (f *fileImporter) importWorker(wg *sync.WaitGroup, icons <-chan models.Chart, chartFiles <-chan importChartFilesJob, repo Repo, userAgent string, passCredentials bool) {
 	defer wg.Done()
 	for c := range icons {
-		log.WithFields(log.Fields{"name": c.Name}).Debug("importing icon")
+		log.V(4).Infof("importing icon, name=%s", c.Name)
 		if err := f.fetchAndImportIcon(c, repo.Repo(), userAgent, passCredentials); err != nil {
-			log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to import icon")
+			log.Errorf("failed to import icon, name=%s: %v", c.Name, err)
 		}
 	}
 	for j := range chartFiles {
-		log.WithFields(log.Fields{"name": j.Name, "version": j.ChartVersion.Version}).Debug("importing readme and values")
+		log.V(4).Infof("importing readme and values, name=%s, version=%s", j.Name, j.ChartVersion.Version)
 		if err := f.fetchAndImportFiles(j.Name, repo, j.ChartVersion, userAgent, passCredentials); err != nil {
-			log.WithFields(log.Fields{"name": j.Name, "version": j.ChartVersion.Version}).WithError(err).Error("failed to import files")
+			log.Errorf("failed to import files, name=%s, version=%s: %v", j.Name, j.ChartVersion.Version, err)
 		}
 	}
 }
 
 func (f *fileImporter) fetchAndImportIcon(c models.Chart, r *models.RepoInternal, userAgent string, passCredentials bool) error {
 	if c.Icon == "" {
-		log.WithFields(log.Fields{"name": c.Name}).Info("icon not found")
+		log.Info("icon not found, name=%s", c.Name)
 		return nil
 	}
 
@@ -831,7 +831,7 @@ func (f *fileImporter) fetchAndImportIcon(c models.Chart, r *models.RepoInternal
 		// if the icon is an SVG, it requires special processing
 		icon, err := oksvg.ReadIconStream(reader)
 		if err != nil {
-			log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to decode icon")
+			log.Errorf("failed to decode icon, name=%s: %v", c.Name, err)
 			return err
 		}
 		w, h := int(icon.ViewBox.W), int(icon.ViewBox.H)
@@ -842,7 +842,7 @@ func (f *fileImporter) fetchAndImportIcon(c models.Chart, r *models.RepoInternal
 	} else {
 		img, err = imaging.Decode(reader)
 		if err != nil {
-			log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to decode icon")
+			log.Errorf("failed to decode icon, name=%s: %v", c.Name, err)
 			return err
 		}
 	}
@@ -852,7 +852,7 @@ func (f *fileImporter) fetchAndImportIcon(c models.Chart, r *models.RepoInternal
 	var buf bytes.Buffer
 	err = imaging.Encode(&buf, resizedImg, imaging.PNG)
 	if err != nil {
-		log.WithFields(log.Fields{"name": c.Name}).WithError(err).Error("failed to encode icon")
+		log.Errorf("failed to encode icon, name=%s: %v", c.Name, err)
 		return err
 	}
 	b := buf.Bytes()
@@ -868,10 +868,10 @@ func (f *fileImporter) fetchAndImportFiles(name string, repo Repo, cv models.Cha
 
 	// Check if we already have indexed files for this chart version and digest
 	if f.manager.filesExist(models.Repo{Namespace: r.Namespace, Name: r.Name}, chartFilesID, cv.Digest) {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Debug("skipping existing files")
+		log.V(4).Infof("skipping existing files, name: %s, version: %s", name, cv.Version)
 		return nil
 	}
-	log.WithFields(log.Fields{"name": name, "version": cv.Version}).Debug("fetching files")
+	log.V(4).Infof("fetching files, name=%s, version=%s", name, cv.Version)
 
 	files, err := repo.FetchFiles(name, cv, userAgent, passCredentials)
 	if err != nil {
@@ -882,17 +882,17 @@ func (f *fileImporter) fetchAndImportFiles(name string, repo Repo, cv models.Cha
 	if v, ok := files[models.ReadmeKey]; ok {
 		chartFiles.Readme = v
 	} else {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("README.md not found")
+		log.Info("README.md not found, name=%s, version=%s", name, cv.Version)
 	}
 	if v, ok := files[models.ValuesKey]; ok {
 		chartFiles.Values = v
 	} else {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.yaml not found")
+		log.Info("values.yaml not found, name=%s, version=%s", name, cv.Version)
 	}
 	if v, ok := files[models.SchemaKey]; ok {
 		chartFiles.Schema = v
 	} else {
-		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.schema.json not found")
+		log.Info("values.schema.json not found, name=%s, version=%s", name, cv.Version)
 	}
 
 	// inserts the chart files if not already indexed, or updates the existing

--- a/cmd/assetsvc/cmd/root.go
+++ b/cmd/assetsvc/cmd/root.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/server"
@@ -81,6 +80,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Errorf("Using config file: %v", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/assetsvc/server/handler.go
+++ b/cmd/assetsvc/server/handler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kubeapps/kubeapps/cmd/assetsvc/pkg/utils"
 	"github.com/kubeapps/kubeapps/pkg/chart/models"
 	"github.com/kubeapps/kubeapps/pkg/response"
-	log "github.com/sirupsen/logrus"
+	log "k8s.io/klog/v2"
 )
 
 // Params a key-value map of path params
@@ -138,7 +138,7 @@ func getChartCategories(w http.ResponseWriter, req *http.Request, params Params)
 
 	chartCategories, err := getAllChartCategories(cq)
 	if err != nil {
-		log.WithError(err).Error("could not fetch categories")
+		log.Errorf("could not fetch categories: %v", err)
 		response.NewErrorResponse(http.StatusInternalServerError, "could not fetch chart categories").Write(w)
 		return
 	}
@@ -156,7 +156,7 @@ func getChart(w http.ResponseWriter, req *http.Request, params Params) {
 
 	chart, err := manager.GetChart(namespace, chartID)
 	if err != nil {
-		log.WithError(err).Errorf("could not find chart with id %s", chartID)
+		log.Errorf("could not find chart with id %s: %v", chartID, err)
 		response.NewErrorResponse(http.StatusNotFound, "could not find chart").Write(w)
 		return
 	}
@@ -176,7 +176,7 @@ func listChartVersions(w http.ResponseWriter, req *http.Request, params Params) 
 
 	chart, err := manager.GetChart(namespace, chartID)
 	if err != nil {
-		log.WithError(err).Errorf("could not find chart with id %s", chartID)
+		log.Errorf("could not find chart with id %s: %v", chartID, err)
 		response.NewErrorResponse(http.StatusNotFound, "could not find chart").Write(w)
 		return
 	}
@@ -196,7 +196,7 @@ func getChartVersion(w http.ResponseWriter, req *http.Request, params Params) {
 
 	chart, err := manager.GetChartVersion(namespace, chartID, version)
 	if err != nil {
-		log.WithError(err).Errorf("could not find chart with id %s", chartID)
+		log.Errorf("could not find chart with id %s: %v", chartID, err)
 		response.NewErrorResponse(http.StatusNotFound, "could not find chart version").Write(w)
 		return
 	}
@@ -216,7 +216,7 @@ func getChartIcon(w http.ResponseWriter, req *http.Request, params Params) {
 
 	chart, err := manager.GetChart(namespace, chartID)
 	if err != nil {
-		log.WithError(err).Errorf("could not find chart with id %s", chartID)
+		log.Errorf("could not find chart with id %s: %v", chartID, err)
 		http.NotFound(w, req)
 		return
 	}
@@ -246,7 +246,7 @@ func getChartVersionReadme(w http.ResponseWriter, req *http.Request, params Para
 
 	files, err := manager.GetChartFiles(namespace, fileID)
 	if err != nil {
-		log.WithError(err).Errorf("could not find files with id %s", fileID)
+		log.Errorf("could not find files with id %s: %v", fileID, err)
 		http.NotFound(w, req)
 		return
 	}
@@ -270,7 +270,7 @@ func getChartVersionValues(w http.ResponseWriter, req *http.Request, params Para
 
 	files, err := manager.GetChartFiles(namespace, fileID)
 	if err != nil {
-		log.WithError(err).Errorf("could not find values.yaml with id %s", fileID)
+		log.Errorf("could not find values.yaml with id %s: %v", fileID, err)
 		http.NotFound(w, req)
 		return
 	}
@@ -289,7 +289,7 @@ func getChartVersionSchema(w http.ResponseWriter, req *http.Request, params Para
 
 	files, err := manager.GetChartFiles(namespace, fileID)
 	if err != nil {
-		log.WithError(err).Errorf("could not find values.schema.json with id %s", fileID)
+		log.Errorf("could not find values.schema.json with id %s: %v", fileID, err)
 		http.NotFound(w, req)
 		return
 	}
@@ -309,7 +309,7 @@ func listChartsWithFilters(w http.ResponseWriter, req *http.Request, params Para
 	pageNumber, pageSize := getPageAndSizeParams(req)
 	charts, totalPages, err := manager.GetPaginatedChartListWithFilters(cq, pageNumber, pageSize)
 	if err != nil {
-		log.WithError(err).Errorf("could not find charts with the given namespace=%s, chartName=%s, version=%s, appversion=%s, repos=%s, categories=%s, searchQuery=%s",
+		log.Errorf("could not find charts with the given namespace=%s, chartName=%s, version=%s, appversion=%s, repos=%s, categories=%s, searchQuery=%s: %v",
 			cq.Namespace, cq.ChartName, cq.Version, cq.AppVersion, cq.Repos, cq.Categories, cq.SearchQuery,
 		)
 		// continue to return empty list
@@ -415,7 +415,7 @@ func newChartVersionListResponse(c *models.Chart) apiListResponse {
 }
 
 func handleDecodeError(paramErr string, w http.ResponseWriter, err error) {
-	log.WithError(err).Errorf("could not decode param %s", paramErr)
+	log.Errorf("could not decode param %s: %v", paramErr, err)
 	response.NewErrorResponse(http.StatusBadRequest, "could not decode params").Write(w)
 }
 

--- a/cmd/kubeapps-apis/cmd/root.go
+++ b/cmd/kubeapps-apis/cmd/root.go
@@ -5,8 +5,6 @@ package cmd
 
 import (
 	goflag "flag"
-	"fmt"
-	"os"
 
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/server"
@@ -95,6 +93,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Errorf("Using config file: %v", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/kubeops/cmd/root.go
+++ b/cmd/kubeops/cmd/root.go
@@ -88,7 +88,7 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		log.Errorf("Using config file: %v", viper.ConfigFileUsed())
 	}
 }
 

--- a/cmd/kubeops/internal/handler/handler.go
+++ b/cmd/kubeops/internal/handler/handler.go
@@ -17,11 +17,11 @@ import (
 	"github.com/kubeapps/kubeapps/pkg/handlerutil"
 	"github.com/kubeapps/kubeapps/pkg/kube"
 	"github.com/kubeapps/kubeapps/pkg/response"
-	log "github.com/sirupsen/logrus"
 	negroni "github.com/urfave/negroni/v2"
 	"helm.sh/helm/v3/pkg/action"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	log "k8s.io/klog/v2"
 )
 
 const (

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -19,6 +18,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	log "k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -4,7 +4,6 @@
 package agent
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -133,7 +132,7 @@ func UpgradeRelease(actionConfig *action.Configuration, name, valuesYaml string,
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Upgrading release %s", name)
+	log.Infof("Upgrading release %s", name)
 	cmd := action.NewUpgrade(actionConfig)
 	if timeoutSeconds > 0 {
 		// Given that `cmd.Wait` is not used, this timeout will only affect pre/post hooks
@@ -157,7 +156,7 @@ func UpgradeRelease(actionConfig *action.Configuration, name, valuesYaml string,
 
 // RollbackRelease rolls back a release to the specified revision.
 func RollbackRelease(actionConfig *action.Configuration, releaseName string, revision int, timeoutSeconds int32) (*release.Release, error) {
-	log.Printf("Rolling back %s to revision %d.", releaseName, revision)
+	log.Infof("Rolling back %s to revision %d.", releaseName, revision)
 	rollback := action.NewRollback(actionConfig)
 	rollback.Version = revision
 	if timeoutSeconds > 0 {
@@ -258,7 +257,7 @@ func ParseDriverType(raw string) (StorageForDriver, error) {
 	case "memory":
 		return StorageForMemory, nil
 	default:
-		return nil, errors.New("Invalid Helm driver type: " + raw)
+		return nil, fmt.Errorf("Invalid Helm driver type: %s", raw)
 	}
 }
 

--- a/pkg/agent/docker_secrets_postrenderer.go
+++ b/pkg/agent/docker_secrets_postrenderer.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/distribution/distribution/reference"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
+	log "k8s.io/klog/v2"
 )
 
 const (

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"path"
@@ -28,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	log "k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 )
 
@@ -331,7 +331,7 @@ func (c *HelmRepoClient) GetChart(details *Details, repoURL string) (*chart.Char
 		}
 	} else {
 		// TODO(agamez): remove this branch as it is really expensive and it is solely used in a few places in kubeops
-		log.Printf("calling GetChart without any tarball url, please note this action is memory-expensive")
+		log.Infof("calling GetChart without any tarball url, please note this action is memory-expensive")
 		indexURL := strings.TrimSuffix(strings.TrimSpace(repoURL), "/") + "/index.yaml"
 		repoIndex, err := fetchRepoIndex(&c.netClient, indexURL)
 		if err != nil {
@@ -342,7 +342,7 @@ func (c *HelmRepoClient) GetChart(details *Details, repoURL string) (*chart.Char
 			return nil, err
 		}
 	}
-	log.Printf("Downloading %s ...", chartURL)
+	log.Infof("Downloading %s ...", chartURL)
 	chart, err := fetchChart(&c.netClient, chartURL)
 	if err != nil {
 		return nil, err

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/containerd/containerd/remotes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	helmregistry "helm.sh/helm/v3/pkg/registry"
 	log "k8s.io/klog/v2"
 	"oras.land/oras-go/pkg/content"
@@ -102,7 +101,7 @@ func (p *OCIPuller) PullOCIChart(ref string) (*bytes.Buffer, string, error) {
 
 	_, chartData, ok := memoryStore.Get(*chartDescriptor)
 	if !ok {
-		return nil, manifest.Digest.String(), errors.Errorf("Unable to retrieve blob with digest %s", chartDescriptor.Digest)
+		return nil, manifest.Digest.String(), fmt.Errorf("Unable to retrieve blob with digest %s", chartDescriptor.Digest)
 	}
 
 	return bytes.NewBuffer(chartData), manifest.Digest.String(), nil

--- a/pkg/http-handler/http-handler.go
+++ b/pkg/http-handler/http-handler.go
@@ -14,10 +14,10 @@ import (
 	"github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/apis/apprepository/v1alpha1"
 	"github.com/kubeapps/kubeapps/pkg/auth"
 	"github.com/kubeapps/kubeapps/pkg/kube"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	log "k8s.io/klog/v2"
 )
 
 // namespacesResponse is used to marshal the JSON response

--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -23,7 +23,6 @@ import (
 	apprepoclientset "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned"
 	v1alpha1typed "github.com/kubeapps/kubeapps/cmd/apprepository-controller/pkg/client/clientset/versioned/typed/apprepository/v1alpha1"
 	httpclient "github.com/kubeapps/kubeapps/pkg/http-client"
-	log "github.com/sirupsen/logrus"
 	authorizationapi "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,6 +33,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	log "k8s.io/klog/v2"
 )
 
 const OCIImageManifestMediaType = "application/vnd.oci.image.manifest.v1+json"


### PR DESCRIPTION
### Description of the change

This PR continues the effort started some time ago in unifying the logging libraries. We opted for `klog`, the one used in Kubernetes. Some minor changes have been introduced in order to adapt the log operations to the ones available in klog (no `WithParams` or `WithError` are available here).

### Benefits

Reduce same-purpose deps. It also simplifies the task of moving to structured logging as we were asked in the past.

### Possible drawbacks

N/A

### Applicable issues

- rel #3848

### Additional information

N/A