### PR TITLE
Update error in AppView to use ErrorAlert.

### DIFF
--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -126,7 +126,13 @@ export function getApp(
       }
       dispatch(selectApp(installedPackageDetail!, resourceRefs, availablePackageDetail));
     } catch (e: any) {
-      dispatch(errorApp(new FetchError(e.message)));
+      dispatch(
+        errorApp(
+          e instanceof Error
+            ? new FetchError("Unable to get installed package", [e])
+            : new FetchError(`Unable to get installed package: ${e.message}`),
+        ),
+      );
     }
   };
 }

--- a/dashboard/src/actions/apps.ts
+++ b/dashboard/src/actions/apps.ts
@@ -126,13 +126,7 @@ export function getApp(
       }
       dispatch(selectApp(installedPackageDetail!, resourceRefs, availablePackageDetail));
     } catch (e: any) {
-      dispatch(
-        errorApp(
-          e instanceof Error
-            ? new FetchError("Unable to get installed package", [e])
-            : new FetchError(`Unable to get installed package: ${e.message}`),
-        ),
-      );
+      dispatch(errorApp(new FetchError("Unable to get installed package", [e])));
     }
   };
 }
@@ -168,13 +162,7 @@ export function fetchApps(
       dispatch(receiveAppList(installedPackageSummaries));
       return installedPackageSummaries;
     } catch (e: any) {
-      dispatch(
-        errorApp(
-          e instanceof Error
-            ? new FetchError("Unable to list apps", [e])
-            : new FetchError("Unable to list apps: " + e.message),
-        ),
-      );
+      dispatch(errorApp(new FetchError("Unable to list apps", [e])));
       return [];
     }
   };

--- a/dashboard/src/components/AppList/AppList.tsx
+++ b/dashboard/src/components/AppList/AppList.tsx
@@ -134,7 +134,7 @@ function AppList() {
         className="margin-t-xl"
       >
         {error ? (
-          <ErrorAlert>{error}</ErrorAlert>
+          <ErrorAlert error={error} />
         ) : (
           <AppListGrid
             appList={listOverview}

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -4,6 +4,7 @@
 import { CdsButton } from "@cds/react/button";
 import actions from "actions";
 import Alert from "components/js/Alert";
+import ErrorAlert from "components/ErrorAlert";
 import Column from "components/js/Column";
 import Row from "components/js/Row";
 import PageHeader from "components/PageHeader/PageHeader";
@@ -216,13 +217,12 @@ export default function AppView() {
 
   if (error && error.constructor === FetchError) {
     return (
-      <Alert theme="danger">
-        Application not found: {error.message}
+      <ErrorAlert error={error}>
         <CdsButton size="sm" action="flat" onClick={forceRetry} type="button">
           {" "}
           Try again{" "}
         </CdsButton>
-      </Alert>
+      </ErrorAlert>
     );
   }
   const { services, ingresses, deployments, statefulsets, daemonsets, secrets, otherResources } =

--- a/dashboard/src/components/ErrorAlert/ErrorAlert.test.tsx
+++ b/dashboard/src/components/ErrorAlert/ErrorAlert.test.tsx
@@ -7,52 +7,39 @@ import ErrorAlert from "./ErrorAlert";
 import { CustomError } from "shared/types";
 
 describe("Error Alert", () => {
-  it("should render string messages", () => {
-    const wrapper = mount(<ErrorAlert>foo</ErrorAlert>);
-    expect(wrapper.text()).toContain("foo");
-  });
-
-  it("should handle empty strings", () => {
-    const error = "";
-    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
-    expect(wrapper.text()).toContain("");
+  it("should render string errors", () => {
+    const wrapper = mount(<ErrorAlert error={new Error("foo")} />);
+    expect(wrapper.text()).toEqual("foo");
   });
 
   it("should handle empty string Error", () => {
     const error = new Error("");
-    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
-    expect(wrapper.text()).toContain("");
+    const wrapper = mount(<ErrorAlert error={error} />);
+    expect(wrapper.text()).toEqual("");
   });
 
   it("should handle empty Error", () => {
     const error = new Error();
-    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
-    expect(wrapper.text()).toContain("");
+    const wrapper = mount(<ErrorAlert error={error} />);
+    expect(wrapper.text()).toEqual("");
   });
 
-  it("should render string messages without breaklines", () => {
+  it("should render regular errors without breaklines", () => {
     const wrapper = mount(
-      <ErrorAlert>Error occurred: Another error message. Yet another msg.</ErrorAlert>,
+      <ErrorAlert error={new Error("Error occurred: Another error message. Yet another msg.")} />,
     );
     expect(wrapper.find(Alert)).toExist();
-    expect(wrapper.text()).toContain("Error occurred: Another error message. Yet another msg.");
-  });
-
-  it("should render regular errors", () => {
-    const error = new Error("Error occurred");
-    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
-    expect(wrapper.find(Alert)).toExist();
-    expect(wrapper.text()).toContain("Error occurred");
+    expect(wrapper.text()).toEqual("Error occurred: Another error message. Yet another msg.");
   });
 
   it("should render custom errors with plain messages", () => {
     const error = new CustomError(
       "An error occurred for tests: cause of the error. Another cause.",
     );
-    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
+    const wrapper = mount(<ErrorAlert error={error} />);
     const alertTag = wrapper.find(Alert);
     expect(alertTag).toExist();
-    expect(alertTag.text()).toContain(
+    expect(alertTag.text()).toEqual(
       "An error occurred for tests: cause of the error. Another cause.",
     );
   });
@@ -62,7 +49,7 @@ describe("Error Alert", () => {
       new Error("The first cause"),
       new Error("Second cause"),
     ]);
-    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
+    const wrapper = mount(<ErrorAlert error={error} />);
     const alertTag = wrapper.find(Alert);
     expect(alertTag).toExist();
     expect(alertTag.find("div.error-alert")).toHaveLength(1);
@@ -80,7 +67,7 @@ describe("Error Alert", () => {
       ),
       new Error("Even a third cause"),
     ]);
-    const wrapper = mount(<ErrorAlert>{error}</ErrorAlert>);
+    const wrapper = mount(<ErrorAlert error={error} />);
     const alertTag = wrapper.find(Alert);
     expect(alertTag).toExist();
     expect(alertTag.find("div.error-alert")).toHaveLength(1);
@@ -92,5 +79,17 @@ describe("Error Alert", () => {
       "An error occurred when performing request: ",
     );
     expect(alertTag.find("div.error-alert-indent").at(2).text()).toBe("Even a third cause");
+  });
+
+  it("should render errors and children when present", () => {
+    const wrapper = mount(
+      <ErrorAlert error={new Error("Error message")}>
+        <h1>Bang!</h1>
+      </ErrorAlert>,
+    );
+    expect(wrapper.find(Alert)).toExist();
+    expect(wrapper.text()).toEqual("Error messageBang!");
+    expect(wrapper.find("h1")).toHaveLength(1);
+    expect(wrapper.find("h1").text()).toBe("Bang!");
   });
 });

--- a/dashboard/src/components/ErrorAlert/ErrorAlert.tsx
+++ b/dashboard/src/components/ErrorAlert/ErrorAlert.tsx
@@ -8,7 +8,8 @@ import { CustomError } from "shared/types";
 import "./ErrorAlert.css";
 
 export interface IErrorAlert {
-  children: CustomError | Error | string;
+  error: CustomError | Error;
+  children?: React.ReactChildren | React.ReactNode | string;
 }
 
 function createWrap(message: any, index: number, indented: boolean): JSX.Element {
@@ -30,17 +31,22 @@ function buildMessages(errors: Error[]): JSX.Element[] {
 }
 
 // Extension of Alert component for showing more meaningful Errors
-export default function ErrorAlert({ children }: IErrorAlert) {
+export default function ErrorAlert({ error, children }: IErrorAlert) {
   let messages: any[];
-  if (children instanceof CustomError) {
-    messages = [createWrap(children.message, 0, false)];
-    if (children.causes) {
-      messages.push(buildMessages(children.causes));
+  if (error instanceof CustomError) {
+    messages = [createWrap(error.message, 0, false)];
+    if (error.causes) {
+      messages.push(buildMessages(error.causes));
     }
-  } else if (children instanceof Error) {
-    messages = [createWrap(children.message, 0, false)];
+  } else if (error instanceof Error) {
+    messages = [createWrap(error.message, 0, false)];
   } else {
-    messages = [children];
+    messages = [error];
   }
-  return <Alert theme="danger">{messages}</Alert>;
+  return (
+    <Alert theme="danger">
+      {messages}
+      {children}
+    </Alert>
+  );
 }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Initially was just to update the error displayed in the AppView to use the `ErrorAlert` component, but the `ErrorAlert` component didn't currently support child elements like the old one did, which the AppView uses. So after chatting with Rafa, I've updated that component to take the error as a prop allowing the children to be normal react nodes.

### Benefits

Before:
![appview-error-before](https://user-images.githubusercontent.com/497518/151917484-f7bb51c8-9eb6-4076-ae84-ec14c225eae2.png)

After:
![appview-error-after](https://user-images.githubusercontent.com/497518/151917395-2e3b7957-9cec-4d4a-9523-3a7ddfc3fce5.png)

Clicking on the "Try again" does what it always did, re-issuing the request and rendering the view when it succeeds.

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #4190 
- Ref #3695 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
