### PR TITLE
Separate action for requesting resource refs.

### DIFF
--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -230,7 +230,7 @@ describe("AppView", () => {
       ] as ResourceRef[];
 
       const wrapper = mountWrapper(
-        getStore({ apps: { selected: { ...installedPackage, apiResourceRefs } } }),
+        getStore({ apps: { selected: installedPackage, resourceRefs: apiResourceRefs } }),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -253,7 +253,7 @@ describe("AppView", () => {
       ] as ResourceRef[];
 
       const wrapper = mountWrapper(
-        getStore({ apps: { selected: { ...installedPackage, apiResourceRefs } } }),
+        getStore({ apps: { selected: installedPackage, resourceRefs: apiResourceRefs } }),
         <MemoryRouter initialEntries={[routePathParam]}>
           <Route path={routePath}>
             <AppView />
@@ -315,7 +315,7 @@ describe("AppView", () => {
   it("forwards statefulsets and daemonsets to the application status", () => {
     const apiResourceRefs = [resourceRefs.statefulset, resourceRefs.daemonset] as ResourceRef[];
     const wrapper = mountWrapper(
-      getStore({ apps: { selected: { ...installedPackage, apiResourceRefs } } }),
+      getStore({ apps: { selected: installedPackage, resourceRefs: apiResourceRefs } }),
       <MemoryRouter initialEntries={[routePathParam]}>
         <Route path={routePath}>
           <AppView />
@@ -338,7 +338,7 @@ describe("AppView actions", () => {
       resourceRefs.service,
       resourceRefs.secret,
     ] as ResourceRef[];
-    const store = getStore({ apps: { selected: { ...installedPackage, apiResourceRefs } } });
+    const store = getStore({ apps: { selected: installedPackage, resourceRefs: apiResourceRefs } });
 
     mountWrapper(
       store,
@@ -351,7 +351,10 @@ describe("AppView actions", () => {
 
     expect(store.getActions()).toEqual([
       {
-        type: getType(actions.apps.requestApps),
+        type: getType(actions.apps.requestApp),
+      },
+      {
+        type: getType(actions.apps.requestAppResourceRefs),
       },
       {
         type: getType(actions.kube.requestResources),
@@ -380,7 +383,7 @@ describe("AppView actions", () => {
   it("closes the watches when unmounted", async () => {
     const apiResourceRefs = [resourceRefs.deployment, resourceRefs.service] as ResourceRef[];
 
-    const store = getStore({ apps: { selected: { ...installedPackage, apiResourceRefs } } });
+    const store = getStore({ apps: { selected: installedPackage, resourceRefs: apiResourceRefs } });
     const wrapper = mountWrapper(
       store,
       <MemoryRouter initialEntries={[routePathParam]}>
@@ -394,7 +397,10 @@ describe("AppView actions", () => {
     const watch = true;
     expect(store.getActions()).toEqual([
       {
-        type: getType(actions.apps.requestApps),
+        type: getType(actions.apps.requestApp),
+      },
+      {
+        type: getType(actions.apps.requestAppResourceRefs),
       },
       {
         type: getType(actions.kube.requestResources),

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -152,31 +152,32 @@ export default function AppView() {
     secrets: [],
   } as IAppViewResourceRefs);
   const {
-    apps: { error, selected: app, selectedDetails: appDetails },
+    apps: { error, selected: app, resourceRefs, selectedDetails: appDetails },
     config: { customAppViews },
   } = useSelector((state: IStoreState) => state);
 
   const [pluginObj] = useState({ name: pluginName, version: pluginVersion } as Plugin);
 
   useEffect(() => {
-    dispatch(
-      actions.apps.getApp({
-        context: { cluster: cluster, namespace: namespace },
-        identifier: releaseName,
-        plugin: pluginObj,
-      } as InstalledPackageReference),
-    );
+    const installedPkgRef = {
+      context: { cluster: cluster, namespace: namespace },
+      identifier: releaseName,
+      plugin: pluginObj,
+    } as InstalledPackageReference;
+
+    dispatch(actions.apps.getApp(installedPkgRef));
+    dispatch(actions.apps.getAppResourceRefs(installedPkgRef));
   }, [cluster, dispatch, namespace, releaseName, pluginObj]);
 
   useEffect(() => {
-    if (!app?.apiResourceRefs) {
+    if (!resourceRefs) {
       return () => {};
     }
 
-    const parsedRefs = parseResources(app.apiResourceRefs);
+    const parsedRefs = parseResources(resourceRefs);
     setAppViewResourceRefs(parsedRefs);
     return () => {};
-  }, [app?.apiResourceRefs]);
+  }, [resourceRefs]);
 
   useEffect(() => {
     if (!app?.installedPackageRef) {

--- a/dashboard/src/reducers/apps.test.ts
+++ b/dashboard/src/reducers/apps.test.ts
@@ -11,7 +11,7 @@ describe("appsReducer", () => {
 
   const actionTypes = {
     listApps: getType(actions.apps.listApps),
-    requestApps: getType(actions.apps.requestApps),
+    requestApp: getType(actions.apps.requestApp),
   };
 
   beforeEach(() => {
@@ -26,7 +26,7 @@ describe("appsReducer", () => {
       [true, false].forEach(_e => {
         expect(
           appsReducer(undefined, {
-            type: actionTypes.requestApps as any,
+            type: actionTypes.requestApp as any,
           }),
         ).toEqual({ ...initialState, isFetching: true });
       });

--- a/dashboard/src/reducers/apps.ts
+++ b/dashboard/src/reducers/apps.ts
@@ -18,12 +18,13 @@ const appsReducer = (
   action: AppsAction | LocationChangeAction,
 ): IAppState => {
   switch (action.type) {
-    case getType(actions.apps.requestApps):
+    case getType(actions.apps.requestApp):
       return {
         ...state,
         isFetching: true,
         selected: undefined,
         selectedDetails: undefined,
+        resourceRefs: undefined,
       };
     case getType(actions.apps.errorApp):
       return { ...state, isFetching: false, error: action.payload };
@@ -48,9 +49,13 @@ const appsReducer = (
           ...action.payload.app,
           // TODO(agamez): remove it once we have a core mechanism for rolling back
           revision: revision,
-          apiResourceRefs: action.payload.resourceRefs,
         },
         selectedDetails: action.payload.details,
+      };
+    case getType(actions.apps.receiveAppResourceRefs):
+      return {
+        ...state,
+        resourceRefs: action.payload,
       };
     case getType(actions.apps.listApps):
       return { ...state, isFetching: true };

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -315,6 +315,7 @@ export interface IAppState {
   selected?: CustomInstalledPackageDetail;
   // TODO(agamez): add tests for this new state field
   selectedDetails?: AvailablePackageDetail;
+  resourceRefs?: ResourceRef[];
 }
 
 export interface IStoreState {
@@ -501,6 +502,5 @@ export interface IBasicFormSliderParam extends IBasicFormParam {
 }
 
 export interface CustomInstalledPackageDetail extends InstalledPackageDetail {
-  apiResourceRefs: ResourceRef[];
   revision: number;
 }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Separates out the action for fetching resource refs for an installed application.

### Benefits

When the resource refs were first added to the `SelectedApp` state, I think Antonio and I both agreed that it didn't belong there (in the `CustomInstalledPackageDetail` which was temporarily created to accommodate the helm version field), but at the time I wasn't keen to refactor it.

Now we have an unrelated issue that for flux (and carvel), the call to fetch the resource refs fails with a 404 initially (within 1 second of creating the installed package) because the underlying reconciliation creates the helm (for flux) release very soon after creating the installed package, but not immediately.

I'm going to create an issue for the plugin backend so that the request for resource refs (a valid one, for which there's already an installed package) doesn't return until the underlying helm release is created (within a second), but am also planning here in the dashboard to work around the issue for now by requesting the resource refs a few times with a fallback (next branch). But to do that, I needed to fix this tech-debt to separate out the call for the resource refs.


<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

Behaviour is the same.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3695

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
