### PR TITLE
Fix bearer token login on E2E tests (#2898)

### DIFF
--- a/integration/tests/utils/kubeapps-login.js
+++ b/integration/tests/utils/kubeapps-login.js
@@ -7,12 +7,14 @@ exports.KubeappsLogin = class KubeappsLogin {
   constructor(page) {
     this.page = page;
     this.oidc = process.env.USE_MULTICLUSTER_OIDC_ENV === "true";
+    this.token = "";
   }
 
   isOidc = () => this.oidc;
 
   setToken(token) {
-    if ((token.match(/Bearer/g)).length > 1) {
+    let bearerMatch = token.match(/Bearer/g);
+    if (bearerMatch && bearerMatch.length > 1) {
       token = token.split(",")[0];
     }
     this.token = token.trim().startsWith("Bearer") ? token.trim().substring(7) : token;
@@ -71,8 +73,8 @@ exports.KubeappsLogin = class KubeappsLogin {
     await this.page.goto(utils.getUrl("/"));
     await this.page.waitForLoadState("networkidle");
 
-    const formLocator = page.locator("form");
-    await formLocator.type("input[name=token]", token);
+    const inputLocator = this.page.locator("form input[name=token]");
+    await inputLocator.type(token);
     await this.page.click("#login-submit-button");
 
     await this.page.waitForLoadState("networkidle");


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR fixes the login in E2E when using Bearer token.
It is the mechanism used for testing in GKE and therefore important for releasing Kubeapps.

### Benefits

Bearer token login is working now

### Possible drawbacks

N/A

### Applicable issues

- Fix on top of functionality delivered for #2898
