### PR TITLE
Call GetInstalledPackageResourceRefs with exp backoff.

### DIFF
--- a/dashboard/src/shared/InstalledPackage.test.ts
+++ b/dashboard/src/shared/InstalledPackage.test.ts
@@ -197,6 +197,25 @@ describe("InstalledPackage", () => {
         installedPackageRef: installedPackageReference,
       });
     });
+
+    it("retries up to five times before returning error", async () => {
+      const mockClientGetInstalledPackageResourceRefs = jest
+        .fn()
+        .mockImplementation(() => Promise.reject(new Error("Bang!")));
+      setMockCoreClient(
+        "GetInstalledPackageResourceRefs",
+        mockClientGetInstalledPackageResourceRefs,
+      );
+
+      await expect(
+        InstalledPackage.GetInstalledPackageResourceRefs(installedPackageReference, 0),
+      ).rejects.toThrowError("Bang!");
+
+      expect(mockClientGetInstalledPackageResourceRefs).toHaveBeenCalledTimes(5);
+      expect(mockClientGetInstalledPackageResourceRefs).toHaveBeenLastCalledWith({
+        installedPackageRef: installedPackageReference,
+      });
+    });
   });
 });
 

--- a/dashboard/src/shared/InstalledPackage.ts
+++ b/dashboard/src/shared/InstalledPackage.ts
@@ -43,7 +43,7 @@ export class InstalledPackage {
 
   public static async GetInstalledPackageResourceRefs(
     installedPackageRef?: InstalledPackageReference,
-    initialWait: number = 500,
+    initialWait = 500,
   ) {
     // TODO(minelson): The backend plugin may take care of waiting
     // for the required data to become available in which case this


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

See #4213 for description of the problem.

This change just ensures that the call will retry a number of times, backing off exponentially. For Flux it only needs to be a second, but carvel has other needs.

### Benefits

Error no longer shown when first deploying flux package.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Ref #4213 
- Ref #3695 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
