### PR TITLE
Add initial tpl validation for plugins

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.8.0-dev3
+version: 7.8.0-dev4

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -203,6 +203,7 @@ Compile all warnings into a single message, and call fail.
 {{- define "kubeapps.validateValues" -}}
 {{- $messages := list -}}
 {{- $messages := append $messages (include "kubeapps.validateValues.ingress.tls" .) -}}
+{{- $messages := append $messages (include "kubeapps.validateValues.kubeappsapis.enabledPlugins" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -225,6 +226,25 @@ kubeapps: ingress.tls
       - Relay on cert-manager to create it by adding its supported annotations in `ingress.annotations`
       - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
 {{- end -}}
+{{- end -}}
+
+
+{{/*
+# Validate values of common mistakes in kubeappsapis.enabledPlugins
+*/}}
+{{- define "kubeapps.validateValues.kubeappsapis.enabledPlugins" -}}
+    {{- if has "flux" .Values.kubeappsapis.enabledPlugins }}
+    kubeapps: kubeappsapis.enabledPlugins 
+        You enter "flux", perhaps you meant "fluxv2"?
+    {{- end -}}
+    {{- if has "kapp_controller" .Values.kubeappsapis.enabledPlugins }}
+    kubeapps: kubeappsapis.enabledPlugins 
+        You enter "kapp_controller", perhaps you meant "kapp-controller"?
+    {{- end -}}
+    {{- if and (has "fluxv2" .Values.kubeappsapis.enabledPlugins) (not .Values.redis.enabled) }}
+    kubeapps: kubeappsapis.enabledPlugins 
+        If you enable the "fluxv2" plugin, you must also set redis.enabled=true
+    {{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

While I was enabling/disabling plugins in my local env, I've spent some time wondering what was wrong in my setup... it turned to be just a typo in the plugin name :facepalm: 

This PR adds some validation to the plugin names we are using, at least, for the mistakes I use to make :P
Feel free to suggest more.

### Benefits

No "OSI layer 8"-derived problems, haha

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information
```bash
    kubeapps: kubeappsapis.enabledPlugins 
        You enter "flux", perhaps you meant "fluxv2"?
    kubeapps: kubeappsapis.enabledPlugins 
        You enter "kapp_controller", perhaps you meant "kapp-controller"?
    kubeapps: kubeappsapis.enabledPlugins 
        If you enable the "fluxv2" plugin, you must also set redis.enabled=true
```