### PR TITLE
Add same workaround to show repo in flux

### DIFF
--- a/dashboard/src/components/Catalog/PackageCatalogItem.tsx
+++ b/dashboard/src/components/Catalog/PackageCatalogItem.tsx
@@ -23,11 +23,8 @@ export default function PackageCatalogItem(props: IPackageCatalogItem) {
 
   // Get the pkg repository for the plugins that have one.
   switch (availablePackageSummary.availablePackageRef?.plugin?.name) {
-    case PluginNames.PACKAGES_HELM:
+    case (PluginNames.PACKAGES_HELM, PluginNames.PACKAGES_FLUX):
       pkgRepository = availablePackageSummary.availablePackageRef?.identifier.split("/")[0];
-      break;
-    case PluginNames.PACKAGES_FLUX:
-      // TODO: get repo from flux
       break;
     case PluginNames.PACKAGES_KAPP:
       // TODO: get repo from kapp-controller


### PR DESCRIPTION
### Description of the change

This simple PR just adds the same workaround to get the repository for those packages coming from the flux plugin.
Until we came up with a better solution, I think it solves the short-term problem for some users.

### Benefits

Repo will be displayed in pkgs from Fluxv2

### Possible drawbacks

It's just a short-term solution, but so was the Helm one as well.

### Applicable issues

- fixes #4231

### Additional information

![image](https://user-images.githubusercontent.com/11535726/152572799-b4886f18-89d2-4e01-8f9e-0a7acbe65dbb.png)
