### PR TITLE
E2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ build_on_tag_or_prerelease: &build_on_tag_or_prerelease
     tags:
       only: /^v.*/
     branches:
-      only: prerelease
+      only: e2e-tests
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,10 @@ common_envars: &common_envars
   POSTGRESQL_VERSION: << pipeline.parameters.POSTGRESQL_VERSION >>
   RUST_VERSION: << pipeline.parameters.RUST_VERSION >>
 
+common_gke_envars: &common_gke_envars
+  USE_MULTICLUSTER_OIDC_ENV: "false"
+  TEST_TIMEOUT: 6
+
 install_gcloud_sdk: &install_gcloud_sdk
   run:
     name: "Install gcloud sdk"
@@ -364,7 +368,6 @@ install_additional_cluster: &install_additional_cluster
         kubectl --context kind-kubeapps-ci-additional --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci-additional apply --kubeconfig=${HOME}/.kube/kind-config-kubeapps-ci-additional -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml &&
         kubectl --context kind-kubeapps-ci-additional --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci-additional apply --kubeconfig=${HOME}/.kube/kind-config-kubeapps-ci-additional -f ./docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml &&
 
-        kubectl --context kind-kubeapps-ci-additional --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci-additional delete rolebinding kubeapps-user -n  kubeapps-user-namespace &&
         kubectl --context kind-kubeapps-ci-additional --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci-additional create rolebinding kubeapps-view-secret-oidc --role view-secrets --user oidc:kubeapps-user@example.com &&
         kubectl --context kind-kubeapps-ci-additional --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci-additional create clusterrolebinding kubeapps-view-oidc  --clusterrole=view --user oidc:kubeapps-user@example.com &&
         echo "Additional cluster created"
@@ -375,7 +378,6 @@ install_additional_cluster: &install_additional_cluster
         kubectl --context kind-kubeapps-ci-additional --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci-additional apply --kubeconfig=${HOME}/.kube/kind-config-kubeapps-ci-additional -f ./docs/user/manifests/kubeapps-local-dev-users-rbac.yaml &&
         kubectl --context kind-kubeapps-ci-additional --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci-additional apply --kubeconfig=${HOME}/.kube/kind-config-kubeapps-ci-additional -f ./docs/user/manifests/kubeapps-local-dev-namespace-discovery-rbac.yaml &&
 
-        kubectl --context kind-kubeapps-ci-additional --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci-additional delete rolebinding kubeapps-user -n  kubeapps-user-namespace &&
         kubectl --context kind-kubeapps-ci-additional --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci-additional create rolebinding kubeapps-view-secret-oidc --role view-secrets --user oidc:kubeapps-user@example.com &&
         kubectl --context kind-kubeapps-ci-additional --kubeconfig ${HOME}/.kube/kind-config-kubeapps-ci-additional create clusterrolebinding kubeapps-view-oidc  --clusterrole=view --user oidc:kubeapps-user@example.com &&
         echo "Additional cluster created"
@@ -490,7 +492,7 @@ run_e2e_tests: &run_e2e_tests
         DEV_TAG=${latest/v/}
         IMG_MODIFIER=""
       fi
-      if ./script/e2e-test.sh $USE_MULTICLUSTER_OIDC_ENV $OLM_VERSION $DEV_TAG $IMG_MODIFIER $DEFAULT_DEX_IP $ADDITIONAL_CLUSTER_IP; then
+      if ./script/e2e-test.sh $USE_MULTICLUSTER_OIDC_ENV $OLM_VERSION $DEV_TAG $IMG_MODIFIER $DOCKER_USERNAME $DOCKER_PASSWORD $TEST_TIMEOUT $DEFAULT_DEX_IP $ADDITIONAL_CLUSTER_IP; then
         # Test success
         echo "export TEST_RESULT=$?" >> $BASH_ENV
       else
@@ -544,6 +546,12 @@ gke_test: &gke_test
         command: |
           ./script/start-gke-env.sh $ESCAPED_GKE_CLUSTER $GKE_ZONE $GKE_BRANCH $GKE_ADMIN > /dev/null
     - <<: *install_helm_cli
+    - run:
+        # TODO(castelblanque) Unify shared resources with kubeapps-local-dev-users-rbac.yaml
+        # that only applies to Kind clusters
+        name: Apply customizations to GKE cluster
+        command: |
+          kubectl create namespace kubeapps-user-namespace
     - <<: *run_e2e_tests
     - store_artifacts:
         path: integration/reports
@@ -699,6 +707,7 @@ jobs:
       TEST_UPGRADE: "1"
       USE_MULTICLUSTER_OIDC_ENV: "true"
       TEST_OPERATORS: "1"
+      TEST_TIMEOUT: 4
       <<: *common_envars
     parameters:
       number:
@@ -708,28 +717,24 @@ jobs:
     <<: *gke_test
     environment:
       GKE_BRANCH: << pipeline.parameters.GKE_REGULAR_VERSION >>
-      USE_MULTICLUSTER_OIDC_ENV: "false"
-      <<: *common_envars
+      <<: [*common_envars, *common_gke_envars]
   GKE_REGULAR_VERSION_LATEST_RELEASE:
     <<: *gke_test
     environment:
       GKE_BRANCH: << pipeline.parameters.GKE_REGULAR_VERSION >>
       TEST_LATEST_RELEASE: 1
-      USE_MULTICLUSTER_OIDC_ENV: "false"
-      <<: *common_envars
+      <<: [*common_envars, *common_gke_envars]
   GKE_STABLE_VERSION_MAIN:
     <<: *gke_test
     environment:
       GKE_BRANCH: << pipeline.parameters.GKE_STABLE_VERSION >>
-      USE_MULTICLUSTER_OIDC_ENV: "false"
-      <<: *common_envars
+      <<: [*common_envars, *common_gke_envars]
   GKE_STABLE_VERSION_LATEST_RELEASE:
     <<: *gke_test
     environment:
       GKE_BRANCH: << pipeline.parameters.GKE_STABLE_VERSION >>
       TEST_LATEST_RELEASE: 1
-      USE_MULTICLUSTER_OIDC_ENV: "false"
-      <<: *common_envars
+      <<: [*common_envars, *common_gke_envars]
   sync_chart_to_bitnami:
     environment:
       <<: *common_envars

--- a/integration/global-setup.js
+++ b/integration/global-setup.js
@@ -1,0 +1,17 @@
+// Copyright 2022 the Kubeapps contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+// global-setup.js
+const utils = require("./tests/utils/util-functions");
+
+module.exports = async config => {
+  const timeDisplayFactor = 60000;
+  console.log("Setting up Playwright tests");
+  console.log(`>> Global timeout: ${config.globalTimeout / timeDisplayFactor} mins`);
+  config.projects.forEach(project => {
+    console.log(
+      `>> Project ${project.name} test timeout: ${project.timeout / timeDisplayFactor} mins`,
+    );
+  });
+  console.log(`>> Deployments timeout: ${utils.getDeploymentTimeout() / timeDisplayFactor} mins`);
+};

--- a/integration/manifests/executor.yaml
+++ b/integration/manifests/executor.yaml
@@ -21,7 +21,7 @@ spec:
             - tail
             - -f
             - /dev/null
-          image: kubeapps/integration-tests-pw:v1.0.0
+          image: kubeapps/integration-tests-pw:v1.0.1
           name: integration
           # TODO (castelblanque) Adjust properly the resources. 
           # Current values are not empirically demonstrated.

--- a/integration/playwright.config.js
+++ b/integration/playwright.config.js
@@ -7,7 +7,9 @@ const { devices } = require("@playwright/test");
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
-  globalTimeout: (process.env.CI_TIMEOUT ? parseInt(process.env.CI_TIMEOUT) : 10) * 60 * 1000,
+  globalSetup: require.resolve('./global-setup'),
+  globalTimeout: (process.env.CI_TIMEOUT ? parseInt(process.env.CI_TIMEOUT) : 10) * 60 * 1000, // Global timeout for the whole execution
+  timeout: (process.env.TEST_TIMEOUT ? parseInt(process.env.TEST_TIMEOUT) : 4) * 60 * 1000, // Default timeout for each test
   retries: 2,
   use: {
     headless: true,

--- a/integration/tests/main/01-missing-permissions.spec.js
+++ b/integration/tests/main/01-missing-permissions.spec.js
@@ -7,11 +7,14 @@ const utils = require("../utils/util-functions");
 
 test.describe("Limited user simple deployments", () => {
   test("Regular user fails to deploy package due to missing permissions", async ({ page }) => {
-    test.setTimeout(60000);
-
     // Log in
     const k = new KubeappsLogin(page);
     await k.doLogin("kubeapps-user@example.com", "password", process.env.VIEW_TOKEN);
+
+    // Change to user's namespace using UI
+    await page.click(".kubeapps-dropdown .kubeapps-nav-link");
+    await page.selectOption('select[name="namespaces"]', "default");
+    await page.click('cds-button:has-text("Change Context")');
 
     // Select package to deploy
     await page.click('a.nav-link:has-text("Catalog")');
@@ -22,7 +25,7 @@ test.describe("Limited user simple deployments", () => {
     const releaseNameLocator = page.locator("#releaseName");
     await releaseNameLocator.waitFor();
     await expect(releaseNameLocator).toHaveText("");
-    await releaseNameLocator.type(utils.getRandomName("test-01-release"));
+    await releaseNameLocator.fill(utils.getRandomName("test-01-release"));
     await page.locator('cds-button:has-text("Deploy")').click();
 
     const errorLocator = page.locator(".alert-items .alert-text");
@@ -45,8 +48,6 @@ test.describe("Limited user simple deployments", () => {
     // Explanation: User has permissions to deploy in its namespace, but can't actually deploy
     // if the package is from a repo that has a secret to which the user doesn't have access
 
-    test.setTimeout(60000);
-    
     // Log in
     const k = new KubeappsLogin(page);
     await k.doLogin("kubeapps-user@example.com", "password", process.env.VIEW_TOKEN);
@@ -65,7 +66,7 @@ test.describe("Limited user simple deployments", () => {
     const releaseNameLocator = page.locator("#releaseName");
     await releaseNameLocator.waitFor();
     await expect(releaseNameLocator).toHaveText("");
-    await releaseNameLocator.type(utils.getRandomName("test-01-release"));
+    await releaseNameLocator.fill(utils.getRandomName("test-01-release"));
     await page.locator('cds-button:has-text("Deploy")').click();
 
     const errorLocator = page.locator(".alert-items .alert-text");

--- a/integration/tests/main/02-create-package-repository.spec.js
+++ b/integration/tests/main/02-create-package-repository.spec.js
@@ -6,8 +6,6 @@ const { KubeappsLogin } = require("../utils/kubeapps-login");
 const utils = require("../utils/util-functions");
 
 test("Create a new package repository successfully", async ({ page }) => {
-  test.setTimeout(60000);
-
   // Log in
   const k = new KubeappsLogin(page);
   await k.doLogin("kubeapps-operator@example.com", "password", process.env.ADMIN_TOKEN);
@@ -20,8 +18,8 @@ test("Create a new package repository successfully", async ({ page }) => {
   // Add new repo
   console.log('Creating repository "my-repo"');
   await page.click('cds-button:has-text("Add App Repository")');
-  await page.type("input#kubeapps-repo-name", "my-repo");
-  await page.type("input#kubeapps-repo-url", "https://charts.gitlab.io/");
+  await page.fill("input#kubeapps-repo-name", "my-repo");
+  await page.fill("input#kubeapps-repo-url", "https://charts.gitlab.io/");
   await page.click('cds-button:has-text("Install Repo")');
 
   // Wait for new packages to be indexed
@@ -36,6 +34,6 @@ test("Create a new package repository successfully", async ({ page }) => {
   await page.click(".dropdown.kubeapps-menu button.kubeapps-nav-link");
   await page.click('a.dropdown-menu-link:has-text("App Repositories")');
   await page.waitForTimeout(3000);
-  await page.click('cds-button#delete-repo-my-repo');
+  await page.click("cds-button#delete-repo-my-repo");
   await page.locator('cds-modal-actions button:has-text("Delete")').click();
 });

--- a/integration/tests/main/04-default-deployment.spec.js
+++ b/integration/tests/main/04-default-deployment.spec.js
@@ -6,15 +6,13 @@ const { KubeappsLogin } = require("../utils/kubeapps-login");
 const utils = require("../utils/util-functions");
 
 test("Deploys package with default values in main cluster", async ({ page }) => {
-  test.setTimeout(120000);
-
   // Log in
   const k = new KubeappsLogin(page);
   await k.doLogin("kubeapps-operator@example.com", "password", process.env.ADMIN_TOKEN);
 
   // Select package to deploy
   await page.click('a.nav-link:has-text("Catalog")');
-  await page.locator("input#search").type("apache");
+  await page.locator("input#search").fill("apache");
   await page.waitForTimeout(3000);
   await page.click('a:has-text("foo apache chart for CI")');
   await page.click('cds-button:has-text("Deploy") >> nth=0');
@@ -25,12 +23,16 @@ test("Deploys package with default values in main cluster", async ({ page }) => 
   await expect(releaseNameLocator).toHaveText("");
   const releaseName = utils.getRandomName("test-04-release");
   console.log(`Creating release "${releaseName}"`);
-  await releaseNameLocator.type(releaseName);
+  await releaseNameLocator.fill(releaseName);
   await page.locator('cds-button:has-text("Deploy")').click();
 
   // Assertions
-  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1");
-  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready");
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+    timeout: utils.getDeploymentTimeout(),
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: utils.getDeploymentTimeout(),
+  });
 
   // Clean up
   await page.locator('cds-button:has-text("Delete")').click();

--- a/integration/tests/main/08-rollback.spec.js
+++ b/integration/tests/main/08-rollback.spec.js
@@ -14,9 +14,9 @@ test("Rolls back an application", async ({ page }) => {
 
   // Go to catalog
   await page.click('a.nav-link:has-text("Catalog")');
-  await page.click('.filters-menu label:has-text("bitnami")');  
+  await page.click('.filters-menu label:has-text("bitnami")');
   await page.waitForSelector("input#search");
-  await page.locator("input#search").type("apache");
+  await page.locator("input#search").fill("apache");
   await page.waitForTimeout(3000);
 
   // Select package
@@ -31,17 +31,17 @@ test("Rolls back an application", async ({ page }) => {
   await expect(releaseNameLocator).toHaveText("");
   const releaseName = utils.getRandomName("test-08-rollback");
   console.log(`Creating release "${releaseName}"`);
-  await releaseNameLocator.type(releaseName);
+  await releaseNameLocator.fill(releaseName);
 
   // Trigger deploy
   await page.locator('cds-button:has-text("Deploy")').click();
 
   // Check deployment
   await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
-    timeout: 60000,
+    timeout: utils.getDeploymentTimeout(),
   });
   await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
-    timeout: 60000,
+    timeout: utils.getDeploymentTimeout(),
   });
 
   // Try rollback
@@ -64,10 +64,10 @@ test("Rolls back an application", async ({ page }) => {
 
   // Check upgrade result
   await page.waitForSelector("css=.application-status-pie-chart-number >> text=2", {
-    timeout: 60000,
+    timeout: utils.getDeploymentTimeout(),
   });
   await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
-    timeout: 60000,
+    timeout: utils.getDeploymentTimeout(),
   });
 
   //  Rollback to the previous revision (default selected value)

--- a/integration/tests/main/09-user-positive-installation.spec.js
+++ b/integration/tests/main/09-user-positive-installation.spec.js
@@ -9,8 +9,6 @@ test.describe("Limited user simple deployments", () => {
   test("Regular user can deploy and delete packages in its own namespace from global repo without secrets", async ({
     page,
   }) => {
-    test.setTimeout(120000);
-
     // Log in as admin to create a repo without password
     const k = new KubeappsLogin(page);
     await k.doLogin("kubeapps-operator@example.com", "password", process.env.ADMIN_TOKEN);
@@ -29,8 +27,8 @@ test.describe("Limited user simple deployments", () => {
     const repoName = utils.getRandomName("repo-test-09");
     console.log(`Creating repository "${repoName}"`);
     await page.click('cds-button:has-text("Add App Repository")');
-    await page.type("input#kubeapps-repo-name", repoName);
-    await page.type(
+    await page.fill("input#kubeapps-repo-name", repoName);
+    await page.fill(
       "input#kubeapps-repo-url",
       "https://prometheus-community.github.io/helm-charts",
     );
@@ -48,7 +46,7 @@ test.describe("Limited user simple deployments", () => {
 
     // Select package to deploy
     await page.click('a.nav-link:has-text("Catalog")');
-    await page.locator("input#search").type("alertmanager");
+    await page.locator("input#search").fill("alertmanager");
     await page.waitForTimeout(3000);
     await page.click('a:has-text("alertmanager")');
     await page.click('cds-button:has-text("Deploy") >> nth=0');
@@ -59,12 +57,16 @@ test.describe("Limited user simple deployments", () => {
     await expect(releaseNameLocator).toHaveText("");
     const releaseName = utils.getRandomName("test-09-release");
     console.log(`Creating release "${releaseName}"`);
-    await releaseNameLocator.type(releaseName);
+    await releaseNameLocator.fill(releaseName);
     await page.locator('cds-button:has-text("Deploy")').click();
 
     // Check that package is deployed
-    await page.waitForSelector("css=.application-status-pie-chart-number >> text=1");
-    await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready");
+    await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+      timeout: utils.getDeploymentTimeout(),
+    });
+    await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+      timeout: utils.getDeploymentTimeout(),
+    });
 
     // Delete deployment
     await page.locator('cds-button:has-text("Delete")').click();
@@ -73,7 +75,8 @@ test.describe("Limited user simple deployments", () => {
 
     // Search for package deployed
     await page.click('a.nav-link:has-text("Applications")');
-    await page.locator("input#search").type("alertmanager");
+    await page.waitForTimeout(3000); // Sometimes typing was too fast to get the result shown
+    await page.locator("input#search").fill("alertmanager");
     await page.waitForTimeout(3000);
     const packageLocator = page.locator('a:has-text("alertmanager")');
     await expect(packageLocator).toHaveCount(0);

--- a/integration/tests/multicluster/05-multicluster-deployment.spec.js
+++ b/integration/tests/multicluster/05-multicluster-deployment.spec.js
@@ -19,7 +19,7 @@ test("Deploys package with default values in the second cluster", async ({ page 
 
   // Select package to deploy
   await page.click('a.nav-link:has-text("Catalog")');
-  await page.locator("input#search").type("apache");
+  await page.locator("input#search").fill("apache");
   await page.waitForTimeout(3000);
   await page.click('a:has-text("foo apache chart for CI")');
   await page.click('cds-button:has-text("Deploy") >> nth=0');
@@ -30,12 +30,16 @@ test("Deploys package with default values in the second cluster", async ({ page 
   await expect(releaseNameLocator).toHaveText("");
   const releaseName = utils.getRandomName("test-05-release");
   console.log(`Creating release "${releaseName}"`);
-  await releaseNameLocator.type(releaseName);
+  await releaseNameLocator.fill(releaseName);
   await page.locator('cds-button:has-text("Deploy")').click();
 
   // Assertions
-  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1");
-  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready");
+  await page.waitForSelector("css=.application-status-pie-chart-number >> text=1", {
+    timeout: utils.getDeploymentTimeout(),
+  });
+  await page.waitForSelector("css=.application-status-pie-chart-title >> text=Ready", {
+    timeout: utils.getDeploymentTimeout(),
+  });
 
   // Clean up
   await page.locator('cds-button:has-text("Delete")').click();

--- a/integration/tests/operators/06-operator-deployment.spec.js
+++ b/integration/tests/operators/06-operator-deployment.spec.js
@@ -17,7 +17,7 @@ test("Deploys an Operator", async ({ page }) => {
   await page.waitForTimeout(3000);
 
   // Select operator to deploy
-  await page.locator("input#search").type("prometheus");
+  await page.locator("input#search").fill("prometheus");
   await page.waitForTimeout(3000);
   await page.click('a:has-text("prometheus")');
   await page.click('cds-button:has-text("Deploy") >> nth=0');

--- a/integration/tests/utils/kubeapps-login.js
+++ b/integration/tests/utils/kubeapps-login.js
@@ -82,7 +82,7 @@ exports.KubeappsLogin = class KubeappsLogin {
     await this.page.waitForLoadState("networkidle");
 
     const inputLocator = this.page.locator("form input[name=token]");
-    await inputLocator.type(token);
+    await inputLocator.fill(token);
     await this.page.click("#login-submit-button");
 
     await this.page.waitForLoadState("networkidle");

--- a/integration/tests/utils/util-functions.js
+++ b/integration/tests/utils/util-functions.js
@@ -1,16 +1,17 @@
 // Copyright 2022 the Kubeapps contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-const path = require("path");
-const fs = require("fs");
 const axios = require("axios");
-const https = require('https');
+const https = require("https");
 
 module.exports = {
-
   getRandomName: base => {
     const randomNumber = Math.floor(Math.random() * Math.floor(100000));
     return base + "-" + randomNumber;
+  },
+
+  getDeploymentTimeout: () => {
+    return (process.env.TEST_TIMEOUT ? parseInt(process.env.TEST_TIMEOUT) / 2 : 2) * 60 * 1000;
   },
 
   getUrl: path => `${process.env.INTEGRATION_ENTRYPOINT}${path}`,
@@ -25,20 +26,21 @@ module.exports = {
     }
   },
 
-  getAxiosInstance: async (page) => {
+  getAxiosInstance: async (page, token) => {
     const cookies = await page.context().cookies(page.url());
-    const agent = new https.Agent({  
-      rejectUnauthorized: false
+    const agent = new https.Agent({
+      rejectUnauthorized: false,
     });
     const axiosConfig = {
       baseURL: `${process.env.INTEGRATION_ENTRYPOINT}`,
       headers: {
+        Authorization: `Bearer ${token}`,
         Cookie: `${cookies[0] ? cookies[0].name : ""}=${cookies[0] ? cookies[0].value : ""}`,
-        Accept: "application/json"
+        Accept: "application/json",
       },
       httpsAgent: agent,
-      timeout: 30000
+      timeout: 30000,
     };
     return await axios.create(axiosConfig);
-  }
+  },
 };


### PR DESCRIPTION
### Description of the change

This PR tries to fix problems with CI E2E tests in both local Kind and GKE environments.
It adds some logging of the parameters used in the `e2e-test.sh script`.
One of the problems was in resources created by test `03` being unable to have images pulled due to a `401 Unauthorized` error. Now the existing Docker credentials are used, but still the secret is created in the test.

More comments below.

### Benefits

E2E tests should pass successfully now in both local Kind and GKE.

### Possible drawbacks

No one knows what is the next surprise with E2E tests...

### Applicable issues

- Related to #2898

