### PR TITLE
CI: Don't overwrite `/app/reports` directory with html reporter.

### DIFF
--- a/docs/developer/end-to-end-tests.md
+++ b/docs/developer/end-to-end-tests.md
@@ -72,7 +72,7 @@ kubectl apply -f manifests/executor.yaml
 pod=$(kubectl get po -l run=integration -o jsonpath="{.items[0].metadata.name}")
 
 # Copy latest tests
-kubectl cp ./use-cases ${pod}:/app/
+kubectl cp ./tests ${pod}:/app/
 
 # If you also modify the test configuration, you will need to update the files
 # for f in *.js; do   kubectl cp "./${f}" "${pod}:/app/"; done

--- a/integration/playwright.config.js
+++ b/integration/playwright.config.js
@@ -25,7 +25,7 @@ const config = {
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  //reporter: [ ['list'], ['html', { open: 'never', outputFolder: 'reports/' }] ],
+  reporter: [ ['list'], ['html', { open: 'never', outputFolder: 'reports-html/' }] ],
   outputDir: 'reports/',
 };
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This PR doesn't fix any failing tests (see Rafa's #4243 for that), but rather solves an issue of the disappearing local screenshots and videos.

In the end, it was simply that the 1.0.0 image had the html reporter enabled and set to write to the *same* directory as the test reports. Turns out the reporter *overwrites* the directory. So the screenshots and videos were being written and saved, then at the end the html report was generated and overwrote the directory.

This doesn't happen by default, because the [default output directory used for automatic screenshots etc. is `test-results`](https://playwright.dev/docs/test-configuration#automatic-screenshots) and the [default output for the html reporter is `playwright-report`](https://playwright.dev/docs/test-reporters#html-reporter). But on the 1.0.0 image, both were set to the same `reports/`.

I've enabled the reporter, assuming that is the intention given it's enabled on the 1.0.0 image (though I noticed it's commented out on the 1.0.1 image, but perhaps it was for this reason). I'll let you push the 1.0.2 image if you approve Rafa.

### Benefits

We can view the screenshots and videos as well as the html report.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

How did I find the cause? I wrote a new test which created explicit screenshots to different paths, and noted that even then, all would be written fine except the ones I added to the `/app/reports` directory, which were missing. I then touched some files in that directory and re-ran my test, noting that those files disappeared when the test ran, so something was wiping the directory clean. Then it was just figuring out what was causing it.