### PR TITLE
Add powershell instructions

### DIFF
--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -43,6 +43,17 @@ kubectl get --namespace default secret $(kubectl get --namespace default service
 
 ### On Windows:
 
+#### Using Powershell
+
+Open a Powershell terminal and run:
+
+```powershell
+[Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($(kubectl get --namespace default secret $(kubectl get --namespace default serviceaccount kubeapps-operator -o jsonpath='{.secrets[].name}') -o jsonpath='{.data.token}')))
+```
+
+
+#### Using CMD
+
 Create a file called `GetDashToken.cmd` with the following lines in it:
 
 ```bat


### PR DESCRIPTION
### Description of the change

Adding instructions on how to get the token if using Powershell (the typical console in recent Windows versions)

### Benefits

Windows users will have an easy way to get the token.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

![image](https://user-images.githubusercontent.com/11535726/153005994-9bcf9aad-6522-41ad-93dd-c7d57aa846a0.png)
