### PR TITLE
Trigger fetch of package status after resources are updated.

### DIFF
--- a/dashboard/src/actions/installedpackages.test.tsx
+++ b/dashboard/src/actions/installedpackages.test.tsx
@@ -7,9 +7,11 @@ import {
   InstalledPackageSummary,
   GetInstalledPackageSummariesResponse,
   InstalledPackageReference,
+  InstalledPackageStatus,
   VersionReference,
   ReconciliationOptions,
   ResourceRef,
+  InstalledPackageStatus_StatusReason,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import configureMockStore from "redux-mock-store";
@@ -460,6 +462,38 @@ describe("getInstalledPkgResourceRefs", () => {
     await store.dispatch(getInstalledPkgResourceRefsAction);
 
     expect(InstalledPackage.GetInstalledPackageResourceRefs).toHaveBeenCalledWith(installedPkgRef);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe("getInstalledPkgStatus", () => {
+  it("fetches the package and dispatches the status", async () => {
+    const installedPkgRef = {
+      context: { cluster: "default-c", namespace: "default-ns" },
+      identifier: "my-release",
+      plugin: { name: "bad-plugin", version: "0.0.1" } as Plugin,
+    } as InstalledPackageReference;
+    const status = {
+      reason: InstalledPackageStatus_StatusReason.STATUS_REASON_INSTALLED,
+    } as InstalledPackageStatus;
+    const installedPackageDetail = { status } as InstalledPackageDetail;
+    InstalledPackage.GetInstalledPackageDetail = jest.fn().mockReturnValue({
+      installedPackageDetail,
+    });
+
+    const expectedActions = [
+      { type: getType(actions.installedpackages.requestInstalledPackageStatus) },
+      {
+        type: getType(actions.installedpackages.receiveInstalledPackageStatus),
+        payload: status,
+      },
+    ];
+
+    const getInstalledPkgStatusAction =
+      actions.installedpackages.getInstalledPkgStatus(installedPkgRef);
+    await store.dispatch(getInstalledPkgStatusAction);
+
+    expect(InstalledPackage.GetInstalledPackageDetail).toHaveBeenCalledWith(installedPkgRef);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/installedpackages.ts
+++ b/dashboard/src/actions/installedpackages.ts
@@ -7,6 +7,7 @@ import {
   Context,
   InstalledPackageDetail,
   InstalledPackageReference,
+  InstalledPackageStatus,
   InstalledPackageSummary,
   ReconciliationOptions,
   ResourceRef,
@@ -73,6 +74,15 @@ export const receiveRollbackInstalledPackage = createAction(
   "RECEIVE_ROLLBACK_INSTALLED_PACKAGE_CONFIRMATION",
 );
 
+export const requestInstalledPackageStatus = createAction("REQUEST_INSTALLED_PACKAGE_STATUS");
+
+export const receiveInstalledPackageStatus = createAction(
+  "RECEIVE_INSTALLED_PACKAGE_STATUS",
+  resolve => {
+    return (status: InstalledPackageStatus) => resolve(status);
+  },
+);
+
 export const errorInstalledPackage = createAction("ERROR_INSTALLED_PACKAGE", resolve => {
   return (err: FetchError | CreateError | UpgradeError | RollbackError | DeleteError) =>
     resolve(err);
@@ -89,6 +99,8 @@ const allActions = [
   requestInstalledPackageList,
   requestInstalledPackage,
   receiveInstalledPackageList,
+  requestInstalledPackageStatus,
+  receiveInstalledPackageStatus,
   requestInstalledPkgResourceRefs,
   receiveInstalledPkgResourceRefs,
   requestDeleteInstalledPackage,
@@ -139,6 +151,23 @@ export function getInstalledPackage(
       dispatch(selectInstalledPackage(installedPackageDetail!, availablePackageDetail));
     } catch (e: any) {
       dispatch(errorInstalledPackage(new FetchError("Unable to get installed package", [e])));
+    }
+  };
+}
+
+export function getInstalledPkgStatus(
+  installedPackageRef?: InstalledPackageReference,
+): ThunkAction<Promise<void>, IStoreState, null, InstalledPackagesAction> {
+  return async dispatch => {
+    dispatch(requestInstalledPackageStatus());
+    try {
+      // Get the details of an installed package for the status.
+      const { installedPackageDetail } = await InstalledPackage.GetInstalledPackageDetail(
+        installedPackageRef,
+      );
+      dispatch(receiveInstalledPackageStatus(installedPackageDetail!.status!));
+    } catch (e: any) {
+      dispatch(errorInstalledPackage(new FetchError("Unable to refresh installed package", [e])));
     }
   };
 }

--- a/dashboard/src/actions/kube.test.tsx
+++ b/dashboard/src/actions/kube.test.tsx
@@ -128,8 +128,40 @@ describe("getResources", () => {
     store.dispatch(actions.kube.getResources(pkg, refs, watch));
     expect(store.getActions()).toEqual(expectedActions);
 
-    const expectedCompletionActions = [
+    const expectedResource = {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        name: "foo",
+        namespace: "default",
+      },
+    } as IResource;
+    const getResourcesResponse = {
+      resourceRef: {
+        apiVersion: "v1",
+        kind: "Service",
+        name: "foo",
+        namespace: "default",
+      } as APIResourceRef,
+      manifest: JSON.stringify(expectedResource),
+    } as GetResourcesResponse;
+
+    const expectedHandlerActions = [
       expectedActions[0],
+      {
+        type: getType(actions.kube.receiveResource),
+        payload: {
+          key: "v1/Service/default/foo",
+          resource: expectedResource,
+        },
+      },
+    ];
+    const handler = store.getActions()[0].payload.handler;
+    handler(getResourcesResponse);
+    expect(store.getActions()).toEqual(expectedHandlerActions);
+
+    const expectedCompletionActions = [
+      ...expectedHandlerActions,
       {
         type: getType(actions.kube.closeRequestResources),
         payload: pkg,

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -97,8 +97,10 @@ export function getResources(
   // it once after a bunch of resources have been processed is enough.
   // To do this, we use the lodash debounce function so that the status is refreshed
   // 2s after the last resource is processed.
-  const dispatchGetInstalledPkgStatus = (dispatch: ThunkDispatch<IStoreState, null, KubeAction>, pkg: InstalledPackageReference) =>
-    dispatch(actions.installedpackages.getInstalledPkgStatus(pkg));
+  const dispatchGetInstalledPkgStatus = (
+    dispatch: ThunkDispatch<IStoreState, null, KubeAction>,
+    pkg: InstalledPackageReference,
+  ) => dispatch(actions.installedpackages.getInstalledPkgStatus(pkg));
   const debouncedGetInstalledPkgStatus = debounce(dispatchGetInstalledPkgStatus, 2000);
   return dispatch => {
     dispatch(

--- a/dashboard/src/actions/kube.tsx
+++ b/dashboard/src/actions/kube.tsx
@@ -11,6 +11,8 @@ import {
   InstalledPackageReference,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { GetResourcesResponse } from "gen/kubeappsapis/plugins/resources/v1alpha1/resources";
+import actions from "actions";
+import { debounce } from "lodash";
 
 const { createAction } = deprecated;
 
@@ -89,6 +91,15 @@ export function getResources(
   refs: APIResourceRef[],
   watch: boolean,
 ): ThunkAction<void, IStoreState, null, KubeAction> {
+  // After resources are processed, we want to refresh the status of the
+  // installed package (since other UX components rely on the status), but
+  // we don't need to do this after every resource is processed, rather doing
+  // it once after a bunch of resources have been processed is enough.
+  // To do this, we use the lodash debounce function so that the status is refreshed
+  // 2s after the last resource is processed.
+  const dispatchGetInstalledPkgStatus = (dispatch: ThunkDispatch<IStoreState, null, KubeAction>, pkg: InstalledPackageReference) =>
+    dispatch(actions.installedpackages.getInstalledPkgStatus(pkg));
+  const debouncedGetInstalledPkgStatus = debounce(dispatchGetInstalledPkgStatus, 2000);
   return dispatch => {
     dispatch(
       requestResources(
@@ -97,6 +108,7 @@ export function getResources(
         watch,
         (r: GetResourcesResponse) => {
           processGetResourcesResponse(r, dispatch);
+          debouncedGetInstalledPkgStatus(dispatch, pkg);
         },
         (e: any) => {
           dispatch(receiveResourcesError(e));

--- a/dashboard/src/reducers/installedpackages.ts
+++ b/dashboard/src/reducers/installedpackages.ts
@@ -52,6 +52,18 @@ const installedPackagesReducer = (
         },
         selectedDetails: action.payload.details,
       };
+    case getType(actions.installedpackages.receiveInstalledPackageStatus):
+      if (state.selected) {
+        return {
+          ...state,
+          selected: {
+            ...state.selected!,
+            revision: state.selected!.revision,
+            status: action.payload,
+          },
+        };
+      }
+      return state;
     case getType(actions.installedpackages.receiveInstalledPkgResourceRefs):
       return {
         ...state,


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Fixes an issue whereby a package installs successfully but the upgrade/delete buttons remain disabled.

With this change, we refresh the package status whenever a bunch of resources are processed.

### Benefits

When using Flux plugin to install a package, the buttons enable once the package is reconciled.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3695 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
