### PR TITLE
Ensure only one of helm or fluxv2 plugins are configured.

### DIFF
--- a/chart/kubeapps/Chart.lock
+++ b/chart/kubeapps/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.0
+  version: 1.11.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 10.16.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 15.7.6
-digest: sha256:4102035f8d115bb5ea6d4bc51767abbee940de90425077245ecc8117567561bf
-generated: "2022-02-01T17:58:10.326513+01:00"
+digest: sha256:f225a14382bc93090ee52dff0a1b5228a430e6f1a49e1b32e1a57990199fd26f
+generated: "2022-02-10T16:23:19.494542064+11:00"

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.8.0-dev4
+version: 7.8.0-dev5

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -223,16 +223,20 @@ kubeapps: ingress.tls
 */}}
 {{- define "kubeapps.validateValues.kubeappsapis.enabledPlugins" -}}
     {{- if has "flux" .Values.kubeappsapis.enabledPlugins }}
-    kubeapps: kubeappsapis.enabledPlugins 
+    kubeapps: kubeappsapis.enabledPlugins
         You enter "flux", perhaps you meant "fluxv2"?
     {{- end -}}
     {{- if has "kapp_controller" .Values.kubeappsapis.enabledPlugins }}
-    kubeapps: kubeappsapis.enabledPlugins 
+    kubeapps: kubeappsapis.enabledPlugins
         You enter "kapp_controller", perhaps you meant "kapp-controller"?
     {{- end -}}
     {{- if and (has "fluxv2" .Values.kubeappsapis.enabledPlugins) (not .Values.redis.enabled) }}
-    kubeapps: kubeappsapis.enabledPlugins 
+    kubeapps: kubeappsapis.enabledPlugins
         If you enable the "fluxv2" plugin, you must also set redis.enabled=true
+    {{- end -}}
+    {{- if and (has "fluxv2" .Values.kubeappsapis.enabledPlugins) (has "helm" .Values.kubeappsapis.enabledPlugins) }}
+    kubeapps: kubeappsapis.enabledPlugins
+        Please choose just one of the flux2 and helm plugins, since they both operate on Helm releases.
     {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Currently it's possible to configure the kubeapps apis service with both the fluxv2 and helm plugins running. This is not something we are able to support right now, since it would enable interacting with the helm releases directly when they are being managed by flux (as well as confusingly display apps twice).

I've used the new chart validation that @antgamdia added recently, since it's nice to catch the configuration issue *before* doing the deployment.

### Benefits

We don't allow a configuration which we don't intend to support.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3695 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
Next up, removing the need to enable redis (and removing postgres when helm plugin is not used? - possibly, depends on effects, may need to also remove assetsvc, apprepo controller etc.).
