### PR TITLE
Prevent install if the resources plugin is not defined

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -222,6 +222,10 @@ kubeapps: ingress.tls
 # Validate values of common mistakes in kubeappsapis.enabledPlugins
 */}}
 {{- define "kubeapps.validateValues.kubeappsapis.enabledPlugins" -}}
+    {{- if not (has "resources" .Values.kubeappsapis.enabledPlugins) }}
+    kubeapps: kubeappsapis.enabledPlugins
+        The 'resources' plugin is required for Kubeapps to work properly. Please add it to the enabledPlugins list.
+    {{- end -}}
     {{- if has "flux" .Values.kubeappsapis.enabledPlugins }}
     kubeapps: kubeappsapis.enabledPlugins
         You enter "flux", perhaps you meant "fluxv2"?


### PR DESCRIPTION
### Description of the change

As usual with this Helm template validation PR of mine, there's always a story behind it: after a bunch of time wondering what was failing in the authentication (with the auth-proxy, the AKS environments, ect...) I noticed I've defined my `enabledPlugins` property in the values.yaml, hence overriding the default one. I just forgot to add `resouces` to the list of plugins....

This PR adds a validations step to prevent the chart installation if this plugin is not enabled.

### Benefits

No more silly errors

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A
