### PR TITLE
Enable specifying plugins that determine chart dependencies.

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami
     version: 15.x.x
-    condition: kubeapps.plugins.flux.enabled
+    condition: packaging.flux.enabled
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 home: https://kubeapps.com
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/main/docs/img/logo.png

--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami
     version: 15.x.x
-    condition: redis.enabled
+    condition: kubeapps.plugins.flux.enabled
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 home: https://kubeapps.com
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/main/docs/img/logo.png
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.8.0-dev5
+version: 7.8.0-dev6

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -192,7 +192,6 @@ Compile all warnings into a single message, and call fail.
 {{- define "kubeapps.validateValues" -}}
 {{- $messages := list -}}
 {{- $messages := append $messages (include "kubeapps.validateValues.ingress.tls" .) -}}
-{{- $messages := append $messages (include "kubeapps.validateValues.kubeappsapis.enabledPlugins" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -248,27 +247,6 @@ kubeapps: ingress.tls
       {{- $enabledPlugins = append $enabledPlugins "resources" }}
     {{- end }}
     {{- $enabledPlugins | toJson }}
-{{- end -}}
-{{/*
-TODO: update to include values from deprecated kubeappsapis.enabledPlugins
-*/}}
-
-{{/*
-# Validate values of common mistakes in kubeappsapis.enabledPlugins
-*/}}
-{{- define "kubeapps.validateValues.kubeappsapis.enabledPlugins" -}}
-    {{- if has "flux" .Values.kubeappsapis.enabledPlugins }}
-    kubeapps: kubeappsapis.enabledPlugins
-        You enter "flux", perhaps you meant "fluxv2"?
-    {{- end -}}
-    {{- if has "kapp_controller" .Values.kubeappsapis.enabledPlugins }}
-    kubeapps: kubeappsapis.enabledPlugins
-        You enter "kapp_controller", perhaps you meant "kapp-controller"?
-    {{- end -}}
-    {{- if and (has "fluxv2" .Values.kubeappsapis.enabledPlugins) (has "helm" .Values.kubeappsapis.enabledPlugins) }}
-    kubeapps: kubeappsapis.enabledPlugins
-        Please choose just one of the flux2 and helm plugins, since they both operate on Helm releases.
-    {{- end -}}
 {{- end -}}
 
 {{/*

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -230,11 +230,11 @@ kubeapps: ingress.tls
       {{- range $plugin, $options := .Values.packaging }}
         {{- if $options.enabled }}
           {{- if eq $plugin "carvel" }}
-            {{- $enabledPlugins = append $enabledPlugins "kapp-controller" }}
+            {{- $enabledPlugins = append $enabledPlugins "kapp-controller-packages" }}
           {{- else if eq $plugin "flux" }}
-            {{- $enabledPlugins = append $enabledPlugins "fluxv2" }}
+            {{- $enabledPlugins = append $enabledPlugins "fluxv2-packages" }}
           {{- else if eq $plugin "helm" }}
-            {{- $enabledPlugins = append $enabledPlugins "helm" }}
+            {{- $enabledPlugins = append $enabledPlugins "helm-packages" }}
           {{- else }}
             {{ $msg := printf "packaging: Unsupported packaging option: %s" $plugin }}
             {{- fail $msg }}

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -221,24 +221,31 @@ kubeapps: ingress.tls
 # Calculate the kubeappsapis enabledPlugins.
 */}}
 {{- define "kubeapps.kubeappsapis.enabledPlugins" -}}
-    {{- if and .Values.plugins.flux.enabled .Values.plugins.helm.enabled }}
-    {{- fail "plugins: Please enable only one of the flux and helm plugins, since they both operate on Helm releases." }}
-    {{- end -}}
     {{- $enabledPlugins := list }}
-    {{- $enabledPlugins = append $enabledPlugins "resources" }}
-    {{- range $plugin, $options := .Values.plugins }}
-      {{- if $options.enabled }}
-        {{- if eq $plugin "carvel" }}
-          {{- $enabledPlugins = append $enabledPlugins "kapp-controller" }}
-        {{- else if eq $plugin "flux" }}
-          {{- $enabledPlugins = append $enabledPlugins "fluxv2" }}
-        {{- else if eq $plugin "helm" }}
-          {{- $enabledPlugins = append $enabledPlugins "helm" }}
-        {{- else }}
-    kubeapps: plugins
-        Unsupported plugin: {{ $plugin }}
+    {{- if .Values.kubeappsapis.enabledPlugins }}
+      {{- $enabledPlugins = .Values.kubeappsapis.enabledPlugins }}
+    {{- else }}
+      {{- if and .Values.packaging.flux.enabled .Values.packaging.helm.enabled }}
+        {{- fail "packaging: Please enable only one of the flux and helm plugins, since they both operate on Helm releases." }}
+      {{- end -}}
+      {{- range $plugin, $options := .Values.packaging }}
+        {{- if $options.enabled }}
+          {{- if eq $plugin "carvel" }}
+            {{- $enabledPlugins = append $enabledPlugins "kapp-controller" }}
+          {{- else if eq $plugin "flux" }}
+            {{- $enabledPlugins = append $enabledPlugins "fluxv2" }}
+          {{- else if eq $plugin "helm" }}
+            {{- $enabledPlugins = append $enabledPlugins "helm" }}
+          {{- else }}
+      kubeapps: plugins
+          Unsupported plugin: {{ $plugin }}
+          {{- end }}
         {{- end }}
       {{- end }}
+      {{- if not $enabledPlugins }}
+        {{- fail "packaging: Please enable at least one of the packaging plugins." }}
+      {{- end }}
+      {{- $enabledPlugins = append $enabledPlugins "resources" }}
     {{- end }}
     {{- $enabledPlugins | toJson }}
 {{- end -}}

--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -236,8 +236,8 @@ kubeapps: ingress.tls
           {{- else if eq $plugin "helm" }}
             {{- $enabledPlugins = append $enabledPlugins "helm" }}
           {{- else }}
-      kubeapps: plugins
-          Unsupported plugin: {{ $plugin }}
+            {{ $msg := printf "packaging: Unsupported packaging option: %s" $plugin }}
+            {{- fail $msg }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -68,7 +68,8 @@ spec:
           command:
             - /kubeapps-apis
           args:
-            {{- range .Values.kubeappsapis.enabledPlugins }}
+            {{- $enabledPlugins := include "kubeapps.kubeappsapis.enabledPlugins" . | fromJsonArray }}
+            {{- range $enabledPlugins }}
             - --plugin-dir
             - /plugins/{{ . }}
             {{- end }}
@@ -90,7 +91,7 @@ spec:
             {{- end }}
           env:
             - name: GOGC
-              value: "50" # default is 100. 50 means increasing x2 the frequency of GC 
+              value: "50" # default is 100. 50 means increasing x2 the frequency of GC
             - name: PORT
               value: {{ .Values.kubeappsapis.containerPort | quote }}
             {{- if .Values.redis.enabled }}

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -1867,18 +1867,12 @@ kubeappsapis:
 ## @section Redis&trade; chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
 ##
+## Redis will be enabled and installed if `packages.flux.enabled` is true.
 redis:
   ## @param redis.redisPassword Password used in Redis&trade;
   ## ref: https://github.com/bitnami/bitnami-docker-redis/blob/master/README.md#setting-the-server-password-on-first-run
   ##
   redisPassword: ""
-  ## @param redis.enabled Enable the Redis&trade; deployment when deploying Kubeapps APIs.
-  ## We currently have the situation that Redis is required for the fluxv2 plugin only.
-  ## Until such a point that we're releasing with the fluxv2 plugin enabled, or the
-  ## plugin cache support has been generalised so all plugins use Redis, we'll need
-  ## to manually enable this in dev while ensuring it is false for releases (as it
-  ## is a conditional dependency in the Chart.yaml).
-  enabled: false
   master:
     ## @param redis.master.extraFlags Array with additional command line flags for Redis&trade; master
     extraFlags:

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -136,10 +136,13 @@ ingress:
   ##
   secrets: []
 
-## @section Kubeapps plugin options
+## @section Kubeapps packaging options
 ## Note: the helm and flux plugins are mutually exclusive, you can only
 ## enable one or the other since they both operate on Helm release objects.
-plugins:
+## Enabling carvel or flux does *not* install the required related Carvel or
+## Flux controllers on your cluster. Please read the documentation for running
+## Kubeapps with Carvel or Flux support.
+packaging:
   ## Default helm plugin
   ## @param plugins.helm.enabled Enable the standard helm plugin.
   helm:
@@ -1626,8 +1629,13 @@ postgresql:
 
 ## @section kubeappsapis parameters
 kubeappsapis:
-  ## @param kubeappsapis.enabledPlugins Enabled plugins for the Kubeapps-APIs service
-  ## DEPRECATED: use the top-level `plugins` value instead.
+  ## @param kubeappsapis.enabledPlugins Manually override which plugins are
+  ## enabled for the Kubeapps-APIs service
+  ##
+  ## NOTE: normally this should remain blank, with the top-level `packaging`
+  ## value automatically determining which plugins should be enabled. Only
+  ## set this value if you want to manually override the list of plugins
+  ## enabled for the service.
   ##
   enabledPlugins:
   pluginConfig:

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -143,16 +143,16 @@ ingress:
 ## Flux controllers on your cluster. Please read the documentation for running
 ## Kubeapps with Carvel or Flux support.
 packaging:
-  ## Default helm plugin
-  ## @param plugins.helm.enabled Enable the standard helm plugin.
+  ## Default helm packaging
+  ## @param packaging.helm.enabled Enable the standard Helm packaging.
   helm:
     enabled: true
-  ## Carvel plugin
-  ## @param plugins.carvel.enabled Enable the carvel plugin.
+  ## Carvel packaging
+  ## @param packaging.carvel.enabled Enable support for the Carvel (kapp-controller) packaging.
   carvel:
     enabled: false
-  ## Flux (v2) plugin
-  ## @param plugins.flux.enabled Enable the Flux plugin.
+  ## Flux (v2) packaging
+  ## @param packaging.flux.enabled Enable support for Flux (v2) packaging.
   flux:
     enabled: false
 

--- a/chart/kubeapps/values.yaml
+++ b/chart/kubeapps/values.yaml
@@ -136,6 +136,23 @@ ingress:
   ##
   secrets: []
 
+## @section Kubeapps plugin options
+## Note: the helm and flux plugins are mutually exclusive, you can only
+## enable one or the other since they both operate on Helm release objects.
+plugins:
+  ## Default helm plugin
+  ## @param plugins.helm.enabled Enable the standard helm plugin.
+  helm:
+    enabled: true
+  ## Carvel plugin
+  ## @param plugins.carvel.enabled Enable the carvel plugin.
+  carvel:
+    enabled: false
+  ## Flux (v2) plugin
+  ## @param plugins.flux.enabled Enable the Flux plugin.
+  flux:
+    enabled: false
+
 ## @section Frontend parameters
 
 ## Frontend parameters
@@ -1610,15 +1627,9 @@ postgresql:
 ## @section kubeappsapis parameters
 kubeappsapis:
   ## @param kubeappsapis.enabledPlugins Enabled plugins for the Kubeapps-APIs service
-  ## e.g:
-  ## enabledPlugins:
-  ## - helm
-  ## - fluxv2
-  ## - kapp-controller
+  ## DEPRECATED: use the top-level `plugins` value instead.
   ##
   enabledPlugins:
-    - helm
-    - resources
   pluginConfig:
     core:
       packages:
@@ -1641,7 +1652,7 @@ kubeappsapis:
           ## @param kubeappsapis.pluginConfig.kappController.packages.v1alpha1.defaultPrereleasesVersionSelection Default policy for allowing prereleases containing one of the identifiers
           ## ref: https://carvel.dev/kapp-controller/docs/latest/package-consumer-concepts/#prereleases
           ## e.g:
-          # defaultPrereleasesVersionSelection: 
+          # defaultPrereleasesVersionSelection:
           # - rc
           defaultPrereleasesVersionSelection: null
           ## @param kubeappsapis.pluginConfig.kappController.packages.v1alpha1.defaultAllowDowngrades Default policy for allowing applications to be downgraded to previous versions

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -66,9 +66,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM bitnami/minideb:buster
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kubeapps/kubeapps/kubeapps-apis /kubeapps-apis
-COPY --from=builder /kapp-controller-packages-v1alpha1-plugin.so /plugins/kapp-controller/
-COPY --from=builder /fluxv2-packages-v1alpha1-plugin.so /plugins/fluxv2/
-COPY --from=builder /helm-packages-v1alpha1-plugin.so /plugins/helm/
+COPY --from=builder /kapp-controller-packages-v1alpha1-plugin.so /plugins/kapp-controller-packages/
+COPY --from=builder /fluxv2-packages-v1alpha1-plugin.so /plugins/fluxv2-packages/
+COPY --from=builder /helm-packages-v1alpha1-plugin.so /plugins/helm-packages/
 COPY --from=builder /resources-v1alpha1-plugin.so /plugins/resources/
 
 EXPOSE 50051

--- a/docs/user/managing-carvel-packages.md
+++ b/docs/user/managing-carvel-packages.md
@@ -72,19 +72,17 @@ This `kapp-controller` plugin is currently being built by default in the Kubeapp
 
 > **TIP**: Please refer to the [getting started documentation](./getting-started.md) for more information on how to install Kubeapps and pass custom configuration values.
 
-In the [values.yaml](../../chart/kubeapps/values.yaml) file, under `kubeappsapis.enabledPlugins` add
-`kapp-controller` to the list of enabled plugins. For example:
+In the [values.yaml](../../chart/kubeapps/values.yaml) file, enable the `packaging.carvel` option (and disable helm, depending on your needs):
 
 ```yaml
-kubeappsapis:
-  ...
-  enabledPlugins:
-  - resources
-  - helm
-  - kapp-controller # add this one
+packaging:
+  helm:
+    enabled: false
+  carvel:
+    enabled: true
 ```
 
-Additionally, you can pass the following configuration values to the `kapp-controller` plugin:
+If required, you can additionally pass the following configuration values to modify the defaults used by Kubeapps for the Carvel support. These are options passed to the `kapp-controller` plugin that handles the Carvel packaging support:
 
 - `defaultUpgradePolicy`: represents the default upgrade policy for the packages. If other than `none` is selected, the kapp-controller will automatically upgrade the packages to the latest matching semantic version. For instance, assuming we installed the version `1.2.3`:
   - With `major` selected, the package will be upgraded to `>=1.2.3`, for example, `2.0.0`, for

--- a/docs/user/managing-carvel-packages.md
+++ b/docs/user/managing-carvel-packages.md
@@ -72,12 +72,10 @@ This `kapp-controller` plugin is currently being built by default in the Kubeapp
 
 > **TIP**: Please refer to the [getting started documentation](./getting-started.md) for more information on how to install Kubeapps and pass custom configuration values.
 
-In the [values.yaml](../../chart/kubeapps/values.yaml) file, enable the `packaging.carvel` option (and disable helm, depending on your needs):
+In the [values.yaml](../../chart/kubeapps/values.yaml) file, enable the `packaging.carvel` option:
 
 ```yaml
 packaging:
-  helm:
-    enabled: false
   carvel:
     enabled: true
 ```


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

@batiati If approved, feel free to land this and include in the release if you want.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR has two related changes:
1. Create a user-centric `packaging` option in the values for specifying whether Kubeapps should run with helm, flux or carvel packaging. Defaulting to helm of course.
2. Uses these new boolean values to control whether the Redis chart dependency is installed, so that we no longer need to manually specify `redis.enabled` (removed that from the chart, since it's no longer used in the chart dependency condition).

```
# Default plugins are helm and resources:
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 5              
            - /kubeapps-apis
          args:
            - --plugin-dir
            - /plugins/helm
            - --plugin-dir
            - /plugins/resources

# Enabling carvel updates the enabled plugins.
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
diff --git a/docs/user/manifests/kubeapps-local-dev-values.yaml b/docs/user/manifests/kubeapps-local-dev-values.yaml
index 3b7518cc..ff73074b 100644
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -30,3 +30,6 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  carvel:
+    enabled: true
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 7
            - /kubeapps-apis
          args:
            - --plugin-dir
            - /plugins/kapp-controller
            - --plugin-dir
            - /plugins/helm
            - --plugin-dir
            - /plugins/resources

# Enabling flux results in an error as helm is also enabled:
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
diff --git a/docs/user/manifests/kubeapps-local-dev-values.yaml b/docs/user/manifests/kubeapps-local-dev-values.yaml
index 3b7518cc..7117cbaa 100644
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -30,3 +30,8 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  carvel:
+    enabled: true
+  flux:
+    enabled: true
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 7              
Error: execution error at (kubeapps/templates/kubeappsapis/deployment.yaml:71:35): packaging: Please enable only one of the flux and helm plugins, since they both operate on Helm releases.

Use --debug flag to render out invalid YAML
make: *** [script/makefiles/deploy-dev.mk:40: deploy-dev-kubeapps] Error 1

# Disabling helm gets things going as expected:
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
diff --git a/docs/user/manifests/kubeapps-local-dev-values.yaml b/docs/user/manifests/kubeapps-local-dev-values.yaml
index 3b7518cc..ba928fcc 100644
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -30,3 +30,10 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  carvel:
+    enabled: true
+  flux:
+    enabled: true
+  helm:
+    enabled: false
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 7              
            - /kubeapps-apis
          args:
            - --plugin-dir
            - /plugins/kapp-controller
            - --plugin-dir
            - /plugins/fluxv2
            - --plugin-dir
            - /plugins/resources

# Adding some other key to the packaging value causes a fail:
Use --debug flag to render out invalid YAML
make: *** [script/makefiles/deploy-dev.mk:40: deploy-dev-kubeapps] Error 1
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
diff --git a/docs/user/manifests/kubeapps-local-dev-values.yaml b/docs/user/manifests/kubeapps-local-dev-values.yaml
index 3b7518cc..c3a43886 100644
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -30,3 +30,12 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  carvel:
+    enabled: true
+  flux:
+    enabled: true
+  helm:
+    enabled: false
+  unknownpkg:
+    enabled: true
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 7              
Error: execution error at (kubeapps/templates/kubeappsapis/deployment.yaml:71:35): packaging: Unsupported packaging option: unknownpkg

Use --debug flag to render out invalid YAML
make: *** [script/makefiles/deploy-dev.mk:40: deploy-dev-kubeapps] Error 1

# Manually overriding the enabled plugins is still possible:
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
diff --git a/docs/user/manifests/kubeapps-local-dev-values.yaml b/docs/user/manifests/kubeapps-local-dev-values.yaml
index 3b7518cc..e1fe4b91 100644
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -18,6 +18,9 @@ postgresql:
   existingSecret: postgresql-db
 kubeappsapis:
   replicaCount: 1
+  enabledPlugins:
+  - unknownpkg
+  - anotherunknownpkg
 ingress:
   enabled: true
   hostname: localhost
@@ -30,3 +33,12 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  carvel:
+    enabled: true
+  flux:
+    enabled: true
+  helm:
+    enabled: false
+  unknownpkg:
+    enabled: true
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 7              
            - /kubeapps-apis
          args:
            - --plugin-dir
            - /plugins/unknownpkg
            - --plugin-dir
            - /plugins/anotherunknownpkg
            - --clusters-config-path=/config/clusters.conf
            - --plugin-config-path=/config/kubeapps-apis/plugins.conf
```
### Benefits

Users don't need to care about "plugins" and ensuring the names are correct nor ensuring the resources plugin has been enabled etc.

Checks automatically that at least 1 packaging plugin has been enabled. Also continues to ensure that you can't run with flux and helm together.

Still retains the option to explicitly set the `kubeappsapis.enabledPlugins` if the user really wants to (in case of new or in-development plugins etc).

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #4264 

### Additional information

