### PR TITLE
Add DCO in the bot's commits

### DIFF
--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -209,7 +209,7 @@ commitAndSendExternalPR() {
     sed -i.bk -e "s/<EMAIL>/$(git config user.email)/g" "${PR_EXTERNAL_TEMPLATE_FILE}"
     git checkout -b "${TARGET_BRANCH}"
     git add --all .
-    git commit -m "kubeapps: bump chart version to ${CHART_VERSION}"
+    git commit --signoff -m "kubeapps: bump chart version to ${CHART_VERSION}"
     # NOTE: This expects to have a loaded SSH key
     if [[ $(git ls-remote origin "${TARGET_BRANCH}" | wc -l) -eq 0 ]]; then
         git push -u origin "${TARGET_BRANCH}"
@@ -242,7 +242,7 @@ commitAndSendInternalPR() {
     fi
     git checkout -b "${TARGET_BRANCH}"
     git add --all .
-    git commit -m "bump chart version to ${CHART_VERSION}"
+    git commit --signoff -m "bump chart version to ${CHART_VERSION}"
     # NOTE: This expects to have a loaded SSH key
     if [[ $(git ls-remote origin "${TARGET_BRANCH}" | wc -l) -eq 0 ]]; then
         git push -u origin "${TARGET_BRANCH}"


### PR DESCRIPTION
### Description of the change

Recently, our bot's PR was failing because bitnami/charts is actively enforcing the DCO-signed commits in every PR in their repo. This PR is just adding the `--signoff` flag in the `git commit` commands.

### Benefits

New automated PRs to bitnami/charts will continue to work.

### Possible drawbacks

A bot is legally entitled to sign a DCO?

### Applicable issues

N/A

### Additional information

N/A
