### PR TITLE
Autologin if a token is passed as queryParam

### DIFF
--- a/dashboard/src/components/LoginForm/LoginForm.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.test.tsx
@@ -3,7 +3,6 @@
 
 import LoadingWrapper from "components/LoadingWrapper";
 import { Location } from "history";
-import qs from "qs";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Redirect } from "react-router-dom";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";

--- a/dashboard/src/components/LoginForm/LoginForm.test.tsx
+++ b/dashboard/src/components/LoginForm/LoginForm.test.tsx
@@ -3,8 +3,9 @@
 
 import LoadingWrapper from "components/LoadingWrapper";
 import { Location } from "history";
+import qs from "qs";
 import { act } from "react-dom/test-utils";
-import { Redirect } from "react-router-dom";
+import { MemoryRouter, Redirect } from "react-router-dom";
 import { defaultStore, getStore, mountWrapper } from "shared/specs/mountWrapper";
 import LoginForm from "./LoginForm";
 import OAuthLogin from "./OauthLogin";
@@ -114,6 +115,44 @@ describe("token login form", () => {
       wrapper.find("form").simulate("submit", { preventDefault: jest.fn() });
     });
     expect(authenticate).toBeCalledWith(defaultCluster, "f00b4r");
+  });
+
+  it("calls the authenticate handler if a token is passed as query param", () => {
+    const authenticate = jest.fn();
+    mountWrapper(
+      defaultStore,
+      <MemoryRouter initialEntries={["/login?token=f00b4r"]}>
+        <LoginForm {...defaultProps} authenticate={authenticate} />
+      </MemoryRouter>,
+    );
+    expect(authenticate).toBeCalledWith(defaultCluster, "f00b4r");
+  });
+
+  it("calls the authenticate handler just once if a failed token is passed as query param", () => {
+    const authenticate = jest.fn();
+    mountWrapper(
+      defaultStore,
+      <MemoryRouter initialEntries={["/login?token=bad-token"]}>
+        <LoginForm
+          {...defaultProps}
+          authenticate={authenticate}
+          authenticationError={authenticationError}
+        />
+      </MemoryRouter>,
+    );
+    expect(authenticate).toBeCalledWith(defaultCluster, "bad-token");
+    expect(authenticate).toBeCalledTimes(1);
+  });
+
+  it("does not call the authenticate handler in oauth login if token is passed as query param", () => {
+    const authenticate = jest.fn();
+    mountWrapper(
+      defaultStore,
+      <MemoryRouter initialEntries={["/login?token=f00b4r"]}>
+        <LoginForm {...defaultProps} authenticate={authenticate} oauthLoginURI={"/sign/in"} />
+      </MemoryRouter>,
+    );
+    expect(authenticate).not.toBeCalled();
   });
 
   it("displays an error if the authentication error is passed", () => {


### PR DESCRIPTION
### Description of the change

This PR just allows passing a `?token=xxxxxx` in the token login view so that we can bypass manually entering a value.

### Benefits

No human interaction for accessing Kubeapps with a token, if desired.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

x

![Animation1](https://user-images.githubusercontent.com/11535726/153884598-4c16ea0c-b13c-49d1-b81f-cc614d737770.gif)
