### PR TITLE
Use an up-to-date circleci machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,9 @@ parameters:
   GKE_REGULAR_VERSION:
     type: "string"
     default: "1.21"
+  DEFAULT_MACHINE_IMG:
+    type: "string"
+    default: "ubuntu-2004:202111-02"
   IMAGES_TO_PUSH:
     type: "string"
     default: "kubeapps/apprepository-controller kubeapps/dashboard kubeapps/asset-syncer kubeapps/assetsvc kubeapps/kubeops kubeapps/pinniped-proxy kubeapps/kubeapps-apis"
@@ -698,7 +701,8 @@ jobs:
           command: |
             ./script/create_release.sh ${CIRCLE_TAG} << pipeline.parameters.KUBEAPPS_REPO >>
   local_e2e_tests:
-    machine: true
+    machine:
+      image: << pipeline.parameters.DEFAULT_MACHINE_IMG >>
     # Reference for available machines
     # https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux
     resource_class: large

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -41,6 +41,7 @@ The versions used there _must_ match the ones used for building the container im
 - `NODE_VERSION` _must_ match the **major** version used by the [dashboard](../../dashboard/Dockerfile).
 - `RUST_VERSION` _must_ match the version used by the [pinniped-proxy](../../dashboard/Dockerfile).
 - `POSTGRESQL_VERSION` _must_ match the version used by the [Bitnami PostgreSQL chart](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml).
+- `DEFAULT_MACHINE_IMG` _should_ be up to date according to the [list of available machines in CircleCI](https://circleci.com/docs/2.0/configuration-reference/#available-machine-images).
 
 Besides, the `GKE_STABLE_VERSION_XX` and the `GKE_REGULAR_VERSION_XX` might have to be updated if the _Stable_ and _Regular_ Kubernetes versions in GKE have changed. Check this information on [this GKE release notes website](https://cloud.google.com/kubernetes-engine/docs/release-notes).
 


### PR DESCRIPTION
### Description of the change

As per the instructions received by CircleCI (https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration), we should migrate to Ubuntu 20.04. This was one of the changes performed at https://github.com/kubeapps/kubeapps/pull/4170, but it didn't get merged finally.

### Benefits

We will use a non-deprecated way to define the machine image used by the CircleCI

### Possible drawbacks

Perhaps a problem with some deps? Let's see what the CI thinks.

### Applicable issues

N/A

### Additional information

N/A