### PR TITLE
Update to use the same plugin directories that bitnami Dockerfile uses.

### DIFF
--- a/chart/kubeapps/templates/_helpers.tpl
+++ b/chart/kubeapps/templates/_helpers.tpl
@@ -230,11 +230,11 @@ kubeapps: ingress.tls
       {{- range $plugin, $options := .Values.packaging }}
         {{- if $options.enabled }}
           {{- if eq $plugin "carvel" }}
-            {{- $enabledPlugins = append $enabledPlugins "kapp-controller" }}
+            {{- $enabledPlugins = append $enabledPlugins "kapp-controller-packages" }}
           {{- else if eq $plugin "flux" }}
-            {{- $enabledPlugins = append $enabledPlugins "fluxv2" }}
+            {{- $enabledPlugins = append $enabledPlugins "fluxv2-packages" }}
           {{- else if eq $plugin "helm" }}
-            {{- $enabledPlugins = append $enabledPlugins "helm" }}
+            {{- $enabledPlugins = append $enabledPlugins "helm-packages" }}
           {{- else }}
             {{ $msg := printf "packaging: Unsupported packaging option: %s" $plugin }}
             {{- fail $msg }}

--- a/cmd/kubeapps-apis/Dockerfile
+++ b/cmd/kubeapps-apis/Dockerfile
@@ -66,9 +66,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM bitnami/minideb:buster
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/kubeapps/kubeapps/kubeapps-apis /kubeapps-apis
-COPY --from=builder /kapp-controller-packages-v1alpha1-plugin.so /plugins/kapp-controller/
-COPY --from=builder /fluxv2-packages-v1alpha1-plugin.so /plugins/fluxv2/
-COPY --from=builder /helm-packages-v1alpha1-plugin.so /plugins/helm/
+COPY --from=builder /kapp-controller-packages-v1alpha1-plugin.so /plugins/kapp-controller-packages/
+COPY --from=builder /fluxv2-packages-v1alpha1-plugin.so /plugins/fluxv2-packages/
+COPY --from=builder /helm-packages-v1alpha1-plugin.so /plugins/helm-packages/
 COPY --from=builder /resources-v1alpha1-plugin.so /plugins/resources/
 
 EXPOSE 50051


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Small follow-up to #4264 that updates the location that kubeapps-apis plugins are located (to match the Bitnami containers).

@castelblanque If you do want this change, just be sure to merge it first (as it's currently targeting #4264 and so will be merged into there, but if that PR is merged first to main, this will be automatically updated by GH to target main and may need rebasing, depending).

### Benefits

Consistency. Nice to explicitly identify packaging plugins.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3695 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
