### PR TITLE
Fix Flux deployment for local dev env.

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.8.0-dev6
+version: 7.8.0-dev7

--- a/chart/kubeapps/templates/NOTES.txt
+++ b/chart/kubeapps/templates/NOTES.txt
@@ -71,7 +71,7 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
 ##########################################################################################################
 {{- end }}
 
-{{ if and (.Values.redis.enabled) (not .Values.redis.existingSecret) (empty .Values.redis.redisPassword) -}}
+{{ if and (.Values.packaging.flux.enabled) (not .Values.redis.existingSecret) (empty .Values.redis.redisPassword) -}}
 ##########################################################################################################
 ### WARNING: You did not provide a value for the redisPassword so one has been generated randomly      ###
 ##########################################################################################################

--- a/chart/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -94,7 +94,7 @@ spec:
               value: "50" # default is 100. 50 means increasing x2 the frequency of GC
             - name: PORT
               value: {{ .Values.kubeappsapis.containerPort | quote }}
-            {{- if .Values.redis.enabled }}
+            {{- if .Values.packaging.flux.enabled }}
             # REDIS-* vars are required by the plugins for caching functionality
             # TODO (gfichtenolt) this as required by the kubeapps apis service (which will
             # longer-term pass something to the plugins so that the plugins won't need to

--- a/chart/kubeapps/templates/kubeappsapis/rbac_fluxv2.yaml
+++ b/chart/kubeapps/templates/kubeappsapis/rbac_fluxv2.yaml
@@ -1,4 +1,4 @@
-{{- if has "fluxv2" .Values.kubeappsapis.enabledPlugins }}
+{{- if .Values.packaging.flux.enabled }}
 {{- if .Values.rbac.create -}}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

I broke the Flux deployment in my recent commit because I focused on the enabling of the correct plugins and installation of the chart dependency, but didn't check it running IRL.

Turns out we had two places in the chart still referring to the old `redis.enabled`.

This fixes that,  and I just verified IRL that with this I can deploy flux locally :)

I'll update the upstream PR later (just going AFK).

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
