### PR TITLE
Update devel chart version to be higher than Bitnami's

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.8.0-dev6
+version: 7.8.1-dev1


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

CI step **_Run the check_upstream_chart script_** is failing due to
`Current chart version (7.8.0-dev6) is less than the chart external version (7.8.0)`.

This PR tries to tackle that problem by bumping up the development chart version to `7.8.1-dev1`.

### Benefits

Chart versions should be correct between Bitnami and Kubeapps devel charts.

### Possible drawbacks

Hopefully none until versions are changed again in either side.

### Additional information

[Current Kubeapps devel chart version](https://github.com/kubeapps/kubeapps/blob/main/chart/kubeapps/Chart.yaml#L36)
[Bitnami Kubeapps chart version](https://github.com/bitnami/charts/blob/master/bitnami/kubeapps/Chart.yaml#L36)
[Example of failing CI run](https://app.circleci.com/pipelines/github/kubeapps/kubeapps/6216/workflows/6587f4eb-3ec1-4208-9f13-941a0a9d6d6a/jobs/75467)