### PR TITLE
Ensure consistent status in tile for different plugins.

### DIFF
--- a/dashboard/src/components/AppList/AppListItem.test.tsx
+++ b/dashboard/src/components/AppList/AppListItem.test.tsx
@@ -56,7 +56,7 @@ it("renders an app item", () => {
       plugin: { name: "my.plugin", version: "0.0.1" },
     } as InstalledPackageReference),
     tag1Class: "label-success",
-    tag1Content: "deployed",
+    tag1Content: "installed",
     title: defaultProps.app.name,
   });
 });

--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Tooltip from "components/js/Tooltip";
-import { InstalledPackageSummary } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
+import {
+  InstalledPackageSummary,
+  InstalledPackageStatus_StatusReason,
+  installedPackageStatus_StatusReasonToJSON,
+} from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { getPluginIcon } from "shared/utils";
 import placeholder from "../../placeholder.png";
 import * as url from "../../shared/url";
@@ -14,10 +18,19 @@ export interface IAppListItemProps {
   cluster: string;
 }
 
+function getAppStatusLabel(
+  statusReason: InstalledPackageStatus_StatusReason = InstalledPackageStatus_StatusReason.STATUS_REASON_UNSPECIFIED,
+): string {
+  // The JSON versions of the reasons are forced to follow the standard
+  // pattern STATUS_REASON_<reason> by buf.
+  const jsonReason = installedPackageStatus_StatusReasonToJSON(statusReason);
+  return jsonReason.replace("STATUS_REASON_", "").toLowerCase();
+}
+
 function AppListItem(props: IAppListItemProps) {
   const { app } = props;
   const icon = app.iconUrl ?? placeholder;
-  const appStatus = app.status?.userReason?.toLocaleLowerCase();
+  const appStatus = getAppStatusLabel(app.status?.reason);
   const appReady = app.status?.ready ?? false;
   let tooltipContent;
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

The status displayed in the application list was using the plugin-specific `status.userReason` field, resulting in the following when displaying both flux and carvel packages together:

![status-reason-before](https://user-images.githubusercontent.com/497518/155049838-b974ea7a-f535-480f-a051-993d82533ae3.png)

 rather than the `status.reason` field which is consistent across plugins, which results in:

![status-reason-after](https://user-images.githubusercontent.com/497518/155049851-58758879-5833-4287-876a-98fa6ae194aa.png)

### Benefits

We avoid formatting issues with the plugin specific user reason on the tiles. Get standard status's across plugins for apps.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

Changes the default from "deployed" to "installed". We could put a condition in there, but it seems appropriate to use `installed` (given our generic packaging wording) so left it. Let me know.


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3695

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
