### PR TITLE
Update empty catalog message to include docs for flux/carvel

### DIFF
--- a/dashboard/src/components/Catalog/Catalog.tsx
+++ b/dashboard/src/components/Catalog/Catalog.tsx
@@ -87,7 +87,7 @@ export default function Catalog() {
     },
     operators,
     repos: { repos },
-    config: { kubeappsCluster, kubeappsNamespace, featureFlags },
+    config: { appVersion, kubeappsCluster, kubeappsNamespace, featureFlags },
   } = useSelector((state: IStoreState) => state);
   const { cluster, namespace } = ReactRouter.useParams() as IRouteParams;
   const location = ReactRouter.useLocation();
@@ -345,12 +345,23 @@ export default function Catalog() {
           <CdsIcon shape="bundle" />
           <p>The current catalog is empty.</p>
           <p>
-            Manage your Package Repositories in Kubeapps by visiting the App repositories
+            Manage your Helm Package Repositories in Kubeapps by visiting the App repositories
             configuration page.
           </p>
           <Link to={app.config.apprepositories(cluster, namespace)}>
             <CdsButton>Manage App Repositories</CdsButton>
           </Link>
+          <p>
+            For help managing other packaging formats, such as Flux or Carvel, please refer to the{" "}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={`https://github.com/kubeapps/kubeapps/blob/${appVersion}/docs/`}
+            >
+              Kubeapps documentation
+            </a>
+            .
+          </p>
         </div>
       ) : (
         <Row>


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Just adds an extra paragraph to the empty catalog display page, linking directly to our docs:

<!-- Describe the scope of your change - i.e. what the change does. -->
![empty-catalog](https://user-images.githubusercontent.com/497518/155245296-160f4634-6697-4e1b-9f5b-5e9d4fa32b90.png)

### Benefits

A user has more information about where to go if they see an empty catalog.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3695 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
I was originally planning to check which plugins are configured and just show info related to that plugin, but it looks to be more work than it is worth given that we're currently investing in the app repository API (which will be aggregated etc. and replace the current AppRepository handling).

I had also planned to link to specific documentation for flux and carvel, but given the current doc restructuring that @ppbaena is working on, I instead just pointed to the root of the docs.