### PR TITLE
Include installed pkg status and user reason on app detail.

### DIFF
--- a/dashboard/src/components/AppList/AppListItem.tsx
+++ b/dashboard/src/components/AppList/AppListItem.tsx
@@ -2,12 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Tooltip from "components/js/Tooltip";
-import {
-  InstalledPackageSummary,
-  InstalledPackageStatus_StatusReason,
-  installedPackageStatus_StatusReasonToJSON,
-} from "gen/kubeappsapis/core/packages/v1alpha1/packages";
-import { getPluginIcon } from "shared/utils";
+import { InstalledPackageSummary } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
+import { getAppStatusLabel, getPluginIcon } from "shared/utils";
 import placeholder from "../../placeholder.png";
 import * as url from "../../shared/url";
 import InfoCard from "../InfoCard/InfoCard";
@@ -16,15 +12,6 @@ import "./AppListItem.css";
 export interface IAppListItemProps {
   app: InstalledPackageSummary;
   cluster: string;
-}
-
-function getAppStatusLabel(
-  statusReason: InstalledPackageStatus_StatusReason = InstalledPackageStatus_StatusReason.STATUS_REASON_UNSPECIFIED,
-): string {
-  // The JSON versions of the reasons are forced to follow the standard
-  // pattern STATUS_REASON_<reason> by buf.
-  const jsonReason = installedPackageStatus_StatusReasonToJSON(statusReason);
-  return jsonReason.replace("STATUS_REASON_", "").toLowerCase();
 }
 
 function AppListItem(props: IAppListItemProps) {

--- a/dashboard/src/components/AppView/PackageInfo/PackageInfo.test.tsx
+++ b/dashboard/src/components/AppView/PackageInfo/PackageInfo.test.tsx
@@ -54,7 +54,7 @@ it("renders an app item", () => {
   const wrapper = mountWrapper(defaultStore, <PackageInfo {...defaultProps} />);
   // Renders info about the description and versions
   const subsections = wrapper.find(".left-menu-subsection");
-  expect(subsections).toHaveLength(2);
+  expect(subsections).toHaveLength(3);
 });
 
 context("PackageUpdateInfo: when information about updates is available", () => {

--- a/dashboard/src/components/AppView/PackageInfo/PackageInfo.tsx
+++ b/dashboard/src/components/AppView/PackageInfo/PackageInfo.tsx
@@ -4,8 +4,11 @@
 import {
   AvailablePackageDetail,
   InstalledPackageDetail,
+  InstalledPackageStatus_StatusReason,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import PackageUpdateInfo from "./PackageUpdateInfo";
+import { getAppStatusLabel } from "shared/utils";
+
 interface IPackageInfoProps {
   installedPackageDetail: InstalledPackageDetail;
   availablePackageDetail?: AvailablePackageDetail;
@@ -16,6 +19,17 @@ function PackageInfo({ installedPackageDetail, availablePackageDetail }: IPackag
     <section className="left-menu">
       {installedPackageDetail && (
         <>
+          {installedPackageDetail.status && (
+            <section className="left-menu-subsection" aria-labelledby="packageinfo-versions">
+              <div>
+                Status: <strong>{getAppStatusLabel(installedPackageDetail.status.reason)}</strong>
+              </div>
+              {installedPackageDetail.status.reason !==
+                InstalledPackageStatus_StatusReason.STATUS_REASON_INSTALLED && (
+                <div>{installedPackageDetail.status.userReason}</div>
+              )}
+            </section>
+          )}
           <section className="left-menu-subsection" aria-labelledby="packageinfo-versions">
             <h5 className="left-menu-subsection-title" id="packageinfo-versions">
               Versions

--- a/dashboard/src/shared/utils.ts
+++ b/dashboard/src/shared/utils.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
+import {
+  InstalledPackageStatus_StatusReason,
+  installedPackageStatus_StatusReasonToJSON,
+} from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import carvelIcon from "../icons/carvel.svg";
 import fluxIcon from "../icons/flux.svg";
 import helmIcon from "../icons/helm.svg";
@@ -135,4 +139,13 @@ export function getPluginsRequiringSA(): string[] {
 
 export function getPluginsSupportingRollback(): string[] {
   return [PluginNames.PACKAGES_HELM];
+}
+
+export function getAppStatusLabel(
+  statusReason: InstalledPackageStatus_StatusReason = InstalledPackageStatus_StatusReason.STATUS_REASON_UNSPECIFIED,
+): string {
+  // The JSON versions of the reasons are forced to follow the standard
+  // pattern STATUS_REASON_<reason> by buf.
+  const jsonReason = installedPackageStatus_StatusReasonToJSON(statusReason);
+  return jsonReason.replace("STATUS_REASON_", "").toLowerCase();
 }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Currently we haven't included the installed package status on the detail page at all (only on the list page, as a tag). For Helm this wasn't a problem, as we only ever got to the detail page if the helm chart was installed, but for Flux (and others) the semantics are slightly different: The `HelmRelease` is created, but the helm chart may not be installed.

This happens most obviously when the service account chosen for the install doesn't have the required perms. The install details page shows zero information about the state of the install.

With this change, we update to display the status (`installed`, `pending`, etc.), and for the case where the status isn't `installed`, we also display the user reason:

![flux-pending-failed](https://user-images.githubusercontent.com/497518/155264265-fb08b37d-38b5-4e3e-aec2-77a429c0b110.png)

In the above example, the user reason isn't great: it should ideally be saying:
> secrets is forbidden: User "system:serviceaccount:kubeapps-user-namespace:default" cannot list resource "secrets" in API group "" in the namespace "kubeapps-user-namespace"

or even

> Selected service account does not have the required RBAC.

but that's the plugin's responsibility (I may take a look at that separately).

### Benefits

In the case of a pending install, the user has some information about what is wrong.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3695 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
When a package is installed successfully, the status is still currently displayed (just not any user reason):

![apache-success](https://user-images.githubusercontent.com/497518/155266309-9bf8bb14-ce2b-4719-8a62-c6c4014f2d80.png)
