### PR TITLE
Continue to poll for resource references when not found

### DIFF
--- a/dashboard/src/actions/installedpackages.test.tsx
+++ b/dashboard/src/actions/installedpackages.test.tsx
@@ -16,11 +16,7 @@ import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { InstalledPackage } from "shared/InstalledPackage";
-import {
-  IInstalledPackageState,
-  UnprocessableEntity,
-  UpgradeError,
-} from "shared/types";
+import { IInstalledPackageState, UnprocessableEntity, UpgradeError } from "shared/types";
 import { PluginNames } from "shared/utils";
 import { getType } from "typesafe-actions";
 import actions from ".";

--- a/dashboard/src/actions/installedpackages.test.tsx
+++ b/dashboard/src/actions/installedpackages.test.tsx
@@ -10,7 +10,6 @@ import {
   InstalledPackageStatus,
   VersionReference,
   ReconciliationOptions,
-  ResourceRef,
   InstalledPackageStatus_StatusReason,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
@@ -18,7 +17,6 @@ import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { InstalledPackage } from "shared/InstalledPackage";
 import {
-  FetchError,
   IInstalledPackageState,
   UnprocessableEntity,
   UpgradeError,
@@ -405,63 +403,6 @@ describe("rollbackInstalledPackage", () => {
       1,
     );
     await store.dispatch(rollbackInstalledPackageBadAction);
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-});
-
-describe("getInstalledPkgResourceRefs", () => {
-  const installedPkgRef = {
-    context: { cluster: "default-c", namespace: "default-ns" },
-    identifier: "my-release",
-    plugin: { name: "bad-plugin", version: "0.0.1" } as Plugin,
-  } as InstalledPackageReference;
-  const expectedRefs = [
-    {
-      apiVersion: "apps/v1",
-      kind: "Deployment",
-      name: "my-deployment",
-      namespace: "my-namespace",
-    },
-  ] as ResourceRef[];
-
-  it("dispatches the resource refs when successful", async () => {
-    InstalledPackage.GetInstalledPackageResourceRefs = jest
-      .fn()
-      .mockReturnValue({ resourceRefs: expectedRefs });
-    const expectedActions = [
-      { type: getType(actions.installedpackages.requestInstalledPkgResourceRefs) },
-      {
-        type: getType(actions.installedpackages.receiveInstalledPkgResourceRefs),
-        payload: expectedRefs,
-      },
-    ];
-
-    const getInstalledPkgResourceRefsAction =
-      actions.installedpackages.getInstalledPkgResourceRefs(installedPkgRef);
-    await store.dispatch(getInstalledPkgResourceRefsAction);
-
-    expect(InstalledPackage.GetInstalledPackageResourceRefs).toHaveBeenCalledWith(installedPkgRef);
-    expect(store.getActions()).toEqual(expectedActions);
-  });
-
-  it("dispatches a fetch error when unsuccessful", async () => {
-    const e = new Error("Bang!");
-    InstalledPackage.GetInstalledPackageResourceRefs = jest.fn().mockImplementation(() => {
-      throw e;
-    });
-    const expectedActions = [
-      { type: getType(actions.installedpackages.requestInstalledPkgResourceRefs) },
-      {
-        type: getType(actions.installedpackages.errorInstalledPackage),
-        payload: new FetchError("Unable to get installed package resources", [e]),
-      },
-    ];
-
-    const getInstalledPkgResourceRefsAction =
-      actions.installedpackages.getInstalledPkgResourceRefs(installedPkgRef);
-    await store.dispatch(getInstalledPkgResourceRefsAction);
-
-    expect(InstalledPackage.GetInstalledPackageResourceRefs).toHaveBeenCalledWith(installedPkgRef);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/dashboard/src/actions/installedpackages.ts
+++ b/dashboard/src/actions/installedpackages.ts
@@ -10,7 +10,6 @@ import {
   InstalledPackageStatus,
   InstalledPackageSummary,
   ReconciliationOptions,
-  ResourceRef,
   VersionReference,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
 import { ThunkAction } from "redux-thunk";

--- a/dashboard/src/actions/installedpackages.ts
+++ b/dashboard/src/actions/installedpackages.ts
@@ -34,15 +34,6 @@ const { createAction } = deprecated;
 
 export const requestInstalledPackage = createAction("REQUEST_INSTALLED_PACKAGE");
 
-export const requestInstalledPkgResourceRefs = createAction("REQUEST_INSTALLED_PKG_RESOURCE_REFS");
-
-export const receiveInstalledPkgResourceRefs = createAction(
-  "RECEIVE_INSTALLED_PKG_RESOURCE_REFS",
-  resolve => {
-    return (refs: ResourceRef[]) => resolve(refs);
-  },
-);
-
 export const requestInstalledPackageList = createAction("REQUEST_INSTALLED_PACKAGE_LIST");
 
 export const receiveInstalledPackageList = createAction(
@@ -101,8 +92,6 @@ const allActions = [
   receiveInstalledPackageList,
   requestInstalledPackageStatus,
   receiveInstalledPackageStatus,
-  requestInstalledPkgResourceRefs,
-  receiveInstalledPkgResourceRefs,
   requestDeleteInstalledPackage,
   receiveDeleteInstalledPackage,
   requestInstallPackage,
@@ -168,25 +157,6 @@ export function getInstalledPkgStatus(
       dispatch(receiveInstalledPackageStatus(installedPackageDetail!.status!));
     } catch (e: any) {
       dispatch(errorInstalledPackage(new FetchError("Unable to refresh installed package", [e])));
-    }
-  };
-}
-
-export function getInstalledPkgResourceRefs(
-  installedPackageRef?: InstalledPackageReference,
-): ThunkAction<Promise<void>, IStoreState, null, InstalledPackagesAction> {
-  return async dispatch => {
-    dispatch(requestInstalledPkgResourceRefs());
-
-    try {
-      const { resourceRefs } = await InstalledPackage.GetInstalledPackageResourceRefs(
-        installedPackageRef,
-      );
-      dispatch(receiveInstalledPkgResourceRefs(resourceRefs));
-    } catch (e: any) {
-      dispatch(
-        errorInstalledPackage(new FetchError("Unable to get installed package resources", [e])),
-      );
     }
   };
 }

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -10,6 +10,8 @@ import ApplicationStatusContainer from "containers/ApplicationStatusContainer";
 import {
   AvailablePackageReference,
   Context,
+  GetAvailablePackageDetailResponse,
+  GetInstalledPackageDetailResponse,
   GetInstalledPackageResourceRefsResponse,
   InstalledPackageDetail,
   InstalledPackageReference,
@@ -35,6 +37,7 @@ import PackageInfo from "./PackageInfo/PackageInfo";
 import CustomAppView from "./CustomAppView";
 import ResourceTabs from "./ResourceTabs";
 import { InstalledPackage } from "shared/InstalledPackage";
+import PackagesService from "shared/PackagesService";
 
 const routeParams = {
   cluster: "cluster-1",
@@ -117,6 +120,16 @@ beforeEach(() => {
     .mockReturnValue(
       Promise.resolve({ resourceRefs: [] } as GetInstalledPackageResourceRefsResponse),
     );
+  InstalledPackage.GetInstalledPackageDetail = jest.fn().mockReturnValue(
+    Promise.resolve({
+      installedPackageDetail: {},
+    } as GetInstalledPackageDetailResponse),
+  );
+  PackagesService.getAvailablePackageDetail = jest.fn().mockReturnValue(
+    Promise.resolve({
+      availablePackageDetail: {},
+    } as GetAvailablePackageDetailResponse),
+  );
 });
 afterEach(() => {
   jest.resetAllMocks();
@@ -433,6 +446,13 @@ describe("AppView actions", () => {
         type: getType(actions.installedpackages.requestInstalledPackage),
       },
       {
+        type: getType(actions.installedpackages.selectInstalledPackage),
+        payload: {
+          pkg: {},
+          details: {},
+        },
+      },
+      {
         type: getType(actions.kube.requestResources),
         payload: {
           pkg: installedPackage.installedPackageRef,
@@ -484,6 +504,13 @@ describe("AppView actions", () => {
     expect(store.getActions()).toEqual([
       {
         type: getType(actions.installedpackages.requestInstalledPackage),
+      },
+      {
+        type: getType(actions.installedpackages.selectInstalledPackage),
+        payload: {
+          pkg: {},
+          details: {},
+        },
       },
       {
         type: getType(actions.kube.requestResources),

--- a/dashboard/src/components/AppView/AppView.test.tsx
+++ b/dashboard/src/components/AppView/AppView.test.tsx
@@ -261,13 +261,11 @@ describe("AppView", () => {
         resourceRefs.ingress,
         resourceRefs.secret,
       ] as ResourceRef[];
-      InstalledPackage.GetInstalledPackageResourceRefs = jest
-        .fn()
-        .mockReturnValue(
-          Promise.resolve({
-            resourceRefs: apiResourceRefs,
-          } as GetInstalledPackageResourceRefsResponse),
-        );
+      InstalledPackage.GetInstalledPackageResourceRefs = jest.fn().mockReturnValue(
+        Promise.resolve({
+          resourceRefs: apiResourceRefs,
+        } as GetInstalledPackageResourceRefsResponse),
+      );
 
       let wrapper: any;
       await act(async () => {
@@ -295,13 +293,11 @@ describe("AppView", () => {
         resourceRefs.configMap,
         resourceRefs.secret,
       ] as ResourceRef[];
-      InstalledPackage.GetInstalledPackageResourceRefs = jest
-        .fn()
-        .mockReturnValue(
-          Promise.resolve({
-            resourceRefs: apiResourceRefs,
-          } as GetInstalledPackageResourceRefsResponse),
-        );
+      InstalledPackage.GetInstalledPackageResourceRefs = jest.fn().mockReturnValue(
+        Promise.resolve({
+          resourceRefs: apiResourceRefs,
+        } as GetInstalledPackageResourceRefsResponse),
+      );
 
       let wrapper: any;
       await act(async () => {
@@ -381,13 +377,11 @@ describe("AppView", () => {
 
   it("forwards statefulsets and daemonsets to the application status", async () => {
     const apiResourceRefs = [resourceRefs.statefulset, resourceRefs.daemonset] as ResourceRef[];
-    InstalledPackage.GetInstalledPackageResourceRefs = jest
-      .fn()
-      .mockReturnValue(
-        Promise.resolve({
-          resourceRefs: apiResourceRefs,
-        } as GetInstalledPackageResourceRefsResponse),
-      );
+    InstalledPackage.GetInstalledPackageResourceRefs = jest.fn().mockReturnValue(
+      Promise.resolve({
+        resourceRefs: apiResourceRefs,
+      } as GetInstalledPackageResourceRefsResponse),
+    );
     let wrapper: any;
     await act(async () => {
       wrapper = mountWrapper(
@@ -416,13 +410,11 @@ describe("AppView actions", () => {
       resourceRefs.service,
       resourceRefs.secret,
     ] as ResourceRef[];
-    InstalledPackage.GetInstalledPackageResourceRefs = jest
-      .fn()
-      .mockReturnValue(
-        Promise.resolve({
-          resourceRefs: apiResourceRefs,
-        } as GetInstalledPackageResourceRefsResponse),
-      );
+    InstalledPackage.GetInstalledPackageResourceRefs = jest.fn().mockReturnValue(
+      Promise.resolve({
+        resourceRefs: apiResourceRefs,
+      } as GetInstalledPackageResourceRefsResponse),
+    );
     const store = getStore({ apps: { selected: installedPackage } });
 
     await act(async () => {
@@ -466,13 +458,11 @@ describe("AppView actions", () => {
   });
   it("closes the watches when unmounted", async () => {
     const apiResourceRefs = [resourceRefs.deployment, resourceRefs.service] as ResourceRef[];
-    InstalledPackage.GetInstalledPackageResourceRefs = jest
-      .fn()
-      .mockReturnValue(
-        Promise.resolve({
-          resourceRefs: apiResourceRefs,
-        } as GetInstalledPackageResourceRefsResponse),
-      );
+    InstalledPackage.GetInstalledPackageResourceRefs = jest.fn().mockReturnValue(
+      Promise.resolve({
+        resourceRefs: apiResourceRefs,
+      } as GetInstalledPackageResourceRefsResponse),
+    );
 
     const store = getStore({ apps: { selected: installedPackage } });
     let wrapper: any;

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -177,14 +177,14 @@ export default function AppView() {
   }, [dispatch, installedPkgRef]);
 
   useEffect(() => {
-    // We're fetching the resource refs directly (rather than using redux),
-    // which is inline with the general direction of React components, but here
-    // particularly important as we need to handle the retrying of fetching
-    // resource refs when they are not found.  This is because it is not
-    // possible currently to tell whether resource refs are unavailable because
-    // the package is being installed (ie.  Package is "Pending" the actual
-    // installation) or the package is currently unable to be installed because
-    // the RBAC isn't yet correct (ie. Package is "Pending" required RBAC).
+    // TODO(minelson): currently it is not possible for a client to determine
+    // whether resource refs are unavailable because the package is being
+    // installed (ie.  Package is "Pending" the actual installation) or the
+    // package is currently unable to be installed because the RBAC isn't yet
+    // correct (ie. Package is "Pending" required RBAC). The work-around here
+    // is to continue polling for the resource refs every two seconds as long
+    // as a `NotFound` is returned.
+    // See https://github.com/kubeapps/kubeapps/issues/4337
     let abort = false;
     const fetchResourceRefs = async () => {
       while (!abort) {

--- a/dashboard/src/components/AppView/AppView.tsx
+++ b/dashboard/src/components/AppView/AppView.tsx
@@ -12,9 +12,10 @@ import {
   InstalledPackageReference,
   ResourceRef,
 } from "gen/kubeappsapis/core/packages/v1alpha1/packages";
+import { InstalledPackage } from "shared/InstalledPackage";
 import { Plugin } from "gen/kubeappsapis/core/plugins/v1alpha1/plugins";
 import * as yaml from "js-yaml";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as ReactRouter from "react-router-dom";
 import { Action } from "redux";
@@ -40,6 +41,7 @@ import AppValues from "./AppValues/AppValues";
 import CustomAppView from "./CustomAppView";
 import PackageInfo from "./PackageInfo/PackageInfo";
 import ResourceTabs from "./ResourceTabs";
+import { grpc } from "@improbable-eng/grpc-web";
 
 export interface IAppViewResourceRefs {
   deployments: ResourceRef[];
@@ -152,25 +154,67 @@ export default function AppView() {
     secrets: [],
   } as IAppViewResourceRefs);
   const {
-    apps: { error, selected: app, resourceRefs, selectedDetails: appDetails },
+    apps: { error, selected: app, selectedDetails: appDetails },
     config: { customAppViews },
   } = useSelector((state: IStoreState) => state);
 
+  const [fetchError, setFetchError] = useState(error);
   const [pluginObj] = useState({ name: pluginName, version: pluginVersion } as Plugin);
+  const [resourceRefs, setResourceRefs] = useState([] as ResourceRef[]);
 
-  useEffect(() => {
-    const installedPkgRef = {
-      context: { cluster: cluster, namespace: namespace },
+  // useMemo used so that when installedPkgRef is a dependency of other effects,
+  // it does not trigger the effect on every render.
+  const installedPkgRef = useMemo(() => {
+    return {
+      context: { cluster, namespace },
       identifier: releaseName,
       plugin: pluginObj,
     } as InstalledPackageReference;
-
-    dispatch(actions.installedpackages.getInstalledPackage(installedPkgRef));
-    dispatch(actions.installedpackages.getInstalledPkgResourceRefs(installedPkgRef));
-  }, [cluster, dispatch, namespace, releaseName, pluginObj]);
+  }, [cluster, namespace, releaseName, pluginObj]);
 
   useEffect(() => {
-    if (!resourceRefs) {
+    dispatch(actions.installedpackages.getInstalledPackage(installedPkgRef));
+  }, [dispatch, installedPkgRef]);
+
+  useEffect(() => {
+    // We're fetching the resource refs directly (rather than using redux),
+    // which is inline with the general direction of React components, but here
+    // particularly important as we need to handle the retrying of fetching
+    // resource refs when they are not found.  This is because it is not
+    // possible currently to tell whether resource refs are unavailable because
+    // the package is being installed (ie.  Package is "Pending" the actual
+    // installation) or the package is currently unable to be installed because
+    // the RBAC isn't yet correct (ie. Package is "Pending" required RBAC).
+    let abort = false;
+    const fetchResourceRefs = async () => {
+      while (!abort) {
+        try {
+          const response = await InstalledPackage.GetInstalledPackageResourceRefs(installedPkgRef);
+          if (abort) {
+            return;
+          }
+          setResourceRefs(response.resourceRefs);
+          return;
+        } catch (e: any) {
+          if (e.code !== grpc.Code.NotFound) {
+            // If we get any other error, we want the user to know about it.
+            setFetchError(new FetchError("unable to fetch resource references", [e]));
+            return;
+          }
+          await new Promise(r => setTimeout(r, 2000));
+        }
+      }
+    };
+    fetchResourceRefs();
+
+    // Ensure we abort fetching resource refs when unmounted.
+    return () => {
+      abort = true;
+    };
+  }, [installedPkgRef]);
+
+  useEffect(() => {
+    if (resourceRefs.length === 0) {
       return () => {};
     }
 
@@ -207,24 +251,20 @@ export default function AppView() {
 
   const forceRetry = () => {
     dispatch(actions.installedpackages.clearErrorInstalledPackage());
-    dispatch(
-      actions.installedpackages.getInstalledPackage({
-        context: { cluster: cluster, namespace: namespace },
-        identifier: releaseName,
-        plugin: pluginObj,
-      } as InstalledPackageReference),
-    );
+    dispatch(actions.installedpackages.getInstalledPackage(installedPkgRef));
   };
 
-  if (error && error.constructor === FetchError) {
-    return (
-      <ErrorAlert error={error}>
-        <CdsButton size="sm" action="flat" onClick={forceRetry} type="button">
-          {" "}
-          Try again{" "}
-        </CdsButton>
-      </ErrorAlert>
-    );
+  if (fetchError) {
+    if (fetchError.constructor === FetchError) {
+      return (
+        <ErrorAlert error={fetchError}>
+          <CdsButton size="sm" action="flat" onClick={forceRetry} type="button">
+            {" "}
+            Try again{" "}
+          </CdsButton>
+        </ErrorAlert>
+      );
+    }
   }
   const { services, ingresses, deployments, statefulsets, daemonsets, secrets, otherResources } =
     appViewResourceRefs;
@@ -243,7 +283,6 @@ export default function AppView() {
   ) {
     return <CustomAppView resourceRefs={appViewResourceRefs} app={app!} appDetails={appDetails!} />;
   }
-
   return (
     <LoadingWrapper loaded={!!app} loadingText="Retrieving application..." className="margin-t-xl">
       {!app || !app?.installedPackageRef ? (

--- a/dashboard/src/reducers/installedpackages.ts
+++ b/dashboard/src/reducers/installedpackages.ts
@@ -64,11 +64,6 @@ const installedPackagesReducer = (
         };
       }
       return state;
-    case getType(actions.installedpackages.receiveInstalledPkgResourceRefs):
-      return {
-        ...state,
-        resourceRefs: action.payload,
-      };
     case getType(actions.installedpackages.requestInstalledPackageList):
       return { ...state, isFetching: true };
     case getType(actions.installedpackages.receiveInstalledPackageList):

--- a/dashboard/src/shared/InstalledPackage.test.ts
+++ b/dashboard/src/shared/InstalledPackage.test.ts
@@ -197,25 +197,6 @@ describe("InstalledPackage", () => {
         installedPackageRef: installedPackageReference,
       });
     });
-
-    it("retries up to five times before returning error", async () => {
-      const mockClientGetInstalledPackageResourceRefs = jest
-        .fn()
-        .mockImplementation(() => Promise.reject(new Error("Bang!")));
-      setMockCoreClient(
-        "GetInstalledPackageResourceRefs",
-        mockClientGetInstalledPackageResourceRefs,
-      );
-
-      await expect(
-        InstalledPackage.GetInstalledPackageResourceRefs(installedPackageReference, 0),
-      ).rejects.toThrowError("Bang!");
-
-      expect(mockClientGetInstalledPackageResourceRefs).toHaveBeenCalledTimes(5);
-      expect(mockClientGetInstalledPackageResourceRefs).toHaveBeenLastCalledWith({
-        installedPackageRef: installedPackageReference,
-      });
-    });
   });
 });
 

--- a/dashboard/src/shared/InstalledPackage.ts
+++ b/dashboard/src/shared/InstalledPackage.ts
@@ -43,20 +43,8 @@ export class InstalledPackage {
 
   public static async GetInstalledPackageResourceRefs(
     installedPackageRef?: InstalledPackageReference,
-    initialWait = 500,
   ) {
-    // TODO(minelson): The backend plugin may take care of waiting
-    // for the required data to become available in which case this
-    // can be removed.
-    // See https://github.com/kubeapps/kubeapps/issues/4213
-    // Note: initialWait is set with a default value so it can be
-    // tested with a value of 0 (because I couldn't get jest's mock
-    // timers to work with promises here.)
-    const fn = async () =>
-      this.coreClient().GetInstalledPackageResourceRefs({
-        installedPackageRef: installedPackageRef,
-      });
-    return await callWithRetry(fn, initialWait);
+    return await this.coreClient().GetInstalledPackageResourceRefs({ installedPackageRef });
   }
 
   public static async CreateInstalledPackage(
@@ -115,21 +103,3 @@ export class InstalledPackage {
     } as DeleteInstalledPackageRequest);
   }
 }
-
-// Helpers to be able to call with a retry backing off exponentially
-// with 500ms, 1000ms, 2000ms, 4000ms etc.
-const wait = (ms: number) => new Promise(res => setTimeout(res, ms));
-
-const callWithRetry = async (fn: any, initialWait: number, depth = 0): Promise<any> => {
-  try {
-    return await fn();
-  } catch (e) {
-    if (depth >= 4) {
-      throw e;
-    }
-    // Wait for initialWait ms first time, doubling each time.
-    await wait(initialWait * 2 ** depth);
-
-    return callWithRetry(fn, initialWait, depth + 1);
-  }
-};

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -67,8 +67,6 @@ export class RollbackError extends CustomError {}
 
 export class DeleteError extends CustomError {}
 
-export class ResourceRefsNotFound extends CustomError {}
-
 export type DeploymentEvent = "install" | "upgrade";
 
 export interface IRepo {

--- a/dashboard/src/shared/types.ts
+++ b/dashboard/src/shared/types.ts
@@ -67,6 +67,8 @@ export class RollbackError extends CustomError {}
 
 export class DeleteError extends CustomError {}
 
+export class ResourceRefsNotFound extends CustomError {}
+
 export type DeploymentEvent = "install" | "upgrade";
 
 export interface IRepo {


### PR DESCRIPTION

### Description of the change

This PR updates the AppView so it handles the fetching of the resource references directly (rather than dispatching and going through redux) so that it can decide itself when to poll and importantly, can abort the polling when the component is unmounted.

This fixes a couple of issues that I found recently while testing deploying a flux package with a service account that doesn't have the required RBAC:

1. The existing code would retry the request up to 4 times, then display the not found error. This was find for the case where we expect the resources to exist in a short time-frame, but not for the case where they will never exist until RBAC is updated (see #4337 ),
2. The existing code would continue to retry the request even when you navigated away from the app view. This was because there was not a way currently to abort the requests when they are abstracted away through the redux dispatch/state-update lifecycle.

Since the direction of React's function components with `useEffect` etc. seems to be encouraging local state (rather than requiring redux for global state), I updated the component to request the refs directly and use local state. 
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->
People won't be confronted with a NotFound error when viewing the detail of an installed app that is pending due to insufficient RBAC.


### Possible drawbacks

<!-- Describe any known limitations with your change -->
Testing components that manage local state via async network requests is more challenging (had to re-read about `async act()` to understand why components weren't rendered in tests etc.).

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #3695 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
