### PR TITLE
Use env var instead of git config for setting the ssh key

### DIFF
--- a/script/chart_sync_utils.sh
+++ b/script/chart_sync_utils.sh
@@ -166,8 +166,7 @@ updateRepoWithRemoteChanges() {
     git -C "${TARGET_REPO}" pull upstream "${BRANCH_CHARTS_REPO_ORIGINAL}"
 
     # https://superuser.com/questions/232373/how-to-tell-git-which-private-key-to-use
-    git -C "${TARGET_REPO}" config --local core.sshCommand "ssh -i ~/.ssh/${FORKED_SSH_KEY_FILENAME} -F /dev/null"
-    git -C "${TARGET_REPO}" push origin "${BRANCH_CHARTS_REPO_FORKED}"
+    GIT_SSH_COMMAND="ssh -i ~/.ssh/${FORKED_SSH_KEY_FILENAME}" git -C "${TARGET_REPO}" push origin "${BRANCH_CHARTS_REPO_FORKED}"
 
     rm -rf "${KUBEAPPS_CHART_DIR}"
     cp -R "${targetChartPath}" "${KUBEAPPS_CHART_DIR}"


### PR DESCRIPTION
### Description of the change

Probably after the update of the images used in CircleCI, I don't know, but the sync chart from bitnami step stopped working.  This PR just changes the way the ssh key is passed back to git: before, we were setting the local git config, which was working nicely, but now this same info is passed through an env var.


### Benefits

CI step will work again

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

Tested while accessing via ssh to the circle ci machine with a successful output: https://github.com/kubeapps/kubeapps/pull/4348
