### PR TITLE
Allowing empty values applied when upgrading installation

### DIFF
--- a/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import actions from "actions";
+import { cloneDeep } from "lodash";
 import DeploymentFormBody from "components/DeploymentFormBody/DeploymentFormBody";
 import Alert from "components/js/Alert";
 import LoadingWrapper from "components/LoadingWrapper/LoadingWrapper";
@@ -309,6 +310,32 @@ describe("renders an error", () => {
     expect(wrapper.find(Alert).exists()).toBe(true);
     expect(wrapper.find(Alert).first()).toIncludeText("wrong format!");
   });
+});
+
+it("empty values applied is allowed", () => {
+  const installedPackageDetails = cloneDeep(installedPkgDetail);
+  installedPackageDetails.valuesApplied = "";
+  const state = {
+    ...defaultStore,
+    apps: {
+      selected: installedPackageDetails,
+      selectedDetails: availablePkgDetail,
+      isFetching: false,
+    } as IInstalledPackageState,
+    packages: {
+      selected: selectedPkg,
+    } as IPackageState,
+  };
+
+  const wrapper = mountWrapper(
+    getStore({ ...state }),
+    <MemoryRouter initialEntries={[routePathParam]}>
+      <Route path={routePath}>
+        <UpgradeForm />,
+      </Route>
+    </MemoryRouter>,
+  );
+  expect(wrapper.find(DeploymentFormBody).prop("packageVersion")).toBe("1.0.0");
 });
 
 it("defaults the upgrade version to the current version", () => {

--- a/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
+++ b/dashboard/src/components/UpgradeForm/UpgradeForm.tsx
@@ -106,7 +106,8 @@ function UpgradeForm(props: IUpgradeFormProps) {
     if (installedAppAvailablePackageDetail?.defaultValues && !modifications) {
       // Calculate modifications from the default values
       const defaultValuesObj = yaml.load(installedAppAvailablePackageDetail?.defaultValues) || {};
-      const deployedValuesObj = yaml.load(installedAppInstalledPackageDetail?.valuesApplied || "");
+      const deployedValuesObj =
+        yaml.load(installedAppInstalledPackageDetail?.valuesApplied || "") || {};
       const newModifications = jsonpatch.compare(defaultValuesObj as any, deployedValuesObj as any);
       const values = applyModifications(
         newModifications,


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

This PR fixes a small UI bug for the upgrade cases in which there were no installation applied values. This is mainly happening with the Carvel plugin.

When trying to render the `UpgradeForm`, there was an error due to the impossibility to convert a null/empty string to json.

### Benefits

Upgrade view now renders and no error is shown.

### Possible drawbacks

N/A

### Applicable issues

- fixes #4352 

