### PR TITLE
Don't send empty Auth header when syncing repos.

### DIFF
--- a/cmd/asset-syncer/server/utils.go
+++ b/cmd/asset-syncer/server/utils.go
@@ -726,7 +726,11 @@ func fetchRepoIndex(url, authHeader string, cli httpclient.Client, userAgent str
 		return nil, err
 	}
 	indexURL.Path = path.Join(indexURL.Path, "index.yaml")
-	return doReq(indexURL.String(), cli, map[string]string{"Authorization": authHeader}, userAgent)
+	headers := map[string]string{}
+	if authHeader != "" {
+		headers["Authorization"] = authHeader
+	}
+	return doReq(indexURL.String(), cli, headers, userAgent)
 }
 
 func chartTarballURL(r *models.RepoInternal, cv models.ChartVersion) string {

--- a/cmd/asset-syncer/server/utils_test.go
+++ b/cmd/asset-syncer/server/utils_test.go
@@ -59,6 +59,13 @@ func (h *goodHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	if strings.HasPrefix(req.URL.Path, "//") {
 		w.WriteHeader(500)
 	}
+
+	// Sending an empty Authorization header is not valid for http spec,
+	// some servers returning 401 for public resources in this case.
+	if v, ok := req.Header["Authorization"]; ok && len(v) == 1 && v[0] == "" {
+		w.WriteHeader(401)
+	}
+
 	// If subpath repo URL test, check that index.yaml is correctly added to the
 	// subpath
 	if req.URL.Host == "subpath.test" && req.URL.Path != "/subpath/index.yaml" {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change
See #4345 

### Benefits

No issues syncing public repos on services that send 401 for requests with empty auth header.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #4345 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
