### PR TITLE
Enable an empty response from carvel.GetAvailablePackageSummaries

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -53,8 +53,10 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 	// paginate the list of results
 	availablePackageSummaries := make([]*corev1.AvailablePackageSummary, len(pkgMetadatas))
 
-	// create the waiting group for processing each item aynchronously
-	var wg sync.WaitGroup
+	// Create a channel to receive any errors. The channel is also used as a
+	// natural waitgroup to synchronize the results.
+	errs := make(chan error)
+	numRoutines := 0
 
 	// TODO(agamez): DRY up this logic (cf GetInstalledPackageSummaries)
 	if len(pkgMetadatas) > 0 {
@@ -63,32 +65,38 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 			startAt = int(pageSize) * pageOffset
 		}
 		for i, pkgMetadata := range pkgMetadatas {
-			wg.Add(1)
 			if startAt <= i {
-				go func(i int, pkgMetadata *datapackagingv1alpha1.PackageMetadata) error {
-					defer wg.Done()
+				numRoutines++
+				go func(i int, pkgMetadata *datapackagingv1alpha1.PackageMetadata) {
 					// fetch the associated packages
 					// Use the field selector to return only Package CRs that match on the spec.refName.
 					// TODO(agamez): perhaps we better fetch all the packages and filter ourselves to reduce the k8s calls
 					fieldSelector := fmt.Sprintf("spec.refName=%s", pkgMetadata.Name)
 					pkgs, err := s.getPkgsWithFieldSelector(ctx, cluster, namespace, fieldSelector)
 					if err != nil {
-						return statuserror.FromK8sError("get", "Package", pkgMetadata.Name, err)
+						log.Errorf("Error: %+v", err)
+						errs <- statuserror.FromK8sError("get", "Package", pkgMetadata.Name, err)
+						return
 					}
 					pkgVersionsMap, err := getPkgVersionsMap(pkgs)
 					if err != nil {
-						return err
+						log.Errorf("Error: %+v", err)
+						errs <- err
+						return
 					}
 
 					// generate the availablePackageSummary from the fetched information
 					availablePackageSummary, err := s.buildAvailablePackageSummary(pkgMetadata, pkgVersionsMap, cluster)
 					if err != nil {
-						return statuserror.FromK8sError("create", "AvailablePackageSummary", pkgMetadata.Name, err)
+						log.Errorf("Error: %+v", err)
+						errs <- statuserror.FromK8sError("create", "AvailablePackageSummary", pkgMetadata.Name, err)
+						return
 					}
 
 					// append the availablePackageSummary to the slice
 					availablePackageSummaries[i] = availablePackageSummary
-					return nil
+					// Ensure we signal a completion.
+					errs <- nil
 				}(i, pkgMetadata)
 			}
 			// if we've reached the end of the page, stop iterating
@@ -97,7 +105,14 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 			}
 		}
 	}
-	wg.Wait() // Wait until each goroutine has finished
+	// Return an error if any is found. We continue only if there were no
+	// errors.
+	for i := 0; i < numRoutines; i++ {
+		err := <-errs
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, fmt.Sprintf("unexpected error while gathering available packages: %v", err))
+		}
+	}
 
 	// TODO(agamez): the slice with make is filled with <nil>, in case of an error in the
 	// i goroutine, the i-th <nil> stub will remain. Check if 'errgroup' works here, but I haven't
@@ -113,10 +128,6 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 			categories = append(categories, availablePackageSummary.Categories...)
 
 		}
-	}
-	// if no results whatsoever, throw an error
-	if len(availablePackageSummariesNilSafe) == 0 {
-		return nil, status.Errorf(codes.NotFound, fmt.Sprintf("no available packages: %v", err))
 	}
 
 	// Only return a next page token if the request was for pagination and

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_ctrl_packages.go
@@ -74,13 +74,11 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 					fieldSelector := fmt.Sprintf("spec.refName=%s", pkgMetadata.Name)
 					pkgs, err := s.getPkgsWithFieldSelector(ctx, cluster, namespace, fieldSelector)
 					if err != nil {
-						log.Errorf("Error: %+v", err)
 						errs <- statuserror.FromK8sError("get", "Package", pkgMetadata.Name, err)
 						return
 					}
 					pkgVersionsMap, err := getPkgVersionsMap(pkgs)
 					if err != nil {
-						log.Errorf("Error: %+v", err)
 						errs <- err
 						return
 					}
@@ -88,7 +86,6 @@ func (s *Server) GetAvailablePackageSummaries(ctx context.Context, request *core
 					// generate the availablePackageSummary from the fetched information
 					availablePackageSummary, err := s.buildAvailablePackageSummary(pkgMetadata, pkgVersionsMap, cluster)
 					if err != nil {
-						log.Errorf("Error: %+v", err)
 						errs <- statuserror.FromK8sError("create", "AvailablePackageSummary", pkgMetadata.Name, err)
 						return
 					}

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_test.go
@@ -151,33 +151,12 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 		expectedStatusCode codes.Code
 	}{
 		{
-			name: "it returns a not found error status if a package meta does not contain spec.displayName",
-			existingObjects: []runtime.Object{
-				&datapackagingv1alpha1.PackageMetadata{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       pkgMetadataResource,
-						APIVersion: datapackagingAPIVersion,
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "tetris.foo.example.com",
-					},
-					Spec: datapackagingv1alpha1.PackageMetadataSpec{
-						DisplayName:        "Classic Tetris",
-						IconSVGBase64:      "Tm90IHJlYWxseSBTVkcK",
-						ShortDescription:   "A great game for arcade gamers",
-						LongDescription:    "A few sentences but not really a readme",
-						Categories:         []string{"logging", "daemon-set"},
-						Maintainers:        []datapackagingv1alpha1.Maintainer{{Name: "person1"}, {Name: "person2"}},
-						SupportDescription: "Some support information",
-						ProviderName:       "Tetris inc.",
-					},
-				},
-			},
-			expectedStatusCode: codes.NotFound,
+			name:               "it returns without error if there are no packages available",
+			expectedPackages:   []*corev1.AvailablePackageSummary{},
+			expectedStatusCode: codes.OK,
 		},
 		{
-			name: "it returns an not found error status if a package does not contain version",
+			name: "it returns an internal error status if there is no corresponding package for a package metadata",
 			existingObjects: []runtime.Object{
 				&datapackagingv1alpha1.PackageMetadata{
 					TypeMeta: metav1.TypeMeta{
@@ -200,7 +179,7 @@ func TestGetAvailablePackageSummaries(t *testing.T) {
 					},
 				},
 			},
-			expectedStatusCode: codes.NotFound,
+			expectedStatusCode: codes.Internal,
 		},
 		{
 			name: "it returns carvel package summaries with basic info from the cluster",


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

See #4328 for description of the visible problem.

In the code, AFAICT, within the Carvel plugin, there was no difference in functionality for an empty state vs an incorrect state. So if no repo was setup, an error was returned as per #4328 in the same way that the error was returned if a carvel package metadata did not have a corresponding package (version).

This change separates errors from an empty result, returning a specific Internal error when it happens, but not returning an error for an empty catalog.

### Benefits

<!-- What benefits will be realized by the code change? -->
Users can see the empty catalog view with links to documentation for setting up repositories etc.

![empty-catalog](https://user-images.githubusercontent.com/497518/156090981-aaafc883-abc3-4009-bb0e-8e0ec4335476.png)


### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #4328 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Since I needed a channel to gather any errors, it seemed convenient to use that channel for synchronization rather than a separate waitgroup.

I'll probably do a follow-up PR that also updates the channel to include the result (not just error), so that we're not doing write operations on a shared slice concurrently, but it's not necessary, just a suggestion.
