### PR TITLE
Carvel docs to specify namespace for repository.

### DIFF
--- a/docs/user/managing-carvel-packages.md
+++ b/docs/user/managing-carvel-packages.md
@@ -139,10 +139,10 @@ EOF
 Then, you need to apply the `PackageRepository` CR to your cluster using `kubectl` (or, alternatively, the `kapp` CLI), by running the following command:
 
 ```bash
-kubectl apply -f repo.yaml
+kubectl apply --namespace kapp-controller-packaging-global -f repo.yaml
 ```
 
-Under the hood, kapp-controller will create `Package` and `PackageMetadata` CRs for each of the packages in the repository.
+Under the hood, kapp-controller will create `Package` and `PackageMetadata` CRs for each of the packages in the repository in the global packaging namespace for kapp-controller, enabling those packages to be installed via Kubeapps in any namespace. Note you can instead install the repository in a different namespace if the packages should only be available for install via Kubeapps in a particular namespace.
 
 > **TIP**: Run `kubectl get packagerepository`, `kubectl get packages` and `kubectl get packagemetadatas` to get the created CRs.
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

While testing yesterday I'd added the TCE carvel repo as per the docs, but noticed I still had an empty catalog. Turned out to be because the TCE `packagerepository` was created in the `default` namespace, so the packages were only visible in the catalog when I switched context to the default namespace.

### Benefits

<!-- What benefits will be realized by the code change? -->
Avoid confusion when trying out the carvel support.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
