### PR TITLE
Set reasonable QPS/Burst for resources RESTMapper client

### DIFF
--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
@@ -45,6 +45,10 @@ type GRPCPluginRegistrationOptions struct {
 	ConfigGetter     core.KubernetesConfigGetter
 	ClustersConfig   kube.ClustersConfig
 	PluginConfigPath string
+	// The QPS and Burst options that have been configured for any
+	// clients of the K8s API server created by plugins.
+	ClientQPS   float32
+	ClientBurst int
 }
 
 // PluginWithServer keeps a record of a GRPC server and its plugin detail.
@@ -131,7 +135,7 @@ func (s *PluginsServer) registerPlugins(pluginPaths []string, grpcReg grpc.Servi
 			return err
 		}
 
-		if grpcServer, err := s.registerGRPC(p, pluginDetail, grpcReg, configGetter, serveOpts.PluginConfigPath); err != nil {
+		if grpcServer, err := s.registerGRPC(p, pluginDetail, grpcReg, configGetter, serveOpts); err != nil {
 			return err
 		} else {
 			pluginsWithServers = append(pluginsWithServers, PluginWithServer{
@@ -156,7 +160,7 @@ func (s *PluginsServer) registerPlugins(pluginPaths []string, grpcReg grpc.Servi
 
 // registerGRPC finds and calls the required function for registering the plugin for the GRPC server.
 func (s *PluginsServer) registerGRPC(p *plugin.Plugin, pluginDetail *plugins.Plugin, registrar grpc.ServiceRegistrar,
-	clientGetter core.KubernetesConfigGetter, pluginConfigPath string) (interface{}, error) {
+	configGetter core.KubernetesConfigGetter, serveOpts core.ServeOptions) (interface{}, error) {
 	grpcRegFn, err := p.Lookup(grpcRegisterFunction)
 	if err != nil {
 		return nil, fmt.Errorf("unable to lookup %q for %v: %w", grpcRegisterFunction, pluginDetail, err)
@@ -171,7 +175,14 @@ func (s *PluginsServer) registerGRPC(p *plugin.Plugin, pluginDetail *plugins.Plu
 		return nil, fmt.Errorf("unable to use %q in plugin %v due to mismatched signature.\nwant: %T\ngot: %T", grpcRegisterFunction, pluginDetail, stubFn, grpcRegFn)
 	}
 
-	server, err := grpcFn(GRPCPluginRegistrationOptions{registrar, clientGetter, s.clustersConfig, pluginConfigPath})
+	server, err := grpcFn(GRPCPluginRegistrationOptions{
+		Registrar:        registrar,
+		ConfigGetter:     configGetter,
+		ClustersConfig:   s.clustersConfig,
+		PluginConfigPath: serveOpts.PluginConfigPath,
+		ClientQPS:        serveOpts.QPS,
+		ClientBurst:      serveOpts.Burst,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("plug-in %q failed to register due to: %v", pluginDetail, err)
 	} else if server == nil {

--- a/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
+++ b/cmd/kubeapps-apis/core/plugins/v1alpha1/plugins.go
@@ -300,7 +300,7 @@ func createConfigGetter(serveOpts core.ServeOptions, clustersConfig kube.Cluster
 // createClientGetter takes the required params and returns the closure fuction.
 // it's splitted for testing this fn separately
 func createConfigGetterWithParams(inClusterConfig *rest.Config, serveOpts core.ServeOptions, clustersConfig kube.ClustersConfig) (core.KubernetesConfigGetter, error) {
-	// return the closure fuction that takes the context, but preserving the required scope,
+	// return the closure function that takes the context, but preserving the required scope,
 	// 'inClusterConfig' and 'config'
 	return func(ctx context.Context, cluster string) (*rest.Config, error) {
 		log.V(4).Infof("+clientGetter.GetClient")

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
@@ -33,7 +33,7 @@ func init() {
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
 func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) (interface{}, error) {
-	svr, err := NewServer(opts.ConfigGetter)
+	svr, err := NewServer(opts.ConfigGetter, opts.ClientQPS, opts.ClientBurst)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/server.go
@@ -69,6 +69,11 @@ func createRESTMapper() (meta.RESTMapper, error) {
 	// See https://github.com/kubernetes/client-go/issues/657#issuecomment-842960258
 	config.GroupVersion = &schema.GroupVersion{Group: "", Version: "v1"}
 	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs}
+
+	// Avoid client-side throttling while the rest mapper initializes.
+	config.QPS = 50.0
+	config.Burst = 100
+
 	client, err := rest.RESTClientFor(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

Sets reasonable QPS and Burst for the client config used only in the discovery of the REST API (by the RESTMapper).

Before this change, registering the resources plugin took around 8 seconds due to client throttling:
```
I0302 00:40:47.539843       1 plugins.go:137] Successfully registered plugin "/plugins/fluxv2-packages/fluxv2-packages-v1alpha1-plugin.so"
I0302 00:40:48.318594       1 request.go:597] Waited for 109.310691ms due to client-side throttling,
 not priority and fairness, request: GET:https://10.96.0.1:443/apis/networking.k8s.io/v1beta1
...
I0302 00:40:56.919228       1 request.go:665] Waited for 8.611529015s due to client-side throttling,
 not priority and fairness, request: GET:https://10.96.0.1:443/apis/kustomize.toolkit.fluxcd.io/v1beta1

I0302 00:40:56.923634       1 plugins.go:137] Successfully registered plugin "/plugins/resources/resources-v1alpha1-plugin.so"
...
I0302 00:40:56.924955       1 server.go:158] Starting server on :50051
```

With this change, it's under 500ms (with no warnings of throttling):

```
I0302 05:39:33.515837       1 plugins.go:137] Successfully registered plugin "/plugins/fluxv2-packages/fluxv2-packages-v1alpha1-plugin.so"
I0302 05:39:34.010957       1 plugins.go:137] Successfully registered plugin "/plugins/resources/resources-v1alpha1-plugin.so"
```

### Benefits

Faster startup time for the kubeapps-apis server (see #4329).

### Possible drawbacks

Initial hammer of the k8s API server when the rest mapper initialises, but don't see this as an issue.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #4329 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
I did investigate whether we could use the client-getter to create a client using the chart configured defaults, but the client-getter is very careful to restrict itself to user requests, enforcing a user token, ensuring any service account token from the service is not used, etc., which I do not think we should change. Given that this client is used only for generating the rest mapper, I ended up going for simple constants.