### PR TITLE
Replace args with struct for grpc registration.

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/main.go
@@ -9,16 +9,14 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
+	pluginsv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/pkg/kube"
 	log "k8s.io/klog/v2"
 )
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
-	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
+func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) (interface{}, error) {
 	log.Infof("+fluxv2 RegisterWithGRPCServer")
 
 	// TODO (gfichtenholt) stub channel for now. Ideally, the caller (kubeappsapis-server)
@@ -26,12 +24,12 @@ func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.Kubernete
 	// 'Shutdown' hook
 	stopCh := make(chan struct{})
 
-	svr, err := NewServer(configGetter, clustersConfig.KubeappsClusterName, stopCh, pluginConfigPath)
+	svr, err := NewServer(opts.ConfigGetter, opts.ClustersConfig.KubeappsClusterName, stopCh, opts.PluginConfigPath)
 	if err != nil {
 		return nil, err
 	}
-	v1alpha1.RegisterFluxV2PackagesServiceServer(s, svr)
-	v1alpha1.RegisterFluxV2RepositoriesServiceServer(s, svr)
+	v1alpha1.RegisterFluxV2PackagesServiceServer(opts.Registrar, svr)
+	v1alpha1.RegisterFluxV2RepositoriesServiceServer(opts.Registrar, svr)
 	return svr, nil
 }
 

--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/main.go
@@ -9,18 +9,17 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	pluginsv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core/plugins/v1alpha1"
+	pluginsgrpcv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/kapp_controller/packages/v1alpha1"
-	"github.com/kubeapps/kubeapps/pkg/kube"
 )
 
 // Set the pluginDetail once during a module init function so the single struct
 // can be used throughout the plugin.
-var pluginDetail plugins.Plugin
+var pluginDetail pluginsgrpcv1alpha1.Plugin
 
 func init() {
-	pluginDetail = plugins.Plugin{
+	pluginDetail = pluginsgrpcv1alpha1.Plugin{
 		Name:    "kapp_controller.packages",
 		Version: "v1alpha1",
 	}
@@ -28,10 +27,9 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter,
-	clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
-	svr := NewServer(configGetter, clustersConfig.KubeappsClusterName, pluginConfigPath)
-	v1alpha1.RegisterKappControllerPackagesServiceServer(s, svr)
+func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) (interface{}, error) {
+	svr := NewServer(opts.ConfigGetter, opts.ClustersConfig.KubeappsClusterName, opts.PluginConfigPath)
+	v1alpha1.RegisterKappControllerPackagesServiceServer(opts.Registrar, svr)
 	return svr, nil
 }
 
@@ -42,6 +40,6 @@ func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux,
 }
 
 // GetPluginDetail returns a core.plugins.Plugin describing itself.
-func GetPluginDetail() *plugins.Plugin {
+func GetPluginDetail() *pluginsgrpcv1alpha1.Plugin {
 	return &pluginDetail
 }

--- a/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
+++ b/cmd/kubeapps-apis/plugins/resources/v1alpha1/main.go
@@ -9,23 +9,22 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core"
-	plugins "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
+	pluginsv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core/plugins/v1alpha1"
+	pluginsgrpcv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
 	"github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/resources/v1alpha1"
-	"github.com/kubeapps/kubeapps/pkg/kube"
 )
 
 // Set the pluginDetail once during a module init function so the single struct
 // can be used throughout the plugin.
 var (
-	pluginDetail plugins.Plugin
+	pluginDetail pluginsgrpcv1alpha1.Plugin
 	// This version var is updated during the build (see the -ldflags option
 	// in the cmd/kubeapps-apis/Dockerfile)
 	version = "devel"
 )
 
 func init() {
-	pluginDetail = plugins.Plugin{
+	pluginDetail = pluginsgrpcv1alpha1.Plugin{
 		Name:    "resources",
 		Version: "v1alpha1",
 	}
@@ -33,12 +32,12 @@ func init() {
 
 // RegisterWithGRPCServer enables a plugin to register with a gRPC server
 // returning the server implementation.
-func RegisterWithGRPCServer(s grpc.ServiceRegistrar, configGetter core.KubernetesConfigGetter, clustersConfig kube.ClustersConfig, pluginConfigPath string) (interface{}, error) {
-	svr, err := NewServer(configGetter)
+func RegisterWithGRPCServer(opts pluginsv1alpha1.GRPCPluginRegistrationOptions) (interface{}, error) {
+	svr, err := NewServer(opts.ConfigGetter)
 	if err != nil {
 		return nil, err
 	}
-	v1alpha1.RegisterResourcesServiceServer(s, svr)
+	v1alpha1.RegisterResourcesServiceServer(opts.Registrar, svr)
 	return svr, nil
 }
 
@@ -49,6 +48,6 @@ func RegisterHTTPHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux,
 }
 
 // GetPluginDetail returns a core.plugins.Plugin describing itself.
-func GetPluginDetail() *plugins.Plugin {
+func GetPluginDetail() *pluginsgrpcv1alpha1.Plugin {
 	return &pluginDetail
 }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

This is a prequel to #4370 . It doesn't make any functional change, but just pulls out the arguments to the dynamically loaded grpc registration function into a struct defined in the one place. This makes it easier moving forward for us to modify it when needed in the one place. Please see #4370 for an example where we ensure plugins have access to QPS and Burst options without having to change other plugins necessarily.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Easier to modify grpc registration args in the future.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- ref #4329 

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

I again hit an import naming issue here, because some plugins import both the generated plugins/v1alpha1 as well as our implementation module for plugins/v1alpha1. So  @antgamdia , I looked up your earlier #4176 where you'd put some thought into this and found in the list there, where I think you found options for this same situation:

```
pluginsgrpcv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
pluginsgrpcv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/plugins/fluxv2/packages/v1alpha1"
pluginsv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/core/plugins/v1alpha1"
pluginsv1alpha1 "github.com/kubeapps/kubeapps/cmd/kubeapps-apis/gen/core/plugins/v1alpha1"
```

Now I assume the last entry there is incorrect (probably before you'd realised that some modules import both) as it duplicates the alias of the 3rd and the import path of the first. Similarly, I think the 2nd is misnamed (it's a flux plugin), and so I have used here the examples from the 1st and 3rd entries in the above snippet for the generated module and our implementation module.

Let me know if that's not what you intended.
