### PR TITLE
Switch to standalone cobra-cli dependency

### DIFF
--- a/cmd/kubeapps-apis/Makefile
+++ b/cmd/kubeapps-apis/Makefile
@@ -14,7 +14,7 @@ build-plugins:
 # See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 cli-dependencies:
 	go get \
-		github.com/spf13/cobra/cobra \
+		github.com/spf13/cobra-cli \
 		google.golang.org/grpc/cmd/protoc-gen-go-grpc \
 		google.golang.org/protobuf/cmd/protoc-gen-go \
 		github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 \

--- a/cmd/kubeapps-apis/tools/tools.go
+++ b/cmd/kubeapps-apis/tools/tools.go
@@ -13,7 +13,7 @@ package tools
 import (
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2"
-	_ "github.com/spf13/cobra/cobra"
+	_ "github.com/spf13/cobra-cli"
 	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )

--- a/docs/developer/kubeapps-apis.md
+++ b/docs/developer/kubeapps-apis.md
@@ -230,7 +230,7 @@ You should be able to install the exact versions of the various go CLI dependenc
 make cli-dependencies
 ```
 
-This will ensure that the cobra command is available should you need to add a sub-command.
+This will ensure that the `cobra-cli` command is available should you need to add a sub-command.
 
 ### Install buf
 

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.3.0
+	github.com/spf13/cobra-cli v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
 	github.com/srwiley/oksvg v0.0.0-20220128195007-1f435e4c2b44

--- a/go.sum
+++ b/go.sum
@@ -1528,6 +1528,8 @@ github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSW
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/cobra v1.3.0 h1:R7cSvGu+Vv+qX0gW5R/85dx2kmmJT5z5NM8ifdYjdn0=
 github.com/spf13/cobra v1.3.0/go.mod h1:BrRVncBjOJa/eUcVVm9CE+oC6as8k+VYr4NY7WCi9V4=
+github.com/spf13/cobra-cli v1.3.0 h1:Y/qy0X40kDT+k7PCyBQrsjh/qOf9t/ZVScbn0OyZD84=
+github.com/spf13/cobra-cli v1.3.0/go.mod h1:zq1KeHo/9SQm1tNdbJhwVDd9bVpokbQwuG6MR0TFCdE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=


### PR DESCRIPTION
### Description of the change

Switches to use the extracted `cobra-cli` command since it is being removed from the `github.com/spf13/cobra` module (xref https://github.com/spf13/cobra/issues/1597)

### Benefits

Makefile and docs will continue to be accurate after https://github.com/spf13/cobra/issues/1597 is completed

### Possible drawbacks

-

### Applicable issues

xref https://github.com/spf13/cobra/issues/1597