### PR TITLE
Fix TestGetPkgVersionsMap

### DIFF
--- a/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
+++ b/cmd/kubeapps-apis/plugins/kapp_controller/packages/v1alpha1/server_utils_test.go
@@ -22,6 +22,7 @@ func TestGetPkgVersionsMap(t *testing.T) {
 	version123, _ := semver.NewVersion("1.2.3")
 	version124, _ := semver.NewVersion("1.2.4")
 	version127, _ := semver.NewVersion("1.2.7")
+	version1210, _ := semver.NewVersion("1.2.10")
 	tests := []struct {
 		name                   string
 		packages               []*datapackagingv1alpha1.Package
@@ -70,6 +71,23 @@ func TestGetPkgVersionsMap(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
+					Name:      "tetris.foo.example.com.1.2.10",
+				},
+				Spec: datapackagingv1alpha1.PackageSpec{
+					RefName:                         "tetris.foo.example.com",
+					Version:                         "1.2.10",
+					Licenses:                        []string{"my-license"},
+					ReleaseNotes:                    "release notes",
+					CapactiyRequirementsDescription: "capacity description",
+				},
+			},
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       pkgResource,
+					APIVersion: datapackagingAPIVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
 					Name:      "tetris.foo.example.com.1.2.4",
 				},
 				Spec: datapackagingv1alpha1.PackageSpec{
@@ -83,16 +101,16 @@ func TestGetPkgVersionsMap(t *testing.T) {
 		}, map[string][]pkgSemver{
 			"tetris.foo.example.com": {
 				{
-					pkg:     &datapackagingv1alpha1.Package{},
-					version: version123,
+					version: version1210,
 				},
 				{
-					pkg:     &datapackagingv1alpha1.Package{},
+					version: version127,
+				},
+				{
 					version: version124,
 				},
 				{
-					pkg:     &datapackagingv1alpha1.Package{},
-					version: version127,
+					version: version123,
 				},
 			},
 		}},
@@ -103,7 +121,11 @@ func TestGetPkgVersionsMap(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			opts := cmpopts.IgnoreUnexported(pkgSemver{})
+			// We want to compare the `version` field of pkgSemver.
+			opts := cmp.Options{
+				cmp.AllowUnexported(pkgSemver{}),
+				cmpopts.IgnoreFields(pkgSemver{}, "pkg"),
+			}
 			if want, got := tt.expectedPkgVersionsMap, pkgVersionsMap; !cmp.Equal(want, got, opts) {
 				t.Errorf("in %s: mismatch (-want +got):\n%s", tt.name, cmp.Diff(want, got, opts))
 			}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Fixes a test issue I noticed the other day, but wasn't sure then the best way to fix it.

The test was giving a false positive: the test appears to check that the versions are returned in the order of earliest to latest, when I knew that that wasn't the case (since code was grabbing the [0] version as the latest).

Turns out the reason it was passing was because we'd asked it to ignore all hidden fields of the struct that we were comparing - `pkgSemver` - which includes the `.version` field that we're wanting to check. So it effectively accepted any `pkgSemver` instances in the slice, it just had to be the correct length.

The update is to instead allow checking of unexported fields, but ignore the `.pkg` field that this test wasn't interested in.

While there, I added an extra version to ensure semver (and not just ascii) ordering (that's what I tried to do the other day before finding the test issue).

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
