### PR TITLE
Add to Github actions the first Custodian rule check for unattached disks

### DIFF
--- a/.github/workflows/ci-custodian-rules.yaml
+++ b/.github/workflows/ci-custodian-rules.yaml
@@ -1,6 +1,8 @@
 name: Custodian rules for Kubeapps
 on:
-  workflow_dispatch:
+  push:
+    branches:    
+      - '4402-custodian-rule-disks'
   #schedule:
   #  - cron: "0 8 * * *"
 env:

--- a/.github/workflows/ci-custodian-rules.yaml
+++ b/.github/workflows/ci-custodian-rules.yaml
@@ -1,10 +1,7 @@
 name: Custodian rules for Kubeapps
 on:
-  push:
-    branches:    
-      - '4402-custodian-rule-disks'
-  #schedule:
-  #  - cron: "0 8 * * *"
+  schedule:
+    - cron: "0 8 * * *"
 env:
   GOOGLE_APPLICATION_CREDENTIALS: key.json
   GCLOUD_CUSTODIAN_KEY: ${{ secrets.GCLOUD_CUSTODIAN_KEY }}

--- a/.github/workflows/ci-custodian-rules.yaml
+++ b/.github/workflows/ci-custodian-rules.yaml
@@ -1,0 +1,19 @@
+name: Custodian rules for Kubeapps
+on:
+  workflow_dispatch:
+  #schedule:
+  #  - cron: "0 8 * * *"
+env:
+  GOOGLE_APPLICATION_CREDENTIALS: key.json
+  GCLOUD_CUSTODIAN_KEY: ${{ secrets.GCLOUD_CUSTODIAN_KEY }}
+  CLOUDSDK_CORE_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
+jobs:
+  remove-unattached-disks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gscho/setup-cloud-custodian@v1
+        with:
+          include-gcp: true
+      - run: echo $GCLOUD_CUSTODIAN_KEY > $GOOGLE_APPLICATION_CREDENTIALS
+      - run: custodian run -s out .github/workflows/custodian-rules/remove-unattached-disks.yaml

--- a/.github/workflows/custodian-rules/remove-unattached-disks.yaml
+++ b/.github/workflows/custodian-rules/remove-unattached-disks.yaml
@@ -1,0 +1,20 @@
+---
+policies:
+  - name: remove-unattached-disks
+    resource: gcp.disk
+    comment: |
+      Remove all unattached disks AND created by a GKE cluster
+    actions:
+      - type: delete
+    filters:
+      - type: value
+        key: labels
+        op: contains
+        value: "goog-gke-volume"
+      - type: value
+        key: users
+        value: absent
+      - type: value
+        key: description
+        op: regex
+        value: "^.*kubernetes.io/created-for/pv/name.*$"


### PR DESCRIPTION
### Description of the change

With this PR, a cronjob is set to check every day at 8AM that there no unattached disks in the GCloud project used for CI when releasing.

It makes use of the Custodian rule provided by Jorge Bianquetti, plus the use of the available [Cloud Custodian Github action](https://github.com/marketplace/actions/setup-cloud-custodian).

### Benefits

No unused, unattached disks will live more than 1 day. This saves money from cloud infrastructure invoice.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- implements #4402 

### Additional information

A couple of secrets are created:
- GOOGLE_CLOUD_PROJECT
- GCLOUD_CUSTODIAN_KEY
