### PR TITLE
Add repo restriction to Github action

### DIFF
--- a/.github/workflows/ci-custodian-rules.yaml
+++ b/.github/workflows/ci-custodian-rules.yaml
@@ -8,6 +8,7 @@ env:
   CLOUDSDK_CORE_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
 jobs:
   remove-unattached-disks:
+    if: github.repository == 'kubeapps/kubeapps'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Description of the change

Restrict the execution of Custodian rule github action to the `kubeapps/kubeapps` repo only.

### Benefits

When forking Kubeapps repo, there will be no failing runs for the Github action.
