### PR TITLE
Create add-issues-to-project.yaml

### DIFF
--- a/.github/workflows/add-issues-to-project.yaml
+++ b/.github/workflows/add-issues-to-project.yaml
@@ -1,0 +1,23 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign NEW issues to project
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/orgs/kubeapps/projects/4'
+    - name: Assign NEW issues to classic project
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/orgs/kubeapps/kubeapps/projects/11'


### PR DESCRIPTION
### Description of the change

For the management of the project to track issues it is necessary an automatic process to add issues to projects, so every new issue can be included in the triage process and then moved to the Backlog.

For that, a github action that assign issues to projects is included. At this moment, it is configured to assign NEW issues to the [old project](https://github.com/kubeapps/kubeapps/projects/11) and the [new project](https://github.com/kubeapps/projects/4).

### Benefits

New issues are automatically added to the project.

### Possible drawbacks

It is a public github action from the marketplace, so it is something to be considered for the maintenance.

### Additional information

GitHub Action: [Assign to One Project](https://github.com/marketplace/actions/assign-to-one-project)
