### PR TITLE
Add dependabot to github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,10 @@ updates:
       interval: "daily"
       time: "03:00"
     open-pull-requests-limit: 2
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
### Description of the change

As we continue to add new github actions to the project, we need to keep them (the images) up to date; therefore, this PR is to add a dependabot step looking at these new deps.

### Benefits

GHA up to date.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A