### PR TITLE
Bumped dev chart version to 8.0.4-dev1

### DIFF
--- a/chart/kubeapps/Chart.yaml
+++ b/chart/kubeapps/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 8.0.3
+version: 8.0.4-dev1


### PR DESCRIPTION
Signed-off-by: Rafa Castelblanque <rcastelblanq@vmware.com>

### Description of the change

Simply increase the dev chart version to `8.0.4-dev1` as noticed that the latest sync from Bitnami (#4511) didn't have it.
@absoludity Is it correct like this?